### PR TITLE
KafkaStore SSL support.

### DIFF
--- a/bin/schema-registry-run-class
+++ b/bin/schema-registry-run-class
@@ -63,7 +63,7 @@ fi
 
 # Memory options
 if [ -z "$SCHEMA_REGISTRY_HEAP_OPTS" ]; then
-  SCHEMA_REGISTRY_HEAP_OPTS="-Xmx256M"
+  SCHEMA_REGISTRY_HEAP_OPTS="-Xmx512M"
 fi
 
 # JVM performance options

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -82,6 +82,19 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15on</artifactId>
+            <version>${bouncycastle.bcpkix.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
             <version>${project.version}</version>

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -32,6 +32,9 @@ public class SchemaRegistryConfig extends RestConfig {
 
   private static final int SCHEMAREGISTRY_PORT_DEFAULT = 8081;
 
+  public static final String KAFKASTORE_SECURITY_PROTOCOL_SSL = "SSL";
+  public static final String KAFKASTORE_SECURITY_PROTOCOL_PLAINTEXT = "PLAINTEXT";
+
   public static final String KAFKASTORE_CONNECTION_URL_CONFIG = "kafkastore.connection.url";
   /**
    * <code>kafkastore.zk.session.timeout.ms</code>
@@ -76,6 +79,36 @@ public class SchemaRegistryConfig extends RestConfig {
    * <code>avro.compatibility.level</code>
    */
   public static final String COMPATIBILITY_CONFIG = "avro.compatibility.level";
+  public static final String KAFKASTORE_SECURITY_PROTOCOL_CONFIG =
+      "kafkastore.security.protocol";
+  public static final String KAFKASTORE_SSL_TRUSTSTORE_LOCATION_CONFIG =
+      "kafkastore.ssl.truststore.location";
+  public static final String KAFKASTORE_SSL_TRUSTSTORE_PASSWORD_CONFIG =
+      "kafkastore.ssl.truststore.password";
+  public static final String KAFKASTORE_SSL_KEYSTORE_LOCATION_CONFIG =
+      "kafkastore.ssl.keystore.location";
+  public static final String KAFKASTORE_SSL_TRUSTSTORE_TYPE_CONFIG =
+          "kafkastore.ssl.truststore.type";
+  public static final String KAFKASTORE_SSL_TRUSTMANAGER_ALGORITHM_CONFIG =
+          "kafkastore.ssl.trustmanager.algorithm";
+  public static final String KAFKASTORE_SSL_KEYSTORE_PASSWORD_CONFIG =
+      "kafkastore.ssl.keystore.password";
+  public static final String KAFKASTORE_SSL_KEYSTORE_TYPE_CONFIG =
+          "kafkastore.ssl.keystore.type";
+  public static final String KAFKASTORE_SSL_KEYMANAGER_ALGORITHM_CONFIG =
+          "kafkastore.ssl.keymanager.algorithm";
+  public static final String KAFKASTORE_SSL_KEY_PASSWORD_CONFIG =
+      "kafkastore.ssl.key.password";
+  public static final String KAFKASTORE_SSL_ENABLED_PROTOCOLS_CONFIG =
+      "kafkastore.ssl.enabled.protocols";
+  public static final String KAFKASTORE_SSL_PROTOCOL_CONFIG =
+      "kafkastore.ssl.protocol";
+  public static final String KAFKASTORE_SSL_PROVIDER_CONFIG =
+      "kafkastore.ssl.provider";
+  public static final String KAFKASTORE_SSL_CIPHER_SUITES_CONFIG =
+      "kafkastore.ssl.cipher.suites";
+  public static final String KAFKASTORE_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG =
+      "kafkastore.ssl.endpoint.identification.algorithm";
   protected static final String KAFKASTORE_CONNECTION_URL_DOC =
       "Zookeeper url for the Kafka cluster";
   protected static final String SCHEMAREGISTRY_ZK_NAMESPACE_DOC =
@@ -111,10 +144,43 @@ public class SchemaRegistryConfig extends RestConfig {
       + "forward (latest registered schema can read data produced by the new schema), "
       + "full (new schema is backward and forward compatible with latest registered schema)";
   protected static final String MASTER_ELIGIBILITY_DOC = 
-      "If true, this node can participate in master election. In a multi-colo setup, turn this off" 
-      + "for clusters in the slave data center.";                               
+      "If true, this node can participate in master election. In a multi-colo setup, turn this off "
+      + "for clusters in the slave data center.";
+  protected static final String KAFKASTORE_SECURITY_PROTOCOL_DOC =
+      "The security protocol to use when connecting with Kafka, the underlying persistent storage. "
+      + "Values can be `PLAINTEXT` or `SSL`.";
+  protected static final String KAFKASTORE_SSL_TRUSTSTORE_LOCATION_DOC =
+      "The location of the SSL trust store file.";
+  protected static final String KAFKASTORE_SSL_TRUSTSTORE_PASSWORD_DOC =
+      "The password to access the trust store.";
+  protected static final String KAFAKSTORE_SSL_TRUSTSTORE_TYPE_DOC =
+      "The file format of the trust store.";
+  protected static final String KAFKASTORE_SSL_TRUSTMANAGER_ALGORITHM_DOC =
+      "The algorithm used by the trust manager factory for SSL connections.";
+  protected static final String KAFKASTORE_SSL_KEYSTORE_LOCATION_DOC =
+      "The location of the SSL keystore file.";
+  protected static final String KAFKASTORE_SSL_KEYSTORE_PASSWORD_DOC =
+      "The password to access the keystore.";
+  protected static final String KAFAKSTORE_SSL_KEYSTORE_TYPE_DOC =
+      "The file format of the keystore.";
+  protected static final String KAFKASTORE_SSL_KEYMANAGER_ALGORITHM_DOC =
+      "The algorithm used by key manager factory for SSL connections.";
+  protected static final String KAFKASTORE_SSL_KEY_PASSWORD_DOC =
+      "The password of the key contained in the keystore.";
+  protected static final String KAFAKSTORE_SSL_ENABLED_PROTOCOLS_DOC =
+      "Protocols enabled for SSL connections.";
+  protected static final String KAFAKSTORE_SSL_PROTOCOL_DOC =
+      "The SSL protocol used.";
+  protected static final String KAFAKSTORE_SSL_PROVIDER_DOC =
+      "The name of the security provider used for SSL.";
+  protected static final String KAFKASTORE_SSL_CIPHER_SUITES_DOC =
+      "A list of cipher suites used for SSL.";
+  protected static final String KAFKASTORE_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC =
+      "The endpoint identification algorithm to validate the server hostname using the server certificate.";
   private static final String COMPATIBILITY_DEFAULT = "backward";
   private static final String METRICS_JMX_PREFIX_DEFAULT_OVERRIDE = "kafka.schema.registry";
+
+  // TODO: move to Apache's ConfigDef
   private static final ConfigDef config;
   static {
     config = baseConfigDef()
@@ -152,7 +218,52 @@ public class SchemaRegistryConfig extends RestConfig {
                 ConfigDef.Importance.MEDIUM, MASTER_ELIGIBILITY_DOC)
         .defineOverride(METRICS_JMX_PREFIX_CONFIG, ConfigDef.Type.STRING,
                         METRICS_JMX_PREFIX_DEFAULT_OVERRIDE, ConfigDef.Importance.LOW,
-                        METRICS_JMX_PREFIX_DOC);
+                        METRICS_JMX_PREFIX_DOC)
+        .define(KAFKASTORE_SECURITY_PROTOCOL_CONFIG, ConfigDef.Type.STRING,
+                KAFKASTORE_SECURITY_PROTOCOL_PLAINTEXT, ConfigDef.Importance.MEDIUM,
+                KAFKASTORE_SECURITY_PROTOCOL_DOC)
+        .define(KAFKASTORE_SSL_TRUSTSTORE_LOCATION_CONFIG, ConfigDef.Type.STRING,
+                "", ConfigDef.Importance.HIGH,
+                KAFKASTORE_SSL_TRUSTSTORE_LOCATION_DOC)
+        .define(KAFKASTORE_SSL_TRUSTSTORE_PASSWORD_CONFIG, ConfigDef.Type.STRING,
+                "", ConfigDef.Importance.HIGH,
+                KAFKASTORE_SSL_TRUSTSTORE_PASSWORD_DOC)
+        .define(KAFKASTORE_SSL_TRUSTSTORE_TYPE_CONFIG, ConfigDef.Type.STRING,
+                "JKS", ConfigDef.Importance.MEDIUM,
+                KAFAKSTORE_SSL_TRUSTSTORE_TYPE_DOC)
+        .define(KAFKASTORE_SSL_TRUSTMANAGER_ALGORITHM_CONFIG, ConfigDef.Type.STRING,
+                "PKIX", ConfigDef.Importance.LOW,
+                KAFKASTORE_SSL_TRUSTMANAGER_ALGORITHM_DOC)
+        .define(KAFKASTORE_SSL_KEYSTORE_LOCATION_CONFIG, ConfigDef.Type.STRING,
+                "", ConfigDef.Importance.HIGH,
+                KAFKASTORE_SSL_KEYSTORE_LOCATION_DOC)
+        .define(KAFKASTORE_SSL_KEYSTORE_PASSWORD_CONFIG, ConfigDef.Type.STRING,
+                "", ConfigDef.Importance.HIGH,
+                KAFKASTORE_SSL_KEYSTORE_PASSWORD_DOC)
+        .define(KAFKASTORE_SSL_KEYSTORE_TYPE_CONFIG, ConfigDef.Type.STRING,
+                "JKS", ConfigDef.Importance.MEDIUM,
+                KAFAKSTORE_SSL_KEYSTORE_TYPE_DOC)
+        .define(KAFKASTORE_SSL_KEYMANAGER_ALGORITHM_CONFIG, ConfigDef.Type.STRING,
+                "SunX509", ConfigDef.Importance.LOW,
+                KAFKASTORE_SSL_KEYMANAGER_ALGORITHM_DOC)
+        .define(KAFKASTORE_SSL_KEY_PASSWORD_CONFIG, ConfigDef.Type.STRING,
+                "", ConfigDef.Importance.HIGH,
+                KAFKASTORE_SSL_KEY_PASSWORD_DOC)
+        .define(KAFKASTORE_SSL_ENABLED_PROTOCOLS_CONFIG, ConfigDef.Type.STRING,
+                "TLSv1.2,TLSv1.1,TLSv1", ConfigDef.Importance.MEDIUM,
+                KAFAKSTORE_SSL_ENABLED_PROTOCOLS_DOC)
+        .define(KAFKASTORE_SSL_PROTOCOL_CONFIG, ConfigDef.Type.STRING,
+                "TLS", ConfigDef.Importance.MEDIUM,
+                KAFAKSTORE_SSL_PROTOCOL_DOC)
+        .define(KAFKASTORE_SSL_PROVIDER_CONFIG, ConfigDef.Type.STRING,
+                "", ConfigDef.Importance.MEDIUM,
+                KAFAKSTORE_SSL_PROVIDER_DOC)
+        .define(KAFKASTORE_SSL_CIPHER_SUITES_CONFIG, ConfigDef.Type.STRING,
+                "", ConfigDef.Importance.LOW,
+                KAFKASTORE_SSL_CIPHER_SUITES_DOC)
+        .define(KAFKASTORE_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, ConfigDef.Type.STRING,
+                "", ConfigDef.Importance.LOW,
+                KAFKASTORE_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC);
   }
   private final AvroCompatibilityLevel compatibilityType;
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
@@ -49,7 +49,7 @@ public abstract class ClusterTestHarness {
 
   public static final int DEFAULT_NUM_BROKERS = 1;
   public static final String KAFKASTORE_TOPIC = SchemaRegistryConfig.DEFAULT_KAFKASTORE_TOPIC;
-  private static final Option<Properties> SASL_PROPERTIES = Option$.MODULE$.<Properties>empty();
+  protected static final Option<Properties> SASL_PROPERTIES = Option$.MODULE$.<Properties>empty();
 
   /**
    * Choose a number of random available ports
@@ -126,18 +126,7 @@ public abstract class ClusterTestHarness {
     configs = new Vector<>();
     servers = new Vector<>();
     for (int i = 0; i < numBrokers; i++) {
-      final Option<java.io.File> noFile = scala.Option.apply(null);
-      final Option<SecurityProtocol> noInterBrokerSecurityProtocol = scala.Option.apply(null);
-      Properties props = TestUtils.createBrokerConfig(
-          i, zkConnect, false, false, TestUtils.RandomPort(), noInterBrokerSecurityProtocol,
-          noFile, SASL_PROPERTIES, true, false, TestUtils.RandomPort(), false, TestUtils.RandomPort(), false,
-          TestUtils.RandomPort(), Option.<String>empty());
-      props.setProperty("auto.create.topics.enable", "true");
-      props.setProperty("num.partitions", "1");
-      // We *must* override this to use the port we allocated (Kafka currently allocates one port
-      // that it always uses for ZK
-      props.setProperty("zookeeper.connect", this.zkConnect);
-      KafkaConfig config = KafkaConfig.fromProps(props);
+      KafkaConfig config = getKafkaConfig(i);
       configs.add(config);
 
       KafkaServer server = TestUtils.createServer(config, SystemTime$.MODULE$);
@@ -146,12 +135,32 @@ public abstract class ClusterTestHarness {
 
     brokerList =
         TestUtils.getBrokerListStrFromServers(JavaConversions.asScalaBuffer(servers),
-                                              SecurityProtocol.PLAINTEXT);
+                                              getSecurityProtocol());
 
     if (setupRestApp) {
       restApp = new RestApp(choosePort(), zkConnect, KAFKASTORE_TOPIC, compatibilityType);
       restApp.start();
     }
+  }
+
+  protected KafkaConfig getKafkaConfig(int brokerId) {
+    final Option<java.io.File> noFile = scala.Option.apply(null);
+    final Option<SecurityProtocol> noInterBrokerSecurityProtocol = scala.Option.apply(null);
+    Properties props = TestUtils.createBrokerConfig(
+            brokerId, zkConnect, false, false, TestUtils.RandomPort(), noInterBrokerSecurityProtocol,
+            noFile, SASL_PROPERTIES, true, false, TestUtils.RandomPort(), false, TestUtils.RandomPort(), false,
+            TestUtils.RandomPort(), Option.<String>empty());
+    props.setProperty("auto.create.topics.enable", "true");
+    props.setProperty("num.partitions", "1");
+
+    // We *must* override this to use the ZooKeeper port chosen in this test harness, instead of the
+    // port chosen by TestUtils.createBrokerConfig().
+    props.setProperty("zookeeper.connect", this.zkConnect);
+    return KafkaConfig.fromProps(props);
+  }
+
+  protected SecurityProtocol getSecurityProtocol() {
+    return SecurityProtocol.PLAINTEXT;
   }
 
   @After

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/SSLClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/SSLClusterTestHarness.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.kafka.schemaregistry;
+
+import kafka.server.KafkaConfig;
+import kafka.utils.TestUtils;
+import org.apache.kafka.common.network.Mode;
+import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.apache.kafka.test.TestSslUtils;
+import scala.Option;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+
+public class SSLClusterTestHarness extends ClusterTestHarness {
+  public Map<String, Object> clientSslConfigs;
+
+  public SSLClusterTestHarness() {
+    super(DEFAULT_NUM_BROKERS);
+  }
+
+  protected SecurityProtocol getSecurityProtocol() {
+    return SecurityProtocol.SSL;
+  }
+
+  protected KafkaConfig getKafkaConfig(int brokerId) {
+    File trustStoreFile;
+    try {
+      trustStoreFile = File.createTempFile("SSLClusterTestHarness-truststore", ".jks");
+    } catch (IOException ioe) {
+      throw new RuntimeException("Unable to create temporary file for the truststore.");
+    }
+    final Option<File> trustStoreFileOption = scala.Option.apply(trustStoreFile);
+    final Option<SecurityProtocol> sslInterBrokerSecurityProtocol = scala.Option.apply(SecurityProtocol.SSL);
+    Properties props = TestUtils.createBrokerConfig(
+            brokerId, zkConnect, false, false, TestUtils.RandomPort(), sslInterBrokerSecurityProtocol,
+            trustStoreFileOption, SASL_PROPERTIES, false, false, TestUtils.RandomPort(), true, TestUtils.RandomPort(),
+            false, TestUtils.RandomPort(), Option.<String>empty());
+
+    // setup client SSL. Needs to happen before the broker is initialized, because the client's cert
+    // needs to be added to the broker's trust store.
+    Map<String, Object> sslConfigs;
+    try {
+      this.clientSslConfigs = TestSslUtils.createSslConfig(true, true, Mode.CLIENT,
+              trustStoreFile, "client", "localhost");
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    props.setProperty("auto.create.topics.enable", "true");
+    props.setProperty("num.partitions", "1");
+    if (requireSSLClientAuth()) {
+      props.setProperty("ssl.client.auth", "required");
+    }
+    // We *must* override this to use the port we allocated (Kafka currently allocates one port
+    // that it always uses for ZK
+    props.setProperty("zookeeper.connect", this.zkConnect);
+
+    return KafkaConfig.fromProps(props);
+  }
+
+  protected boolean requireSSLClientAuth() {
+    return true;
+  }
+}

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreSSLAuthTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreSSLAuthTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.kafka.schemaregistry.storage;
+
+import io.confluent.kafka.schemaregistry.SSLClusterTestHarness;
+import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
+import io.confluent.kafka.schemaregistry.storage.exceptions.StoreInitializationException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.kafka.common.errors.TimeoutException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class KafkaStoreSSLAuthTest extends SSLClusterTestHarness {
+  private static final Logger log = LoggerFactory.getLogger(KafkaStoreSSLAuthTest.class);
+
+  @Before
+  public void setup() {
+    log.debug("Zk conn url = " + zkConnect);
+  }
+
+  @After
+  public void teardown() {
+    log.debug("Shutting down");
+  }
+
+  @Test
+  public void testInitialization() {
+    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSSLKafkaStoreInstance(zkConnect,
+            zkClient, clientSslConfigs, requireSSLClientAuth());
+    kafkaStore.close();
+  }
+
+  @Test(expected = TimeoutException.class)
+  public void testInitializationWithoutClientAuth() {
+    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSSLKafkaStoreInstance(zkConnect,
+            zkClient, clientSslConfigs, false);
+    kafkaStore.close();
+
+    // TODO: make the timeout shorter so the test fails quicker.
+  }
+
+  @Test
+  public void testDoubleInitialization() {
+    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSSLKafkaStoreInstance(zkConnect,
+            zkClient, clientSslConfigs, requireSSLClientAuth());
+    try {
+      kafkaStore.init();
+      fail("Kafka store repeated initialization should fail");
+    } catch (StoreInitializationException e) {
+      // this is expected
+    }
+    kafkaStore.close();
+  }
+
+  @Test
+  public void testSimplePut() throws InterruptedException {
+    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSSLKafkaStoreInstance(zkConnect,
+            zkClient, clientSslConfigs, requireSSLClientAuth());
+    String key = "Kafka";
+    String value = "Rocks";
+    try {
+      try {
+        kafkaStore.put(key, value);
+      } catch (StoreException e) {
+        throw new RuntimeException("Kafka store put(Kafka, Rocks) operation failed", e);
+      }
+      String retrievedValue = null;
+      try {
+        retrievedValue = kafkaStore.get(key);
+      } catch (StoreException e) {
+        throw new RuntimeException("Kafka store get(Kafka) operation failed", e);
+      }
+      assertEquals("Retrieved value should match entered value", value, retrievedValue);
+    } finally {
+      kafkaStore.close();
+    }
+  }
+}

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreSSLNoAuthTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreSSLNoAuthTest.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.kafka.schemaregistry.storage;
+
+import org.junit.Test;
+
+public class KafkaStoreSSLNoAuthTest extends KafkaStoreSSLAuthTest {
+  protected boolean requireSSLClientAuth() {
+    return false;
+  }
+
+  // ignore this test because it doesn't apply when SSL client auth is off.
+  @Test
+  @Override
+  public void testInitializationWithoutClientAuth() {}
+}

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
@@ -64,7 +64,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
   }
 
   @Test
-  public void testIncorrectInitialization() {
+  public void testDoubleInitialization() {
     KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(zkConnect,
                                                                                        zkClient);
     try {
@@ -83,18 +83,21 @@ public class KafkaStoreTest extends ClusterTestHarness {
     String key = "Kafka";
     String value = "Rocks";
     try {
-      kafkaStore.put(key, value);
-    } catch (StoreException e) {
-      fail("Kafka store put(Kafka, Rocks) operation failed");
+      try {
+        kafkaStore.put(key, value);
+      } catch (StoreException e) {
+        throw new RuntimeException("Kafka store put(Kafka, Rocks) operation failed", e);
+      }
+      String retrievedValue = null;
+      try {
+        retrievedValue = kafkaStore.get(key);
+      } catch (StoreException e) {
+        throw new RuntimeException("Kafka store get(Kafka) operation failed", e);
+      }
+      assertEquals("Retrieved value should match entered value", value, retrievedValue);
+    } finally {
+      kafkaStore.close();
     }
-    String retrievedValue = null;
-    try {
-      retrievedValue = kafkaStore.get(key);
-    } catch (StoreException e) {
-      fail("Kafka store get(Kafka) operation failed");
-    }
-    assertEquals("Retrieved value should match entered value", value, retrievedValue);
-    kafkaStore.close();
   }
 
   // TODO: This requires fix for https://issues.apache.org/jira/browse/KAFKA-1788
@@ -137,30 +140,35 @@ public class KafkaStoreTest extends ClusterTestHarness {
                                                                                        inMemoryStore);
     String key = "Kafka";
     String value = "Rocks";
-    try {
-      kafkaStore.put(key, value);
-    } catch (StoreException e) {
-      fail("Kafka store put(Kafka, Rocks) operation failed");
-    }
     String retrievedValue = null;
     try {
-      retrievedValue = kafkaStore.get(key);
-    } catch (StoreException e) {
-      fail("Kafka store get(Kafka) operation failed");
+      try {
+        kafkaStore.put(key, value);
+      } catch (StoreException e) {
+        throw new RuntimeException("Kafka store put(Kafka, Rocks) operation failed", e);
+      }
+      try {
+        retrievedValue = kafkaStore.get(key);
+      } catch (StoreException e) {
+        throw new RuntimeException("Kafka store get(Kafka) operation failed", e);
+      }
+      assertEquals("Retrieved value should match entered value", value, retrievedValue);
+    } finally {
+      kafkaStore.close();
     }
-    assertEquals("Retrieved value should match entered value", value, retrievedValue);
-    kafkaStore.close();
 
     // recreate kafka store
     kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(zkConnect, zkClient, inMemoryStore);
-    retrievedValue = null;
     try {
-      retrievedValue = kafkaStore.get(key);
-    } catch (StoreException e) {
-      fail("Kafka store get(Kafka) operation failed");
+      try {
+        retrievedValue = kafkaStore.get(key);
+      } catch (StoreException e) {
+        throw new RuntimeException("Kafka store get(Kafka) operation failed", e);
+      }
+      assertEquals("Retrieved value should match entered value", value, retrievedValue);
+    } finally {
+      kafkaStore.close();
     }
-    assertEquals("Retrieved value should match entered value", value, retrievedValue);
-    kafkaStore.close();
   }
 
   @Test
@@ -170,31 +178,33 @@ public class KafkaStoreTest extends ClusterTestHarness {
     String key = "Kafka";
     String value = "Rocks";
     try {
-      kafkaStore.put(key, value);
-    } catch (StoreException e) {
-      fail("Kafka store put(Kafka, Rocks) operation failed");
+      try {
+        kafkaStore.put(key, value);
+      } catch (StoreException e) {
+        throw new RuntimeException("Kafka store put(Kafka, Rocks) operation failed", e);
+      }
+      String retrievedValue = null;
+      try {
+        retrievedValue = kafkaStore.get(key);
+      } catch (StoreException e) {
+        throw new RuntimeException("Kafka store get(Kafka) operation failed", e);
+      }
+      assertEquals("Retrieved value should match entered value", value, retrievedValue);
+      try {
+        kafkaStore.delete(key);
+      } catch (StoreException e) {
+        throw new RuntimeException("Kafka store delete(Kafka) operation failed", e);
+      }
+      // verify that value is deleted
+      try {
+        retrievedValue = kafkaStore.get(key);
+      } catch (StoreException e) {
+        throw new RuntimeException("Kafka store get(Kafka) operation failed", e);
+      }
+      assertNull("Value should have been deleted", retrievedValue);
+    } finally {
+      kafkaStore.close();
     }
-    String retrievedValue = null;
-    try {
-      retrievedValue = kafkaStore.get(key);
-    } catch (StoreException e) {
-      fail("Kafka store get(Kafka) operation failed");
-    }
-    assertEquals("Retrieved value should match entered value", value, retrievedValue);
-    try {
-      kafkaStore.delete(key);
-    } catch (StoreException e) {
-      fail("Kafka store delete(Kafka) operation failed");
-    }
-    // verify that value is deleted
-    retrievedValue = value;
-    try {
-      retrievedValue = kafkaStore.get(key);
-    } catch (StoreException e) {
-      fail("Kafka store get(Kafka) operation failed");
-    }
-    assertNull("Value should have been deleted", retrievedValue);
-    kafkaStore.close();
   }
 
   @Test
@@ -206,43 +216,45 @@ public class KafkaStoreTest extends ClusterTestHarness {
     String key = "Kafka";
     String value = "Rocks";
     try {
-      kafkaStore.put(key, value);
-    } catch (StoreException e) {
-      fail("Kafka store put(Kafka, Rocks) operation failed");
+      try {
+        kafkaStore.put(key, value);
+      } catch (StoreException e) {
+        throw new RuntimeException("Kafka store put(Kafka, Rocks) operation failed", e);
+      }
+      String retrievedValue = null;
+      try {
+        retrievedValue = kafkaStore.get(key);
+      } catch (StoreException e) {
+        throw new RuntimeException("Kafka store get(Kafka) operation failed", e);
+      }
+      assertEquals("Retrieved value should match entered value", value, retrievedValue);
+      // delete the key
+      try {
+        kafkaStore.delete(key);
+      } catch (StoreException e) {
+        throw new RuntimeException("Kafka store delete(Kafka) operation failed", e);
+      }
+      // verify that key is deleted
+      try {
+        retrievedValue = kafkaStore.get(key);
+      } catch (StoreException e) {
+        throw new RuntimeException("Kafka store get(Kafka) operation failed", e);
+      }
+      assertNull("Value should have been deleted", retrievedValue);
+      kafkaStore.close();
+      // recreate kafka store
+      kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(zkConnect, zkClient, inMemoryStore);
+      // verify that key still doesn't exist in the store
+      retrievedValue = value;
+      try {
+        retrievedValue = kafkaStore.get(key);
+      } catch (StoreException e) {
+        throw new RuntimeException("Kafka store get(Kafka) operation failed", e);
+      }
+      assertNull("Value should have been deleted", retrievedValue);
+    } finally {
+      kafkaStore.close();
     }
-    String retrievedValue = null;
-    try {
-      retrievedValue = kafkaStore.get(key);
-    } catch (StoreException e) {
-      fail("Kafka store get(Kafka) operation failed");
-    }
-    assertEquals("Retrieved value should match entered value", value, retrievedValue);
-    // delete the key
-    try {
-      kafkaStore.delete(key);
-    } catch (StoreException e) {
-      fail("Kafka store delete(Kafka) operation failed");
-    }
-    // verify that key is deleted
-    retrievedValue = value;
-    try {
-      retrievedValue = kafkaStore.get(key);
-    } catch (StoreException e) {
-      fail("Kafka store get(Kafka) operation failed");
-    }
-    assertNull("Value should have been deleted", retrievedValue);
-    kafkaStore.close();
-    // recreate kafka store
-    kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(zkConnect, zkClient, inMemoryStore);
-    // verify that key still doesn't exist in the store
-    retrievedValue = value;
-    try {
-      retrievedValue = kafkaStore.get(key);
-    } catch (StoreException e) {
-      fail("Kafka store get(Kafka) operation failed");
-    }
-    assertNull("Value should have been deleted", retrievedValue);
-    kafkaStore.close();
   }
 
   @Test
@@ -266,7 +278,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
   }
 
   /**
-   * This test creates three brokers, two with PLAINTEXT endpoints and one with a SASL endpoint. This scenario
+   * This test creates brokers with different security protocols. This scenario
    * where different brokers in the same cluster support different security endpoints wouldn't exist.
    * However, this setup creates the needed test scenario for getBrokerEndpoints().
    */
@@ -276,12 +288,17 @@ public class KafkaStoreTest extends ClusterTestHarness {
     brokersList.add(new Broker(0, "localhost", TestUtils.RandomPort(), SecurityProtocol.PLAINTEXT));
     brokersList.add(new Broker(1, "localhost1", TestUtils.RandomPort(), SecurityProtocol.PLAINTEXT));
     brokersList.add(new Broker(2, "localhost2", TestUtils.RandomPort(), SecurityProtocol.SASL_PLAINTEXT));
+    brokersList.add(new Broker(3, "localhost3", TestUtils.RandomPort(), SecurityProtocol.SSL));
 
     String endpointsString = KafkaStore.getBrokerEndpoints(brokersList);
     String[] endpoints = endpointsString.split(",");
     assertEquals("Expected a different number of endpoints.", brokersList.size() - 1, endpoints.length);
     for (String endpoint : endpoints) {
-      assertTrue("Endpoint must be a PLAINTEXT endpoint.", endpoint.contains("PLAINTEXT://"));
+      if (endpoint.contains("localhost3")) {
+        assertTrue("Endpoint must be a SSL endpoint.", endpoint.contains("SSL://"));
+      } else {
+        assertTrue("Endpoint must be a PLAINTEXT endpoint.", endpoint.contains("PLAINTEXT://"));
+      }
     }
   }
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/StoreUtils.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/StoreUtils.java
@@ -17,12 +17,16 @@ package io.confluent.kafka.schemaregistry.storage;
 
 import org.I0Itec.zkclient.ZkClient;
 
+import java.util.Map;
 import java.util.Properties;
 
 import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreInitializationException;
 import io.confluent.rest.RestConfigException;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.types.Password;
 
 import static org.junit.Assert.fail;
 
@@ -39,13 +43,50 @@ public class StoreUtils {
     Store<String, String> inMemoryStore = new InMemoryStore<String, String>();
     return createAndInitKafkaStoreInstance(zkConnect, zkClient, inMemoryStore);
   }
-
   /**
    * Get a new instance of KafkaStore and initialize it.
    */
   public static KafkaStore<String, String> createAndInitKafkaStoreInstance(
       String zkConnect, ZkClient zkClient, Store<String, String> inMemoryStore) {
+    return createAndInitKafkaStoreInstance(zkConnect, zkClient, inMemoryStore,
+            new Properties());
+  }
+
+  /**
+   * Get a new instance of an SSL KafkaStore and initialize it.
+   */
+  public static KafkaStore<String, String> createAndInitSSLKafkaStoreInstance(
+          String zkConnect, ZkClient zkClient, Map<String, Object> sslConfigs,
+          boolean requireSSLClientAuth) {
     Properties props = new Properties();
+    props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,
+            SchemaRegistryConfig.KAFKASTORE_SECURITY_PROTOCOL_SSL);
+
+    props.put(SchemaRegistryConfig.KAFKASTORE_SECURITY_PROTOCOL_CONFIG,
+            SchemaRegistryConfig.KAFKASTORE_SECURITY_PROTOCOL_SSL);
+    props.put(SchemaRegistryConfig.KAFKASTORE_SSL_TRUSTSTORE_LOCATION_CONFIG,
+            sslConfigs.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG));
+    props.put(SchemaRegistryConfig.KAFKASTORE_SSL_TRUSTSTORE_PASSWORD_CONFIG,
+            ((Password)sslConfigs.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG)).value());
+    if (requireSSLClientAuth) {
+      props.put(SchemaRegistryConfig.KAFKASTORE_SSL_KEYSTORE_LOCATION_CONFIG,
+              sslConfigs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG));
+      props.put(SchemaRegistryConfig.KAFKASTORE_SSL_KEYSTORE_PASSWORD_CONFIG,
+              ((Password) sslConfigs.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG)).value());
+      props.put(SchemaRegistryConfig.KAFKASTORE_SSL_KEY_PASSWORD_CONFIG,
+              ((Password) sslConfigs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG)).value());
+    }
+
+    Store<String, String> inMemoryStore = new InMemoryStore<String, String>();
+    return createAndInitKafkaStoreInstance(zkConnect, zkClient, inMemoryStore, props);
+  }
+
+  /**
+   * Get a new instance of KafkaStore and initialize it.
+   */
+  public static KafkaStore<String, String> createAndInitKafkaStoreInstance(
+          String zkConnect, ZkClient zkClient, Store<String, String> inMemoryStore,
+          Properties props) {
     props.put(SchemaRegistryConfig.KAFKASTORE_CONNECTION_URL_CONFIG, zkConnect);
     props.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG, ClusterTestHarness.KAFKASTORE_TOPIC);
 
@@ -57,9 +98,9 @@ public class StoreUtils {
     }
 
     KafkaStore<String, String> kafkaStore =
-        new KafkaStore<String, String>(config, new StringMessageHandler(),
-                                       StringSerializer.INSTANCE,
-                                       inMemoryStore, new NoopKey().toString());
+            new KafkaStore<String, String>(config, new StringMessageHandler(),
+                    StringSerializer.INSTANCE,
+                    inMemoryStore, new NoopKey().toString());
     try {
       kafkaStore.init();
     } catch (StoreInitializationException e) {

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -51,6 +51,48 @@ Configuration Options
   * Default: "localhost"
   * Importance: high
 
+``kafkastore.ssl.truststore.location``
+  The location of the SSL trust store file.
+
+  * Type: string
+  * Default: ""
+  * Importance: high
+
+``kafkastore.ssl.truststore.password``
+  The password to access the trust store.
+
+  * Type: password
+  * Default: ""
+  * Importance: high
+
+``kafkastore.ssl.keystore.location``
+  The location of the SSL keystore file.
+
+  * Type: string
+  * Default: ""
+  * Importance: high
+
+``kafkastore.ssl.keystore.password``
+  The password to access the keystore.
+
+  * Type: password
+  * Default: ""
+  * Importance: high
+
+``kafkastore.ssl.key.password``
+  The password of the key contained in the keystore.
+
+  * Type: password
+  * Default: ""
+  * Importance: high
+
+``kafkastore.security.protocol``
+  The security protocol to use when connecting with Kafka, the underlying persistent storage. Values can be `PLAINTEXT` or `SSL`.
+
+  * Type: string
+  * Default: "PLAINTEXT"
+  * Importance: medium
+
 ``kafkastore.init.timeout.ms``
   The timeout for initialization of the Kafka store, including creation of the Kafka topic that stores schema data.
 
@@ -70,6 +112,41 @@ Configuration Options
 
   * Type: boolean
   * Default: true
+  * Importance: medium
+
+``kafkastore.ssl.enabled.protocols``
+  The list of protocols enabled for SSL.
+
+  * Type: string
+  * Default: "TLSv1.2,TLSv1.1,TLSv1"
+  * Importance: medium
+
+``kafkastore.ssl.keystore.type``
+  The file format of the keystore file.
+
+  * Type: string
+  * Default: "JKS"
+  * Importance: medium
+
+``kafkastore.ssl.protocol``
+  The SSL protocol used to generate the SSLContext.
+
+  * Type: string
+  * Default: "TLS"
+  * Importance: medium
+
+``kafkastore.ssl.provider``
+  The name of the securitiy provider used for SSL.
+
+  * Type: string
+  * Default: ""
+  * Importance: medium
+
+``kafkastore.ssl.truststore.type``
+  The file format of the trust store file.
+
+  * Type: string
+  * Default: "JKS"
   * Importance: medium
 
 ``access.control.allow.origin``
@@ -147,4 +224,32 @@ Configuration Options
 
   * Type: int
   * Default: 1000
+  * Importance: low
+
+``kafkastore.ssl.cipher.suites``
+  A list of cipher suites used for SSL.
+
+  * Type: string
+  * Default: ""
+  * Importance: low
+
+``kafkastore.ssl.endpoint.identification.algorithm``
+  The endpoint identification algorithm to validate the server hostname using the server certificate.
+
+  * Type: string
+  * Default: ""
+  * Importance: low
+
+``kafkastore.ssl.keymanager.algorithm``
+  The algorithm used by key manager factory for SSL connections.
+
+  * Type: string
+  * Default: "SunX509"
+  * Importance: low
+
+``kafkastore.ssl.trustmanager.algorithm``
+  The algorithm used by the trust manager factory for SSL connections.
+
+  * Type: string
+  * Default: "PKIX"
   * Importance: low

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,4 +17,5 @@ Contents:
    config
    design
    operations
+   security
    serializer-formatter

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -1,0 +1,12 @@
+.. _schemaregistry_security:
+
+Security Overview
+-----------------
+The Schema Registry currently only supports communication with a secure Kafka cluster over SSL. At this time, https and ZooKeeper security are not yet supported. Kafka SASL authentication is not supported yet either.
+
+Kafka Store
+~~~~~~~~~~~
+The Schema Registry uses Kafka to persist schemas. The following Kafka security configurations are currently supported:
+
+* SSL encryption
+* SSL authentication

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven-assembly.version>2.6</maven-assembly.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
+        <bouncycastle.bcpkix.version>1.54</bouncycastle.bcpkix.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
This diff adds support for an SSL KafkaStore. The implementation is pretty straightforward, mostly involving forwarding config parameters to the Kafka clients. The tests were a little tricky, though.

There were a few implementation choices I made which I'm not sure are ideal:

 * Some Kafka client configuration parameters have a default value of `null`. `ConfigDef` doesn't support optional parameters with a default value of `null`. My workaround is to make the default value in the schema registry `""` and convert that to `null` when I initialize the Kafka clients.
 * I introduced two new test classes, one testing SSL with authentication, and the other testing SSL without authentication. I copy-pasted some code between these two, which feels bad. However, I couldn't figure out a better alternative.

Thanks ahead of time for taking a look!