### PR TITLE
Added get all subjects.

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -171,5 +171,9 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
     return response.getCompatibilityLevel();
   }
 
+  @Override
+  public List<String> getAllSubjects() throws IOException, RestClientException {
+    return restService.getAllSubjects();
+  }
 
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -23,6 +23,7 @@ import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientExcept
 import org.apache.avro.Schema;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -172,7 +173,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
-  public List<String> getAllSubjects() throws IOException, RestClientException {
+  public Collection<String> getAllSubjects() throws IOException, RestClientException {
     return restService.getAllSubjects();
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -20,8 +20,10 @@ import org.apache.avro.Schema;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -227,5 +229,13 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
       compatibility = defaultCompatibility;
     }
     return compatibility;
+  }
+
+  @Override
+  public List<String> getAllSubjects() throws IOException, RestClientException {
+    List<String> results = new ArrayList<>();
+    results.addAll(this.schemaCache.keySet());
+    Collections.sort(results, String.CASE_INSENSITIVE_ORDER);
+    return results;
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -19,8 +19,8 @@ import org.apache.avro.Schema;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -232,7 +232,7 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
-  public List<String> getAllSubjects() throws IOException, RestClientException {
+  public Collection<String> getAllSubjects() throws IOException, RestClientException {
     List<String> results = new ArrayList<>();
     results.addAll(this.schemaCache.keySet());
     Collections.sort(results, String.CASE_INSENSITIVE_ORDER);

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -18,7 +18,7 @@ package io.confluent.kafka.schemaregistry.client;
 import org.apache.avro.Schema;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Collection;
 
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 
@@ -40,5 +40,5 @@ public interface SchemaRegistryClient {
 
   public String getCompatibility(String subject) throws IOException, RestClientException;
 
-  public List<String> getAllSubjects() throws IOException, RestClientException;
+  public Collection<String> getAllSubjects() throws IOException, RestClientException;
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -18,6 +18,7 @@ package io.confluent.kafka.schemaregistry.client;
 import org.apache.avro.Schema;
 
 import java.io.IOException;
+import java.util.List;
 
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 
@@ -38,4 +39,6 @@ public interface SchemaRegistryClient {
   public String updateCompatibility(String subject, String compatibility) throws IOException, RestClientException;
 
   public String getCompatibility(String subject) throws IOException, RestClientException;
+
+  public List<String> getAllSubjects() throws IOException, RestClientException;
 }


### PR DESCRIPTION
The call to return all of the subjects for a schema registry instance was not implemented on the client. Added to interface, mock, & cache.