### PR TITLE
Fix avro.compatibility.level full_transitive typo

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -19,7 +19,7 @@ Configuration Options
   * Importance: high
 
 ``avro.compatibility.level``
-  The Avro compatibility type. Valid values are: none (new schema can be any valid Avro schema), backward (new schema can read data produced by latest registered schema), backward_transitive (new schema can read data produced by all previously registered schemas), forward (latest registered schema can read data produced by the new schema), forward_transitive (all previously registered schemas can read data produced by the new schema), full (new schema is backward and forward compatible with latest registered schema), transitive_full (new schema is backward and forward compatible with all previously registered schemas)
+  The Avro compatibility type. Valid values are: none (new schema can be any valid Avro schema), backward (new schema can read data produced by latest registered schema), backward_transitive (new schema can read data produced by all previously registered schemas), forward (latest registered schema can read data produced by the new schema), forward_transitive (all previously registered schemas can read data produced by the new schema), full (new schema is backward and forward compatible with latest registered schema), full_transitive (new schema is backward and forward compatible with all previously registered schemas)
 
   * Type: string
   * Default: "backward"


### PR DESCRIPTION
The documentation provides the `transitive_full` option to the `avro.compatibility.level` configuration option but the valid option is actually `full_transitive`.

Fatal error when using `transitive_full`:
```
INFO SchemaRegistryConfig values: 
	...
	avro.compatibility.level = transitive_full
	...
 (io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig)
ERROR Server configuration failed:  (io.confluent.kafka.schemaregistry.rest.SchemaRegistryMain)
io.confluent.rest.RestConfigException: Unknown Avro compatibility level: transitive_full
	at io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig.<init>(SchemaRegistryConfig.java:362)
	at io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig.<init>(SchemaRegistryConfig.java:354)
	at io.confluent.kafka.schemaregistry.rest.SchemaRegistryMain.main(SchemaRegistryMain.java:41)
```

Enum source:
https://github.com/confluentinc/schema-registry/blob/74454b71e6b6aa3ed8646148e6ba9f7529ce5a79/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityLevel.java