### PR TITLE
Updated config doc for kafkastore.security.protocol to include all su…

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -145,7 +145,7 @@ Configuration Options
   * Importance: medium
 
 ``kafkastore.security.protocol``
-  The security protocol to use when connecting with Kafka, the underlying persistent storage. Values can be `PLAINTEXT` or `SSL`.
+  The security protocol to use when connecting with Kafka, the underlying persistent storage. Values can be `PLAINTEXT`, `SASL_PLAINTEXT`, `SSL` or `SASL_SSL`.
 
   * Type: string
   * Default: "PLAINTEXT"


### PR DESCRIPTION
…pported protocols

From [here](https://github.com/confluentinc/schema-registry/blob/master/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java#L67-L69) it seems registry supports `SASL_PLAINTEXT` and `SSL_SASL` as well