### PR TITLE
MINOR: Kafka should be a provided dependency for core too

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -25,6 +25,7 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${kafka.scala.version}</artifactId>
             <version>${kafka.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
I feel kafka should be not be pulled in as a dependency by core schema-registry. It should be a provided dep, as marked for the rest of the submodules. 