### PR TITLE
Set default to null if schema is optional

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -874,7 +874,7 @@ public class AvroData {
       fieldAvroSchema.withDefault(defaultValueFromConnect(fieldSchema, fieldSchema.defaultValue()));
     } else {
       if (fieldSchema.isOptional()) {
-        fieldAvroSchema.withDefault(null);
+        fieldAvroSchema.withDefault(JsonNodeFactory.instance.nullNode());
       } else {
         fieldAvroSchema.noDefault();
       }

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -245,6 +245,30 @@ public class AvroDataTest {
   }
   
   @Test
+  public void testFromConnectOptionalWithDefaultNull() {
+    Schema schema = SchemaBuilder.struct()
+        .field("optionalBool", SchemaBuilder.bool().optional().defaultValue(null).build())
+        .build();
+    org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(schema);
+    org.apache.avro.Schema expectedAvroSchema = org.apache.avro.SchemaBuilder.builder()
+        .record("ConnectDefault").namespace("io.confluent.connect.avro").fields()
+        .name("optionalBool").type(org.apache.avro.SchemaBuilder.builder()
+            .unionOf().nullType().and().booleanType().endUnion()).withDefault(null)
+        .endRecord();
+
+    assertEquals(expectedAvroSchema, avroSchema);
+
+    Struct struct = new Struct(schema)
+        .put("optionalBool", true);
+    Object convertedRecord = avroData.fromConnectData(schema, struct);
+    org.apache.avro.generic.GenericRecord avroRecord = new org.apache.avro.generic.GenericRecordBuilder(avroSchema)
+        .set("optionalBool", true)
+        .build();
+
+    assertEquals(avroRecord, convertedRecord);
+  }
+
+  @Test
   public void testFromConnectOptionalComplex() {
     Schema optionalStructSchema = SchemaBuilder.struct().optional()
         .name("optionalStruct")


### PR DESCRIPTION
Addresses https://github.com/confluentinc/schema-registry/issues/480.
Adds "default: null" property to Avro schema for Kafka Connect schema's
that are marked as optional.