### PR TITLE
change the documentation on port to have a high priority and list it higher up in the docs

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -9,6 +9,13 @@ Configuration Options
   * Default:
   * Importance: high
 
+``port``
+  Port to listen on for new connections.
+
+  * Type: int
+  * Default: 8081
+  * Importance: high
+
 ``avro.compatibility.level``
   The Avro compatibility type. Valid values are: none (new schema can be any valid Avro schema), backward (new schema can read data produced by latest registered schema), forward (latest registered schema can read data produced by the new schema), full (new schema is backward and forward compatible with latest registered schema)
 
@@ -112,13 +119,6 @@ Configuration Options
 
   * Type: long
   * Default: 30000
-  * Importance: low
-
-``port``
-  Port to listen on for new connections.
-
-  * Type: int
-  * Default: 8081
   * Importance: low
 
 ``request.logger.name``


### PR DESCRIPTION
If you look at this page: http://docs.confluent.io/1.0/schema-registry/docs/config.html and this page: http://docs.confluent.io/1.0/schema-registry/docs/deployment.html#schemaregistry-mirroring there is an inconsistency between whether or not the port has high or low importance. I think that the port your process is running on is hugely important and so we should change the docs to agree on priority high.   