### PR TITLE
Don't re-invoke SchemaBuilder.version() and SchemaBuilder.name() if the value has already been set.

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -1353,7 +1353,15 @@ public class AvroData {
       if (!version.isIntegralNumber()) {
         throw new DataException("Invalid Connect version found: " + version.toString());
       }
-      builder.version(version.asInt());
+      final int versionInt = version.asInt();
+      if (builder.version() != null) {
+        if (versionInt != builder.version()) {
+          throw new DataException("Mismatched versions: version already added to SchemaBuilder (" + builder.version() +
+                  ") differs from version in source schema (" + version.toString() + ")");
+        }
+      } else {
+        builder.version(versionInt);
+      }
     }
 
     JsonNode parameters = schema.getJsonProp(CONNECT_PARAMETERS_PROP);
@@ -1400,7 +1408,14 @@ public class AvroData {
       name = schema.getFullName();
     }
     if (name != null && !name.equals(DEFAULT_SCHEMA_FULL_NAME)) {
-      builder.name(name);
+      if (builder.name() != null) {
+        if (!name.equals(builder.name())) {
+          throw new DataException("Mismatched names: name already added to SchemaBuilder (" + builder.name() +
+                  ") differs from name in source schema (" + name + ")");
+        }
+      } else {
+        builder.name(name);
+      }
     }
 
     if (forceOptional) {

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -1361,6 +1361,30 @@ public class AvroDataTest {
     avroData.toConnectSchema(avroSchema);
   }
 
+  @Test
+  public void testLogicalTypeWithMatchingNameAndVersion() {
+    // When we use a logical type, the builder we get sets a version. If a version is also included in the schema we're
+    // converting, the conversion should still work as long as the versions match.
+    org.apache.avro.Schema schema = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Message\",\"namespace\":\"org.cmatta.kafka.connect.irc\",\"fields\":[{\"name\":\"createdat\",\"type\":{\"type\":\"long\",\"connect.doc\":\"When this message was received.\",\"connect.version\":1,\"connect.name\":\"org.apache.kafka.connect.data.Timestamp\",\"logicalType\":\"timestamp-millis\"}}]}");
+    avroData.toConnectSchema(schema);
+  }
+
+  @Test(expected = DataException.class)
+  public void testLogicalTypeWithMismatchingName() {
+    // When we use a logical type, the builder we get sets a version. If a version is also included in the schema we're
+    // converting, a mismatch between the versions should cause an exception.
+    org.apache.avro.Schema schema = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Message\",\"namespace\":\"org.cmatta.kafka.connect.irc\",\"fields\":[{\"name\":\"createdat\",\"type\":{\"type\":\"long\",\"connect.doc\":\"When this message was received.\",\"connect.version\":1,\"connect.name\":\"com.custom.Timestamp\",\"logicalType\":\"timestamp-millis\"}}]}");
+    avroData.toConnectSchema(schema);
+  }
+
+  @Test(expected = DataException.class)
+  public void testLogicalTypeWithMismatchingVersion() {
+    // When we use a logical type, the builder we get sets a version. If a version is also included in the schema we're
+    // converting, a mismatch between the versions should cause an exception.
+    org.apache.avro.Schema schema = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"Message\",\"namespace\":\"org.cmatta.kafka.connect.irc\",\"fields\":[{\"name\":\"createdat\",\"type\":{\"type\":\"long\",\"connect.doc\":\"When this message was received.\",\"connect.version\":2,\"connect.name\":\"org.apache.kafka.connect.data.Timestamp\",\"logicalType\":\"timestamp-millis\"}}]}");
+    avroData.toConnectSchema(schema);
+  }
+
   private NonRecordContainer checkNonRecordConversion(
       org.apache.avro.Schema expectedSchema, Object expected,
       Schema schema, Object value)


### PR DESCRIPTION
Logical type schema builders come pre-configured with the schema name and version. The generic code for setting the name and
version from an Avro schema would then cause exceptions because they check to see that the field has never been set
before. To handle this case properly, check whether the fields have been set and their values before trying to set them.