### PR TITLE
Fixing a broken link in the docs (pull request 2 of 2)

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -125,7 +125,7 @@ The timeout for an operation on the Kafka store. This is the maximum time that a
 Kafka & ZooKeeper
 ~~~~~~~~~~~~~~~~~
 
-Please refer to :ref:`schemaregistry_operations` for recommendations on operationalizing Kafka and ZooKeeper.
+Please refer to :ref:`kafka_zookeeper_deployment` for recommendations on operationalizing Kafka and ZooKeeper.
 
 .. _schemaregistry_mirroring:
 


### PR DESCRIPTION
Changing an internal reference to fix a broken link to Zookeeper operations. This change is happening in parallel to a change in docs.git.

The parallel change being made is here: [PR-75 in docs](https://github.com/confluentinc/docs/pull/75).