### PR TITLE
Expose more information when registry fails to start

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -350,7 +350,7 @@ public class KafkaStore<K, V> implements Store<K, V> {
       producerRecord =
           new ProducerRecord<byte[], byte[]>(topic, 0, this.serializer.serializeKey(noopKey), null);
     } catch (SerializationException e) {
-      throw new StoreException("Failed to serialize noop key.");
+      throw new StoreException("Failed to serialize noop key.", e);
     }
     
     try {
@@ -360,7 +360,7 @@ public class KafkaStore<K, V> implements Store<K, V> {
       this.lastWrittenOffset = metadata.offset();
       return this.lastWrittenOffset;
     } catch (Exception e) {
-      throw new StoreException("Failed to write Noop record to kafka store.");
+      throw new StoreException("Failed to write Noop record to kafka store.", e);
     }
   }
 }


### PR DESCRIPTION
Current, if there's an error while the registry is trying to initialize, writing a Noop to Kafka, the error message is informative enough to know why the write failed.

If you include the nested exceptions, there should be more information to figure out the issue.