### PR TITLE
Allows any CharSequence implementation to be considered a string

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
@@ -89,7 +89,7 @@ public abstract class AbstractKafkaAvroSerDe {
       return primitiveSchemas.get("Float");
     } else if (object instanceof Double) {
       return primitiveSchemas.get("Double");
-    } else if (object instanceof String) {
+    } else if (object instanceof CharSequence) {
       return primitiveSchemas.get("String");
     } else if (object instanceof byte[]) {
       return primitiveSchemas.get("Bytes");

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
@@ -20,6 +20,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.util.Utf8;
 import org.apache.kafka.common.errors.SerializationException;
 import org.junit.Test;
 
@@ -144,6 +145,10 @@ public class KafkaAvroSerializerTest {
     bytes = avroSerializer.serialize(topic, "abc".getBytes());
     assertArrayEquals("abc".getBytes(), (byte[])avroDeserializer.deserialize(topic, bytes));
     assertArrayEquals("abc".getBytes(), (byte[])avroDecoder.fromBytes(bytes));
+
+    bytes = avroSerializer.serialize(topic, new Utf8("abc"));
+    assertEquals("abc", avroDeserializer.deserialize(topic, bytes));
+    assertEquals("abc", avroDecoder.fromBytes(bytes));
   }
 
   @Test


### PR DESCRIPTION
This PR fixes the issue confluentinc/kafka-rest#118, where we are sending a `org.apache.avro.util.Utf8` object as a string to the `KafkaAvroSerializer`, and are getting an `IllegalArgumentException` error.

Check confluentinc/kafka-rest/pull/165 for more details.
