### PR TITLE
Create new parser on each remote call to Schema Registry server

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -34,7 +34,6 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   private final Map<String, Map<Schema, Integer>> schemaCache;
   private final Map<Integer, Schema> idCache;
   private final Map<String, Map<Schema, Integer>> versionCache;
-  private final Schema.Parser parser = new Schema.Parser();
 
   public CachedSchemaRegistryClient(String baseUrl, int identityMapCapacity) {
     this.baseUrl = baseUrl;
@@ -56,7 +55,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   private Schema getSchemaByIdFromRegistry(int id) throws IOException, RestClientException {
     SchemaString restSchema =
         RestUtils.getId(baseUrl, RestUtils.DEFAULT_REQUEST_PROPERTIES, id);
-    return parser.parse(restSchema.getSchemaString());
+    return new Schema.Parser().parse(restSchema.getSchemaString());
   }
 
 


### PR DESCRIPTION
This is to handle the case that two Avro schemas may have the same record name. 
@junrao @ewencp Can you take a quick look at this?
