### PR TITLE
issue-101; registering the same schema under different subjects gives di...

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -218,7 +218,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry {
         SchemaKey keyForNewVersion = new SchemaKey(subject, newVersion);
         schema.setVersion(newVersion);
 
-        if (schemaId > 0) {
+        if (schemaId >= 0) {
           schema.setId(schemaId);
         } else {
           schema.setId(schemaIdCounter.getAndIncrement());

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -122,6 +122,15 @@ public class RestApiTest extends ClusterTestHarness {
   }
 
   @Test
+  public void testRegisterSameSchemaOnDifferentSubject() throws Exception {
+    String schema = TestUtils.getRandomCanonicalAvroString(1).get(0);
+    int id1 = TestUtils.registerSchema(restApp.restConnect, schema, "subject1");
+    int id2 = TestUtils.registerSchema(restApp.restConnect, schema, "subject2");
+    assertEquals("Registering the same schema under different subjects should return the same id",
+                 id1, id2);
+  }
+
+  @Test
   public void testCompatibleSchemaLookupBySubject() throws Exception {
     String subject = "testSubject";
     int numRegisteredSchemas = 0;


### PR DESCRIPTION
...fferent ids

The issue is an off-by-1 error. Valid schemas include 0. So the issue only happens if you register the same schema as the one with id 0.
