### PR TITLE
Fix version caching in client

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -123,6 +123,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
       schemaVersionMap = versionCache.get(subject);
     } else {
       schemaVersionMap = new IdentityHashMap<Schema, Integer>();
+      versionCache.put(subject, schemaVersionMap);
     }
 
     if (schemaVersionMap.containsKey(schema)) {


### PR DESCRIPTION
Current release of Schema Registry Client has a performance defect --- version caching does not work, which causes excessive amount of requests to be sent from client (e.g. Camus) to Schema Registry server.