### PR TITLE
Fixed schema registry build against kafka trunk

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -191,7 +191,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry {
     ZkUtils zkUtilsForNamespaceCreation = ZkUtils.apply(
         zkConnForNamespaceCreation,
         zkSessionTimeoutMs, zkSessionTimeoutMs,
-        JaasUtils.isZkSecurityEnabled(System.getProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM)));
+        JaasUtils.isZkSecurityEnabled());
     // create the zookeeper namespace using cluster.name if it doesn't already exist
     zkUtilsForNamespaceCreation.makeSurePersistentPathExists(
         schemaRegistryNamespace,
@@ -201,7 +201,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry {
     zkUtilsForNamespaceCreation.close();
     this.zkUtils = ZkUtils.apply(
         schemaRegistryZkUrl, zkSessionTimeoutMs, zkSessionTimeoutMs,
-        JaasUtils.isZkSecurityEnabled(System.getProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM)));
+        JaasUtils.isZkSecurityEnabled());
   }
   
   public boolean isMaster() {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -105,7 +105,7 @@ public class KafkaStore<K, V> implements Store<K, V> {
         config.getInt(SchemaRegistryConfig.KAFKASTORE_ZK_SESSION_TIMEOUT_MS_CONFIG);
     this.zkUtils = ZkUtils.apply(
         kafkaClusterZkUrl, zkSessionTimeoutMs, zkSessionTimeoutMs,
-        JaasUtils.isZkSecurityEnabled(System.getProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM)));
+        JaasUtils.isZkSecurityEnabled());
     this.kafkaTopicReader =
         new KafkaStoreReaderThread<>(zkUtils, kafkaClusterZkUrl, topic, groupId,
                                          Integer.MIN_VALUE, this.storeUpdateHandler,

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
@@ -121,7 +121,7 @@ public abstract class ClusterTestHarness {
     zkConnect = String.format("127.0.0.1:%d", zookeeper.port());
     zkUtils = ZkUtils.apply(
         zkConnect, zkSessionTimeout, zkConnectionTimeout,
-        JaasUtils.isZkSecurityEnabled(System.getProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM)));
+        JaasUtils.isZkSecurityEnabled());
     zkClient = zkUtils.zkClient();
 
     configs = new Vector<>();


### PR DESCRIPTION
@ewencp @fpj 
Quick review - just updating the args of `isZkSecurityEnabled` to match the change in signature in kafka trunk