### PR TITLE
Fixes Typo in the docs. 'actsas' -> 'acts as'

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -17,7 +17,7 @@ Configuration Options
   * Importance: high
 
 ``kafkastore.topic``
-  The durable single partition topic that actsas the durable log for the data
+  The durable single partition topic that acts as the durable log for the data
 
   * Type: string
   * Default: _schemas

--- a/licenses/COPYRIGHT.jonathan-rodan.txt
+++ b/licenses/COPYRIGHT.jonathan-rodan.txt
@@ -1,0 +1,13 @@
+Copyright 2015 Jonathan Rodan
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
Fixes a simple typo. Not a big change, but at least something.