### PR TITLE
Update docu to show that KAFKA_STORE_CONNECTION is a list

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -83,9 +83,9 @@ To configure the Schema Registry to use ZooKeeper for master election, configure
 ``kafkastore.connection.url`` setting.
 
 ``kafkastore.connection.url``
-Zookeeper url for the Kafka cluster
+Comma separated list for Zookeeper urls for the Kafka cluster
 
-* Type: string
+* Type: list
 * Importance: high
 
 To configure the Schema Registry to use Kafka for master election, configure the


### PR DESCRIPTION
The parameter kafkastore.connection.url can actually provide a comma-separated list.