### PR TITLE
Test cases for optional nested structs (issue #267)

### DIFF
--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -692,6 +692,53 @@ public class AvroDataTest {
                  avroData.toConnectData(avroSchema, avroRecord));
   }
   
+  @Test
+  public void testToConnectNestedRecordWithOptionalRecordValue() {  
+	org.apache.avro.Schema avroSchema  = nestedRecordAvroSchema();
+	Schema schema = nestedRecordSchema();
+	GenericRecord avroRecord = new GenericRecordBuilder(avroSchema)
+	     .set("nestedRecord", new GenericRecordBuilder(recordWithStringAvroSchema()).set("string", "xx").build())
+	     .build();
+	Struct struct = new Struct(schema).put("nestedRecord", new Struct(recordWithStringSchema()).put("string", "xx"));
+    assertEquals(new SchemaAndValue(schema, struct),
+	             avroData.toConnectData(avroSchema, avroRecord));
+  }
+
+ @Test
+  public void testToConnectNestedRecordWithOptionalRecordNullValue() {     
+    org.apache.avro.Schema avroSchema  = nestedRecordAvroSchema();
+    Schema schema = nestedRecordSchema();;
+    GenericRecord avroRecord = new GenericRecordBuilder(avroSchema)
+        .set("nestedRecord", null)
+        .build();
+    Struct struct = new Struct(schema).put("nestedRecord", null);
+    assertEquals(new SchemaAndValue(schema, struct),
+                 avroData.toConnectData(avroSchema, avroRecord));
+  }
+ 
+ private  org.apache.avro.Schema  recordWithStringAvroSchema(){
+      return org.apache.avro.SchemaBuilder.builder().record("nestedRecord").fields().requiredString("string").endRecord();
+ }
+  private  org.apache.avro.Schema  nestedRecordAvroSchema(){
+	  org.apache.avro.Schema optionalRecordAvroSchema = org.apache.avro.SchemaBuilder.builder().unionOf()
+		 .type(recordWithStringAvroSchema()).and()
+		 .nullType()
+		 .endUnion();
+	  return  org.apache.avro.SchemaBuilder.builder()
+		  .record("Record").fields()
+		  .name("nestedRecord").type(optionalRecordAvroSchema).noDefault()
+		  .endRecord();
+  }
+  private Schema recordWithStringSchema(){
+	  return  SchemaBuilder.struct().optional().name("nestedRecord").field("string", Schema.STRING_SCHEMA).build();
+  }
+  private Schema nestedRecordSchema(){
+	  return SchemaBuilder.struct()
+		  .name("Record")
+		  .field("nestedRecord", recordWithStringSchema())
+		  .build();
+  }
+  
   // Avro -> Connect: Connect logical types
 
   @Test

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -694,17 +694,17 @@ public class AvroDataTest {
   
   @Test
   public void testToConnectNestedRecordWithOptionalRecordValue() {  
-	org.apache.avro.Schema avroSchema  = nestedRecordAvroSchema();
-	Schema schema = nestedRecordSchema();
-	GenericRecord avroRecord = new GenericRecordBuilder(avroSchema)
-	     .set("nestedRecord", new GenericRecordBuilder(recordWithStringAvroSchema()).set("string", "xx").build())
-	     .build();
-	Struct struct = new Struct(schema).put("nestedRecord", new Struct(recordWithStringSchema()).put("string", "xx"));
+    org.apache.avro.Schema avroSchema  = nestedRecordAvroSchema();
+    Schema schema = nestedRecordSchema();
+    GenericRecord avroRecord = new GenericRecordBuilder(avroSchema)
+        .set("nestedRecord", new GenericRecordBuilder(recordWithStringAvroSchema()).set("string", "xx").build())
+        .build();
+    Struct struct = new Struct(schema).put("nestedRecord", new Struct(recordWithStringSchema()).put("string", "xx"));
     assertEquals(new SchemaAndValue(schema, struct),
-	             avroData.toConnectData(avroSchema, avroRecord));
+                  avroData.toConnectData(avroSchema, avroRecord));
   }
 
- @Test
+  @Test
   public void testToConnectNestedRecordWithOptionalRecordNullValue() {     
     org.apache.avro.Schema avroSchema  = nestedRecordAvroSchema();
     Schema schema = nestedRecordSchema();;
@@ -713,30 +713,30 @@ public class AvroDataTest {
         .build();
     Struct struct = new Struct(schema).put("nestedRecord", null);
     assertEquals(new SchemaAndValue(schema, struct),
-                 avroData.toConnectData(avroSchema, avroRecord));
+                  avroData.toConnectData(avroSchema, avroRecord));
   }
- 
- private  org.apache.avro.Schema  recordWithStringAvroSchema(){
-      return org.apache.avro.SchemaBuilder.builder().record("nestedRecord").fields().requiredString("string").endRecord();
- }
+
+  private  org.apache.avro.Schema  recordWithStringAvroSchema(){
+    return org.apache.avro.SchemaBuilder.builder().record("nestedRecord").fields().requiredString("string").endRecord();
+  }
   private  org.apache.avro.Schema  nestedRecordAvroSchema(){
-	  org.apache.avro.Schema optionalRecordAvroSchema = org.apache.avro.SchemaBuilder.builder().unionOf()
-		 .type(recordWithStringAvroSchema()).and()
-		 .nullType()
-		 .endUnion();
-	  return  org.apache.avro.SchemaBuilder.builder()
-		  .record("Record").fields()
-		  .name("nestedRecord").type(optionalRecordAvroSchema).noDefault()
-		  .endRecord();
+    org.apache.avro.Schema optionalRecordAvroSchema = org.apache.avro.SchemaBuilder.builder().unionOf()
+        .type(recordWithStringAvroSchema()).and()
+        .nullType()
+        .endUnion();
+    return  org.apache.avro.SchemaBuilder.builder()
+        .record("Record").fields()
+        .name("nestedRecord").type(optionalRecordAvroSchema).noDefault()
+        .endRecord();
   }
   private Schema recordWithStringSchema(){
-	  return  SchemaBuilder.struct().optional().name("nestedRecord").field("string", Schema.STRING_SCHEMA).build();
+    return  SchemaBuilder.struct().optional().name("nestedRecord").field("string", Schema.STRING_SCHEMA).build();
   }
   private Schema nestedRecordSchema(){
-	  return SchemaBuilder.struct()
-		  .name("Record")
-		  .field("nestedRecord", recordWithStringSchema())
-		  .build();
+    return SchemaBuilder.struct()
+        .name("Record")
+        .field("nestedRecord", recordWithStringSchema())
+        .build();
   }
   
   // Avro -> Connect: Connect logical types


### PR DESCRIPTION
#276 fixed NPE when using nested optional fields. However it added unit tests only for optional Strings and Arrays. 
It also fixed issue #267, which was originally reported to fix NPE when using optional nested structs.
Just adding a test case for nested structs for completeness.   