### PR TITLE
Avoid ClassCastException for the same class when used with Flink

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializerConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializerConfig.java
@@ -28,13 +28,19 @@ public class KafkaAvroDeserializerConfig extends AbstractKafkaAvroSerDeConfig {
   public static final boolean SPECIFIC_AVRO_READER_DEFAULT = false;
   public static final String SPECIFIC_AVRO_READER_DOC =
       "If true, tries to look up the SpecificRecord class ";
+  
+  public static final String AVRO_FORCE_NEW_SPECIFIC_DATA_CONFIG = "force.new.specific.avro.instance";
+  public static final boolean AVRO_FORCE_NEW_SPECIFIC_DATA_DEFAULT = false;
+  public static final String AVRO_FORCE_NEW_SPECIFIC_DATA_DOC = "If true, it passes a new instace of SpecificData to SpecificDatumReader ";
 
   private static ConfigDef config;
 
   static {
     config = baseConfigDef()
         .define(SPECIFIC_AVRO_READER_CONFIG, Type.BOOLEAN, SPECIFIC_AVRO_READER_DEFAULT,
-                Importance.LOW, SPECIFIC_AVRO_READER_DOC);
+                Importance.LOW, SPECIFIC_AVRO_READER_DOC)
+        .define(AVRO_FORCE_NEW_SPECIFIC_DATA_CONFIG, Type.BOOLEAN, AVRO_FORCE_NEW_SPECIFIC_DATA_DEFAULT,
+                Importance.LOW, AVRO_FORCE_NEW_SPECIFIC_DATA_DOC);
   }
 
   public KafkaAvroDeserializerConfig(Map<?, ?> props) {


### PR DESCRIPTION
Fix to avoid the ClassCastException for the same class when used with Flink.


https://ci.apache.org/projects/flink/flink-docs-release-1.2/monitoring/debugging_classloading.html#x-cannot-be-cast-to-x-exceptions

It is documented that when Avro is used with Flink, a ClassCastException is thrown, due to a caching issue. The issue occurs, then the confluent kafka client is configured with "specific.avro.reader" = true, and the de-serialization is performed with the SpecificDatumReader, instead of the generic reader.
Based on Flink documentation, it is recommended to pass a new SpecificData to SpecificDatumReader each time.

This fix extends the deserializer with an extra configuration option "force.new.specific.avro.instance" to force SpecificDatumReader to use a new instance of SpecificData when used together with specific.avro.reader.

TODO: investigate  performance penalty of generating a new instance instead of using Singleton