### PR TITLE
Expose low-level schema registration functions from de/serializers.

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -69,4 +69,12 @@ public abstract class AbstractKafkaAvroDeserializer {
       throw new SerializationException("Error deserializing Avro message", e);
     }
   }
+
+  public int register(String subject, Schema schema) throws IOException {
+    return schemaRegistry.register(subject, schema);
+  }
+
+  public Schema getByID(int id) throws IOException {
+    return schemaRegistry.getByID(id);
+  }
 }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -113,4 +113,12 @@ public abstract class AbstractKafkaAvroSerializer {
       throw new SerializationException("Error serializing Avro message", e);
     }
   }
+
+  public int register(String subject, Schema schema) throws IOException {
+    return schemaRegistry.register(subject, schema);
+  }
+
+  public Schema getByID(int id) throws IOException {
+    return schemaRegistry.getByID(id);
+  }
 }


### PR DESCRIPTION
kafka-rest needs to access these before serialization occurs because it needs
the schemas to perform data translation and needs the schema IDs to return to
clients. The simplest way to provide access is to provide a public interface on
the de/serializers to their underlying schema registry client implementation.
