### PR TITLE
different executions for integration and unit tests

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -44,5 +44,11 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>common-utils</artifactId>
+            <version>${confluent-common.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
@@ -15,12 +15,14 @@
  */
 package io.confluent.kafka.schemaregistry;
 
+import io.confluent.common.utils.IntegrationTest;
 import kafka.utils.CoreUtils;
 import org.I0Itec.zkclient.ZkClient;
 import org.apache.kafka.common.protocol.SecurityProtocol;
 import org.apache.kafka.common.utils.Time;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -45,6 +47,7 @@ import scala.collection.JavaConversions;
  * Kafka's ZookeeperTestHarness and KafkaServerTestHarness traits combined and ported to Java with
  * the addition of the REST proxy. Defaults to a 1-ZK, 3-broker, 1 REST proxy cluster.
  */
+@Category({IntegrationTest.class})
 public abstract class ClusterTestHarness {
 
   public static final int DEFAULT_NUM_BROKERS = 1;

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -37,7 +37,12 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>common-utils</artifactId>
+            <version>${confluent-common.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,8 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>slow-tests</id>
+                        <id>integration-test</id>
+                        <phase>integration-test</phase>
                         <goals>
                             <goal>test</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>common-utils</artifactId>
+                <version>${confluent-common.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -153,10 +158,30 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>2.19.1</version>
                 <configuration>
                     <argLine>-Djava.awt.headless=true</argLine>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>default-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <excludedGroups>io.confluent.common.utils.IntegrationTest</excludedGroups>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>slow-tests</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <groups>io.confluent.common.utils.IntegrationTest</groups>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Use junit categories to separate unit from integration tests. Configured executions of the sure-fire plugin.