### PR TITLE
Allow for some retries when validating that all nodes have the same master

### DIFF
--- a/core/src/test/java/io/confluent/kafka/schemaregistry/zookeeper/MasterElectorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/zookeeper/MasterElectorTest.java
@@ -596,8 +596,21 @@ public class MasterElectorTest extends ClusterTestHarness {
   private static void checkMasterIdentity(Collection<RestApp> cluster,
                                           SchemaRegistryIdentity expectedMasterIdentity) {
     for (RestApp restApp: cluster) {
-      assertEquals("Each master identity should be " + expectedMasterIdentity,
-                   expectedMasterIdentity, restApp.masterIdentity());
+      for (int i = 0; i < 3; i++) {
+        SchemaRegistryIdentity masterIdentity = restApp.masterIdentity();
+        // There can be some latency in all the nodes picking up the new master from ZK so we need
+        // to allow for some retries here.
+        if (masterIdentity == null) {
+          try {
+            Thread.sleep(1000);
+          } catch (InterruptedException e) {
+            // ignore
+          }
+          continue;
+        }
+        assertEquals("Each master identity should be " + expectedMasterIdentity,
+                     expectedMasterIdentity, masterIdentity);
+      }
     }
   }
 


### PR DESCRIPTION
There can be some latency in all the nodes picking up the master change from Zookeeper. It is ok for nodes to think there
isn't a master for some time, so allow for that in the validation code and sleep and retry a few times.