### PR TITLE
ZooKeeper and Kafka SASL support.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -100,7 +100,12 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.directory.server</groupId>
+            <artifactId>apacheds-all</artifactId>
+            <version>2.0.0-M21</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -25,6 +25,7 @@ import io.confluent.common.config.ConfigException;
 import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
 import io.confluent.rest.RestConfig;
 import io.confluent.rest.RestConfigException;
+import org.apache.kafka.common.protocol.SecurityProtocol;
 
 import static io.confluent.common.config.ConfigDef.Range.atLeast;
 
@@ -33,9 +34,6 @@ public class SchemaRegistryConfig extends RestConfig {
   private static final int SCHEMAREGISTRY_PORT_DEFAULT = 8081;
   // TODO: change this to "http://0.0.0.0:8081" when PORT_CONFIG is deleted.
   private static final String SCHEMAREGISTRY_LISTENERS_DEFAULT = "";
-
-  public static final String KAFKASTORE_SECURITY_PROTOCOL_SSL = "SSL";
-  public static final String KAFKASTORE_SECURITY_PROTOCOL_PLAINTEXT = "PLAINTEXT";
 
   public static final String KAFKASTORE_CONNECTION_URL_CONFIG = "kafkastore.connection.url";
   /**
@@ -81,6 +79,8 @@ public class SchemaRegistryConfig extends RestConfig {
    * <code>avro.compatibility.level</code>
    */
   public static final String COMPATIBILITY_CONFIG = "avro.compatibility.level";
+
+  public static final String ZOOKEEPER_SET_ACL_CONFIG = "zookeeper.set.acl";
   public static final String KAFKASTORE_SECURITY_PROTOCOL_CONFIG =
       "kafkastore.security.protocol";
   public static final String KAFKASTORE_SSL_TRUSTSTORE_LOCATION_CONFIG =
@@ -111,6 +111,18 @@ public class SchemaRegistryConfig extends RestConfig {
       "kafkastore.ssl.cipher.suites";
   public static final String KAFKASTORE_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG =
       "kafkastore.ssl.endpoint.identification.algorithm";
+  public static final String KAFKASTORE_SASL_KERBEROS_SERVICE_NAME_CONFIG =
+      "kafkastore.sasl.kerberos.service.name";
+  public static final String KAFKASTORE_SASL_MECHANISM_CONFIG =
+      "kafkastore.sasl.mechanism";
+  public static final String KAFKASTORE_SASL_KERBEROS_KINIT_CMD_CONFIG =
+      "kafkastore.sasl.kerberos.kinit.cmd";
+  public static final String KAFKASTORE_SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN_CONFIG =
+      "kafkastore.sasl.kerberos.min.time.before.relogin";
+  public static final String KAFKASTORE_SASL_KERBEROS_TICKET_RENEW_JITTER_CONFIG =
+      "kafkastore.sasl.kerberos.ticket.renew.jitter";
+  public static final String KAFKASTORE_SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR_CONFIG =
+      "kafkastore.sasl.kerberos.ticket.renew.window.factor";
   protected static final String KAFKASTORE_CONNECTION_URL_DOC =
       "Zookeeper url for the Kafka cluster";
   protected static final String SCHEMAREGISTRY_ZK_NAMESPACE_DOC =
@@ -139,6 +151,9 @@ public class SchemaRegistryConfig extends RestConfig {
   protected static final String HOST_DOC =
       "The host name advertised in Zookeeper. Make sure to set this if running SchemaRegistry "
       + "with multiple nodes.";
+  protected static final String ZOOKEEPER_SET_ACL_DOC =
+      "Whether or not to set an ACL in ZooKeeper when znodes are written and ZooKeeper SASL authentication is "
+      + "configured. IMPORTANT: if set to `true`, the SASL principal must be the same as the Kafka brokers.";
   protected static final String COMPATIBILITY_DOC =
       "The Avro compatibility type. Valid values are: "
       + "none (new schema can be any valid Avro schema), "
@@ -150,7 +165,7 @@ public class SchemaRegistryConfig extends RestConfig {
       + "for clusters in the slave data center.";
   protected static final String KAFKASTORE_SECURITY_PROTOCOL_DOC =
       "The security protocol to use when connecting with Kafka, the underlying persistent storage. "
-      + "Values can be `PLAINTEXT` or `SSL`.";
+      + "Values can be `PLAINTEXT`, `SSL`, `SASL_PLAINTEXT`, or `SASL_SSL`.";
   protected static final String KAFKASTORE_SSL_TRUSTSTORE_LOCATION_DOC =
       "The location of the SSL trust store file.";
   protected static final String KAFKASTORE_SSL_TRUSTSTORE_PASSWORD_DOC =
@@ -179,6 +194,21 @@ public class SchemaRegistryConfig extends RestConfig {
       "A list of cipher suites used for SSL.";
   protected static final String KAFKASTORE_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC =
       "The endpoint identification algorithm to validate the server hostname using the server certificate.";
+  public static final String KAFKASTORE_SASL_KERBEROS_SERVICE_NAME_DOC =
+      "The Kerberos principal name that the Kafka client runs as. This can be defined either in the JAAS "
+      + "config file or here.";
+  public static final String KAFKASTORE_SASL_MECHANISM_DOC =
+      "The SASL mechanism used for Kafka connections. GSSAPI is the default.";
+  public static final String KAFKASTORE_SASL_KERBEROS_KINIT_CMD_DOC =
+      "The Kerberos kinit command path.";
+  public static final String KAFKASTORE_SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN_DOC =
+      "The login time between refresh attempts.";
+  public static final String KAFKASTORE_SASL_KERBEROS_TICKET_RENEW_JITTER_DOC =
+      "The percentage of random jitter added to the renewal time.";
+  public static final String KAFKASTORE_SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR_DOC =
+      "Login thread will sleep until the specified window factor of time from last refresh to ticket's expiry has "
+      + "been reached, at which time it will try to renew the ticket.";
+  private static final boolean ZOOKEEPER_SET_ACL_DEFAULT = false;
   private static final String COMPATIBILITY_DEFAULT = "backward";
   private static final String METRICS_JMX_PREFIX_DEFAULT_OVERRIDE = "kafka.schema.registry";
 
@@ -218,13 +248,15 @@ public class SchemaRegistryConfig extends RestConfig {
                 ConfigDef.Importance.HIGH, HOST_DOC)
         .define(COMPATIBILITY_CONFIG, ConfigDef.Type.STRING, COMPATIBILITY_DEFAULT,
                 ConfigDef.Importance.HIGH, COMPATIBILITY_DOC)
+        .define(ZOOKEEPER_SET_ACL_CONFIG, ConfigDef.Type.BOOLEAN, ZOOKEEPER_SET_ACL_DEFAULT,
+                ConfigDef.Importance.HIGH, ZOOKEEPER_SET_ACL_DOC)
         .define(MASTER_ELIGIBILITY, ConfigDef.Type.BOOLEAN, DEFAULT_MASTER_ELIGIBILITY, 
                 ConfigDef.Importance.MEDIUM, MASTER_ELIGIBILITY_DOC)
         .defineOverride(METRICS_JMX_PREFIX_CONFIG, ConfigDef.Type.STRING,
                         METRICS_JMX_PREFIX_DEFAULT_OVERRIDE, ConfigDef.Importance.LOW,
                         METRICS_JMX_PREFIX_DOC)
         .define(KAFKASTORE_SECURITY_PROTOCOL_CONFIG, ConfigDef.Type.STRING,
-                KAFKASTORE_SECURITY_PROTOCOL_PLAINTEXT, ConfigDef.Importance.MEDIUM,
+                SecurityProtocol.PLAINTEXT.toString(), ConfigDef.Importance.MEDIUM,
                 KAFKASTORE_SECURITY_PROTOCOL_DOC)
         .define(KAFKASTORE_SSL_TRUSTSTORE_LOCATION_CONFIG, ConfigDef.Type.STRING,
                 "", ConfigDef.Importance.HIGH,
@@ -267,7 +299,25 @@ public class SchemaRegistryConfig extends RestConfig {
                 KAFKASTORE_SSL_CIPHER_SUITES_DOC)
         .define(KAFKASTORE_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, ConfigDef.Type.STRING,
                 "", ConfigDef.Importance.LOW,
-                KAFKASTORE_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC);
+                KAFKASTORE_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC)
+        .define(KAFKASTORE_SASL_KERBEROS_SERVICE_NAME_CONFIG, ConfigDef.Type.STRING,
+                "", ConfigDef.Importance.MEDIUM,
+                KAFKASTORE_SASL_KERBEROS_SERVICE_NAME_DOC)
+        .define(KAFKASTORE_SASL_MECHANISM_CONFIG, ConfigDef.Type.STRING,
+                "GSSAPI", ConfigDef.Importance.MEDIUM,
+                KAFKASTORE_SASL_MECHANISM_DOC)
+        .define(KAFKASTORE_SASL_KERBEROS_KINIT_CMD_CONFIG, ConfigDef.Type.STRING,
+                "/usr/bin/kinit", ConfigDef.Importance.LOW,
+                KAFKASTORE_SASL_KERBEROS_KINIT_CMD_DOC)
+        .define(KAFKASTORE_SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN_CONFIG, ConfigDef.Type.LONG,
+                60000, ConfigDef.Importance.LOW,
+                KAFKASTORE_SASL_KERBEROS_MIN_TIME_BEFORE_RELOGIN_DOC)
+        .define(KAFKASTORE_SASL_KERBEROS_TICKET_RENEW_JITTER_CONFIG, ConfigDef.Type.DOUBLE,
+                0.05, ConfigDef.Importance.LOW,
+                KAFKASTORE_SASL_KERBEROS_TICKET_RENEW_JITTER_DOC)
+        .define(KAFKASTORE_SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR_CONFIG, ConfigDef.Type.DOUBLE,
+                0.8, ConfigDef.Importance.LOW,
+                KAFKASTORE_SASL_KERBEROS_TICKET_RENEW_WINDOW_FACTOR_DOC);
   }
   private final AvroCompatibilityLevel compatibilityType;
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -102,6 +102,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry {
   private ZookeeperMasterElector masterElector = null;
   private Metrics metrics;
   private Sensor masterNodeSensor;
+  private boolean zKAclsEnabled;
 
   // Hand out this id during the next schema registration. Indexed from 1.
   private int nextAvailableSchemaId;
@@ -156,6 +157,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry {
                            + " node where all register schema and config update requests are "
                            + "served.");
     this.masterNodeSensor.add(m, new Gauge());
+    this.zKAclsEnabled = config.getBoolean(SchemaRegistryConfig.ZOOKEEPER_SET_ACL_CONFIG);
   }
 
   @Override
@@ -191,7 +193,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry {
     ZkUtils zkUtilsForNamespaceCreation = ZkUtils.apply(
         zkConnForNamespaceCreation,
         zkSessionTimeoutMs, zkSessionTimeoutMs,
-        JaasUtils.isZkSecurityEnabled());
+        JaasUtils.isZkSecurityEnabled() && zKAclsEnabled);
     // create the zookeeper namespace using cluster.name if it doesn't already exist
     zkUtilsForNamespaceCreation.makeSurePersistentPathExists(
         schemaRegistryNamespace,
@@ -201,7 +203,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry {
     zkUtilsForNamespaceCreation.close();
     this.zkUtils = ZkUtils.apply(
         schemaRegistryZkUrl, zkSessionTimeoutMs, zkSessionTimeoutMs,
-        JaasUtils.isZkSecurityEnabled());
+        JaasUtils.isZkSecurityEnabled() && zKAclsEnabled);
   }
   
   public boolean isMaster() {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThread.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThread.java
@@ -100,7 +100,10 @@ public class KafkaStoreReaderThread<K, V> extends ShutdownableThread {
     consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
             org.apache.kafka.common.serialization.ByteArrayDeserializer.class);
 
+    consumerProps.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,
+            config.getString(SchemaRegistryConfig.KAFKASTORE_SECURITY_PROTOCOL_CONFIG));
     KafkaStore.addSslConfigsToClientProperties(config, consumerProps);
+    KafkaStore.addSaslConfigsToClientProperties(config, consumerProps);
 
     this.consumer = new KafkaConsumer<>(consumerProps);
 

--- a/core/src/main/resources/log4j.properties
+++ b/core/src/main/resources/log4j.properties
@@ -8,5 +8,6 @@ log4j.logger.kafka=ERROR, stdout
 log4j.logger.org.apache.zookeeper=ERROR, stdout
 log4j.logger.org.apache.kafka=ERROR, stdout
 log4j.logger.org.I0Itec.zkclient=ERROR, stdout
+log4j.logger.org.apache.directory=ERROR, stdout
 log4j.additivity.kafka.server=false
 log4j.additivity.kafka.consumer.ZookeeperConsumerConnector=false

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
@@ -18,7 +18,6 @@ package io.confluent.kafka.schemaregistry;
 import kafka.utils.CoreUtils;
 import org.I0Itec.zkclient.ZkClient;
 import org.apache.kafka.common.protocol.SecurityProtocol;
-import org.apache.kafka.common.security.JaasUtils;
 import org.junit.After;
 import org.junit.Before;
 
@@ -50,7 +49,7 @@ public abstract class ClusterTestHarness {
 
   public static final int DEFAULT_NUM_BROKERS = 1;
   public static final String KAFKASTORE_TOPIC = SchemaRegistryConfig.DEFAULT_KAFKASTORE_TOPIC;
-  protected static final Option<Properties> SASL_PROPERTIES = Option$.MODULE$.<Properties>empty();
+  protected static final Option<Properties> EMPTY_SASL_PROPERTIES = Option$.MODULE$.<Properties>empty();
 
   /**
    * Choose a number of random available ports
@@ -87,7 +86,7 @@ public abstract class ClusterTestHarness {
   protected String zkConnect;
   protected ZkClient zkClient;
   protected ZkUtils zkUtils;
-  protected int zkConnectionTimeout = 6000;
+  protected int zkConnectionTimeout = 30000;
   protected int zkSessionTimeout = 6000;
 
   // Kafka Config
@@ -118,10 +117,12 @@ public abstract class ClusterTestHarness {
   @Before
   public void setUp() throws Exception {
     zookeeper = new EmbeddedZookeeper();
-    zkConnect = String.format("127.0.0.1:%d", zookeeper.port());
+    zkConnect = String.format("localhost:%d", zookeeper.port());
     zkUtils = ZkUtils.apply(
         zkConnect, zkSessionTimeout, zkConnectionTimeout,
-        JaasUtils.isZkSecurityEnabled());
+        false); // true of false doesn't matter because the schema registry Kafka principal is the same as the
+                // Kafka broker principal, so ACLs won't make any difference. Read comments in
+                // SASLClusterTestHarness.java for more details.
     zkClient = zkUtils.zkClient();
 
     configs = new Vector<>();
@@ -144,19 +145,19 @@ public abstract class ClusterTestHarness {
     }
   }
 
+  protected void injectProperties(Properties props) {
+    props.setProperty("auto.create.topics.enable", "true");
+    props.setProperty("num.partitions", "1");
+  }
+
   protected KafkaConfig getKafkaConfig(int brokerId) {
     final Option<java.io.File> noFile = scala.Option.apply(null);
     final Option<SecurityProtocol> noInterBrokerSecurityProtocol = scala.Option.apply(null);
     Properties props = TestUtils.createBrokerConfig(
             brokerId, zkConnect, false, false, TestUtils.RandomPort(), noInterBrokerSecurityProtocol,
-            noFile, SASL_PROPERTIES, true, false, TestUtils.RandomPort(), false, TestUtils.RandomPort(), false,
+            noFile, EMPTY_SASL_PROPERTIES, true, false, TestUtils.RandomPort(), false, TestUtils.RandomPort(), false,
             TestUtils.RandomPort(), Option.<String>empty());
-    props.setProperty("auto.create.topics.enable", "true");
-    props.setProperty("num.partitions", "1");
-
-    // We *must* override this to use the ZooKeeper port chosen in this test harness, instead of the
-    // port chosen by TestUtils.createBrokerConfig().
-    props.setProperty("zookeeper.connect", this.zkConnect);
+    injectProperties(props);
     return KafkaConfig.fromProps(props);
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/SASLClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/SASLClusterTestHarness.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry;
+
+import kafka.security.minikdc.MiniKdc;
+import kafka.server.KafkaConfig;
+import kafka.utils.JaasTestUtils;
+import kafka.utils.TestUtils;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.apache.kafka.common.security.authenticator.LoginManager;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Option;
+import scala.collection.Seq;
+
+import javax.security.auth.login.Configuration;
+import java.io.File;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Properties;
+
+// sets up SASL for ZooKeeper and Kafka.
+public class SASLClusterTestHarness extends ClusterTestHarness {
+  public static final String JAAS_CONF = "java.security.auth.login.config";
+  public static final String KRB5_CONF = "java.security.krb5.conf";
+  public static final String ZK_AUTH_PROVIDER = "zookeeper.authProvider.1";
+
+  private static MiniKdc kdc;
+  private static File kdcHome;
+  private static String krb5ConfPath;
+  private static File jaasFile;
+
+  private static final Logger log = LoggerFactory.getLogger(SASLClusterTestHarness.class);
+
+  public SASLClusterTestHarness() {
+    super(DEFAULT_NUM_BROKERS);
+  }
+
+  @Override
+  protected SecurityProtocol getSecurityProtocol() {
+    return SecurityProtocol.SASL_PLAINTEXT;
+  }
+
+  @BeforeClass
+  public static void setUpKdc() throws Exception {
+    destroySaslHelper();
+    File zkServerKeytab = File.createTempFile("zookeeper-", ".keytab");
+    File kafkaKeytab = File.createTempFile("kafka-", ".keytab");
+    File schemaRegistryKeytab = File.createTempFile("schema-registry-", ".keytab");
+
+    // build and write the JAAS file.
+    JaasTestUtils.JaasSection serverSection = createJaasSection(zkServerKeytab,
+            "zookeeper/localhost@EXAMPLE.COM", "Server", "zookeeper");
+    // NOTE: there is only one `Client` section in the Jaas configuraiton file. Both the internal embedded Kafka
+    // cluster and the schema registry share the same principal. This is required because within the same JVM (eg
+    // these tests) one cannot have two sections, each with its own ZooKeeper client SASL credentials.
+    JaasTestUtils.JaasSection clientSection = createJaasSection(kafkaKeytab,
+            "kafka/localhost@EXAMPLE.COM", "Client", "zookeeper");
+    JaasTestUtils.JaasSection kafkaServerSection = createJaasSection(kafkaKeytab,
+            "kafka/localhost@EXAMPLE.COM", "KafkaServer", "kafka");
+    JaasTestUtils.JaasSection kafkaClientSection = createJaasSection(schemaRegistryKeytab,
+            "schema-registry/localhost@EXAMPLE.COM", "KafkaClient", "kafka");
+    jaasFile = File.createTempFile("schema_registry_tests", "_jaas.conf");
+    PrintWriter out = new PrintWriter(jaasFile);
+    out.println(serverSection.toString());
+    out.println(clientSection.toString());
+    out.println(kafkaServerSection.toString());
+    out.println(kafkaClientSection.toString());
+    out.close();
+
+    Properties kdcProps = MiniKdc.createConfig();
+    kdcHome = Files.createTempDirectory("mini-kdc").toFile();
+    log.info("Using KDC home: " + kdcHome.getAbsolutePath());
+    kdc = new MiniKdc(kdcProps, kdcHome);
+    kdc.start();
+
+    krb5ConfPath = System.getProperty("java.security.krb5.conf");
+
+    createPrincipal(zkServerKeytab, "zookeeper/localhost");
+    createPrincipal(kafkaKeytab, "kafka/localhost");
+    createPrincipal(schemaRegistryKeytab, "schema-registry/localhost");
+
+    // destroy SASL settings so all tests don't have SASL enabled. SASL is re-enabled in a @Before method below.
+    destroySaslHelper();
+  }
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    destroySaslHelper();
+    System.setProperty(JAAS_CONF, jaasFile.getAbsolutePath());
+    System.setProperty(KRB5_CONF, krb5ConfPath);
+    System.setProperty(ZK_AUTH_PROVIDER, "org.apache.zookeeper.server.auth.SASLAuthenticationProvider");
+    super.setUp();
+  }
+
+  private static void createPrincipal(File keytab, String principalNoRealm) throws Exception {
+    Seq<String> principals = scala.collection.JavaConversions.asScalaBuffer(
+            Arrays.asList(principalNoRealm)
+    ).seq();
+    kdc.createPrincipal(keytab, principals);
+  }
+
+  private static JaasTestUtils.JaasSection createJaasSection(File keytab, String principalWithRealm,
+                                                      String jaasContextName, String serviceName) {
+    final scala.Option<String> serviceNameOption = scala.Option.apply(serviceName);
+    JaasTestUtils.Krb5LoginModule krbModule = new JaasTestUtils.Krb5LoginModule(true, true,
+            keytab.getAbsolutePath(), principalWithRealm, true, serviceNameOption);
+    Seq<JaasTestUtils.JaasModule> jaasModules = scala.collection.JavaConversions.asScalaBuffer(
+            Arrays.asList(krbModule.toJaasModule())
+    ).seq();
+    return new JaasTestUtils.JaasSection(jaasContextName, jaasModules);
+  }
+
+  @Override
+  protected KafkaConfig getKafkaConfig(int brokerId) {
+    final Option<File> trustStoreFileOption = scala.Option.apply(null);
+    final Option<SecurityProtocol> saslInterBrokerSecurityProtocol =
+            scala.Option.apply(SecurityProtocol.SASL_PLAINTEXT);
+    Properties props = TestUtils.createBrokerConfig(
+            brokerId, zkConnect, false, false, TestUtils.RandomPort(), saslInterBrokerSecurityProtocol,
+            trustStoreFileOption, EMPTY_SASL_PROPERTIES, false, true, TestUtils.RandomPort(),
+            false, TestUtils.RandomPort(),
+            false, TestUtils.RandomPort(), Option.<String>empty());
+
+    injectProperties(props);
+    props.setProperty("zookeeper.connection.timeout.ms", "30000");
+    props.setProperty("sasl.mechanism.inter.broker.protocol", "GSSAPI");
+    props.setProperty(SaslConfigs.SASL_ENABLED_MECHANISMS, "GSSAPI");
+
+    return KafkaConfig.fromProps(props);
+  }
+
+  @After
+  @Override
+  public void tearDown() throws Exception {
+    destroySaslHelper();
+    super.tearDown();
+  }
+
+  @AfterClass
+  public static void tearDownKdc() throws Exception {
+    if (kdc != null) {
+      kdc.stop();
+    }
+    if (kdcHome != null && !kdcHome.delete()) {
+      log.warn("Could not delete the KDC directory.");
+    }
+    destroySaslHelper();
+  }
+
+  private static void destroySaslHelper() {
+    LoginManager.closeAll();
+    System.clearProperty(JAAS_CONF);
+    System.clearProperty(ZK_AUTH_PROVIDER);
+    System.clearProperty(KRB5_CONF);
+    Configuration.setConfiguration(null);
+  }
+}

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/SSLClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/SSLClusterTestHarness.java
@@ -34,10 +34,12 @@ public class SSLClusterTestHarness extends ClusterTestHarness {
     super(DEFAULT_NUM_BROKERS);
   }
 
+  @Override
   protected SecurityProtocol getSecurityProtocol() {
     return SecurityProtocol.SSL;
   }
 
+  @Override
   protected KafkaConfig getKafkaConfig(int brokerId) {
     File trustStoreFile;
     try {
@@ -49,8 +51,8 @@ public class SSLClusterTestHarness extends ClusterTestHarness {
     final Option<SecurityProtocol> sslInterBrokerSecurityProtocol = scala.Option.apply(SecurityProtocol.SSL);
     Properties props = TestUtils.createBrokerConfig(
             brokerId, zkConnect, false, false, TestUtils.RandomPort(), sslInterBrokerSecurityProtocol,
-            trustStoreFileOption, SASL_PROPERTIES, false, false, TestUtils.RandomPort(), true, TestUtils.RandomPort(),
-            false, TestUtils.RandomPort(), Option.<String>empty());
+            trustStoreFileOption, EMPTY_SASL_PROPERTIES, false, false, TestUtils.RandomPort(),
+            true, TestUtils.RandomPort(), false, TestUtils.RandomPort(), Option.<String>empty());
 
     // setup client SSL. Needs to happen before the broker is initialized, because the client's cert
     // needs to be added to the broker's trust store.
@@ -62,14 +64,10 @@ public class SSLClusterTestHarness extends ClusterTestHarness {
       throw new RuntimeException(e);
     }
 
-    props.setProperty("auto.create.topics.enable", "true");
-    props.setProperty("num.partitions", "1");
+    injectProperties(props);
     if (requireSSLClientAuth()) {
       props.setProperty("ssl.client.auth", "required");
     }
-    // We *must* override this to use the port we allocated (Kafka currently allocates one port
-    // that it always uses for ZK
-    props.setProperty("zookeeper.connect", this.zkConnect);
 
     return KafkaConfig.fromProps(props);
   }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreSASLTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreSASLTest.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.kafka.schemaregistry.storage;
+
+import io.confluent.kafka.schemaregistry.SASLClusterTestHarness;
+import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
+import io.confluent.kafka.schemaregistry.storage.exceptions.StoreInitializationException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+// tests SASL with ZooKeeper and Kafka.
+public class KafkaStoreSASLTest extends SASLClusterTestHarness {
+  @Test
+  public void testInitialization() {
+    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSASLStoreInstance(zkConnect,
+            zkClient);
+    kafkaStore.close();
+  }
+
+  @Test
+  public void testDoubleInitialization() {
+    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSASLStoreInstance(zkConnect,
+            zkClient);
+    try {
+      kafkaStore.init();
+      fail("Kafka store repeated initialization should fail");
+    } catch (StoreInitializationException e) {
+      // this is expected
+    }
+    kafkaStore.close();
+  }
+
+  @Test
+  public void testSimplePut() throws InterruptedException {
+    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSASLStoreInstance(zkConnect,
+            zkClient);
+    String key = "Kafka";
+    String value = "Rocks";
+    try {
+      try {
+        kafkaStore.put(key, value);
+      } catch (StoreException e) {
+        throw new RuntimeException("Kafka store put(Kafka, Rocks) operation failed", e);
+      }
+      String retrievedValue = null;
+      try {
+        retrievedValue = kafkaStore.get(key);
+      } catch (StoreException e) {
+        throw new RuntimeException("Kafka store get(Kafka) operation failed", e);
+      }
+      assertEquals("Retrieved value should match entered value", value, retrievedValue);
+    } finally {
+      kafkaStore.close();
+    }
+  }
+}

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
@@ -285,19 +285,25 @@ public class KafkaStoreTest extends ClusterTestHarness {
   @Test
   public void testGetBrokerEndpointsMixed() throws IOException {
     List<Broker> brokersList = new ArrayList<Broker>(3);
-    brokersList.add(new Broker(0, "localhost", TestUtils.RandomPort(), SecurityProtocol.PLAINTEXT));
+    brokersList.add(new Broker(0, "localhost0", TestUtils.RandomPort(), SecurityProtocol.PLAINTEXT));
     brokersList.add(new Broker(1, "localhost1", TestUtils.RandomPort(), SecurityProtocol.PLAINTEXT));
     brokersList.add(new Broker(2, "localhost2", TestUtils.RandomPort(), SecurityProtocol.SASL_PLAINTEXT));
     brokersList.add(new Broker(3, "localhost3", TestUtils.RandomPort(), SecurityProtocol.SSL));
+    brokersList.add(new Broker(4, "localhost4", TestUtils.RandomPort(), SecurityProtocol.SASL_SSL));
+    brokersList.add(new Broker(5, "localhost5", TestUtils.RandomPort(), SecurityProtocol.TRACE));
 
     String endpointsString = KafkaStore.getBrokerEndpoints(brokersList);
     String[] endpoints = endpointsString.split(",");
     assertEquals("Expected a different number of endpoints.", brokersList.size() - 1, endpoints.length);
     for (String endpoint : endpoints) {
-      if (endpoint.contains("localhost3")) {
-        assertTrue("Endpoint must be a SSL endpoint.", endpoint.contains("SSL://"));
-      } else {
+      if (endpoint.contains("localhost0") || endpoint.contains("localhost1")) {
         assertTrue("Endpoint must be a PLAINTEXT endpoint.", endpoint.contains("PLAINTEXT://"));
+      } else if (endpoint.contains("localhost2")) {
+        assertTrue("Endpoint must be a SASL_PLAINTEXT endpoint.", endpoint.contains("SASL_PLAINTEXT://"));
+      } else if (endpoint.contains("localhost3")) {
+        assertTrue("Endpoint must be a SSL endpoint.", endpoint.contains("SSL://"));
+      } else if (endpoint.contains("localhost4")) {
+        assertTrue("Endpoint must be a SASL_SSL endpoint.", endpoint.contains("SASL_SSL://"));
       }
     }
   }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/StoreUtils.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/StoreUtils.java
@@ -24,9 +24,9 @@ import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreInitializationException;
 import io.confluent.rest.RestConfigException;
-import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.common.protocol.SecurityProtocol;
 
 import static org.junit.Assert.fail;
 
@@ -53,17 +53,34 @@ public class StoreUtils {
   }
 
   /**
+   * Get a new instance of a Kafka and ZooKeeper SASL KafkaStore and initialize it.
+   *
+   * Because all SASL tests share the same KDC and JAAS file, when testing Kafka
+   * or ZooKeeper SASL individually, the other must have SASL enabled.
+   */
+  public static KafkaStore<String, String> createAndInitSASLStoreInstance(
+          String zkConnect, ZkClient zkClient) {
+    Properties props = new Properties();
+
+    props.put(SchemaRegistryConfig.KAFKASTORE_SECURITY_PROTOCOL_CONFIG,
+            SecurityProtocol.SASL_PLAINTEXT.toString());
+
+    props.put(SchemaRegistryConfig.ZOOKEEPER_SET_ACL_CONFIG, false);
+
+    Store<String, String> inMemoryStore = new InMemoryStore<String, String>();
+    return createAndInitKafkaStoreInstance(zkConnect, zkClient, inMemoryStore, props);
+  }
+
+  /**
    * Get a new instance of an SSL KafkaStore and initialize it.
    */
   public static KafkaStore<String, String> createAndInitSSLKafkaStoreInstance(
           String zkConnect, ZkClient zkClient, Map<String, Object> sslConfigs,
           boolean requireSSLClientAuth) {
     Properties props = new Properties();
-    props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,
-            SchemaRegistryConfig.KAFKASTORE_SECURITY_PROTOCOL_SSL);
 
     props.put(SchemaRegistryConfig.KAFKASTORE_SECURITY_PROTOCOL_CONFIG,
-            SchemaRegistryConfig.KAFKASTORE_SECURITY_PROTOCOL_SSL);
+            SecurityProtocol.SSL.toString());
     props.put(SchemaRegistryConfig.KAFKASTORE_SSL_TRUSTSTORE_LOCATION_CONFIG,
             sslConfigs.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG));
     props.put(SchemaRegistryConfig.KAFKASTORE_SSL_TRUSTSTORE_PASSWORD_CONFIG,

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/zookeeper/MasterElectorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/zookeeper/MasterElectorTest.java
@@ -46,7 +46,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class MasterElectorTest extends ClusterTestHarness {
-  private static final int ID_BATCH_SIZE =
+  static final int ID_BATCH_SIZE =
       KafkaSchemaRegistry.ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE;
   private static final String ZK_ID_COUNTER_PATH =
       "/schema_registry" + KafkaSchemaRegistry.ZOOKEEPER_SCHEMA_ID_COUNTER;
@@ -601,7 +601,7 @@ public class MasterElectorTest extends ClusterTestHarness {
     }
   }
 
-  private static int getZkIdCounter(ZkClient zkClient) {
+  static int getZkIdCounter(ZkClient zkClient) {
     return Integer.valueOf(ZkUtils.readData(
         zkClient, ZK_ID_COUNTER_PATH).getData());
   }

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -128,6 +128,13 @@ Configuration Options
   * Default: [application/vnd.schemaregistry.v1+json, application/vnd.schemaregistry+json, application/json]
   * Importance: high
 
+``zookeeper.set.acl``
+  Whether or not to set an ACL in ZooKeeper when znodes are written and ZooKeeper SASL authentication is configured. IMPORTANT: if set to `true`, the ZooKeeper SASL principal must be the same as the Kafka brokers.
+
+  * Type: boolean
+  * Default: false
+  * Importance: high
+
 ``kafkastore.init.timeout.ms``
   The timeout for initialization of the Kafka store, including creation of the Kafka topic that stores schema data.
 
@@ -189,6 +196,20 @@ Configuration Options
 
   * Type: boolean
   * Default: true
+  * Importance: medium
+
+``kafkastore.sasl.kerberos.service.name``
+  The Kerberos principal name that the Kafka client runs as. This can be defined either in the JAAS config file or here.
+
+  * Type: string
+  * Default: ""
+  * Importance: medium
+
+``kafkastore.sasl.mechanism``
+  The SASL mechanism used for Kafka connections. GSSAPI is the default.
+
+  * Type: string
+  * Default: "GSSAPI"
   * Importance: medium
 
 ``access.control.allow.methods``
@@ -371,4 +392,32 @@ Configuration Options
 
   * Type: string
   * Default: "" (Jetty's default)
+  * Importance: low
+
+``kafkastore.sasl.kerberos.kinit.cmd``
+  The Kerberos kinit command path.
+
+  * Type: string
+  * Default: "/usr/bin/kinit"
+  * Importance: low
+
+``kafkastore.sasl.kerberos.min.time.before.relogin``
+  The login time between refresh attempts.
+
+  * Type: long
+  * Default: 60000
+  * Importance: low
+
+``kafkastore.sasl.kerberos.ticket.renew.jitter``
+  The percentage of random jitter added to the renewal time.
+
+  * Type: double
+  * Default: 0.05
+  * Importance: low
+
+``kafkastore.sasl.kerberos.ticket.renew.window.factor``
+  Login thread will sleep until the specified window factor of time from last refresh to ticket's expiry has been reached, at which time it will try to renew the ticket.
+
+  * Type: double
+  * Default: 0.8
   * Importance: low

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -2,13 +2,29 @@
 
 Security Overview
 -----------------
-The Schema Registry currently supports two security features: communication with a secure Kafka cluster over SSL; and API calls over HTTPS. At this time, ZooKeeper security and Kafka SASL authentication are not yet supported.
+The Schema Registry currently supports all Kafka security features, including: communication and authentication with a
+secure Kafka cluster over SSL; authentication with ZooKeeper over SASL; authentication with Kafka over SASL; and
+end-user REST API calls over HTTPS.
 
 For more details, check the :ref:`configuration options<schemaregistry_config>`.
 
 Kafka Store
 ~~~~~~~~~~~
-The Schema Registry uses Kafka to persist schemas. The following Kafka security configurations are currently supported:
+The Schema Registry uses Kafka to persist schemas, and all Kafka security features are supported by the Schema Registry.
 
-* SSL encryption
-* SSL authentication
+ZooKeeper
+~~~~~~~~~
+ZooKeeper SASL authentication is supported.
+
+Setting up ZooKeeper SASL authentication for the Schema Registry is similar to Kafka's setup. Namely,
+create a keytab for the Schema Registry, create a JAAS configuration file, and set the appropriate JAAS Java properties.
+
+In addition to the keytab and JAAS setup, be aware of the `zookeeper.set.acl` setting. This setting, when set to `true`
+, enables ZooKeeper ACLs, which limits access to znodes.
+
+Important: if `zookeeper.set.acl` is set to `true`, the Schema Registry's service name must be the same as Kafka's, which
+is most likely `kafka`. The Schema Registry's principal must have the correct service name, too. Otherwise, the Schema
+Registry will fail to create the `_schemas` topic, which will cause a leader not available error.
+
+If the Schema Registry has a different service name than Kafka, at this time `zookeeper.set.acl` must be set to `false`
+in both the Schema Registry and Kafka.


### PR DESCRIPTION
This commit has support for ZooKeeper and Kafka SASL support (and SASL_SSL in Kafka). I'll close https://github.com/confluentinc/schema-registry/pull/339 in favor of this PR.

Would be great to have (@ijuma || @junrao) && (@ewencp || @granders || @Ishiihara) review this. Thanks!