### PR TITLE
Option to apply fully transitive schema compatibility checking

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityChecker.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityChecker.java
@@ -89,7 +89,7 @@ public class AvroCompatibilityChecker {
    * @param previousSchemas Full schema history in chronological order
    */
   public boolean isCompatible(Schema newSchema, List<Schema> previousSchemas) {
-      List<Schema> previousSchemasCopy = new ArrayList<>(previousSchemas);
+    List<Schema> previousSchemasCopy = new ArrayList<>(previousSchemas);
     try {
       // Validator checks in list order, but checks should occur in reverse chronological order
       Collections.reverse(previousSchemasCopy);

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityLevel.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityLevel.java
@@ -18,8 +18,11 @@ package io.confluent.kafka.schemaregistry.avro;
 public enum AvroCompatibilityLevel {
   NONE("NONE", AvroCompatibilityChecker.NO_OP_CHECKER),
   BACKWARD("BACKWARD", AvroCompatibilityChecker.BACKWARD_CHECKER),
+  BACKWARD_TRANSITIVE("BACKWARD_TRANSITIVE", AvroCompatibilityChecker.BACKWARD_TRANSITIVE_CHECKER),
   FORWARD("FORWARD", AvroCompatibilityChecker.FORWARD_CHECKER),
-  FULL("FULL", AvroCompatibilityChecker.FULL_CHECKER);
+  FORWARD_TRANSITIVE("FORWARD_TRANSITIVE", AvroCompatibilityChecker.FORWARD_TRANSITIVE_CHECKER),
+  FULL("FULL", AvroCompatibilityChecker.FULL_CHECKER),
+  FULL_TRANSITIVE("FULL_TRANSITIVE", AvroCompatibilityChecker.FULL_TRANSITIVE_CHECKER);
 
   public final String name;
   public final AvroCompatibilityChecker compatibilityChecker;
@@ -43,8 +46,15 @@ public enum AvroCompatibilityLevel {
       return FORWARD;
     } else if (FULL.name.equals(name)) {
       return FULL;
+    } else if (BACKWARD_TRANSITIVE.name.equals(name)) {
+      return BACKWARD_TRANSITIVE;
+    } else if (FORWARD_TRANSITIVE.name.equals(name)) {
+      return FORWARD_TRANSITIVE;
+    } else if (FULL_TRANSITIVE.name.equals(name)) {
+      return FULL_TRANSITIVE;
     } else {
       return null;
     }
   }
+  
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -124,17 +124,17 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   @Override
   public SchemaMetadata getSchemaMetadata(String subject, int version) throws IOException, RestClientException {
     io.confluent.kafka.schemaregistry.client.rest.entities.Schema response
-    = restService.getVersion(subject, version);
-   int id = response.getId();
-   String schema = response.getSchema();
-   return new SchemaMetadata(id, version, schema);
+      = restService.getVersion(subject, version);
+    int id = response.getId();
+    String schema = response.getSchema();
+    return new SchemaMetadata(id, version, schema);
   }
 
   @Override
   public synchronized SchemaMetadata getLatestSchemaMetadata(String subject)
       throws IOException, RestClientException {
     io.confluent.kafka.schemaregistry.client.rest.entities.Schema response
-     = restService.getLatestVersion(subject);
+      = restService.getLatestVersion(subject);
     int id = response.getId();
     int version = response.getVersion();
     String schema = response.getSchema();

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -122,6 +122,15 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
+  public SchemaMetadata getSchemaMetadata(String subject, int version) throws IOException, RestClientException {
+    io.confluent.kafka.schemaregistry.client.rest.entities.Schema response
+    = restService.getVersion(subject, version);
+   int id = response.getId();
+   String schema = response.getSchema();
+   return new SchemaMetadata(id, version, schema);
+  }
+
+  @Override
   public synchronized SchemaMetadata getLatestSchemaMetadata(String subject)
       throws IOException, RestClientException {
     io.confluent.kafka.schemaregistry.client.rest.entities.Schema response

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -32,6 +32,8 @@ public interface SchemaRegistryClient {
 
   public SchemaMetadata getLatestSchemaMetadata(String subject) throws IOException, RestClientException;
 
+  public SchemaMetadata getSchemaMetadata(String subject, int version) throws IOException, RestClientException;
+
   public int getVersion(String subject, Schema schema) throws IOException, RestClientException;
 
   public boolean testCompatibility(String subject, Schema schema) throws IOException, RestClientException;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -737,7 +737,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry {
       throws SchemaRegistryException {
     if (latestSchema == null) {
       throw new InvalidSchemaException(
-        "Latest schema not provided");
+          "Latest schema not provided");
     }
     return isCompatible(subject, newSchemaObj, Collections.singletonList(latestSchema));
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
@@ -16,6 +16,7 @@
 package io.confluent.kafka.schemaregistry.storage;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.Set;
 
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
@@ -41,9 +42,14 @@ public interface SchemaRegistry {
 
   Schema lookUpSchemaUnderSubject(String subject, Schema schema) throws SchemaRegistryException;
 
-  public boolean isCompatible(String subject,
-                              String inputSchema,
-                              String targetSchema) throws SchemaRegistryException;
+  boolean isCompatible(String subject,
+                       String inputSchema,
+                       String targetSchema) throws SchemaRegistryException;
+
+  boolean isCompatible(String subject,
+                       String newSchema,
+                       List<String> previousSchemas) throws SchemaRegistryException;
 
   void close();
+
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityTest.java
@@ -184,7 +184,7 @@ public class AvroCompatibilityTest {
    * and transitively forward compatible with the entire schema history.
    */
   @Test
-  public void testBasicFullTransitvityCompatibility() {
+  public void testBasicFullTransitiveCompatibility() {
     AvroCompatibilityChecker checker = AvroCompatibilityChecker.FULL_TRANSITIVE_CHECKER;
     
     // Simple check

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityTest.java
@@ -21,72 +21,192 @@ import org.junit.Test;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+import java.util.Collections;
+
 public class AvroCompatibilityTest {
 
+  private final String schemaString1 = "{\"type\":\"record\","
+      + "\"name\":\"myrecord\","
+      + "\"fields\":"
+      + "[{\"type\":\"string\",\"name\":\"f1\"}]}";
+  private final Schema schema1 = AvroUtils.parseSchema(schemaString1).schemaObj;
+  
+  private final String schemaString2 = "{\"type\":\"record\","
+      + "\"name\":\"myrecord\","
+      + "\"fields\":"
+      + "[{\"type\":\"string\",\"name\":\"f1\"},"
+      + " {\"type\":\"string\",\"name\":\"f2\", \"default\": \"foo\"}]}";
+  private final Schema schema2 = AvroUtils.parseSchema(schemaString2).schemaObj;
+  
+  private final String schemaString3 = "{\"type\":\"record\","
+      + "\"name\":\"myrecord\","
+      + "\"fields\":"
+      + "[{\"type\":\"string\",\"name\":\"f1\"},"
+      + " {\"type\":\"string\",\"name\":\"f2\"}]}";
+  private final Schema schema3 = AvroUtils.parseSchema(schemaString3).schemaObj;
+  
+  private final String schemaString4 = "{\"type\":\"record\","
+      + "\"name\":\"myrecord\","
+      + "\"fields\":"
+      + "[{\"type\":\"string\",\"name\":\"f1_new\", \"aliases\": [\"f1\"]}]}";
+  private final Schema schema4 = AvroUtils.parseSchema(schemaString4).schemaObj;
+  
+  private final String schemaString6 = "{\"type\":\"record\","
+      + "\"name\":\"myrecord\","
+      + "\"fields\":"
+      + "[{\"type\":[\"null\", \"string\"],\"name\":\"f1\","
+      + " \"doc\":\"doc of f1\"}]}";
+  private final Schema schema6 = AvroUtils.parseSchema(schemaString6).schemaObj;
+  
+  private final String schemaString7 = "{\"type\":\"record\","
+      + "\"name\":\"myrecord\","
+      + "\"fields\":"
+      + "[{\"type\":[\"null\", \"string\", \"int\"],\"name\":\"f1\","
+      + " \"doc\":\"doc of f1\"}]}";
+  private final Schema schema7 = AvroUtils.parseSchema(schemaString7).schemaObj;
+
+  private final String schemaString8 = "{\"type\":\"record\","
+      + "\"name\":\"myrecord\","
+      + "\"fields\":"
+      + "[{\"type\":\"string\",\"name\":\"f1\"},"
+      + " {\"type\":\"string\",\"name\":\"f2\", \"default\": \"foo\"}]},"
+      + " {\"type\":\"string\",\"name\":\"f3\", \"default\": \"bar\"}]}";
+  private final Schema schema8 = AvroUtils.parseSchema(schemaString8).schemaObj;
+  
+  /*
+   * Backward compatibility: A new schema is backward compatible if it can be used to read the data
+   * written in the previous schema.
+   */
   @Test
-  public void testBasicCompatibility() {
-    String schemaString1 = "{\"type\":\"record\","
-                           + "\"name\":\"myrecord\","
-                           + "\"fields\":"
-                           + "[{\"type\":\"string\",\"name\":\"f1\"}]}";
-    Schema schema1 = AvroUtils.parseSchema(schemaString1).schemaObj;
-
-    String schemaString2 = "{\"type\":\"record\","
-                           + "\"name\":\"myrecord\","
-                           + "\"fields\":"
-                           + "[{\"type\":\"string\",\"name\":\"f1\"},"
-                           + " {\"type\":\"string\",\"name\":\"f2\", \"default\": \"foo\"}]}";
-    Schema schema2 = AvroUtils.parseSchema(schemaString2).schemaObj;
-
-    String schemaString3 = "{\"type\":\"record\","
-                           + "\"name\":\"myrecord\","
-                           + "\"fields\":"
-                           + "[{\"type\":\"string\",\"name\":\"f1\"},"
-                           + " {\"type\":\"string\",\"name\":\"f2\"}]}";
-    Schema schema3 = AvroUtils.parseSchema(schemaString3).schemaObj;
-
-    String schemaString4 = "{\"type\":\"record\","
-                           + "\"name\":\"myrecord\","
-                           + "\"fields\":"
-                           + "[{\"type\":\"string\",\"name\":\"f1_new\", \"aliases\": [\"f1\"]}]}";
-    Schema schema4 = AvroUtils.parseSchema(schemaString4).schemaObj;
-
-    String schemaString6 = "{\"type\":\"record\","
-                           + "\"name\":\"myrecord\","
-                           + "\"fields\":"
-                           + "[{\"type\":[\"null\", \"string\"],\"name\":\"f1\","
-                           + " \"doc\":\"doc of f1\"}]}";
-    Schema schema6 = AvroUtils.parseSchema(schemaString6).schemaObj;
-
-    String schemaString7 = "{\"type\":\"record\","
-                           + "\"name\":\"myrecord\","
-                           + "\"fields\":"
-                           + "[{\"type\":[\"null\", \"string\", \"int\"],\"name\":\"f1\","
-                           + " \"doc\":\"doc of f1\"}]}";
-    Schema schema7 = AvroUtils.parseSchema(schemaString7).schemaObj;
-
-    AvroCompatibilityChecker backwardChecker = AvroCompatibilityChecker.BACKWARD_CHECKER;
+  public void testBasicBackwardsCompatibility() {
+    AvroCompatibilityChecker checker = AvroCompatibilityChecker.BACKWARD_CHECKER;
     assertTrue("adding a field with default is a backward compatible change",
-               backwardChecker.isCompatible(schema2, schema1));
+               checker.isCompatible(schema2, Collections.singletonList(schema1)));
     assertFalse("adding a field w/o default is not a backward compatible change",
-                backwardChecker.isCompatible(schema3, schema1));
+                checker.isCompatible(schema3, Collections.singletonList(schema1)));
     assertFalse("changing field name is not a backward compatible change",
-                backwardChecker.isCompatible(schema4, schema1));
+                checker.isCompatible(schema4, Collections.singletonList(schema1)));
     assertTrue("evolving a field type to a union is a backward compatible change",
-               backwardChecker.isCompatible(schema6, schema1));
+               checker.isCompatible(schema6, Collections.singletonList(schema1)));
     assertFalse("removing a type from a union is not a backward compatible change",
-                backwardChecker.isCompatible(schema1, schema6));
+                checker.isCompatible(schema1, Collections.singletonList(schema6)));
     assertTrue("adding a new type in union is a backward compatible change",
-               backwardChecker.isCompatible(schema7, schema6));
+               checker.isCompatible(schema7, Collections.singletonList(schema6)));
     assertFalse("removing a type from a union is not a backward compatible change",
-                backwardChecker.isCompatible(schema6, schema7));
-
-    AvroCompatibilityChecker forwardChecker = AvroCompatibilityChecker.FORWARD_CHECKER;
-    assertTrue("adding a field is a forward compatible change",
-               forwardChecker.isCompatible(schema2, schema1));
-
-    AvroCompatibilityChecker fullChecker = AvroCompatibilityChecker.FULL_CHECKER;
-    assertTrue("adding a field with default is a backward and a forward compatible change",
-               fullChecker.isCompatible(schema2, schema1));
+                checker.isCompatible(schema6, Collections.singletonList(schema7)));
+    
+    // Only schema 2 is checked
+    assertTrue("removing a default is not a transitively compatible change",
+        checker.isCompatible(schema3, Arrays.asList(schema1, schema2)));
   }
+  
+  /*
+   * Backward transitive compatibility: A new schema is backward compatible if it can be used to read the data
+   * written in all previous schemas.
+   */
+  @Test
+  public void testBasicBackwardsTransitiveCompatibility() {
+    AvroCompatibilityChecker checker = AvroCompatibilityChecker.BACKWARD_TRANSITIVE_CHECKER;
+    // All compatible
+    assertTrue("iteratively adding fields with defaults is a compatible change",
+        checker.isCompatible(schema8, Arrays.asList(schema1, schema2)));
+    
+    // 1 == 2, 2 == 3, 3 != 1
+    assertTrue("adding a field with default is a backward compatible change",
+        checker.isCompatible(schema2, Collections.singletonList(schema1)));
+    assertTrue("removing a default is a compatible change, but not transitively",
+        checker.isCompatible(schema3, Arrays.asList(schema2)));
+    assertFalse("removing a default is not a transitively compatible change",
+        checker.isCompatible(schema3, Arrays.asList(schema2, schema1)));
+  }
+  
+  /*
+   * Forward compatibility: A new schema is forward compatible if the previous schema can read data written in this
+   * schema.
+   */
+  @Test
+  public void testBasicForwardsCompatibility() {
+    AvroCompatibilityChecker checker = AvroCompatibilityChecker.FORWARD_CHECKER;
+    assertTrue("adding a field is a forward compatible change",
+        checker.isCompatible(schema2, Collections.singletonList(schema1)));
+    assertTrue("adding a field is a forward compatible change",
+        checker.isCompatible(schema3, Collections.singletonList(schema1)));
+    assertTrue("adding a field is a forward compatible change",
+        checker.isCompatible(schema3, Collections.singletonList(schema2)));
+    assertTrue("adding a field is a forward compatible change",
+        checker.isCompatible(schema2, Collections.singletonList(schema3)));
+    
+    // Only schema 2 is checked
+    assertTrue("removing a default is not a transitively compatible change",
+        checker.isCompatible(schema1, Arrays.asList(schema3, schema2)));
+  }
+  
+  /*
+   * Forward transitive compatibility: A new schema is forward compatible if all previous schemas can read data written
+   * in this schema.
+   */
+  @Test
+  public void testBasicForwardsTransitiveCompatibility() {
+    AvroCompatibilityChecker checker = AvroCompatibilityChecker.FORWARD_TRANSITIVE_CHECKER;
+    // All compatible
+    assertTrue("iteratively removing fields with defaults is a compatible change",
+        checker.isCompatible(schema1, Arrays.asList(schema8, schema2)));
+    
+    // 1 == 2, 2 == 3, 3 != 1
+    assertTrue("adding default to a field is a compatible change",
+        checker.isCompatible(schema2, Collections.singletonList(schema3)));
+    assertTrue("removing a field with a default is a compatible change",
+        checker.isCompatible(schema1, Arrays.asList(schema2)));
+    assertFalse("removing a default is not a transitively compatible change",
+        checker.isCompatible(schema1, Arrays.asList(schema2, schema3)));
+  }
+  
+  /*
+   * Full compatibility: A new schema is fully compatible if it’s both backward and forward compatible.
+   */
+  @Test
+  public void testBasicFullCompatibility() {
+    AvroCompatibilityChecker checker = AvroCompatibilityChecker.FULL_CHECKER;
+    assertTrue("adding a field with default is a backward and a forward compatible change",
+        checker.isCompatible(schema2, Collections.singletonList(schema1)));
+    
+    // Only schema 2 is checked!
+    assertTrue("transitively adding a field without a default is not a compatible change",
+        checker.isCompatible(schema3, Arrays.asList(schema1, schema2)));
+    // Only schema 2 is checked!
+    assertTrue("transitively removing a field without a default is not a compatible change",
+        checker.isCompatible(schema1, Arrays.asList(schema3, schema2)));
+  }
+  
+  /*
+   * Full transitive compatibility: A new schema is fully compatible if it’s both transitively backward
+   * and transitively forward compatible with the entire schema history.
+   */
+  @Test
+  public void testBasicFullTransitvityCompatibility() {
+    AvroCompatibilityChecker checker = AvroCompatibilityChecker.FULL_TRANSITIVE_CHECKER;
+    
+    // Simple check
+    assertTrue("iteratively adding fields with defaults is a compatible change",
+        checker.isCompatible(schema8, Arrays.asList(schema1, schema2)));
+    assertTrue("iteratively removing fields with defaults is a compatible change",
+        checker.isCompatible(schema1, Arrays.asList(schema8, schema2)));
+    
+    assertTrue("adding default to a field is a compatible change",
+        checker.isCompatible(schema2, Collections.singletonList(schema3)));
+    assertTrue("removing a field with a default is a compatible change",
+        checker.isCompatible(schema1, Arrays.asList(schema2)));
+    
+    assertTrue("adding a field with default is a compatible change",
+        checker.isCompatible(schema2, Collections.singletonList(schema1)));
+    assertTrue("removing a default from a field compatible change",
+        checker.isCompatible(schema3, Arrays.asList(schema2)));
+
+    assertFalse("transitively adding a field without a default is not a compatible change",
+        checker.isCompatible(schema3, Arrays.asList(schema2, schema1)));
+    assertFalse("transitively removing a field without a default is not a compatible change",
+        checker.isCompatible(schema1, Arrays.asList(schema2, schema3)));
+  }
+  
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTransitiveCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTransitiveCompatibilityTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Confluent Inc.
+ * Copyright 2016 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTransitiveCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTransitiveCompatibilityTest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2014 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.kafka.schemaregistry.rest;
+
+import io.confluent.kafka.schemaregistry.ClusterTestHarness;
+import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
+import io.confluent.kafka.schemaregistry.avro.AvroUtils;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.schemaregistry.rest.exceptions.RestIncompatibleAvroSchemaException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class RestApiTransitiveCompatibilityTest extends ClusterTestHarness {
+
+  String baseSchema = AvroUtils.parseSchema(
+      "{\"type\":\"record\","
+      + "\"name\":\"myrecord\","
+      + "\"fields\":"
+      + "[{\"type\":\"string\",\"name\":\"f1\"}]}")
+      .canonicalString;
+  
+  String baseSchemaWithColumnWithDefault = AvroUtils.parseSchema(
+      "{\"type\":\"record\","
+      + "\"name\":\"myrecord\","
+      + "\"fields\":"
+      + "[{\"type\":\"string\",\"name\":\"f1\"},"
+      + " {\"type\":\"string\",\"name\":\"f2\", \"default\": \"foo\"}]}"
+      ).canonicalString;
+  
+  String baseSchemaWithColumnNoDefault = AvroUtils.parseSchema(
+      "{\"type\":\"record\","
+      + "\"name\":\"myrecord\","
+      + "\"fields\":"
+      + "[{\"type\":\"string\",\"name\":\"f1\"},"
+      + " {\"type\":\"string\",\"name\":\"f2\"}]}"
+  ).canonicalString;
+  
+  
+  public RestApiTransitiveCompatibilityTest() {
+    super(1, true, AvroCompatibilityLevel.BACKWARD_TRANSITIVE.name);
+  }
+
+  /* Confirm that removing a default in from a column that was added earlier is not compatible. */
+  @Test
+  public void testCompatibility() throws Exception {
+    String subject = "testSubject";
+
+    // register a valid avro
+    int expectedIdSchema1 = 1;
+    assertEquals("Registering should succeed",
+            expectedIdSchema1,
+            restApp.restClient.registerSchema(baseSchema, subject));
+
+    // register a backward compatible avro
+    int expectedIdSchema2 = 2;
+    assertEquals("Registering a compatible schema should succeed",
+                 expectedIdSchema2,
+                 restApp.restClient.registerSchema(baseSchemaWithColumnWithDefault, subject));
+    
+    // register an incompatible avro
+    String incompatibleSchemaString = baseSchemaWithColumnNoDefault;
+    try {
+      restApp.restClient.registerSchema(incompatibleSchemaString, subject);
+      fail("Registering an incompatible schema should fail");
+    } catch (RestClientException e) {
+      // this is expected.
+      assertEquals("Should get a conflict status",
+                   RestIncompatibleAvroSchemaException.DEFAULT_ERROR_CODE,
+                   e.getStatus());
+    }
+  }
+  
+  /* Confirm that removing a default in isolation is compatible. */
+  @Test
+  public void validateTransitiveEffect() throws Exception {
+    String subject = "testSubject";
+
+    // register a valid avro
+    int expectedIdSchema1 = 1;
+    assertEquals("Registering should succeed",
+            expectedIdSchema1,
+            restApp.restClient.registerSchema(baseSchemaWithColumnWithDefault, subject));
+
+    // register a backward compatible avro
+    int expectedIdSchema2 = 2;
+    assertEquals("Registering a compatible schema should succeed",
+                 expectedIdSchema2,
+                 restApp.restClient.registerSchema(baseSchemaWithColumnNoDefault, subject));
+  }
+}


### PR DESCRIPTION
This pull-request attempts to bring fully transitive schema compatibility checks to the **schema-registry**.

# Background
It has been [noted previously](https://github.com/granders/avro-experiment/blob/master/src/main/java/geoff/AvroThingy.java) that it is possible to generate a sequence of Avro schemas that are incrementally compatible yet the sequence does exhibit full transitive compatibility. For example, given the schema sequence `[A, B, C]`, it is quite possible that `B` is compatible with `A` and `C` is compatible with `B` yet `C` is not compatible with `A`. This situation arises with two Avro schema features: the toggling of `defaults` and the use of `aliases`. The breaking of transitive compatibility has been highlighted as one reason why [support for `aliases` in the **schema-registry**](https://groups.google.com/d/topic/confluent-platform/0NlrxFD5FHk/discussion) should not be provided. However, `defaults` are currently supported even though they do break such compatibility.

The ability to break compatibility has been described as a possibly useful feature as it allows a minimum of incremental compatibility in the event that users have no other choice but to register a new transitively incompatible schema. A less desirable alternative would be for users to disable schema checking completely on that data stream. However, another view point is that a sequence of transitively incompatible schemas might break downstream consumers and that such a divergence is better represented as a new and entirely distinct data stream. Irrespective of one's view-point the **schema-registry** does not currently allow users to opt for the stronger, transitive compatibility checks. This functionality was requested in [schema-registry/issue 209](https://github.com/confluentinc/schema-registry/issues/209) and is provided by this pull request.

# Implementation
* Transitive checks are already supported by the Avro API that the **schema-registry** uses to perform compatibility checking. This implementation simply links through the the `ValidateAll` check in addition to the existing `ValidateLatest` behaviour.
* Transitive compatibility levels are represented with additional values in the `AvroCompatibilityLevel` enum.
* New compatibility check functionality exposed via the **schema-registry** APIs.
* Javadoc updated to distinguish between checks against _all previous_ and _latest_ schema instances.
* Relevant test cases added.

