### PR TITLE
Fix incorrect usage of ClientErrorException

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -22,7 +22,6 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.NotFoundException;
@@ -30,6 +29,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Response;
@@ -98,7 +98,7 @@ public class CompatibilityResource {
         asyncResponse.resume(compatibilityCheckResponse);
       }
     } catch (SchemaRegistryException e) {
-      throw new ClientErrorException(Response.Status.INTERNAL_SERVER_ERROR, e);
+      throw new ServerErrorException(Response.Status.INTERNAL_SERVER_ERROR, e);
     }
   }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -21,13 +21,13 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Set;
 
-import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.core.Response;
 
 import io.confluent.kafka.schemaregistry.client.rest.Versions;
@@ -68,7 +68,7 @@ public class ConfigResource {
                     + request.getCompatibilityLevel());
         }
       } catch (SchemaRegistryException e) {
-        throw new ClientErrorException(Response.Status.INTERNAL_SERVER_ERROR, e);
+        throw new ServerErrorException(Response.Status.INTERNAL_SERVER_ERROR, e);
       }
     }
   }
@@ -80,7 +80,7 @@ public class ConfigResource {
     try {
       config = new Config(schemaRegistry.getCompatibilityLevel(subject));
     } catch (SchemaRegistryException e) {
-      throw new ClientErrorException(Response.Status.INTERNAL_SERVER_ERROR, e);
+      throw new ServerErrorException(Response.Status.INTERNAL_SERVER_ERROR, e);
     }
     return config;
   }
@@ -92,7 +92,7 @@ public class ConfigResource {
         schemaRegistry.updateCompatibilityLevel(null, request.getCompatibilityLevel());
         log.debug("Updated global compatibility level to " + request.getCompatibilityLevel());
       } catch (SchemaRegistryException e) {
-        throw new ClientErrorException(Response.Status.INTERNAL_SERVER_ERROR, e);
+        throw new ServerErrorException(Response.Status.INTERNAL_SERVER_ERROR, e);
       }
     }
   }
@@ -103,7 +103,7 @@ public class ConfigResource {
     try {
       config = new Config(schemaRegistry.getCompatibilityLevel(null));
     } catch (SchemaRegistryException e) {
-      throw new ClientErrorException(Response.Status.INTERNAL_SERVER_ERROR, e);
+      throw new ServerErrorException(Response.Status.INTERNAL_SERVER_ERROR, e);
     }
     return config;
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -24,7 +24,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -33,6 +32,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Response;
@@ -72,7 +72,7 @@ public class SubjectVersionsResource {
     } catch (SchemaRegistryException e) {
       log.debug("Error while retrieving schema for subject " + this.subject + " with version " +
                 version + " from the schema registry", e);
-      throw new ClientErrorException(Response.Status.INTERNAL_SERVER_ERROR, e);
+      throw new ServerErrorException(Response.Status.INTERNAL_SERVER_ERROR, e);
     }
     if (schema == null) {
       throw new NotFoundException(MESSAGE_SCHEMA_NOT_FOUND);
@@ -87,7 +87,7 @@ public class SubjectVersionsResource {
     try {
       allSchemasForThisTopic = schemaRegistry.getAllVersions(this.subject);
     } catch (SchemaRegistryException e) {
-      throw new ClientErrorException(Response.Status.INTERNAL_SERVER_ERROR, e);
+      throw new ServerErrorException(Response.Status.INTERNAL_SERVER_ERROR, e);
     }
     while (allSchemasForThisTopic.hasNext()) {
       Schema schema = allSchemasForThisTopic.next();
@@ -115,7 +115,7 @@ public class SubjectVersionsResource {
     try {
       id = schemaRegistry.registerOrForward(subjectName, schema, headerProperties);
     } catch (SchemaRegistryException e) {
-      throw new ClientErrorException(Response.Status.INTERNAL_SERVER_ERROR, e);
+      throw new ServerErrorException(Response.Status.INTERNAL_SERVER_ERROR, e);
     }
     RegisterSchemaResponse registerSchemaResponse = new RegisterSchemaResponse();
     registerSchemaResponse.setId(id);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -31,6 +30,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Response;
@@ -74,7 +74,7 @@ public class SubjectsResource {
     try {
       matchingSchema = schemaRegistry.lookUpSchemaUnderSubjectOrForward(subject, schema, headerProperties);
     } catch (SchemaRegistryException e) {
-      throw new ClientErrorException(Response.Status.INTERNAL_SERVER_ERROR, e);
+      throw new ServerErrorException(Response.Status.INTERNAL_SERVER_ERROR, e);
     }
     if (matchingSchema == null) {
       throw new NotFoundException("Schema never registered under subject " + subject);
@@ -97,7 +97,7 @@ public class SubjectsResource {
     try {
       return schemaRegistry.listSubjects();
     } catch (SchemaRegistryException e) {
-      throw new ClientErrorException(Response.Status.INTERNAL_SERVER_ERROR, e);
+      throw new ServerErrorException(Response.Status.INTERNAL_SERVER_ERROR, e);
     }
   }
 }


### PR DESCRIPTION
We were incorrectly using ClientErrorException that expects 4xx error codes in places where we intended to throw 500 (Internal Server Error). This patch fixes #65

@granders Ready for you to review.
