### PR TITLE
Add to SchemaRegistryClient a wrapper to RestService.getVersion

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -36,4 +36,6 @@ public interface SchemaRegistryClient {
   public String updateCompatibility(String subject, String compatibility) throws IOException, RestClientException;
   
   public String getCompatibility(String subject) throws IOException, RestClientException;
+
+  public Schema getBySubjectAndVersion(String subject, int version) throws IOException, RestClientException;
 }


### PR DESCRIPTION
Address issue #288 

This turned out to be very helpful when I was adding a feature to Storm to use the schema registry to (de)serialize avro objects across a topology.
