### PR TITLE
Test case for union of null and arrays

### DIFF
--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -39,6 +39,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.GregorianCalendar;
@@ -149,6 +150,21 @@ public class AvroDataTest {
 
     checkNonRecordConversionNull(Schema.OPTIONAL_STRING_SCHEMA);
   }
+
+    @Test
+    public void testFromConnectOptionalArray() {
+        org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.builder()
+                .unionOf().nullType().and()
+                .array().items()
+                .record("Exception")
+                .namespace("com.namespace")
+                .fields()
+                .requiredString("name")
+                .requiredString("stack").endRecord().endUnion();
+        Schema schema = avroData.toConnectSchema(avroSchema);
+        Object converted = avroData.fromConnectData(schema, new ArrayList());
+        assertNull(converted);
+    }
 
   @Test
   public void testFromConnectComplex() {
@@ -565,18 +581,7 @@ public class AvroDataTest {
                  avroData.toConnectData(avroSchema, Arrays.asList(12, 13)));
   }
 
-  @Test
-  public void testToConnectOptionalArray() {
-    org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.builder()
-        .unionOf().nullType().and()
-        .array().items().intType().endUnion();
-    avroSchema.getElementType().addProp("connect.type", "int8");
-    // Use a value type which ensures we test conversion of elements. int8 requires extra
-    // conversion steps but keeps the test simple.
-    Schema schema = SchemaBuilder.array(Schema.OPTIONAL_INT8_SCHEMA).build();
-    assertEquals(new SchemaAndValue(schema, Arrays.asList((byte) 12, (byte) 13)),
-                 avroData.toConnectData(avroSchema, Arrays.asList(12, 13)));
-  }
+
 
   @Test
   public void testToConnectMapStringKeys() {

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -566,6 +566,19 @@ public class AvroDataTest {
   }
 
   @Test
+  public void testToConnectOptionalArray() {
+    org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.builder()
+        .unionOf().nullType().and()
+        .array().items().intType().endUnion();
+    avroSchema.getElementType().addProp("connect.type", "int8");
+    // Use a value type which ensures we test conversion of elements. int8 requires extra
+    // conversion steps but keeps the test simple.
+    Schema schema = SchemaBuilder.array(Schema.OPTIONAL_INT8_SCHEMA).build();
+    assertEquals(new SchemaAndValue(schema, Arrays.asList((byte) 12, (byte) 13)),
+                 avroData.toConnectData(avroSchema, Arrays.asList(12, 13)));
+  }
+
+  @Test
   public void testToConnectMapStringKeys() {
     org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.builder().map()
         .values().intType();


### PR DESCRIPTION
When we have a union of null and an array type,  kafka connect thinks it's just an array type. Throws 
org.apache.avro.AvroRuntimeException: Not an array: ["null",{"type":"array","items":{"type":"record","name":"Exception","namespace":"com.rallydev","fields":[{"name":"exceptionClass","type":"string"},{"name":"exceptionMessage","type":["null","string"]},{"name":"exceptionStack","
type":"string"}],"connect.name":"com.rallydev.Exception"}}]
        at org.apache.avro.Schema.getElementType(Schema.java:262)
        at io.confluent.connect.avro.AvroData.fromConnectData(AvroData.java:391)
        at io.confluent.connect.avro.AvroData.fromConnectData(AvroData.java:450)
        at io.confluent.connect.avro.AvroData.fromConnectData(AvroData.java:450)
        at io.confluent.connect.avro.AvroData.fromConnectData(AvroData.java:267)