### PR TITLE
Scripts: add avro-serializer and json-serializer to CLASSPATH

### DIFF
--- a/bin/schema-registry-run-class
+++ b/bin/schema-registry-run-class
@@ -22,7 +22,8 @@ for dir in $base_dir/package/target/kafka-schema-registry-package-*-development;
 done
 
 # Production jars, including kafka, rest-utils, and schema-registry
-for library in "confluent-common" "rest-utils" "schema-registry"; do
+
+for library in "confluent-common" "rest-utils" "schema-registry" "avro-serializer" "json-serializer"; do
   CLASSPATH=$CLASSPATH:$base_dir/share/java/$library/*
 done
 

--- a/bin/schema-registry-run-class
+++ b/bin/schema-registry-run-class
@@ -23,7 +23,7 @@ done
 
 # Production jars, including kafka, rest-utils, and schema-registry
 for library in "confluent-common" "rest-utils" "schema-registry"; do
-  CLASSPATH=$CLASSPATH:$base_dir/share/java/$library/*      
+  CLASSPATH=$CLASSPATH:$base_dir/share/java/$library/*
 done
 
 # logj4 settings

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,11 @@
         <tag>HEAD</tag>
     </scm>
 
+    <!--
+         Note: When adding new submodules you should ensure that you update the bin/ scripts accordingly.
+         For example, depending on how the new submodule is packaged, you must add it to the CLASSPATH
+         setup in `bin/schema-registry-run-class`.
+    -->
     <modules>
         <module>core</module>
         <module>client</module>


### PR DESCRIPTION
Without this patch schema-registry 2.0.0-SNAPSHOT fails to start when run from a package, e.g. an RPM.