### PR TITLE
Introducing a new config: kafkastore.bootstrap.servers

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -38,6 +38,7 @@ public class SchemaRegistryConfig extends RestConfig {
   public static final String KAFKASTORE_SECURITY_PROTOCOL_PLAINTEXT = "PLAINTEXT";
 
   public static final String KAFKASTORE_CONNECTION_URL_CONFIG = "kafkastore.connection.url";
+  public static final String KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG = "kafkastore.bootstrap.servers";
   /**
    * <code>kafkastore.zk.session.timeout.ms</code>
    */
@@ -113,6 +114,15 @@ public class SchemaRegistryConfig extends RestConfig {
       "kafkastore.ssl.endpoint.identification.algorithm";
   protected static final String KAFKASTORE_CONNECTION_URL_DOC =
       "Zookeeper url for the Kafka cluster";
+  protected static final String KAFKASTORE_BOOTSTRAP_SERVERS_DOC =
+      "A list of Kafka brokers to connect to. For example, `PLAINTEXT://hostname:9092,SSL://hostname2:9092`\n"
+      + "\n"
+      + "If this configuration is not specified, the Schema Registry's internal Kafka clients will get their Kafka bootstrap server list\n"
+      + "from ZooKeeper (configured with `kafkastore.connection.url`). Note that if `kafkastore.bootstrap.servers` is configured,\n"
+      + "`kafkastore.connection.url` still needs to be configured, too.\n"
+      + "\n"
+      + "This configuration is particularly important when Kafka security is enabled, because Kafka may expose multiple endpoints that\n"
+      + "all will be stored in ZooKeeper, but the Schema Registry may need to be configured with just one of those endpoints.";
   protected static final String SCHEMAREGISTRY_ZK_NAMESPACE_DOC =
       "The string that is used as the zookeeper namespace for storing schema registry "
       + "metadata. SchemaRegistry instances which are part of the same schema registry service "
@@ -199,6 +209,8 @@ public class SchemaRegistryConfig extends RestConfig {
                         ConfigDef.Importance.HIGH,
                         RESPONSE_MEDIATYPE_DEFAULT_CONFIG_DOC)
         .define(KAFKASTORE_CONNECTION_URL_CONFIG, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH,
+                KAFKASTORE_CONNECTION_URL_DOC)
+        .define(KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, ConfigDef.Type.LIST, "", ConfigDef.Importance.MEDIUM,
                 KAFKASTORE_CONNECTION_URL_DOC)
         .define(SCHEMAREGISTRY_ZK_NAMESPACE, ConfigDef.Type.STRING,
                 DEFAULT_SCHEMAREGISTRY_ZK_NAMESPACE,

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
@@ -16,8 +16,6 @@
 package io.confluent.kafka.schemaregistry.storage;
 
 import kafka.cluster.Broker;
-import kafka.cluster.EndPoint;
-import kafka.utils.TestUtils;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.protocol.SecurityProtocol;
 import org.junit.After;
@@ -29,12 +27,9 @@ import org.slf4j.LoggerFactory;
 import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreInitializationException;
-import scala.collection.JavaConversions;
-import scala.collection.Seq;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -258,47 +253,58 @@ public class KafkaStoreTest extends ClusterTestHarness {
   }
 
   @Test
-  public void testGetBrokerEndpointsSinglePlaintext() {
-    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(zkConnect,
-            zkClient);
-    Seq<Broker> brokersSeq = zkUtils.getAllBrokersInCluster();
-    List<Broker> brokersList = JavaConversions.seqAsJavaList(brokersSeq);
-
-    Iterator<EndPoint> endpoints =
-            JavaConversions.asJavaCollection(brokersList.get(0).endPoints().values()).iterator();
-    String expectedEndpoint = endpoints.next().connectionString();
-
-    assertEquals("Expected one PLAINTEXT endpoint for localhost", expectedEndpoint,
-            KafkaStore.getBrokerEndpoints(brokersList));
+  public void testFilterBrokerEndpointsSinglePlaintext() {
+    String endpoint = "PLAINTEXT://hostname:1234";
+    List<String> endpointsList = new ArrayList<String>();
+    endpointsList.add("PLAINTEXT://hostname:1234");
+    assertEquals("Expected one PLAINTEXT endpoint for localhost", endpoint,
+            KafkaStore.filterBrokerEndpoints(endpointsList));
   }
 
   @Test(expected = ConfigException.class)
   public void testGetBrokerEndpointsEmpty() {
-    KafkaStore.getBrokerEndpoints(new ArrayList<Broker>());
+    KafkaStore.filterBrokerEndpoints(new ArrayList<String>());
   }
 
-  /**
-   * This test creates brokers with different security protocols. This scenario
-   * where different brokers in the same cluster support different security endpoints wouldn't exist.
-   * However, this setup creates the needed test scenario for getBrokerEndpoints().
-   */
   @Test
   public void testGetBrokerEndpointsMixed() throws IOException {
-    List<Broker> brokersList = new ArrayList<Broker>(3);
-    brokersList.add(new Broker(0, "localhost", TestUtils.RandomPort(), SecurityProtocol.PLAINTEXT));
-    brokersList.add(new Broker(1, "localhost1", TestUtils.RandomPort(), SecurityProtocol.PLAINTEXT));
-    brokersList.add(new Broker(2, "localhost2", TestUtils.RandomPort(), SecurityProtocol.SASL_PLAINTEXT));
-    brokersList.add(new Broker(3, "localhost3", TestUtils.RandomPort(), SecurityProtocol.SSL));
+    List<String> endpointsList = new ArrayList<String>(4);
+    endpointsList.add("PLAINTEXT://localhost:1234");
+    endpointsList.add("PLAINTEXT://localhost1:1234");
+    endpointsList.add("SASL_PLAINTEXT://localhost1:1235");
+    endpointsList.add("SSL://localhost1:1236");
 
-    String endpointsString = KafkaStore.getBrokerEndpoints(brokersList);
+    String endpointsString = KafkaStore.filterBrokerEndpoints(endpointsList);
     String[] endpoints = endpointsString.split(",");
-    assertEquals("Expected a different number of endpoints.", brokersList.size() - 1, endpoints.length);
+    assertEquals("Expected a different number of endpoints.", endpointsList.size() - 1, endpoints.length);
     for (String endpoint : endpoints) {
-      if (endpoint.contains("localhost3")) {
+      if (endpoint.contains("localhost1:1236")) {
         assertTrue("Endpoint must be a SSL endpoint.", endpoint.contains("SSL://"));
       } else {
         assertTrue("Endpoint must be a PLAINTEXT endpoint.", endpoint.contains("PLAINTEXT://"));
       }
+    }
+  }
+
+  @Test
+  public void testBrokersToEndpoints() {
+    List<Broker> brokersList = new ArrayList<Broker>(4);
+    brokersList.add(new Broker(0, "localhost", 1, SecurityProtocol.PLAINTEXT));
+    brokersList.add(new Broker(1, "localhost1", 12, SecurityProtocol.PLAINTEXT));
+    brokersList.add(new Broker(2, "localhost2", 123, SecurityProtocol.SASL_PLAINTEXT));
+    brokersList.add(new Broker(3, "localhost3", 1234, SecurityProtocol.SSL));
+    List<String> endpointsList = KafkaStore.brokersToEndpoints((brokersList));
+
+    List<String> expected = new ArrayList<String>(4);
+    expected.add("PLAINTEXT://localhost:1");
+    expected.add("PLAINTEXT://localhost1:12");
+    expected.add("SASL_PLAINTEXT://localhost2:123");
+    expected.add("SSL://localhost3:1234");
+
+    assertEquals("Expected the same size list.", expected.size(), endpointsList.size());
+
+    for (int i = 0; i < endpointsList.size(); i++) {
+      assertEquals("Expected a different endpoint", expected.get(i), endpointsList.get(i));
     }
   }
 }

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -240,6 +240,20 @@ Configuration Options
   * Default: "" (Jetty's default)
   * Importance: medium
 
+``kafkastore.bootstrap.servers``
+  A list of Kafka brokers to connect to. For example, `PLAINTEXT://hostname:9092,SSL://hostname2:9092`
+
+  If this configuration is not specified, the Schema Registry's internal Kafka clients will get their Kafka bootstrap server list
+  from ZooKeeper (configured with `kafkastore.connection.url`). Note that if `kafkastore.bootstrap.servers` is configured,
+  `kafkastore.connection.url` still needs to be configured, too.
+
+  This configuration is particularly important when Kafka security is enabled, because Kafka may expose multiple endpoints that
+  all will be stored in ZooKeeper, but the Schema Registry may need to be configured with just one of those endpoints.
+
+ * Type: list
+ * Default: "" (when left blank, bootstrap servers are fetched from ZooKeeper)
+ * Importance: medium
+
 ``access.control.allow.origin``
   Set value for Jetty Access-Control-Allow-Origin header
 


### PR DESCRIPTION
Addresses this issue: https://github.com/confluentinc/schema-registry/issues/335, where a Schema Registry operator may want to configure their own Kafka bootstrap servers instead of using what's stored in ZooKeeper.