### PR TITLE
Shutdown the SchemaRegistry gracefully when there is an exception during startup

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
@@ -63,6 +63,7 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
       );
       schemaRegistry.init();
     } catch (SchemaRegistryException e) {
+      onShutdown();
       log.error("Error starting the schema registry", e);
       System.exit(1);
     }
@@ -105,7 +106,11 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
 
   @Override
   public void onShutdown() {
-    schemaRegistry.close();
+
+    if (schemaRegistry != null) {
+      schemaRegistry.close();
+    }
+
     if (schemaRegistryResourceExtension != null) {
       try {
         schemaRegistryResourceExtension.close();

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -93,6 +93,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
   private final Object masterLock = new Object();
   private final AvroCompatibilityLevel defaultCompatibilityLevel;
   private final int kafkaStoreTimeoutMs;
+  private final int initTimeout;
   private final boolean isEligibleForMasterElector;
   private SchemaRegistryIdentity masterIdentity;
   private RestService masterRestService;
@@ -129,6 +130,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     this.sslFactory = new SslFactory(config);
     this.kafkaStoreTimeoutMs =
         config.getInt(SchemaRegistryConfig.KAFKASTORE_TIMEOUT_CONFIG);
+    this.initTimeout = config.getInt(SchemaRegistryConfig.KAFKASTORE_INIT_TIMEOUT_CONFIG);
     this.serializer = serializer;
     this.defaultCompatibilityLevel = config.compatibilityType();
     this.guidToSchemaKey = new HashMap<Integer, SchemaKey>();
@@ -265,7 +267,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
         //ensure the new master catches up with the offsets before it gets nextid and assigns
         // master
         try {
-          kafkaStore.waitUntilKafkaReaderReachesLastOffset(kafkaStoreTimeoutMs);
+          kafkaStore.waitUntilKafkaReaderReachesLastOffset(initTimeout);
         } catch (StoreException e) {
           throw new SchemaRegistryStoreException("Exception getting latest offset ", e);
         }


### PR DESCRIPTION
There could be a scenario where SR node is deemed as master and fails before it can catch up on the offsets. When this happens we need to inform the coordinator that we are shutting down.

Failed ST that led to the fix : https://confluentinc.atlassian.net/browse/CLIENTS-676