### PR TITLE
Updated classpath in schema-registry-run-class to reflect changes in …

### DIFF
--- a/bin/schema-registry-run-class
+++ b/bin/schema-registry-run-class
@@ -17,7 +17,7 @@
 base_dir=$(dirname $0)/..
 
 # Development jars. `mvn package` should collect all the required dependency jars here
-for dir in $base_dir/package/target/kafka-schema-registry-package-*-development; do
+for dir in $base_dir/package-schema-registry/target/kafka-schema-registry-package-*-development; do
   CLASSPATH=$CLASSPATH:$dir/share/java/schema-registry/*
 done
 


### PR DESCRIPTION
@miguno Mind taking a quick look? I noticed that the schema registry start script was failing due to `SchemaRegistryMain` no longer being in the classpath.

My primary question here is whether this is enough, or should we add other modules?
E.g. in pom.xml I now see
```
        <module>core</module>
        <module>client</module>
        <module>avro-serializer</module>
        <module>json-serializer</module>
        <module>avro-converter</module>
        <module>package-schema-registry</module>
        <module>package-kafka-serde-tools</module>
```