### PR TITLE
Generalize schema incompatibility message.

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityLevel.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityLevel.java
@@ -16,26 +16,20 @@
 package io.confluent.kafka.schemaregistry.avro;
 
 public enum AvroCompatibilityLevel {
-  NONE("NONE", AvroCompatibilityChecker.NO_OP_CHECKER, false),
-  BACKWARD("BACKWARD", AvroCompatibilityChecker.BACKWARD_CHECKER, false),
-  BACKWARD_TRANSITIVE("BACKWARD_TRANSITIVE", AvroCompatibilityChecker.BACKWARD_TRANSITIVE_CHECKER, true),
-  FORWARD("FORWARD", AvroCompatibilityChecker.FORWARD_CHECKER, false),
-  FORWARD_TRANSITIVE("FORWARD_TRANSITIVE", AvroCompatibilityChecker.FORWARD_TRANSITIVE_CHECKER, true),
-  FULL("FULL", AvroCompatibilityChecker.FULL_CHECKER, false),
-  FULL_TRANSITIVE("FULL_TRANSITIVE", AvroCompatibilityChecker.FULL_TRANSITIVE_CHECKER, true);
+  NONE("NONE", AvroCompatibilityChecker.NO_OP_CHECKER),
+  BACKWARD("BACKWARD", AvroCompatibilityChecker.BACKWARD_CHECKER),
+  BACKWARD_TRANSITIVE("BACKWARD_TRANSITIVE", AvroCompatibilityChecker.BACKWARD_TRANSITIVE_CHECKER),
+  FORWARD("FORWARD", AvroCompatibilityChecker.FORWARD_CHECKER),
+  FORWARD_TRANSITIVE("FORWARD_TRANSITIVE", AvroCompatibilityChecker.FORWARD_TRANSITIVE_CHECKER),
+  FULL("FULL", AvroCompatibilityChecker.FULL_CHECKER),
+  FULL_TRANSITIVE("FULL_TRANSITIVE", AvroCompatibilityChecker.FULL_TRANSITIVE_CHECKER);
 
   public final String name;
-  public final boolean transitive;
   public final AvroCompatibilityChecker compatibilityChecker;
 
-  private AvroCompatibilityLevel(String name, AvroCompatibilityChecker compatibilityChecker, boolean transitive) {
+  private AvroCompatibilityLevel(String name, AvroCompatibilityChecker compatibilityChecker) {
     this.name = name;
     this.compatibilityChecker = compatibilityChecker;
-    this.transitive = transitive;
-  }
-  
-  public boolean isTransitive() {
-    return transitive;
   }
 
   public static AvroCompatibilityLevel forName(String name) {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityLevel.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityLevel.java
@@ -16,20 +16,26 @@
 package io.confluent.kafka.schemaregistry.avro;
 
 public enum AvroCompatibilityLevel {
-  NONE("NONE", AvroCompatibilityChecker.NO_OP_CHECKER),
-  BACKWARD("BACKWARD", AvroCompatibilityChecker.BACKWARD_CHECKER),
-  BACKWARD_TRANSITIVE("BACKWARD_TRANSITIVE", AvroCompatibilityChecker.BACKWARD_TRANSITIVE_CHECKER),
-  FORWARD("FORWARD", AvroCompatibilityChecker.FORWARD_CHECKER),
-  FORWARD_TRANSITIVE("FORWARD_TRANSITIVE", AvroCompatibilityChecker.FORWARD_TRANSITIVE_CHECKER),
-  FULL("FULL", AvroCompatibilityChecker.FULL_CHECKER),
-  FULL_TRANSITIVE("FULL_TRANSITIVE", AvroCompatibilityChecker.FULL_TRANSITIVE_CHECKER);
+  NONE("NONE", AvroCompatibilityChecker.NO_OP_CHECKER, false),
+  BACKWARD("BACKWARD", AvroCompatibilityChecker.BACKWARD_CHECKER, false),
+  BACKWARD_TRANSITIVE("BACKWARD_TRANSITIVE", AvroCompatibilityChecker.BACKWARD_TRANSITIVE_CHECKER, true),
+  FORWARD("FORWARD", AvroCompatibilityChecker.FORWARD_CHECKER, false),
+  FORWARD_TRANSITIVE("FORWARD_TRANSITIVE", AvroCompatibilityChecker.FORWARD_TRANSITIVE_CHECKER, true),
+  FULL("FULL", AvroCompatibilityChecker.FULL_CHECKER, false),
+  FULL_TRANSITIVE("FULL_TRANSITIVE", AvroCompatibilityChecker.FULL_TRANSITIVE_CHECKER, true);
 
   public final String name;
+  public final boolean transitive;
   public final AvroCompatibilityChecker compatibilityChecker;
 
-  private AvroCompatibilityLevel(String name, AvroCompatibilityChecker compatibilityChecker) {
+  private AvroCompatibilityLevel(String name, AvroCompatibilityChecker compatibilityChecker, boolean transitive) {
     this.name = name;
     this.compatibilityChecker = compatibilityChecker;
+    this.transitive = transitive;
+  }
+  
+  public boolean isTransitive() {
+    return transitive;
   }
 
   public static AvroCompatibilityLevel forName(String name) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -163,8 +163,8 @@ public class SubjectVersionsResource {
       throw Errors.requestForwardingFailedException("Error while forwarding register schema request"
                                                     + " to the master", e);
     } catch (IncompatibleSchemaException e) {
-      throw Errors.incompatibleSchemaException("Schema being registered is incompatible with the"
-                                               + " latest schema", e);
+      throw Errors.incompatibleSchemaException("Schema being registered is incompatible with an"
+                                               + " earlier schema", e);
     } catch (UnknownMasterException e) {
       throw Errors.unknownMasterException("Master not known.", e);
     } catch (SchemaRegistryException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -366,8 +366,14 @@ public class KafkaSchemaRegistry implements SchemaRegistry {
         kafkaStore.put(keyForNewVersion, schemaValue);
         return schema.getId();
       } else {
-        throw new IncompatibleSchemaException(
-            "New schema is incompatible with the latest schema " + latestSchema);
+        AvroCompatibilityLevel compatibility = getCompatibilityLevel(subject);
+        if (compatibility.isTransitive()) {
+          throw new IncompatibleSchemaException(
+              "New schema is incompatible with an earlier schema.");
+        } else {
+          throw new IncompatibleSchemaException(
+              "New schema is incompatible with the latest schema " + latestSchema);
+        }
       }
     } catch (StoreTimeoutException te) {
       throw new SchemaRegistryTimeoutException("Write to the Kafka store timed out while", te);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -366,14 +366,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry {
         kafkaStore.put(keyForNewVersion, schemaValue);
         return schema.getId();
       } else {
-        AvroCompatibilityLevel compatibility = getCompatibilityLevel(subject);
-        if (compatibility.isTransitive()) {
-          throw new IncompatibleSchemaException(
-              "New schema is incompatible with an earlier schema.");
-        } else {
-          throw new IncompatibleSchemaException(
-              "New schema is incompatible with the latest schema " + latestSchema);
-        }
+        throw new IncompatibleSchemaException(
+            "New schema is incompatible with an earlier schema.");
       }
     } catch (StoreTimeoutException te) {
       throw new SchemaRegistryTimeoutException("Write to the Kafka store timed out while", te);


### PR DESCRIPTION
This patch addresses issue #445 by simply modifying the error message returned to users who attempt to register incompatible schemas. The message has been generalized so that it is not misleading in the event that a schema is transitively incompatible with a schema other than the latest.