### PR TITLE
Add support for Avro projections in decoders

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -210,7 +210,10 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaAvroSer
       }
       return new SpecificDatumReader(writerSchema, readerSchema);
     } else {
-      return new GenericDatumReader(writerSchema);
+      if (readerSchema == null) {
+        return new GenericDatumReader(writerSchema);
+      }
+      return new GenericDatumReader(writerSchema, readerSchema);
     }
   }
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -97,6 +97,17 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaAvroSer
    * This behavior is the norm for Decoders/Deserializers.
    *
    * @param payload serialized data
+   * @return the deserialized object
+   * @throws SerializationException
+   */
+  protected Object deserialize(byte[] payload) throws SerializationException {
+    return deserialize(false, null, null, payload, null);
+  }
+
+  /**
+   * Just like single-parameter version but accepts an Avro schema to use for reading
+   *
+   * @param payload serialized data
    * @param readerSchema schema to use for Avro read (optional, enables Avro projection)
    * @return the deserialized object
    * @throws SerializationException
@@ -184,13 +195,12 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaAvroSer
    * in the schema.
    *
    * @param payload the serialized data
-   * @param readerSchema schema to use for Avro read (optional, enables Avro projection)
    * @return a GenericContainer with the schema and data, either as a {@link NonRecordContainer},
    *         {@link org.apache.avro.generic.GenericRecord}, or {@link SpecificRecord}
    * @throws SerializationException
    */
-  protected GenericContainer deserializeWithSchemaAndVersion(String topic, boolean isKey, byte[] payload, Schema readerSchema) throws SerializationException {
-    return (GenericContainer) deserialize(true, topic, isKey, payload, readerSchema);
+  protected GenericContainer deserializeWithSchemaAndVersion(String topic, boolean isKey, byte[] payload) throws SerializationException {
+    return (GenericContainer) deserialize(true, topic, isKey, payload, null);
   }
 
   private DatumReader getDatumReader(Schema writerSchema, Schema readerSchema) {

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDecoder.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDecoder.java
@@ -18,6 +18,7 @@ package io.confluent.kafka.serializers;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import kafka.serializer.Decoder;
 import kafka.utils.VerifiableProperties;
+import org.apache.avro.Schema;
 
 public class KafkaAvroDecoder extends AbstractKafkaAvroDeserializer implements Decoder<Object> {
 
@@ -41,4 +42,9 @@ public class KafkaAvroDecoder extends AbstractKafkaAvroDeserializer implements D
   public Object fromBytes(byte[] bytes) {
     return deserialize(bytes);
   }
+
+  /**
+   * Pass a reader schema to get an Avro projection
+   */
+  public Object fromBytes(byte[] bytes, Schema readerSchema) { return deserialize(bytes, readerSchema); }
 }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
@@ -15,6 +15,7 @@
  **/
 package io.confluent.kafka.serializers;
 
+import org.apache.avro.Schema;
 import org.apache.kafka.common.serialization.Deserializer;
 
 import java.util.Map;
@@ -52,6 +53,11 @@ public class KafkaAvroDeserializer extends AbstractKafkaAvroDeserializer
   public Object deserialize(String s, byte[] bytes) {
     return deserialize(bytes);
   }
+
+  /**
+   * Pass a reader schema to get an Avro projection
+   */
+  public Object deserialize(String s, byte[] bytes, Schema readerSchema) { return deserialize(bytes, readerSchema); }
 
   @Override
   public void close() {

--- a/avro-serializer/src/test/avro/extended_user.avsc
+++ b/avro-serializer/src/test/avro/extended_user.avsc
@@ -1,0 +1,16 @@
+{
+  "namespace": "io.confluent.kafka.example",
+  "doc": "Extending the User type to test projection",
+  "type": "record",
+  "name": "ExtendedUser",
+  "fields": [
+    {
+      "name": "name",
+      "type": "string"
+    },
+    {
+      "name": "age",
+      "type": "int"
+    }
+  ]
+}

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
@@ -15,6 +15,7 @@
  */
 package io.confluent.kafka.serializers;
 
+import io.confluent.kafka.example.ExtendedUser;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -84,6 +85,13 @@ public class KafkaAvroSerializerTest {
 
   private IndexedRecord createSpecificAvroRecord() {
     return User.newBuilder().setName("testUser").build();
+  }
+
+  private IndexedRecord createExtendedSpecificAvroRecord() {
+    return ExtendedUser.newBuilder()
+        .setName("testUser")
+        .setAge(99)
+        .build();
   }
 
   private IndexedRecord createInvalidAvroRecord() {
@@ -159,6 +167,23 @@ public class KafkaAvroSerializerTest {
     obj = specificAvroDeserializer.deserialize(topic, bytes);
     assertTrue("Returned object should be a io.confluent.kafka.example.User", User.class.isInstance(obj));
     assertEquals(avroRecord, obj);
+  }
+
+  @Test
+  public void testKafkaAvroSerializerSpecificRecordWithProjection() {
+    byte[] bytes;
+    Object obj;
+
+    IndexedRecord avroRecord = createExtendedSpecificAvroRecord();
+    bytes = avroSerializer.serialize(topic, avroRecord);
+
+    obj = specificAvroDecoder.fromBytes(bytes);
+    assertTrue("Full object should be a io.confluent.kafka.example.ExtendedUser", ExtendedUser.class.isInstance(obj));
+    assertEquals(avroRecord, obj);
+
+    obj = specificAvroDecoder.fromBytes(bytes, User.getClassSchema());
+    assertTrue("Projection object should be a io.confluent.kafka.example.User", User.class.isInstance(obj));
+    assertEquals("testUser", ((User)obj).getName().toString());
   }
 
   @Test

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
@@ -209,6 +209,14 @@ public class KafkaAvroSerializerTest {
     obj = specificAvroDecoder.fromBytes(bytes, User.getClassSchema());
     assertTrue("Projection object should be a io.confluent.kafka.example.User", User.class.isInstance(obj));
     assertEquals("testUser", ((User)obj).getName().toString());
+
+    obj = specificAvroDeserializer.deserialize(topic, bytes);
+    assertTrue("Full object should be a io.confluent.kafka.example.ExtendedUser", ExtendedUser.class.isInstance(obj));
+    assertEquals(avroRecord, obj);
+
+    obj = specificAvroDeserializer.deserialize(topic, bytes, User.getClassSchema());
+    assertTrue("Projection object should be a io.confluent.kafka.example.User", User.class.isInstance(obj));
+    assertEquals("testUser", ((User)obj).getName().toString());
   }
 
   @Test


### PR DESCRIPTION
There are many scenarios where it's useful to be able to read a subset (projection) of an Avro message.  An example is when doing a stream-table join.  When reading messages from the stream, you need to extract only the primary-key fields from the message to do the lookup.

Confluent Platform should allow the user to optionally pass a schema to use for reading.