### PR TITLE
#544: Add null check for schema doc while adding the property "connect.enum.doc" for schema conversion of enum types

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -1450,7 +1450,9 @@ public class AvroData {
       case ENUM:
         // enums are unwrapped to strings and the original enum is not preserved
         builder = SchemaBuilder.string();
-        builder.parameter(CONNECT_ENUM_DOC_PROP, schema.getDoc());
+        if (schema.getDoc() != null) {
+          builder.parameter(CONNECT_ENUM_DOC_PROP, schema.getDoc());
+        }
         builder.parameter(AVRO_TYPE_ENUM, schema.getFullName());
         for (String enumSymbol : schema.getEnumSymbols()) {
           builder.parameter(AVRO_TYPE_ENUM + "." + enumSymbol, enumSymbol);

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -1295,6 +1295,24 @@ public class AvroDataTest {
   }
 
   @Test
+  public void testToConnectEnumWithNoDoc() {
+    // Enums are just converted to strings, original enum is preserved in parameters
+    org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.builder()
+            .enumeration("TestEnum")
+            .symbols("foo", "bar", "baz");
+    SchemaBuilder builder = SchemaBuilder.string().name("TestEnum");
+    builder.parameter(AVRO_TYPE_ENUM, "TestEnum");
+    for(String enumSymbol : new String[]{"foo", "bar", "baz"}) {
+      builder.parameter(AVRO_TYPE_ENUM+"."+enumSymbol, enumSymbol);
+    }
+
+    assertEquals(new SchemaAndValue(builder.build(), "bar"),
+            avroData.toConnectData(avroSchema, "bar"));
+    assertEquals(new SchemaAndValue(builder.build(), "bar"),
+            avroData.toConnectData(avroSchema, new GenericData.EnumSymbol(avroSchema, "bar")));
+  }
+
+  @Test
   public void testToConnectOptionalPrimitiveWithConnectMetadata() {
     Schema schema = SchemaBuilder.string().
         doc("doc").defaultValue("foo").name("io.confluent.stringtype").version(2).optional()

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -62,6 +62,7 @@ import io.confluent.kafka.serializers.NonRecordContainer;
 
 import static io.confluent.connect.avro.AvroData.AVRO_TYPE_ENUM;
 import static io.confluent.connect.avro.AvroData.CONNECT_ENUM_DOC_PROP;
+import static io.confluent.connect.avro.AvroData.CONNECT_RECORD_DOC_PROP;
 import static org.junit.Assert.*;
 
 public class AvroDataTest {
@@ -1275,10 +1276,14 @@ public class AvroDataTest {
   public void testToConnectEnum() {
     // Enums are just converted to strings, original enum is preserved in parameters
     org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.builder()
-        .enumeration("TestEnum").symbols("foo", "bar", "baz");
+        .enumeration("TestEnum")
+        .doc("some documentation")
+        .symbols("foo", "bar", "baz");
     SchemaBuilder builder = SchemaBuilder.string().name("TestEnum");
-    builder.parameter(CONNECT_ENUM_DOC_PROP, null);
+    builder.parameter(CONNECT_ENUM_DOC_PROP, "some documentation");
+    builder.parameter(CONNECT_RECORD_DOC_PROP, "some documentation");
     builder.parameter(AVRO_TYPE_ENUM, "TestEnum");
+    builder.doc("some documentation");
     for(String enumSymbol : new String[]{"foo", "bar", "baz"}) {
       builder.parameter(AVRO_TYPE_ENUM+"."+enumSymbol, enumSymbol);
     }


### PR DESCRIPTION
Fix for issue #544 