### PR TITLE
Switch serializer config classes to use AbstractConfig from confluent-common instead of from Kafka.

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
@@ -16,10 +16,10 @@
 
 package io.confluent.kafka.serializers;
 
-import org.apache.kafka.common.config.AbstractConfig;
-import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.config.ConfigDef.Type;
-import org.apache.kafka.common.config.ConfigDef.Importance;
+import io.confluent.common.config.AbstractConfig;
+import io.confluent.common.config.ConfigDef;
+import io.confluent.common.config.ConfigDef.Type;
+import io.confluent.common.config.ConfigDef.Importance;
 
 import java.util.Map;
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializerConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializerConfig.java
@@ -16,9 +16,9 @@
 
 package io.confluent.kafka.serializers;
 
-import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.config.ConfigDef.Type;
-import org.apache.kafka.common.config.ConfigDef.Importance;
+import io.confluent.common.config.ConfigDef;
+import io.confluent.common.config.ConfigDef.Type;
+import io.confluent.common.config.ConfigDef.Importance;
 
 import java.util.Map;
 

--- a/json-serializer/pom.xml
+++ b/json-serializer/pom.xml
@@ -27,6 +27,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>common-config</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/json-serializer/src/main/java/io/confluent/kafka/serializers/KafkaJsonDecoderConfig.java
+++ b/json-serializer/src/main/java/io/confluent/kafka/serializers/KafkaJsonDecoderConfig.java
@@ -15,8 +15,8 @@
  **/
 package io.confluent.kafka.serializers;
 
-import org.apache.kafka.common.config.AbstractConfig;
-import org.apache.kafka.common.config.ConfigDef;
+import io.confluent.common.config.AbstractConfig;
+import io.confluent.common.config.ConfigDef;
 
 import java.util.Map;
 

--- a/json-serializer/src/main/java/io/confluent/kafka/serializers/KafkaJsonDeserializerConfig.java
+++ b/json-serializer/src/main/java/io/confluent/kafka/serializers/KafkaJsonDeserializerConfig.java
@@ -15,7 +15,7 @@
  **/
 package io.confluent.kafka.serializers;
 
-import org.apache.kafka.common.config.ConfigDef;
+import io.confluent.common.config.ConfigDef;
 
 import java.util.Map;
 

--- a/json-serializer/src/main/java/io/confluent/kafka/serializers/KafkaJsonSerializerConfig.java
+++ b/json-serializer/src/main/java/io/confluent/kafka/serializers/KafkaJsonSerializerConfig.java
@@ -15,8 +15,8 @@
  **/
 package io.confluent.kafka.serializers;
 
-import org.apache.kafka.common.config.AbstractConfig;
-import org.apache.kafka.common.config.ConfigDef;
+import io.confluent.common.config.AbstractConfig;
+import io.confluent.common.config.ConfigDef;
 
 import java.util.Map;
 


### PR DESCRIPTION
As part of b42bde7d, we switched to using AbstractConfig instead of duplicating
a bunch of config parsing across different serializer/encoder
interfaces. However, it was using Kafka's AbstractConfig, which is not part of
the public interface where compatibility is maintained. This could cause issues
if the serializer is used with a newer version of Kafka where those classes have
changed (as they did recently after 0.8.2.1).

The drawback to this is that we have an extra dependency for
serializers. However, we can ensure compatibility with confluent-common and it
is a pretty tiny dependency.