### PR TITLE
Pass Metrics instance in AppInfoParser call

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/KafkaGroupMasterElector.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/KafkaGroupMasterElector.java
@@ -164,7 +164,7 @@ public class KafkaGroupMasterElector implements MasterElector, SchemaRegistryReb
           this
       );
 
-      AppInfoParser.registerAppInfo(JMX_PREFIX, clientId);
+      AppInfoParser.registerAppInfo(JMX_PREFIX, clientId, metrics);
 
       initTimeout = config.getInt(SchemaRegistryConfig.KAFKASTORE_INIT_TIMEOUT_CONFIG);
 
@@ -308,7 +308,7 @@ public class KafkaGroupMasterElector implements MasterElector, SchemaRegistryReb
     ClientUtils.closeQuietly(coordinator, "coordinator", firstException);
     ClientUtils.closeQuietly(metrics, "consumer metrics", firstException);
     ClientUtils.closeQuietly(client, "consumer network client", firstException);
-    AppInfoParser.unregisterAppInfo(JMX_PREFIX, clientId);
+    AppInfoParser.unregisterAppInfo(JMX_PREFIX, clientId, metrics);
     if (firstException.get() != null && !swallowException) {
       throw new KafkaException(
           "Failed to stop the schema registry group member",


### PR DESCRIPTION
This is due to a change in Apache Kafka for tracking the version and commit id as Kafka Metrics.