### PR TITLE
#577 changed schemaMap to Map<Schema, org.apache.avro.Schema>

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -691,17 +691,17 @@ public class AvroData {
       case STRING:
         if (enhancedSchemaSupport && schema.parameters() != null
             && schema.parameters().containsKey(AVRO_TYPE_ENUM)) {
-            List<String> symbols = new ArrayList<>();
-            for (Map.Entry<String, String> entry : schema.parameters().entrySet()) {
-              if (entry.getKey().startsWith(AVRO_TYPE_ENUM + ".")) {
-                symbols.add(entry.getValue());
-              }
+          List<String> symbols = new ArrayList<>();
+          for (Map.Entry<String, String> entry : schema.parameters().entrySet()) {
+            if (entry.getKey().startsWith(AVRO_TYPE_ENUM + ".")) {
+              symbols.add(entry.getValue());
             }
-            baseSchema =
-                org.apache.avro.SchemaBuilder.builder().enumeration(
-                    schema.parameters().get(AVRO_TYPE_ENUM))
-                    .doc(schema.parameters().get(CONNECT_ENUM_DOC_PROP))
-                    .symbols(symbols.toArray(new String[symbols.size()]));
+          }
+          baseSchema =
+              org.apache.avro.SchemaBuilder.builder().enumeration(
+                  schema.parameters().get(AVRO_TYPE_ENUM))
+                  .doc(schema.parameters().get(CONNECT_ENUM_DOC_PROP))
+                  .symbols(symbols.toArray(new String[symbols.size()]));
         } else {
           baseSchema = org.apache.avro.SchemaBuilder.builder().stringType();
         }


### PR DESCRIPTION
This ensures that Connect schemas with variable properties don't get
cached and reused simply because they have the same name.
See issue #577