### PR TITLE
Unit tests and bugfix for NPE when using nested optional fields

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -294,13 +294,8 @@ public class AvroData {
         return null;
     }
 
-    boolean schemaOptional = schema != null ? schema.isOptional() : true;
-    if (!schemaOptional && logicalValue == null) {
-      throw new DataException("Found null value for non-optional schema");
-    }
+    validateSchemaValue(schema, logicalValue);
 
-    // Now it is safe to handle null values since we have validated that it is a valid value for the
-    // schema
     if (logicalValue == null) {
       // But if this is schemaless, we may not be able to return null directly
       if (schema == null && requireSchemalessContainerNull)
@@ -739,6 +734,12 @@ public class AvroData {
     return result;
   }
 
+  private static void validateSchemaValue(Schema schema, Object value) throws DataException{
+      if (value == null && schema != null && !schema.isOptional()) {
+        throw new DataException("Found null value for non-optional schema");
+      }
+  }
+  
   /**
    * Convert the given object, in Avro format, into an Connect data object.
    */
@@ -752,6 +753,7 @@ public class AvroData {
   }
 
   private Object toConnectData(Schema schema, Object value) {
+    validateSchemaValue(schema, value);
     if (value == null) {
       return null;
     }  

--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -752,6 +752,9 @@ public class AvroData {
   }
 
   private Object toConnectData(Schema schema, Object value) {
+    if (value == null) {
+      return null;
+    }  
     try {
       // If we're decoding schemaless data, we need to unwrap it into just the single value
       if (schema == null) {


### PR DESCRIPTION
General and simplified fix for NullPointerException when optional fields are nested within another container type. Pull request also includes additional unit tests covering cases (not all of them) for nested optional array and string.

This is related to #272 and the patch in #273 which doesn't solve all cases. As described in issues and comments below the patch in #273 deals with optional nested arrays/maps/structs, but the NPE does in fact also occurs for e.g. optional nested strings.

References:
https://github.com/confluentinc/schema-registry/issues/267#issuecomment-170085908
https://github.com/confluentinc/schema-registry/pull/273/files?diff=unified#r49218338

