### PR TITLE
CLIENTS-490: Do not require access to Kafka's Zookeeper

### DIFF
--- a/config/schema-registry.properties
+++ b/config/schema-registry.properties
@@ -12,7 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# The address the socket server listens on.
+#   FORMAT:
+#     listeners = listener_name://host_name:port
+#   EXAMPLE:
+#     listeners = PLAINTEXT://your.host.name:9092
 listeners=http://0.0.0.0:8081
+
+# Zookeeper connection string for the Zookeeper cluster used by your Kafka cluster
+# (see zookeeper docs for details).
+# This is a comma separated host:port pairs, each corresponding to a zk
+# server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
 kafkastore.connection.url=localhost:2181
+
+# Zookeeper connection string for the Zookeeper cluster that schema registry instances
+# should use to coordinate. Defaults to kafkastore.connection.url. Override this value
+# if the Zookeeper cluster used to coordinate Schema Registry instances is different
+# than the one used by the Kafka cluster storing the kafkastore.topic. This may be the
+# case, for example, if you are using a hosted Kafka cluster that does not expose the
+# underlying Zookeeper cluster.
+#schema.registry.connection.url=localhost:2181
+
+# Bootstrap servers for the Kafka cluster where your schemas will be stored.
+# If not specified, bootstrap servers will be loaded from Zookeeper. If the
+# Zookeeper cluster used to coordinate Schema Registry instances is different
+# than the one used by the Kafka cluster storing the kafkastore.topic, this
+# setting can be used instead of kafkastore.connection.url. This may be the case,
+# for example, if you are using a hosted Kafka cluster that does not expose the
+# underlying Zookeeper cluster.
+#kafkastore.bootstrap.servers=PLAINTEXT://localhost:9092
+
+
+# The name of the topic to store schemas in
 kafkastore.topic=_schemas
+
+# If true, API requests that fail will include extra debugging information, including stack traces
 debug=false

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -101,6 +101,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry {
   private final Object masterLock = new Object();
   private final AvroCompatibilityLevel defaultCompatibilityLevel;
   private final String schemaRegistryZkNamespace;
+  private final String srClusterZkUrl;
   private final String kafkaClusterZkUrl;
   private final int zkSessionTimeoutMs;
   private final int kafkaStoreTimeoutMs;
@@ -136,6 +137,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry {
         config.getString(SchemaRegistryConfig.SCHEMAREGISTRY_ZK_NAMESPACE);
     this.isEligibleForMasterElector = config.getBoolean(SchemaRegistryConfig.MASTER_ELIGIBILITY);
     this.myIdentity = new SchemaRegistryIdentity(host, port, isEligibleForMasterElector);
+    this.srClusterZkUrl = config.schemaRegistryZkUrl();
     this.kafkaClusterZkUrl =
         config.getString(SchemaRegistryConfig.KAFKASTORE_CONNECTION_URL_CONFIG);
     this.zkSessionTimeoutMs =
@@ -228,10 +230,10 @@ public class KafkaSchemaRegistry implements SchemaRegistry {
   }
 
   private void createZkNamespace() {
-    int kafkaNamespaceIndex = kafkaClusterZkUrl.indexOf("/");
+    int kafkaNamespaceIndex = srClusterZkUrl.indexOf("/");
     String zkConnForNamespaceCreation = kafkaNamespaceIndex > 0
-                                        ? kafkaClusterZkUrl.substring(0, kafkaNamespaceIndex)
-                                        : kafkaClusterZkUrl;
+                                        ? srClusterZkUrl.substring(0, kafkaNamespaceIndex)
+                                        : srClusterZkUrl;
 
     String schemaRegistryNamespace = "/" + schemaRegistryZkNamespace;
     schemaRegistryZkUrl = zkConnForNamespaceCreation + schemaRegistryNamespace;

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
@@ -41,14 +41,27 @@ public class RestApp {
   }
 
   public RestApp(int port, String zkConnect, String kafkaTopic, String compatibilityType) {
-    this(port, zkConnect, kafkaTopic, compatibilityType, true);
+    this(port, null, zkConnect, kafkaTopic, compatibilityType, true);
   }
 
-  public RestApp(int port, String zkConnect, String kafkaTopic,
+  public RestApp(int port, String srZkConnect, String zkConnect, String kafkaTopic,
                  String compatibilityType, boolean masterEligibility) {
+    this(port, srZkConnect, zkConnect, null, kafkaTopic, compatibilityType, masterEligibility);
+  }
+
+  public RestApp(int port, String srZkConnect, String zkConnect, String bootstrapBrokers,
+                 String kafkaTopic, String compatibilityType, boolean masterEligibility) {
     prop = new Properties();
     prop.setProperty(SchemaRegistryConfig.PORT_CONFIG, ((Integer) port).toString());
-    prop.setProperty(SchemaRegistryConfig.KAFKASTORE_CONNECTION_URL_CONFIG, zkConnect);
+    if (srZkConnect != null) {
+      prop.setProperty(SchemaRegistryConfig.SCHEMAREGISTRY_CONNECTION_URL_CONFIG, srZkConnect);
+    }
+    if (zkConnect != null) {
+      prop.setProperty(SchemaRegistryConfig.KAFKASTORE_CONNECTION_URL_CONFIG, zkConnect);
+    }
+    if (bootstrapBrokers != null) {
+      prop.setProperty(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, bootstrapBrokers);
+    }
     prop.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG, kafkaTopic);
     prop.put(SchemaRegistryConfig.COMPATIBILITY_CONFIG, compatibilityType);
     prop.put(SchemaRegistryConfig.MASTER_ELIGIBILITY, masterEligibility);

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreSASLTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreSASLTest.java
@@ -26,16 +26,14 @@ import static org.junit.Assert.fail;
 // tests SASL with ZooKeeper and Kafka.
 public class KafkaStoreSASLTest extends SASLClusterTestHarness {
   @Test
-  public void testInitialization() {
-    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSASLStoreInstance(zkConnect,
-            zkClient);
+  public void testInitialization() throws Exception {
+    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSASLStoreInstance(zkConnect);
     kafkaStore.close();
   }
 
   @Test(expected = StoreInitializationException.class)
-  public void testDoubleInitialization() throws StoreInitializationException {
-    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSASLStoreInstance(zkConnect,
-            zkClient);
+  public void testDoubleInitialization() throws Exception {
+    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSASLStoreInstance(zkConnect);
     try {
       kafkaStore.init();
     } finally {
@@ -45,8 +43,7 @@ public class KafkaStoreSASLTest extends SASLClusterTestHarness {
 
   @Test
   public void testSimplePut() throws Exception {
-    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSASLStoreInstance(zkConnect,
-            zkClient);
+    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSASLStoreInstance(zkConnect);
     String key = "Kafka";
     String value = "Rocks";
     try {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreSSLAuthTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreSSLAuthTest.java
@@ -43,25 +43,25 @@ public class KafkaStoreSSLAuthTest extends SSLClusterTestHarness {
   }
 
   @Test
-  public void testInitialization() {
+  public void testInitialization() throws Exception {
     KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSSLKafkaStoreInstance(zkConnect,
-            zkClient, clientSslConfigs, requireSSLClientAuth());
+            clientSslConfigs, requireSSLClientAuth());
     kafkaStore.close();
   }
 
-  @Test(expected = TimeoutException.class)
-  public void testInitializationWithoutClientAuth() {
+  @Test(expected = StoreInitializationException.class)
+  public void testInitializationWithoutClientAuth() throws Exception {
     KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSSLKafkaStoreInstance(zkConnect,
-            zkClient, clientSslConfigs, false);
+            clientSslConfigs, false);
     kafkaStore.close();
 
     // TODO: make the timeout shorter so the test fails quicker.
   }
 
   @Test(expected = StoreInitializationException.class)
-  public void testDoubleInitialization() throws StoreInitializationException {
+  public void testDoubleInitialization() throws Exception {
     KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSSLKafkaStoreInstance(zkConnect,
-            zkClient, clientSslConfigs, requireSSLClientAuth());
+            clientSslConfigs, requireSSLClientAuth());
     try {
       kafkaStore.init();
     } finally {
@@ -72,7 +72,7 @@ public class KafkaStoreSSLAuthTest extends SSLClusterTestHarness {
   @Test
   public void testSimplePut() throws Exception {
     KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSSLKafkaStoreInstance(zkConnect,
-            zkClient, clientSslConfigs, requireSSLClientAuth());
+            clientSslConfigs, requireSSLClientAuth());
     String key = "Kafka";
     String value = "Rocks";
     try {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistryDedicatedZkTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistryDedicatedZkTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafka.schemaregistry.storage;
+
+import org.apache.kafka.common.network.ListenerName;
+import org.apache.kafka.common.protocol.SecurityProtocol;
+import org.apache.kafka.common.utils.Utils;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.confluent.kafka.schemaregistry.ClusterTestHarness;
+import io.confluent.kafka.schemaregistry.RestApp;
+import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
+import io.confluent.kafka.schemaregistry.utils.TestUtils;
+import kafka.server.KafkaServer;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SchemaRegistryDedicatedZkTest extends ClusterTestHarness {
+
+  public SchemaRegistryDedicatedZkTest() {
+    super(1, true, false, AvroCompatibilityLevel.BACKWARD.name);
+  }
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+
+    // Initialize the rest app ourselves so we can ensure we don't pass any info about the Kafka
+    // zookeeper. The format for this config includes the security protocol scheme in the URLs so
+    // we can't use the pre-generated server list.
+    String[] serverUrls = new String[servers.size()];
+    ListenerName listenerType = ListenerName.forSecurityProtocol(SecurityProtocol.PLAINTEXT);
+    for(int i = 0; i < servers.size(); i++) {
+      serverUrls[i] = "PLAINTEXT://" +
+                      Utils.formatAddress(
+                          servers.get(i).config().advertisedListeners().head().host(),
+                          servers.get(i).boundPort(listenerType)
+                      );
+    }
+    String bootstrapServers = Utils.join(serverUrls, ",");
+
+    restApp = new RestApp(choosePort(), srZkConnect, null, bootstrapServers, KAFKASTORE_TOPIC,
+                          compatibilityType, true);
+    restApp.start();
+  }
+
+  @Test
+  public void testDedicatedZk() throws Exception {
+    restApp.restClient.registerSchema(TestUtils.getRandomCanonicalAvroString(1).get(0), "foo");
+
+    // Schema registry Zookeeper shouldn't have Kafka-related paths, should have SR nodes
+    assertFalse(srZkClient.exists("/controller"));
+    assertFalse(srZkClient.exists("/cluster"));
+    assertTrue(srZkClient.exists("/schema_registry/schema_id_counter"));
+    assertTrue(srZkClient.exists("/schema_registry/schema_registry_master"));
+
+    // Kafka Zookeeper should have Kafka-related paths, should not have SR nodes
+    assertTrue(zkClient.exists("/controller"));
+    assertTrue(zkClient.exists("/cluster"));
+    assertFalse(zkClient.exists("/schema_registry/schema_id_counter"));
+    assertFalse(zkClient.exists("/schema_registry/schema_registry_master"));
+  }
+}

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/StoreUtils.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/StoreUtils.java
@@ -28,8 +28,6 @@ import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.protocol.SecurityProtocol;
 
-import static org.junit.Assert.fail;
-
 /**
  * For all store related utility methods.
  */
@@ -38,17 +36,18 @@ public class StoreUtils {
   /**
    * Get a new instance of KafkaStore and initialize it.
    */
-  public static KafkaStore<String, String> createAndInitKafkaStoreInstance(
-      String zkConnect, ZkClient zkClient) {
+  public static KafkaStore<String, String> createAndInitKafkaStoreInstance(String zkConnect)
+      throws RestConfigException, StoreInitializationException {
     Store<String, String> inMemoryStore = new InMemoryStore<String, String>();
-    return createAndInitKafkaStoreInstance(zkConnect, zkClient, inMemoryStore);
+    return createAndInitKafkaStoreInstance(zkConnect, inMemoryStore);
   }
   /**
    * Get a new instance of KafkaStore and initialize it.
    */
   public static KafkaStore<String, String> createAndInitKafkaStoreInstance(
-      String zkConnect, ZkClient zkClient, Store<String, String> inMemoryStore) {
-    return createAndInitKafkaStoreInstance(zkConnect, zkClient, inMemoryStore,
+      String zkConnect, Store<String, String> inMemoryStore)
+      throws RestConfigException, StoreInitializationException {
+    return createAndInitKafkaStoreInstance(zkConnect, inMemoryStore,
             new Properties());
   }
 
@@ -59,7 +58,7 @@ public class StoreUtils {
    * or ZooKeeper SASL individually, the other must have SASL enabled.
    */
   public static KafkaStore<String, String> createAndInitSASLStoreInstance(
-          String zkConnect, ZkClient zkClient) {
+          String zkConnect) throws RestConfigException, StoreInitializationException {
     Properties props = new Properties();
 
     props.put(SchemaRegistryConfig.KAFKASTORE_SECURITY_PROTOCOL_CONFIG,
@@ -68,15 +67,15 @@ public class StoreUtils {
     props.put(SchemaRegistryConfig.ZOOKEEPER_SET_ACL_CONFIG, false);
 
     Store<String, String> inMemoryStore = new InMemoryStore<String, String>();
-    return createAndInitKafkaStoreInstance(zkConnect, zkClient, inMemoryStore, props);
+    return createAndInitKafkaStoreInstance(zkConnect, inMemoryStore, props);
   }
 
   /**
    * Get a new instance of an SSL KafkaStore and initialize it.
    */
   public static KafkaStore<String, String> createAndInitSSLKafkaStoreInstance(
-          String zkConnect, ZkClient zkClient, Map<String, Object> sslConfigs,
-          boolean requireSSLClientAuth) {
+          String zkConnect, Map<String, Object> sslConfigs, boolean requireSSLClientAuth)
+      throws RestConfigException, StoreInitializationException {
     Properties props = new Properties();
 
     props.put(SchemaRegistryConfig.KAFKASTORE_SECURITY_PROTOCOL_CONFIG,
@@ -95,34 +94,26 @@ public class StoreUtils {
     }
 
     Store<String, String> inMemoryStore = new InMemoryStore<String, String>();
-    return createAndInitKafkaStoreInstance(zkConnect, zkClient, inMemoryStore, props);
+    return createAndInitKafkaStoreInstance(zkConnect, inMemoryStore, props);
   }
 
   /**
    * Get a new instance of KafkaStore and initialize it.
    */
   public static KafkaStore<String, String> createAndInitKafkaStoreInstance(
-          String zkConnect, ZkClient zkClient, Store<String, String> inMemoryStore,
-          Properties props) {
+          String zkConnect, Store<String, String> inMemoryStore,
+          Properties props) throws RestConfigException, StoreInitializationException{
     props.put(SchemaRegistryConfig.KAFKASTORE_CONNECTION_URL_CONFIG, zkConnect);
     props.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG, ClusterTestHarness.KAFKASTORE_TOPIC);
 
     SchemaRegistryConfig config = null;
-    try {
-      config = new SchemaRegistryConfig(props);
-    } catch (RestConfigException e) {
-      fail("Can't initialize configs");
-    }
+    config = new SchemaRegistryConfig(props);
 
     KafkaStore<String, String> kafkaStore =
             new KafkaStore<String, String>(config, new StringMessageHandler(),
                     StringSerializer.INSTANCE,
                     inMemoryStore, new NoopKey().toString());
-    try {
-      kafkaStore.init();
-    } catch (StoreInitializationException e) {
-      fail("Kafka store failed to initialize");
-    }
+    kafkaStore.init();
     return kafkaStore;
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/zookeeper/MasterElectorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/zookeeper/MasterElectorTest.java
@@ -251,6 +251,7 @@ public class MasterElectorTest extends ClusterTestHarness {
     RestApp aSlave = null;
     for (int i = 0; i < numSlaves; i++) {
       RestApp slave = new RestApp(choosePort(),
+                                  srZkConnect,
                                   zkConnect, KAFKASTORE_TOPIC,
                                   AvroCompatibilityLevel.NONE.name, false);
       slaveApps.add(slave);
@@ -279,6 +280,7 @@ public class MasterElectorTest extends ClusterTestHarness {
     final Set<RestApp> masterApps = new HashSet<RestApp>();
     for (int i = 0; i < numMasters; i++) {
       RestApp master = new RestApp(choosePort(),
+                                   srZkConnect,
                                    zkConnect, KAFKASTORE_TOPIC,
                                    AvroCompatibilityLevel.NONE.name, true);
       masterApps.add(master);
@@ -330,6 +332,7 @@ public class MasterElectorTest extends ClusterTestHarness {
     RestApp aSlave = null;
     for (int i = 0; i < numSlaves; i++) {
       RestApp slave = new RestApp(choosePort(),
+                                  srZkConnect,
                                   zkConnect, KAFKASTORE_TOPIC,
                                   AvroCompatibilityLevel.NONE.name, false);
       slaveApps.add(slave);
@@ -355,6 +358,7 @@ public class MasterElectorTest extends ClusterTestHarness {
     RestApp aMaster = null;
     for (int i = 0; i < numMasters; i++) {
       RestApp master = new RestApp(choosePort(),
+                                   srZkConnect,
                                    zkConnect, KAFKASTORE_TOPIC,
                                    AvroCompatibilityLevel.NONE.name, true);
       masterApps.add(master);

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,39 @@
 Changelog
 =========
 
+Version 3.4.0
+-------------
+
+Upgrade Notes
+^^^^^^^^^^^^^
+
+In 3.4.0, initial creation or validation of the topic used to store schemas has been
+reimplemented to use native Kafka protocol requests instead of accessing Zookeeper directly. This
+means that you are no longer required to have direct access to the Zookeeper cluster backing your
+Kafka cluster. However, note that this also requires appropriate permissions to create topics (on
+first execution of the Schema Registry) or describe topics and configs (on subsequent executions
+to validate the topic is configured correctly). If you have authentication and authorization enabled
+on your Kafka cluster, you must ensure your principal has the correct permissions before
+upgrading the Schema Registry cluster. Your principal must have the following permissions:
+
+Create Schemas Topic
+
+=========  ===========================  ===============================================
+Operation  Resource                     Reason
+=========  ===========================  ===============================================
+Describe   Topic: ``kafkastore.topic``  Check existence of topic
+Create     Cluster                      Create the schemas topic, set compaction policy
+=========  ===========================  ===============================================
+
+Validate Schemas Topic
+
+===============  ===========================  =============================================
+Operation        Resource                     Reason
+===============  ===========================  =============================================
+Describe         Topic: ``kafkastore.topic``  Check existence of topic
+DescribeConfigs  Topic: ``kafkastore.topic``  Validate correct compaction policy on topic
+===============  ===========================  =============================================
+
 Version 3.3.0
 -------------
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -137,6 +137,15 @@ Configuration Options
   * Default: false
   * Importance: high
 
+``schema.registry.connection.url``
+  Zookeeper URL used by the schema registry instances to coordinate. If not specified, it will default to using the kafkastore.connection.url, i.e. the same Zookeeper cluster as your Kafka cluster uses.
+
+  This setting is useful if you need to use a different Zookeeper cluster than your Kafka cluster uses, for example if you use a cloud hosted Kafka cluster that does not expose its underlying Zookeeper cluster.
+
+  * Type: string
+  * Default: ""
+  * Importance: medium
+
 ``kafkastore.init.timeout.ms``
   The timeout for initialization of the Kafka store, including creation of the Kafka topic that stores schema data.
 
@@ -266,16 +275,15 @@ Configuration Options
 ``kafkastore.bootstrap.servers``
   A list of Kafka brokers to connect to. For example, `PLAINTEXT://hostname:9092,SSL://hostname2:9092`
 
-  If this configuration is not specified, the Schema Registry's internal Kafka clients will get their Kafka bootstrap server list
-  from ZooKeeper (configured with `kafkastore.connection.url`). Note that if `kafkastore.bootstrap.servers` is configured,
-  `kafkastore.connection.url` still needs to be configured, too.
+  If this configuration is not specified, the Schema Registry's internal Kafka clients will get their Kafka bootstrap server list from ZooKeeper (configured with `kafkastore.connection.url`). In that case, all available listeners matching the `kafkastore.security.protocol` setting will be used. Note that if `kafkastore.bootstrap.servers` is configured, `kafkastore.connection.url` still needs to be configured, too.
 
-  This configuration is particularly important when Kafka security is enabled, because Kafka may expose multiple endpoints that
-  all will be stored in ZooKeeper, but the Schema Registry may need to be configured with just one of those endpoints.
+  This configuration is particularly important when Kafka security is enabled, because Kafka may expose multiple endpoints that all will be stored in ZooKeeper, but the Schema Registry may need to be configured with just one of those endpoints.
 
- * Type: list
- * Default: "" (when left blank, bootstrap servers are fetched from ZooKeeper)
- * Importance: medium
+  Additionally, this setting should be used if the Zookeeper cluster used to coordinate Schema Registry instances is different than the one used by the Kafka cluster storing the kafkastore.topic. For example, this might be the case if you are using a hosted Kafka service which does not provide access to the underlying Zookeeper cluster.
+
+  * Type: list
+  * Default: []
+  * Importance: medium
 
 ``access.control.allow.origin``
   Set value for Jetty Access-Control-Allow-Origin header

--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -98,6 +98,35 @@ Hostname to publish to ZooKeeper for clients to use. In IaaS environments, this 
      ``min.insync.replicas`` on the Kafka server for the ``kafkastore.topic`` to 2. This ensures that the
      register schema write is considered durable if it gets committed on at least 2 replicas out of 3. Furthermore, it is best to set ``unclean.leader.election.enable`` to false so that a replica outside of the isr is never elected leader (potentially resulting in data loss).
 
+If you are deploying the Schema Registry backed by a Kafka cluster that does not expose the
+underlying Zookeeper nodes (for example, in a hosted cloud environment), you will need to run a
+separate Zookeeper cluster for the Schema Registry instances to use for coordination. The
+connection information for this separate cluster should be used as the setting for
+``schema.registry.connection.url``. You must also specify the ``kafkastore.bootstrap.servers``
+setting to the Kafka cluster.
+
+``schema.registry.connection.url``
+  Zookeeper URL used by the schema registry instances to coordinate. If not specified, it will default to using the kafkastore.connection.url, i.e. the same Zookeeper cluster as your Kafka cluster uses.
+
+  This setting is useful if you need to use a different Zookeeper cluster than your Kafka cluster uses, for example if you use a cloud hosted Kafka cluster that does not expose its underlying Zookeeper cluster.
+
+  * Type: string
+  * Default: ""
+  * Importance: medium
+
+``kafkastore.bootstrap.servers``
+  A list of Kafka brokers to connect to. For example, `PLAINTEXT://hostname:9092,SSL://hostname2:9092`
+
+  If this configuration is not specified, the Schema Registry's internal Kafka clients will get their Kafka bootstrap server list from ZooKeeper (configured with `kafkastore.connection.url`). In that case, all available listeners matching the `kafkastore.security.protocol` setting will be used. Note that if `kafkastore.bootstrap.servers` is configured, `kafkastore.connection.url` still needs to be configured, too.
+
+  This configuration is particularly important when Kafka security is enabled, because Kafka may expose multiple endpoints that all will be stored in ZooKeeper, but the Schema Registry may need to be configured with just one of those endpoints.
+
+  Additionally, this setting is required if the Zookeeper cluster used to coordinate Schema Registry instances is different than the one used by the Kafka cluster storing the kafkastore.topic. For example, this might be the case if you are using a hosted Kafka service which does not provide access to the underlying Zookeeper cluster.
+
+  * Type: list
+  * Default: []
+  * Importance: medium
+
 Don't Touch These Settings!
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Replace uses of ZK for getting cluster information and creating topics with the new Java AdminClient API. Refactor a few
other minor uses of ZK so they will not occur unless bootstrap servers are not specified. Add some additional guidance around
configuring the Zookeeper and Kafka bootstrap server settings in a cloud setting.