### PR TITLE
Change the SubjectVersionsResource to specify the full path instead of b...

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
@@ -61,7 +61,7 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
     config.register(new ConfigResource(schemaRegistry));
     config.register(new SubjectsResource(schemaRegistry));
     config.register(new SchemasResource(schemaRegistry));
-    config.register(SubjectVersionsResource.class);
+    config.register(new SubjectVersionsResource(schemaRegistry));
     config.register(new CompatibilityResource(schemaRegistry));
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -89,16 +89,6 @@ public class SubjectsResource {
     asyncResponse.resume(matchingSchema);
   }
 
-  @Path("/{subject}/versions")
-  public SubjectVersionsResource getSchemas(@PathParam("subject") String subject) {
-    if (subject != null) {
-      subject = subject.trim();
-    } else {
-      throw Errors.subjectNotFoundException();
-    }
-    return new SubjectVersionsResource(schemaRegistry, subject);
-  }
-
   @GET
   @Valid
   @PerformanceMetric("subjects.list")


### PR DESCRIPTION
...eing returned as a subresource from SubjectsResource so its metrics will be auto-discoverable.

This passes all tests, so should be a quick review for @nehanarkhede or @granders 
