### PR TITLE
Adding support for tinyint values

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -316,12 +316,21 @@ public class AvroData {
     try {
       switch (schemaType) {
         case INT8: {
-          Byte byteValue = (Byte) value; // Check for correct type
+          // To take care of unsigned tinyint values, cast directly to a short.
+          Short shortValue = null;
+          if (value != null)
+            shortValue = Short.valueOf(value.toString());
+          Integer convertedShortValue = shortValue == null ? null : shortValue.intValue();
+          return maybeAddContainer(
+                  avroSchema,
+                  maybeWrapSchemaless(schema, convertedShortValue, ANYTHING_SCHEMA_INT_FIELD),
+                  requireContainer);
+          /*Byte byteValue = (Byte) value; // Check for correct type
           Integer convertedByteValue = byteValue == null ? null : byteValue.intValue();
           return maybeAddContainer(
               avroSchema,
               maybeWrapSchemaless(schema, convertedByteValue, ANYTHING_SCHEMA_INT_FIELD),
-              requireContainer);
+              requireContainer);*/
         }
         case INT16: {
           Short shortValue = (Short) value; // Check for correct type
@@ -456,6 +465,7 @@ public class AvroData {
           throw new DataException("Unknown schema type: " + schema.type());
       }
     } catch (ClassCastException e) {
+      e.printStackTrace();
       throw new DataException("Invalid type for " + schema.type() + ": " + value.getClass());
     }
   }


### PR DESCRIPTION
Based upon the theory provided in the official jdbc documentation, I have added a condition to include both Short and Byte as INT8 types in ConnectSchema.

Here's the doc:

8.3.5 SMALLINT

The JDBC type SMALLINT represents a 16-bit signed integer value between -32768 and 32767.

The corresponding SQL type, SMALLINT, is defined in SQL-92 and is supported by all the major databases. The SQL-92 standard leaves the precision of SMALLINT up to the implementation, but in practice, all the major databases support at least 16 bits.

The recommended Java mapping for the JDBC SMALLINT type is as a Java short.
This would allow kafka-connect-jdbc to allow both signed and unsigned values. Currently it fails for unsigned values(i.e values > 127). The relevant PRs have been sent for kafka-connect-jdbc and kafka projects.