### PR TITLE
making sure schema registry doesn't start with uncompacted topic

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -343,8 +343,12 @@ public class KafkaStore<K, V> implements Store<K, V> {
     Properties prop = AdminUtils.fetchEntityConfig(zkUtils, ConfigType.Topic(), topic);
     String retentionPolicy = prop.getProperty(LogConfig.CleanupPolicyProp());
     if (retentionPolicy == null || "compact".compareTo(retentionPolicy) != 0) {
-      log.warn("The retention policy of the schema topic " + topic + " may be incorrect. " +
-               "Please configure it with compact.");
+      log.error("The retention policy of the schema topic " + topic + " is incorrect. " +
+               "You must configure the topic to 'compact' cleanup policy to avoid Kafka deleting your schemas after a week. " +
+               "Refer to Kafka documentation for more details on cleanup policies");
+
+      throw new IllegalStateException("The retention policy of the schema topic " + topic +
+              " is incorrect. Expected cleanup.policy to be 'compact' but it is " + retentionPolicy);
     }
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
@@ -15,7 +15,11 @@
  */
 package io.confluent.kafka.schemaregistry.storage;
 
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
+import kafka.admin.AdminUtils;
+import kafka.admin.RackAwareMode;
 import kafka.cluster.Broker;
+import kafka.log.LogConfig;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.network.ListenerName;
 import org.apache.kafka.common.protocol.SecurityProtocol;
@@ -33,6 +37,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -311,5 +316,18 @@ public class KafkaStoreTest extends ClusterTestHarness {
     for (int i = 0; i < endpointsList.size(); i++) {
       assertEquals("Expected a different endpoint", expected.get(i), endpointsList.get(i));
     }
+  }
+
+  @Test(expected=IllegalStateException.class)
+  public void testMandatoryCompationPolicy() {
+    Properties kafkaProps = new Properties();
+    Properties topicProps = new Properties();
+    topicProps.put(LogConfig.CleanupPolicyProp(), "delete");
+
+    AdminUtils.createTopic(zkUtils, SchemaRegistryConfig.DEFAULT_KAFKASTORE_TOPIC, 1, 1, topicProps, RackAwareMode.Enforced$.MODULE$);
+
+    Store<String, String> inMemoryStore = new InMemoryStore<String, String>();
+
+    KafkaStore kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(zkConnect, zkClient, inMemoryStore, kafkaProps);
   }
 }


### PR DESCRIPTION
We don't want users to accidentally lose all schemas.

In addition to the test in the PR, I also made sure Quickstart didn't break.