### PR TITLE
AbstractCoordinator and ConsumerNetworkClient require a LogContext

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/KafkaGroupMasterElector.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/KafkaGroupMasterElector.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.network.ChannelBuilder;
 import org.apache.kafka.common.network.Selector;
 import org.apache.kafka.common.utils.AppInfoParser;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -133,7 +134,11 @@ public class KafkaGroupMasterElector implements MasterElector, SchemaRegistryReb
           time,
           true,
           new ApiVersions());
+      String groupId = config.getString(SchemaRegistryConfig.SCHEMAREGISTRY_GROUP_ID_CONFIG);
+      LogContext logContext = new LogContext("[Schema registry clientId=" + clientId + ", groupId="
+          + groupId + "] ");
       this.client = new ConsumerNetworkClient(
+          logContext,
           netClient,
           metadata,
           time,
@@ -141,8 +146,9 @@ public class KafkaGroupMasterElector implements MasterElector, SchemaRegistryReb
           clientConfig.getInt(CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG)
       );
       this.coordinator = new SchemaRegistryCoordinator(
+          logContext,
           this.client,
-          config.getString(SchemaRegistryConfig.SCHEMAREGISTRY_GROUP_ID_CONFIG),
+          groupId,
           300000, // Default MAX_POLL_INTERVAL_MS_CONFIG
           10000, // Default SESSION_TIMEOUT_MS_CONFIG)
           3000, // Default HEARTBEAT_INTERVAL_MS_CONFIG

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinator.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.consumer.internals.AbstractCoordinator;
 import org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.requests.JoinGroupRequest;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,6 +53,7 @@ final class SchemaRegistryCoordinator extends AbstractCoordinator implements Clo
    * Initialize the coordination manager.
    */
   public SchemaRegistryCoordinator(
+      LogContext logContext,
       ConsumerNetworkClient client,
       String groupId,
       int rebalanceTimeoutMs,
@@ -63,7 +65,8 @@ final class SchemaRegistryCoordinator extends AbstractCoordinator implements Clo
       long retryBackoffMs,
       SchemaRegistryIdentity identity,
       SchemaRegistryRebalanceListener listener) {
-    super(client,
+    super(logContext,
+          client,
           groupId,
           rebalanceTimeoutMs,
           sessionTimeoutMs,

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinatorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinatorTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.requests.JoinGroupRequest.ProtocolMetadata;
 import org.apache.kafka.common.requests.JoinGroupResponse;
 import org.apache.kafka.common.requests.SyncGroupRequest;
 import org.apache.kafka.common.requests.SyncGroupResponse;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
@@ -88,13 +89,15 @@ public class SchemaRegistryCoordinatorTest {
     this.client = new MockClient(time);
     this.metadata = new Metadata(0, Long.MAX_VALUE, true);
     this.metadata.update(cluster, Collections.<String>emptySet(), time.milliseconds());
-    this.consumerClient = new ConsumerNetworkClient(client, metadata, time, 100, 1000);
+    LogContext logContext = new LogContext();
+    this.consumerClient = new ConsumerNetworkClient(logContext, client, metadata, time, 100, 1000);
     this.metrics = new Metrics(time);
     this.rebalanceListener = new MockRebalanceListener();
 
     client.setNode(node);
 
     this.coordinator = new SchemaRegistryCoordinator(
+        logContext,
         consumerClient,
         groupId,
         rebalanceTimeoutMs,


### PR DESCRIPTION
These are internal classes, so compatibility is not guaranteed.