### PR TITLE
CLIENTS-488 Updated distributed worker config for internal topic creation

### DIFF
--- a/config/connect-avro-distributed.properties
+++ b/config/connect-avro-distributed.properties
@@ -17,25 +17,45 @@ key.converter.schema.registry.url=http://localhost:8081
 value.converter=io.confluent.connect.avro.AvroConverter
 value.converter.schema.registry.url=http://localhost:8081
 
-# The internal converter used for offsets and config data is configurable and must be specified,
-# but most users will always want to use the built-in default. Offset and config data is never
-# visible outside of Connect in this format.
+# Internal Storage Topics.
+#
+# Kafka Connect distributed workers store the connector and task configurations, connector offsets,
+# and connector statuses in three internal topics. These topics MUST be compacted.
+# When the Kafka Connect distributed worker starts, it will check for these topics and attempt to create them
+# as compacted topics if they don't yet exist, using the topic name, replication factor, and number of partitions
+# as specified in these properties, and other topic-specific settings inherited from your brokers'
+# auto-creation settings. If you need more control over these other topic-specific settings, you may want to
+# manually create these topics before starting Kafka Connect distributed workers.
+#
+# The following properties set the names of these three internal topics for storing configs, offsets, and status.
+config.storage.topic=connect-configs
+offset.storage.topic=connect-offsets
+status.storage.topic=connect-statuses
+
+# The following properties set the replication factor for the three internal topics, defaulting to 3 for each
+# and therefore requiring a minimum of 3 brokers in the cluster. Since we want the examples to run with
+# only a single broker, we set the replication factor here to just 1. That's okay for the examples, but
+# ALWAYS use a replication factor of AT LEAST 3 for production environments to reduce the risk of 
+# losing connector offsets, configurations, and status.
+config.storage.replication.factor=1
+offset.storage.replication.factor=1
+status.storage.replication.factor=1
+
+# The config storage topic must have a single partition, and this cannot be changed via properties. 
+# Offsets for all connectors and tasks are written quite frequently and therefore the offset topic
+# should be highly partitioned; by default it is created with 25 partitions, but adjust accordingly
+# with the number of connector tasks deployed to a distributed worker cluster. Kafka Connect records
+# the status less frequently, and so by default the topic is created with 5 partitions.
+#offset.storage.partitions=25
+#status.storage.partitions=5
+
+# The offsets, status, and configurations are written to the topics using converters specified through
+# the following required properties. Most users will always want to use the JSON converter without schemas. 
+# Offset and config data is never visible outside of Connect in this format.
 internal.key.converter=org.apache.kafka.connect.json.JsonConverter
 internal.value.converter=org.apache.kafka.connect.json.JsonConverter
 internal.key.converter.schemas.enable=false
 internal.value.converter.schemas.enable=false
-
-# Kafka topic where connector configuration will be persisted. You should create this topic with a
-# single partition and high replication factor (e.g. 3)
-config.storage.topic=connect-configs
-
-# Kafka topic where connector offset data will be persisted. You should create this topic with many
-# partitions (e.g. 25) and high replication factor (e.g. 3)
-offset.storage.topic=connect-offsets
-
-# Kafka topic where connector status data will be persisted. You should create this topic with many
-# partitions (e.g. 25) and high replication factor (e.g. 3)
-status.storage.topic=connect-statuses
 
 # Confuent Control Center Integration -- uncomment these lines to enable Kafka client interceptors
 # that will report audit data that can be displayed and analyzed in Confluent Control Center


### PR DESCRIPTION
Updated the distributed worker configuration used in the examples to include the new properties used when Connect creates the internal storage topics. The complicating factor is that the examples should work when run with a single broker, but the default replication factor for the topics is 3, which requires at least three brokers. Therefore, like the AK example configuration, the replication factor is set to 1 for the three topics and comments are used to describe why that is done and what should be used for production.

This should be merged into 3.3.x, 3.4.x, and master.