### PR TITLE
CC-53: Add worker configs for Avro Kafka Connect that integrates with schema registry.

### DIFF
--- a/bin/kafka-avro-console-consumer
+++ b/bin/kafka-avro-console-consumer
@@ -16,7 +16,13 @@
 
 base_dir=$(dirname $0)/..
 
-CLASSPATH=$CLASSPATH:$base_dir/share/java/avro-serializer/*
+# Production jars
+export CLASSPATH=$CLASSPATH:$base_dir/share/java/kafka-serde-tools/*
+
+# Development jars. `mvn package` should collect all the required dependency jars here
+for dir in $base_dir/package-kafka-serde-tools/target/kafka-serde-tools-package-*-development; do
+  export CLASSPATH=$CLASSPATH:$dir/share/java/kafka-serde-tools/*
+done
 
 DEFAULT_AVRO_FORMATTER="--formatter io.confluent.kafka.formatter.AvroMessageFormatter"
 

--- a/bin/kafka-avro-console-producer
+++ b/bin/kafka-avro-console-producer
@@ -16,7 +16,14 @@
 
 base_dir=$(dirname $0)/..
 
-CLASSPATH=$CLASSPATH:$base_dir/share/java/avro-serializer/*
+# Production jars
+export CLASSPATH=$CLASSPATH:$base_dir/share/java/kafka-serde-tools/*
+
+# Development jars. `mvn package` should collect all the required dependency jars here
+for dir in $base_dir/package-kafka-serde-tools/target/kafka-serde-tools-package-*-development; do
+  export CLASSPATH=$CLASSPATH:$dir/share/java/kafka-serde-tools/*
+done
+
 
 DEFAULT_LINE_READER="--line-reader io.confluent.kafka.formatter.AvroMessageReader"
 

--- a/config/connect-avro-distributed.properties
+++ b/config/connect-avro-distributed.properties
@@ -1,0 +1,34 @@
+# Sample configuration for a distributed Kafka Connect worker that uses Avro serialization and
+# integrates the the Schema Registry. This sample configuration assumes a local installation of
+# Confluent Platform with all services running on their default ports.
+
+# Bootstrap Kafka servers. If multiple servers are specified, they should be comma-separated.
+bootstrap.servers=localhost:9092
+
+# The group ID is a unique identifier for the set of workers that form a single Kafka Connect
+# cluster
+group.id=connect-cluster
+
+# The converters specify the format of data in Kafka and how to translate it into Connect data.
+# Every Connect user will need to configure these based on the format they want their data in
+# when loaded from or stored into Kafka
+key.converter=io.confluent.connect.avro.AvroConverter
+key.converter.schema.registry.url=http://localhost:8081
+value.converter=io.confluent.connect.avro.AvroConverter
+value.converter.schema.registry.url=http://localhost:8081
+
+# The internal converter used for offsets and config data is configurable and must be specified,
+# but most users will always want to use the built-in default. Offset and config data is never
+# visible outside of Connect in this format.
+internal.key.converter=org.apache.kafka.connect.json.JsonConverter
+internal.value.converter=org.apache.kafka.connect.json.JsonConverter
+internal.key.converter.schemas.enable=false
+internal.value.converter.schemas.enable=false
+
+# Kafka topic where connector configuration will be persisted. You should create this topic with a
+# single partition and high replication factor (e.g. 3)
+config.storage.topic=connect-configs
+
+# Kafka topic where connector offset data will be persisted. You should create this topic with many
+# partitions (e.g. 25) and high replication factor (e.g. 3)
+offset.storage.topic=connect-offsets

--- a/config/connect-avro-standalone.properties
+++ b/config/connect-avro-standalone.properties
@@ -1,0 +1,25 @@
+# Sample configuration for a standalone Kafka Connect worker that uses Avro serialization and
+# integrates the the Schema Registry. This sample configuration assumes a local installation of
+# Confluent Platform with all services running on their default ports.
+
+# Bootstrap Kafka servers. If multiple servers are specified, they should be comma-separated.
+bootstrap.servers=localhost:9092
+
+# The converters specify the format of data in Kafka and how to translate it into Connect data.
+# Every Connect user will need to configure these based on the format they want their data in
+# when loaded from or stored into Kafka
+key.converter=io.confluent.connect.avro.AvroConverter
+key.converter.schema.registry.url=http://localhost:8081
+value.converter=io.confluent.connect.avro.AvroConverter
+value.converter.schema.registry.url=http://localhost:8081
+
+# The internal converter used for offsets and config data is configurable and must be specified,
+# but most users will always want to use the built-in default. Offset and config data is never
+# visible outside of Connect in this format.
+internal.key.converter=org.apache.kafka.connect.json.JsonConverter
+internal.value.converter=org.apache.kafka.connect.json.JsonConverter
+internal.key.converter.schemas.enable=false
+internal.value.converter.schemas.enable=false
+
+# Local storage file for offset data
+offset.storage.file.filename=/tmp/connect.offsets


### PR DESCRIPTION
While testing these, I noticed the scripts for the Avro console
producer/consumer had fallen out of date with the packaging layout and never
seem to have supported development mode packaging. This also addresses both of
those issues.