### PR TITLE
Wrap byte[] in ByteBuffer before passing to Avro's DatumWriter in AvroMessageFormatter

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageFormatter.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageFormatter.java
@@ -28,6 +28,7 @@ import org.apache.kafka.common.errors.SerializationException;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.ByteBuffer;
 import java.util.Properties;
 
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
@@ -124,7 +125,11 @@ public class AvroMessageFormatter extends AbstractKafkaAvroDeserializer
     try {
       JsonEncoder encoder = encoderFactory.jsonEncoder(schema, output);
       DatumWriter<Object> writer = new GenericDatumWriter<Object>(schema);
-      writer.write(object, encoder);
+      if (object instanceof byte[]) {
+        writer.write(ByteBuffer.wrap((byte[])object), encoder);
+      } else {
+        writer.write(object, encoder);
+      }
       encoder.flush();
     } catch (AvroRuntimeException e) {
       throw new SerializationException(

--- a/avro-serializer/src/test/java/io/confluent/kafka/formatter/AvroMessageFormatterTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/formatter/AvroMessageFormatterTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2014 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.kafka.formatter;
+
+import static org.junit.Assert.assertEquals;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Type;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.Test;
+
+public class AvroMessageFormatterTest {
+
+  private static final byte MAGIC_BYTE = 0x0;
+  private static final String A_STRING = "These are bytes.";
+  private static final byte[] SOME_BYTES = A_STRING.getBytes();
+  private static final byte[] SCHEMA_ID = ByteBuffer.allocate(4).putInt(1).array();
+  private static final SchemaRegistryClient schemaRegistry = new MockSchemaRegistryClient();
+
+  @Test
+  public void testDeserializeBytesIssue506() throws IOException, RestClientException {
+    Map<String,String> properties = new HashMap<String,String>();
+    properties.put(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "bogus");
+    AvroMessageFormatter formatter = new AvroMessageFormatter(schemaRegistry, false);
+		
+    byte[] message = new byte[1 + SCHEMA_ID.length + SOME_BYTES.length];
+    message[0] = MAGIC_BYTE;
+    System.arraycopy(SCHEMA_ID, 0, message, 1, SCHEMA_ID.length);
+    System.arraycopy(SOME_BYTES, 0, message, 1 + SCHEMA_ID.length, SOME_BYTES.length);
+
+    Schema schema = Schema.create(Type.BYTES);
+    schemaRegistry.register("topicname", schema);
+		
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    PrintStream ps = new PrintStream(baos);
+    ConsumerRecord<byte[], byte[]> crecord = new ConsumerRecord<>(
+      "topic1", 0, 200, 1000, TimestampType.LOG_APPEND_TIME, 0, 
+	  0, message.length,
+      null, message);
+    formatter.writeTo(crecord, ps);
+    assertEquals("\"" + A_STRING + "\"\n", baos.toString());
+  }
+
+}

--- a/avro-serializer/src/test/java/io/confluent/kafka/formatter/AvroMessageFormatterTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/formatter/AvroMessageFormatterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Confluent Inc.
+ * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Then AvroMessageFormatter passes byte[] to an Avro encoder, but Avro only likes ByteBuffer. 
So we need to ByteBuffer.wrap() instead.
A small unit test has been added.