### PR TITLE
Update the versionCache with a new schemaVersionMap for a subject

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -123,6 +123,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
       schemaVersionMap = versionCache.get(subject);
     } else {
       schemaVersionMap = new IdentityHashMap<Schema, Integer>();
+      versionCache.put(subject, schemaVersionMap);
     }
 
     if (schemaVersionMap.containsKey(schema)) {


### PR DESCRIPTION
Discovered in the course of looking at some poor Camus performance in https://groups.google.com/forum/#!topic/camus_etl/xyQMIGaibq0.

A call to `CachedSchemaRegistryClient#getVersion` will consult the `versionCache`, but on a miss and subsequent call to the remote registry, it won't then update the `versionCache` with the results of the call. In the case of the `AvroMessageDecoder` in Camus, this results in one schema registry call per message, which is very slow.

This PR updates the `versionCache` with the newly updated `schemaVersionMap` after a remote call, which has a major impact on Camus performance that uses the `AvroMessageDecoder`.