### PR TITLE
Clean out some dependencies that are pulled in automatically by rest-uti...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,11 +10,7 @@
     <name>kafka-schema-registry</name>
 
     <properties>
-        <jersey.version>2.13</jersey.version>
-        <jetty.version>9.2.4.v20141103</jetty.version>
-        <jackson.version>2.4.3</jackson.version>
-        <hibernate.version>5.1.3.Final</hibernate.version>
-        <javaxel.version>3.0.0</javaxel.version>
+        <jersey.version>2.6</jersey.version>
         <kafka.version>0.8.2-beta</kafka.version>
         <kafka.scala.version>2.10</kafka.scala.version>
         <log4j.version>1.7.6</log4j.version>
@@ -46,46 +42,6 @@
             <groupId>org.glassfish.jersey.ext</groupId>
             <artifactId>jersey-bean-validation</artifactId>
             <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-server</artifactId>
-            <version>${jetty.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlet</artifactId>
-            <version>${jetty.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-base</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
-            <version>${javaxel.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
-            <version>${javaxel.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
...ls and pin Jersey to 2.6, which is Java 1.6 compatible.

Someone else should just sanity check that this works from scratch (nuke your ~/.m2/) on Java 1.6.
