### PR TITLE
WIP: Make Avro DatumWriter implementation configurable

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
@@ -18,8 +18,12 @@ package io.confluent.kafka.formatter;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.avro.specific.SpecificRecord;
 import org.apache.avro.util.Utf8;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.SerializationException;
@@ -201,5 +205,15 @@ public class AvroMessageReader extends AbstractKafkaAvroSerializer implements Me
   @Override
   public void close() {
     // nothing to do
+  }
+
+  @Override
+  protected DatumWriter<Object> getDatumWriter(Schema schema, Object object) {
+    if (object instanceof SpecificRecord) {
+      return new SpecificDatumWriter<Object>(schema);
+    } else {
+      return new GenericDatumWriter<Object>(schema);
+    }
+
   }
 }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
@@ -15,15 +15,14 @@
  */
 package io.confluent.kafka.serializers;
 
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.generic.GenericContainer;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 
 /**
  * Common fields and helper methods for both the serializer and the deserializer.
@@ -35,6 +34,7 @@ public abstract class AbstractKafkaAvroSerDe {
   protected static final String SCHEMA_REGISTRY_URL = "schema.registry.url";
   protected static final String MAX_SCHEMAS_PER_SUBJECT = "max.schemas.per.subject";
   protected static final String SPECIFIC_AVRO_READER = "specific.avro.reader";
+  protected static final String GENERIC_AVRO_DATUM_WRITER_CLASS = "generic.avro.writer.class";
   protected final int DEFAULT_MAX_SCHEMAS_PER_SUBJECT = 1000;
   private static final Map<String, Schema> primitiveSchemas;
   protected SchemaRegistryClient schemaRegistry;
@@ -74,8 +74,8 @@ public abstract class AbstractKafkaAvroSerDe {
       return primitiveSchemas.get("String");
     } else if (object instanceof byte[]) {
       return primitiveSchemas.get("Bytes");
-    } else if (object instanceof IndexedRecord) {
-      return ((IndexedRecord) object).getSchema();
+    } else if (object instanceof GenericContainer) {
+      return ((GenericContainer) object).getSchema();
     } else {
       throw new IllegalArgumentException(
           "Unsupported Avro type. Supported types are null, Boolean, Integer, Long, " +

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -16,12 +16,9 @@
 package io.confluent.kafka.serializers;
 
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.EncoderFactory;
-import org.apache.avro.specific.SpecificDatumWriter;
-import org.apache.avro.specific.SpecificRecord;
 import org.apache.kafka.common.errors.SerializationException;
 
 import java.io.ByteArrayOutputStream;
@@ -54,12 +51,7 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaAvroSerDe
         out.write((byte[]) object);
       } else {
         BinaryEncoder encoder = encoderFactory.directBinaryEncoder(out, null);
-        DatumWriter<Object> writer;
-        if (object instanceof SpecificRecord) {
-          writer = new SpecificDatumWriter<Object>(schema);
-        } else {
-          writer = new GenericDatumWriter<Object>(schema);
-        }
+        DatumWriter<Object> writer = getDatumWriter(schema, object);
         writer.write(object, encoder);
         encoder.flush();
       }
@@ -76,4 +68,7 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaAvroSerDe
       throw new SerializationException("Error serializing Avro message", e);
     }
   }
+
+  protected abstract DatumWriter<Object> getDatumWriter(Schema schema, Object object);
+
 }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroEncoder.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroEncoder.java
@@ -15,7 +15,12 @@
  */
 package io.confluent.kafka.serializers;
 
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.specific.SpecificDatumWriter;
+import org.apache.avro.specific.SpecificRecord;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.SerializationException;
 
@@ -58,5 +63,15 @@ public class KafkaAvroEncoder extends AbstractKafkaAvroSerializer implements Enc
     } else {
       throw new SerializationException("Primitive types are not supported yet");
     }
+  }
+
+  @Override
+  protected DatumWriter<Object> getDatumWriter(Schema schema, Object object) {
+    if (object instanceof SpecificRecord) {
+      return new SpecificDatumWriter<Object>(schema);
+    } else {
+      return new GenericDatumWriter<Object>(schema);
+    }
+
   }
 }

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
@@ -17,6 +17,7 @@ package io.confluent.kafka.serializers;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.kafka.common.errors.SerializationException;
@@ -46,7 +47,7 @@ public class KafkaAvroSerializerTest {
 
   public KafkaAvroSerializerTest() {
     schemaRegistry = new LocalSchemaRegistryClient();
-    avroSerializer = new KafkaAvroSerializer(schemaRegistry);
+    avroSerializer = new KafkaAvroSerializer(schemaRegistry, GenericDatumWriter.class);
     avroEncoder = new KafkaAvroEncoder(schemaRegistry);
     avroDecoder = new KafkaAvroDecoder(schemaRegistry);
     topic = "test";
@@ -164,7 +165,7 @@ public class KafkaAvroSerializerTest {
   @Test
   public void testNull() {
     SchemaRegistryClient nullSchemaRegistryClient = null;
-    KafkaAvroSerializer nullAvroSerializer = new KafkaAvroSerializer(nullSchemaRegistryClient);
+    KafkaAvroSerializer nullAvroSerializer = new KafkaAvroSerializer(nullSchemaRegistryClient, GenericDatumWriter.class);
 
     // null doesn't require schema registration. So serialization should succeed with a null
     // schema registry client.


### PR DESCRIPTION
Currently, the logic for deciding which avro `DatumWriter` to use is not
open to extension.

This pull requests adds a new configuration option,
"generic.avro.writer.class", for specifying which `DatumWriter`
implementation to use when writing _generic_ records.

This configuration option is respected by `KafkaAvroSerializer` which
will use instances of the specified `DatumWriter` implementation when
serializing. Default is `GenericDatumWriter`.

Note that This PR is work in progress and currently only intended as a base for discussing solutions to https://github.com/confluentinc/schema-registry/issues/164 
