### PR TITLE
add support for unions of multiple types

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -502,25 +502,34 @@ public class AvroData {
 
   /**
    * Connect optional fields are represented as a unions (null & type) in Avro
+   * If multiple types are available prefers the matching one using the full name
    * Return the Avro schema of the actual type in the Union (instead of the union itself)
    * @param schema
    * @param avroSchema
    * @return
    */
-  private static org.apache.avro.Schema avroSchemaForUnderlyingTypeIfOptional(Schema schema, org.apache.avro.Schema avroSchema){
+  private static org.apache.avro.Schema avroSchemaForUnderlyingTypeIfOptional(Schema schema, org.apache.avro.Schema avroSchema) {
 
     if (schema != null && schema.isOptional()) {
       if (avroSchema.getType() == org.apache.avro.Schema.Type.UNION) {
+        org.apache.avro.Schema nonNullTypeSchema = null;
         for (org.apache.avro.Schema typeSchema : avroSchema
             .getTypes()) {
           if (!typeSchema.getType().equals(
-              org.apache.avro.Schema.Type.NULL)) {
-            return typeSchema;
+                  org.apache.avro.Schema.Type.NULL)) {
+            if (typeSchema.getFullName().equals(schema.name())) {
+              return typeSchema;
+            } else if (nonNullTypeSchema == null) {
+              nonNullTypeSchema = typeSchema;
+            }
           }
+        }
+        if (nonNullTypeSchema != null) {
+          return nonNullTypeSchema;
         }
       } else {
         throw new DataException(
-            "An optinal schema should have an Avro Union type, not "
+            "An optimal schema should have an Avro Union type, not "
                 + schema.type());
       }
     }


### PR DESCRIPTION
Hi,

There is currently a bug in kafka-connect where the connectors fail to process schemas which have this kind of field : 
```array[RecordType1|RecordType2]```
When it tries to get the underlying schema it gets the first non null type which sometimes doesn't match the actual payload and then crashes later with a NPE which breaks the connector.
```
java.lang.NullPointerException
	at io.confluent.connect.avro.AvroData.fromConnectData(AvroData.java:486)
	at io.confluent.connect.avro.AvroData.fromConnectData(AvroData.java:477)
	at io.confluent.connect.avro.AvroData.fromConnectData(AvroData.java:418)
	at io.confluent.connect.avro.AvroData.fromConnectData(AvroData.java:487)
	at io.confluent.connect.avro.AvroData.fromConnectData(AvroData.java:295)
	at io.confluent.connect.hdfs.avro.AvroRecordWriterProvider$1.write(AvroRecordWriterProvider.java:64)
	at io.confluent.connect.hdfs.avro.AvroRecordWriterProvider$1.write(AvroRecordWriterProvider.java:60)
...
```

This PR fixes this by preferring to return the type which have the same fully qualified name.
If there is no match the behavior is not changed.

Thanks a lot for the good work with Kafka connect - it really simplifies how we get data in/out of kafka.