### PR TITLE
Added decoder to return a specific Avro record from bytes.

### DIFF
--- a/avro-serializer/pom.xml
+++ b/avro-serializer/pom.xml
@@ -40,4 +40,25 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro-maven-plugin</artifactId>
+                <version>${avro.version}</version>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>schema</goal>
+                        </goals>
+                        <configuration>
+                            <testSourceDirectory>${project.basedir}/src/test/avro</testSourceDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
@@ -32,9 +32,9 @@ public abstract class AbstractKafkaAvroSerDe {
   protected static final byte MAGIC_BYTE = 0x0;
   protected static final int idSize = 4;
 
-  protected final String SCHEMA_REGISTRY_URL = "schema.registry.url";
-  protected final String MAX_SCHEMAS_PER_SUBJECT = "max.schemas.per.subject";
-  protected final int DEFAULT_MAX_SCHEMAS_PER_SUBJECT = 1000;
+  protected static final String SCHEMA_REGISTRY_URL = "schema.registry.url";
+  protected static final String MAX_SCHEMAS_PER_SUBJECT = "max.schemas.per.subject";
+  protected static final int DEFAULT_MAX_SCHEMAS_PER_SUBJECT = 1000;
   private static final Map<String, Schema> primitiveSchemas;
   protected SchemaRegistryClient schemaRegistry;
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
@@ -34,7 +34,8 @@ public abstract class AbstractKafkaAvroSerDe {
 
   protected static final String SCHEMA_REGISTRY_URL = "schema.registry.url";
   protected static final String MAX_SCHEMAS_PER_SUBJECT = "max.schemas.per.subject";
-  protected static final int DEFAULT_MAX_SCHEMAS_PER_SUBJECT = 1000;
+  protected static final String SPECIFIC_AVRO_READER = "specific.avro.reader";
+  protected final int DEFAULT_MAX_SCHEMAS_PER_SUBJECT = 1000;
   private static final Map<String, Schema> primitiveSchemas;
   protected SchemaRegistryClient schemaRegistry;
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDecoder.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDecoder.java
@@ -28,12 +28,17 @@ public class KafkaAvroDecoder extends AbstractKafkaAvroDeserializer implements D
     this.schemaRegistry = schemaRegistry;
   }
 
+  public KafkaAvroDecoder(SchemaRegistryClient schemaRegistry, VerifiableProperties props) {
+    this.schemaRegistry = schemaRegistry;
+    setProperties(props);
+  }
+
   /**
    * Constructor used by Kafka consumer.
    */
   public KafkaAvroDecoder(VerifiableProperties props) {
     if (props == null) {
-      throw new ConfigException("Missing schema registry url!");
+      throw new ConfigException("Missing properties!");
     }
     String url = props.getProperty(SCHEMA_REGISTRY_URL);
     if (url == null) {
@@ -41,6 +46,12 @@ public class KafkaAvroDecoder extends AbstractKafkaAvroDeserializer implements D
     }
     int maxSchemaObject = props.getInt(MAX_SCHEMAS_PER_SUBJECT, DEFAULT_MAX_SCHEMAS_PER_SUBJECT);
     schemaRegistry = new CachedSchemaRegistryClient(url, maxSchemaObject);
+
+    setProperties(props);
+  }
+
+  private void setProperties(VerifiableProperties props) {
+    useSpecificAvroReader = props.getBoolean(SPECIFIC_AVRO_READER, false);
   }
 
   @Override

--- a/avro-serializer/src/test/avro/user.avsc
+++ b/avro-serializer/src/test/avro/user.avsc
@@ -1,0 +1,11 @@
+{
+  "namespace": "io.confluent.kafka.example",
+  "type": "record",
+  "name": "User",
+  "fields": [
+    {
+      "name": "name",
+      "type": "string"
+    }
+  ]
+}


### PR DESCRIPTION
 - Moved getByteBufferer into shared abstract class
 - Added decoder to return specific Avro records

This allows us to work with Java kafka consumers using native compiled Avro objects.

This implements #144 