### PR TITLE
Change STDOUT filename to schemaRegistry.out from nohup.out

### DIFF
--- a/bin/schema-registry-run-class
+++ b/bin/schema-registry-run-class
@@ -16,6 +16,8 @@
 
 base_dir=$(dirname $0)/..
 
+
+
 # Development jars. `mvn package` should collect all the required dependency jars here
 for dir in $base_dir/package-schema-registry/target/kafka-schema-registry-package-*-development; do
   CLASSPATH=$CLASSPATH:$dir/share/java/schema-registry/*
@@ -110,7 +112,7 @@ fi
 
 # Launch mode
 if [ "x$DAEMON_MODE" = "xtrue" ]; then
-  nohup $JAVA $SCHEMA_REGISTRY_HEAP_OPTS $SCHEMA_REGISTRY_JVM_PERFORMANCE_OPTS $SCHEMA_REGISTRY_JMX_OPTS $SCHEMA_REGISTRY_LOG4J_OPTS -cp $CLASSPATH $SCHEMA_REGISTRY_OPTS "$MAIN" "$@" 2>&1 < /dev/null &
+  nohup $JAVA $SCHEMA_REGISTRY_HEAP_OPTS $SCHEMA_REGISTRY_JVM_PERFORMANCE_OPTS $SCHEMA_REGISTRY_JMX_OPTS $SCHEMA_REGISTRY_LOG4J_OPTS -cp $CLASSPATH $SCHEMA_REGISTRY_OPTS "$MAIN" "$@" > "$LOG_DIR/schemaRegistry.out" 2>&1 < /dev/null &
 else
   exec $JAVA $SCHEMA_REGISTRY_HEAP_OPTS $SCHEMA_REGISTRY_JVM_PERFORMANCE_OPTS $SCHEMA_REGISTRY_JMX_OPTS $SCHEMA_REGISTRY_LOG4J_OPTS -cp $CLASSPATH $SCHEMA_REGISTRY_OPTS "$MAIN" "$@"
 fi


### PR DESCRIPTION

## The Problem

Running a schema-registry instance create `nohup.out` in current directory (`$PWD`)

## Solution

Changed STDOUT filename to `$LOG_DIR/schemaRegistry.out` from `$PWD/nohup.out` for better default configuration

## Alternatives

Also, we can add `-name` command like `kafka-run-class.sh`. For example,

```shell
while [ $# -gt 0 ]; do
  COMMAND=$1
  case $COMMAND in
    -name)
      DAEMON_NAME=$2
      CONSOLE_OUTPUT_FILE=$LOG_DIR/$DAEMON_NAME.out
      shift 2
      ;;

     ...
     ...

if [ "x$DAEMON_MODE" = "xtrue" ]; then
  nohup $JAVA $KAFKA_HEAP_OPTS $KAFKA_JVM_PERFORMANCE_OPTS $KAFKA_GC_LOG_OPTS $KAFKA_JMX_OPTS $KAFKA_LOG4J_OPTS -cp $CLASSPATH $KAFKA_OPTS "$@" > "$CONSOLE_OUTPUT_FILE" 2>&1 < /dev/null &
else

```

It would be better solution if users launch multiple schema-registry instances in a single node