### PR TITLE
Update jersey, jackson and junit versions to match `rest-utils`

### DIFF
--- a/docs/monitoring.rst
+++ b/docs/monitoring.rst
@@ -21,8 +21,9 @@ Global Metrics
   ``connections-active``
     Total number of active TCP connections.
 
-  ``connections-accepted-rate``
-    The average rate per second of accepted TCP connections.
+  ``connections-accepted-rate`` (deprecated since 2.0)
+    * In 1.x: The average rate per second of accepted TCP connections.
+    * In 2.x: Same as ``connections-opened-rate``.
 
   ``connections-opened-rate``
     The average rate per second of opened TCP connections.

--- a/pom.xml
+++ b/pom.xml
@@ -43,15 +43,15 @@
     </modules>
 
     <properties>
-        <jersey.version>2.6</jersey.version>
+        <jersey.version>2.19</jersey.version>
         <confluent-common.version>2.0-SNAPSHOT</confluent-common.version>
         <kafka.version>0.8.2.0-cp</kafka.version>
         <kafka.scala.version>2.10</kafka.scala.version>
         <log4j.version>1.7.6</log4j.version>
         <restutils.version>2.0-SNAPSHOT</restutils.version>
         <avro.version>1.7.7</avro.version>
-        <jackson.version>2.4.3</jackson.version>
-        <junit.version>4.11</junit.version>
+        <jackson.version>2.5.4</jackson.version>
+        <junit.version>4.12</junit.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
Follows https://github.com/confluentinc/rest-utils/pull/21