### PR TITLE
Enable test code sharing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,17 @@
                     <argLine>-Djava.awt.headless=true</argLine>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                          </goals>
+                    </execution>
+                </executions>
+              </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Becomes useful e.g. when integration testing with the schema-registry (RestApp)