### PR TITLE
Avro logical types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
         <kafka.version>0.10.0.0-cp1</kafka.version>
         <kafka.scala.version>2.11</kafka.scala.version>
         <log4j.version>1.7.6</log4j.version>
-        <restutils.version>3.0.1-SNAPSHOT</restutils.version>
-        <avro.version>1.7.7</avro.version>
+        <restutils.version>3.1.0-SNAPSHOT</restutils.version>
+        <avro.version>1.8.1</avro.version>
         <jackson.version>2.5.4</jackson.version>
         <junit.version>4.12</junit.version>
         <easymock.version>3.3.1</easymock.version>


### PR DESCRIPTION
Add some extra support for retaining logical type information when converting data from Avro to Kafka Connect format. Addresses https://github.com/confluentinc/schema-registry/issues/351

If an Avro schema's LogicalType attribute is set and retrievable via the [getLogicalType()](https://avro.apache.org/docs/1.8.1/api/java/org/apache/avro/Schema.html#getLogicalType%28%29) method, it can be used as a backup in the event that the "connect.name" property has not been set, and the LogicalType that's found can be converted to a Kafka Connect logical type (some types are still not supported, such as microsecond-precision time and timestamp values).

An update to Avro version 1.8.1 is necessary for this to occur. All Maven tests have completed successfully with this update, so it doesn't seem like it'll be an issue.

String literals are used in place of constants for Avro LogicalType name fields because the names specified by the [Avro 1.8.1 Specification](https://avro.apache.org/docs/1.8.1/spec.html#Logical+Types) are not available as constants via the Avro Java API ([they have private access](https://github.com/apache/avro/blob/branch-1.8/lang/java/avro/src/main/java/org/apache/avro/LogicalTypes.java#L94)). This is definitely undesirable, but I couldn't think of a satisfactory workaround.
