### PR TITLE
Add implementation of new Deserializer interface.

### DIFF
--- a/avro-serializer/pom.xml
+++ b/avro-serializer/pom.xml
@@ -32,6 +32,11 @@
             <artifactId>kafka-schema-registry-client</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>common-config</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageFormatter.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageFormatter.java
@@ -31,6 +31,7 @@ import java.util.Properties;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.serializers.AbstractKafkaAvroDeserializer;
+import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 import kafka.tools.MessageFormatter;
 
 /**
@@ -78,11 +79,12 @@ public class AvroMessageFormatter extends AbstractKafkaAvroDeserializer
     if (props == null) {
       throw new ConfigException("Missing schema registry url!");
     }
-    String url = props.getProperty(SCHEMA_REGISTRY_URL);
+    String url = props.getProperty(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG);
     if (url == null) {
       throw new ConfigException("Missing schema registry url!");
     }
-    schemaRegistry = new CachedSchemaRegistryClient(url, DEFAULT_MAX_SCHEMAS_PER_SUBJECT);
+    schemaRegistry = new CachedSchemaRegistryClient(
+        url, AbstractKafkaAvroSerDeConfig.MAX_SCHEMAS_PER_SUBJECT_DEFAULT);
 
     if (props.containsKey("print.key")) {
       printKey = props.getProperty("print.key").trim().toLowerCase().equals("true");

--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
@@ -30,6 +30,7 @@ import java.io.InputStreamReader;
 
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 import kafka.common.KafkaException;
 import kafka.producer.KeyedMessage;
 import kafka.tools.ConsoleProducer.MessageReader;
@@ -120,11 +121,12 @@ public class AvroMessageReader extends AbstractKafkaAvroSerializer implements Me
       ignoreError = props.getProperty("ignore.error").trim().toLowerCase().equals("true");
     }
     reader = new BufferedReader(new InputStreamReader(inputStream));
-    String url = props.getProperty(SCHEMA_REGISTRY_URL);
+    String url = props.getProperty(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG);
     if (url == null) {
       throw new ConfigException("Missing schema registry url!");
     }
-    schemaRegistry = new CachedSchemaRegistryClient(url, DEFAULT_MAX_SCHEMAS_PER_SUBJECT);
+    schemaRegistry = new CachedSchemaRegistryClient(
+        url, AbstractKafkaAvroSerDeConfig.MAX_SCHEMAS_PER_SUBJECT_DEFAULT);
     if (!props.containsKey("value.schema")) {
       throw new ConfigException("Must provide the Avro schema string in value.schema");
     }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -23,6 +23,7 @@ import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.avro.util.Utf8;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.SerializationException;
 
 import java.io.IOException;
@@ -30,12 +31,52 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import kafka.utils.VerifiableProperties;
 
 public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaAvroSerDe {
   private final DecoderFactory decoderFactory = DecoderFactory.get();
   protected boolean useSpecificAvroReader = false;
   private final Map<String, Schema> readerSchemaCache = new ConcurrentHashMap<String, Schema>();
+
+  protected void configure(KafkaAvroDeserializerConfig config) {
+    try {
+      String url = config.getString(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG);
+      int  maxSchemaObject = config
+          .getInt(KafkaAvroDeserializerConfig.MAX_SCHEMAS_PER_SUBJECT_CONFIG);
+      schemaRegistry = new CachedSchemaRegistryClient(
+          url, maxSchemaObject);
+      configureNonClientProperties(config);
+    } catch (io.confluent.common.config.ConfigException e) {
+      throw new ConfigException(e.getMessage());
+    }
+  }
+
+  /**
+   * Sets properties for this deserializer without overriding the schema registry client itself.
+   * Useful for testing, where a mock client is injected.
+   */
+  protected void configureNonClientProperties(KafkaAvroDeserializerConfig config) {
+    useSpecificAvroReader = config
+        .getBoolean(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG);
+  }
+
+  protected KafkaAvroDeserializerConfig deserializerConfig(Map<String, ?> props) {
+    try {
+      return new KafkaAvroDeserializerConfig(props);
+    } catch (io.confluent.common.config.ConfigException e) {
+      throw new ConfigException(e.getMessage());
+    }
+  }
+
+  protected KafkaAvroDeserializerConfig deserializerConfig(VerifiableProperties props) {
+    try {
+      return new KafkaAvroDeserializerConfig(props.props());
+    } catch (io.confluent.common.config.ConfigException e) {
+      throw new ConfigException(e.getMessage());
+    }
+  }
 
   private ByteBuffer getByteBuffer(byte[] payload) {
     ByteBuffer buffer = ByteBuffer.wrap(payload);

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
@@ -32,10 +32,6 @@ public abstract class AbstractKafkaAvroSerDe {
   protected static final byte MAGIC_BYTE = 0x0;
   protected static final int idSize = 4;
 
-  protected static final String SCHEMA_REGISTRY_URL = "schema.registry.url";
-  protected static final String MAX_SCHEMAS_PER_SUBJECT = "max.schemas.per.subject";
-  protected static final String SPECIFIC_AVRO_READER = "specific.avro.reader";
-  protected final int DEFAULT_MAX_SCHEMAS_PER_SUBJECT = 1000;
   private static final Map<String, Schema> primitiveSchemas;
   protected SchemaRegistryClient schemaRegistry;
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafka.serializers;
+
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+
+import java.util.Map;
+
+/**
+ * Base class for configs for serializers and deserializers, defining a few common configs and
+ * defaults.
+ */
+public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
+
+  public static final String SCHEMA_REGISTRY_URL_CONFIG = "schema.registry.url";
+  public static final String SCHEMA_REGISTRY_URL_DOC =
+      "URL for a schema registry instance that should be used to register or look up schemas.";
+
+  public static final String MAX_SCHEMAS_PER_SUBJECT_CONFIG = "max.schemas.per.subject";
+  public static final int MAX_SCHEMAS_PER_SUBJECT_DEFAULT = 1000;
+  public static final String MAX_SCHEMAS_PER_SUBJECT_DOC =
+      "Maximum number of schemas to create or cache locally.";
+
+  public static ConfigDef baseConfigDef() {
+    return new ConfigDef()
+        .define(SCHEMA_REGISTRY_URL_CONFIG, Type.STRING,
+                Importance.HIGH, SCHEMA_REGISTRY_URL_DOC)
+        .define(MAX_SCHEMAS_PER_SUBJECT_CONFIG, Type.INT, MAX_SCHEMAS_PER_SUBJECT_DEFAULT,
+                Importance.LOW, MAX_SCHEMAS_PER_SUBJECT_DOC);
+  }
+
+  public AbstractKafkaAvroSerDeConfig(ConfigDef config, Map<?, ?> props) {
+    super(config, props);
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDecoder.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDecoder.java
@@ -15,9 +15,6 @@
  */
 package io.confluent.kafka.serializers;
 
-import org.apache.kafka.common.config.ConfigException;
-
-import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import kafka.serializer.Decoder;
 import kafka.utils.VerifiableProperties;
@@ -30,28 +27,14 @@ public class KafkaAvroDecoder extends AbstractKafkaAvroDeserializer implements D
 
   public KafkaAvroDecoder(SchemaRegistryClient schemaRegistry, VerifiableProperties props) {
     this.schemaRegistry = schemaRegistry;
-    setProperties(props);
+    configureNonClientProperties(deserializerConfig(props));
   }
 
   /**
    * Constructor used by Kafka consumer.
    */
   public KafkaAvroDecoder(VerifiableProperties props) {
-    if (props == null) {
-      throw new ConfigException("Missing properties!");
-    }
-    String url = props.getProperty(SCHEMA_REGISTRY_URL);
-    if (url == null) {
-      throw new ConfigException("Missing schema registry url!");
-    }
-    int maxSchemaObject = props.getInt(MAX_SCHEMAS_PER_SUBJECT, DEFAULT_MAX_SCHEMAS_PER_SUBJECT);
-    schemaRegistry = new CachedSchemaRegistryClient(url, maxSchemaObject);
-
-    setProperties(props);
-  }
-
-  private void setProperties(VerifiableProperties props) {
-    useSpecificAvroReader = props.getBoolean(SPECIFIC_AVRO_READER, false);
+    configure(new KafkaAvroDeserializerConfig(props.props()));
   }
 
   @Override

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.confluent.kafka.serializers;
+
+import org.apache.kafka.common.serialization.Deserializer;
+
+import java.util.Map;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+
+public class KafkaAvroDeserializer extends AbstractKafkaAvroDeserializer
+    implements Deserializer<Object> {
+
+  private boolean isKey;
+
+  /**
+   * Constructor used by Kafka consumer.
+   */
+  public KafkaAvroDeserializer() {
+
+  }
+
+  public KafkaAvroDeserializer(SchemaRegistryClient client) {
+    schemaRegistry = client;
+  }
+
+  public KafkaAvroDeserializer(SchemaRegistryClient client, Map<String, ?> props) {
+    schemaRegistry = client;
+    configureNonClientProperties(deserializerConfig(props));
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    this.isKey = isKey;
+    configure(new KafkaAvroDeserializerConfig(configs));
+  }
+
+  @Override
+  public Object deserialize(String s, byte[] bytes) {
+    return deserialize(bytes);
+  }
+
+  @Override
+  public void close() {
+
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializerConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializerConfig.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafka.serializers;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+
+import java.util.Map;
+
+public class KafkaAvroDeserializerConfig extends AbstractKafkaAvroSerDeConfig {
+
+  public static final String SPECIFIC_AVRO_READER_CONFIG = "specific.avro.reader";
+  public static final boolean SPECIFIC_AVRO_READER_DEFAULT = false;
+  public static final String SPECIFIC_AVRO_READER_DOC =
+      "If true, tries to look up the SpecificRecord class ";
+
+  private static ConfigDef config;
+
+  static {
+    config = baseConfigDef()
+        .define(SPECIFIC_AVRO_READER_CONFIG, Type.BOOLEAN, SPECIFIC_AVRO_READER_DEFAULT,
+                Importance.LOW, SPECIFIC_AVRO_READER_DOC);
+  }
+
+  public KafkaAvroDeserializerConfig(Map<?, ?> props) {
+    super(config, props);
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroEncoder.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroEncoder.java
@@ -42,11 +42,13 @@ public class KafkaAvroEncoder extends AbstractKafkaAvroSerializer implements Enc
     if (props == null) {
       throw new ConfigException("Missing schema registry url!");
     }
-    String url = props.getProperty(SCHEMA_REGISTRY_URL);
+    String url = props.getProperty(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG);
     if (url == null) {
       throw new ConfigException("Missing schema registry url!");
     }
-    int maxSchemaObject = props.getInt(MAX_SCHEMAS_PER_SUBJECT, DEFAULT_MAX_SCHEMAS_PER_SUBJECT);
+    int maxSchemaObject = props.getInt(
+        AbstractKafkaAvroSerDeConfig.MAX_SCHEMAS_PER_SUBJECT_CONFIG,
+        AbstractKafkaAvroSerDeConfig.MAX_SCHEMAS_PER_SUBJECT_DEFAULT);
     schemaRegistry = new CachedSchemaRegistryClient(url, maxSchemaObject);
   }
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
@@ -41,19 +41,19 @@ public class KafkaAvroSerializer extends AbstractKafkaAvroSerializer implements 
   @Override
   public void configure(Map<String, ?> configs, boolean isKey) {
     this.isKey = isKey;
-    Object url = configs.get(SCHEMA_REGISTRY_URL);
+    Object url = configs.get(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG);
     if (url == null) {
       throw new ConfigException("Missing Schema registry url!");
     }
-    Object maxSchemaObject = configs.get(MAX_SCHEMAS_PER_SUBJECT);
+    Object maxSchemaObject = configs.get(
+        AbstractKafkaAvroSerDeConfig.MAX_SCHEMAS_PER_SUBJECT_CONFIG);
     if (maxSchemaObject == null) {
       schemaRegistry = new CachedSchemaRegistryClient(
-          (String) url, DEFAULT_MAX_SCHEMAS_PER_SUBJECT);
+          (String) url, AbstractKafkaAvroSerDeConfig.MAX_SCHEMAS_PER_SUBJECT_DEFAULT);
     } else {
       schemaRegistry = new CachedSchemaRegistryClient(
           (String) url, (Integer) maxSchemaObject);
     }
-
   }
 
   @Override


### PR DESCRIPTION
Because some of the option parsing was getting messier between the two types of maps used to hold options (not to mention the significant redundancy across all the ser/deser classes), this also converts option parsing in the deserializers to use common-config's AbstractConfig class. The options are organized so we could also convert the serializers to use some of the same code, but I've left that change for a later patch.

@granders or @junrao should probably review this. One thing to keep an eye out for is whether I've missed any places I need to convert common-config exceptions to Kafka exceptions; since they're runtime exceptions we need to be careful about catching them everywhere they can possibly happen.