### PR TITLE
Schema Registry title -> Introduction

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -1,7 +1,7 @@
 .. _schemaregistry_intro:
 
-Schema Registry
-================
+Introduction
+============
 
 Schema Registry provides a serving layer for your metadata. It provides a RESTful interface for storing and retrieving Avro schemas. It stores a versioned history of all schemas, provides multiple compatibility settings and allows evolution of schemas according to the configured compatibility setting. It provides serializers that plug into Kafka clients that handle schema storage and retrieval for Kafka messages that are sent in the Avro format.
 


### PR DESCRIPTION
I think it makes more sense to title this page "Introduction". It's a sub-page under "Schema Registry" so I think it's a bit confusing calling it "Schema Registry".

@mageshn @gwenshap 