### PR TITLE
Fix fromConnectData for optional complex types

### DIFF
--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -316,8 +316,6 @@ public class AvroDataTest {
     checkNonRecordConversionNull(schema);
   }
 
-  
-  
   @Test
   public void testFromConnectRecordWithMetadata() {
     Schema schema = SchemaBuilder.struct()


### PR DESCRIPTION
Connect optional values are converted to Avro unions of type {null, type}.
In fromConnectData(), avroSchema is used to get the fields of complex types (Struct, Array, Map) - however, if the complex type is optional the avroSchema is a union schema, resulting in NPE. 
Fix this by getting the schema of the underlying type from the Avro union.  