### PR TITLE
Support basic auth credentials embedded in the schema.registry.url

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -43,6 +43,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.xml.bind.DatatypeConverter;
 
 /**
  * Rest access layer for sending requests to the schema registry.
@@ -132,9 +133,13 @@ public class RestService {
     HttpURLConnection connection = null;
     try {
       URL url = new URL(requestUrl);
+      String userInfo = url.getUserInfo();
       connection = (HttpURLConnection) url.openConnection();
       connection.setRequestMethod(method);
-
+      if (userInfo != null) {
+        String authHeader = DatatypeConverter.printBase64Binary(userInfo.getBytes());
+        connection.setRequestProperty("Authorization", "Basic " + authHeader);
+      }
       // connection.getResponseCode() implicitly calls getInputStream, so always set to true.
       // On the other hand, leaving this out breaks nothing.
       connection.setDoInput(true);


### PR DESCRIPTION
This is a rebase of the change in PR https://github.com/confluentinc/schema-registry/pull/418 . Some variables were renamed since the original PR which caused the merge conflict. 

I contacted the original patch author and we agreed that I'll fix the conflict and resend the patch in a new PR. I also left the original author as the git commit author since I only did minor tweaking. According to the original author they've been using this successfully since the original PR was issued.