### PR TITLE
Handle primitive types when specific.avro.reader is true

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -191,7 +191,9 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaAvroSer
   }
 
   private DatumReader getDatumReader(Schema writerSchema, Schema readerSchema) {
-    if (useSpecificAvroReader) {
+    boolean writerSchemaIsPrimitive = getPrimitiveSchemas().values().contains(writerSchema);
+    // do not use SpecificDatumReader if writerSchema is a primitive
+    if (useSpecificAvroReader && !writerSchemaIsPrimitive) {
       if (readerSchema == null) {
         readerSchema = getReaderSchema(writerSchema);
       }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.SerializationException;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -55,6 +56,10 @@ public abstract class AbstractKafkaAvroSerDe {
   private static Schema createPrimitiveSchema(Schema.Parser parser, String type) {
     String schemaString = String.format("{\"type\" : \"%s\"}", type);
     return parser.parse(schemaString);
+  }
+
+  protected static Map<String, Schema> getPrimitiveSchemas() {
+    return Collections.unmodifiableMap(primitiveSchemas);
   }
 
   protected void configureClientProperties(AbstractKafkaAvroSerDeConfig config) {

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
@@ -309,4 +309,24 @@ public class KafkaAvroSerializerTest {
     avroSerializer.configure(props, false);
   }
 
+  @Test
+  public void testKafkaAvroSerializerSpecificRecordWithPrimitives() {
+    byte[] bytes;
+    Object obj;
+
+    String message = "testKafkaAvroSerializerSpecificRecordWithPrimitives";
+    bytes = avroSerializer.serialize(topic, message);
+
+    obj = avroDecoder.fromBytes(bytes);
+    assertTrue("Returned object should be a String", String.class.isInstance(obj));
+
+    obj = specificAvroDecoder.fromBytes(bytes);
+    assertTrue("Returned object should be a String", String.class.isInstance(obj));
+    assertEquals(message, obj);
+
+    obj = specificAvroDeserializer.deserialize(topic, bytes);
+    assertTrue("Returned object should be a String", String.class.isInstance(obj));
+    assertEquals(message, obj);
+  }
+
 }


### PR DESCRIPTION
The KafkaAvroSerializer can serialize any type of message (primitives or Generic or SpecificRecord[1]) and deserialize them using GenericDatumReader. However, if we want to deserialize the messages into SpecificRecord then both key & value types of message must be SpecificRecord else we will get SerializationException[2], the problem is that the config `specific.avro.reader` is a read time property which will throw SerializationException if one of the message's key or value are not a subtype of SpecificRecord. 

We encounter this problem most commonly with keys of the messages which can be primitive type (mostly string/int) or avro type, we could use different serializer for primitives but it would mean changing the producer/consumer config for every topic which is not ideal, besides when keys are avros we would want to leverage schema registry for managing their schemas. In this pull, during deserialization I am checking if the writerSchema is a primitive and using GenericDatumReader else it would fallback to existing flow.

Please review and let me know if there are any additional changes.

Thanks

[1] - https://github.com/confluentinc/schema-registry/blob/v3.1.1/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java#L95-L119
[2] - https://github.com/confluentinc/schema-registry/blob/master/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java#L215-L217