### PR TITLE
Correct example response for GET compatibility

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -521,5 +521,5 @@ The config resource allows you to inspect the cluster-level configuration values
 	  Content-Type: application/vnd.schemaregistry.v1+json
 
 	  {
-	     "compatibility": "FULL"
+	     "compatibilityLevel": "FULL"
 	  }


### PR DESCRIPTION
Schema registry returns `compatibilityLevel` instead of `compatibility`.  This seems inconsistent with the other API endpoints related which behave according to docs and take in a body with `compatibility`.