### PR TITLE
Allow users of kafka-avro-serializer to use any Scala version.

### DIFF
--- a/avro-serializer/pom.xml
+++ b/avro-serializer/pom.xml
@@ -20,6 +20,7 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${kafka.scala.version}</artifactId>
             <version>${kafka.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
Make Kafka a provided dependency for kafka-avro-serializer. The serializer still
needs the core jar that depends on Scala, but doesn't use any Scala
code. Instead of building multiple jars for different Scala versions, we can
instead require them to provide the dependency themselves which they'll already
be doing in order to use those interfaces. Additionally, this works without the
jar available if they only use interfaces from kafka-clients, i.e. new
producer/consumer interfaces. Fixes #60.
