### PR TITLE
Add maxPollTimeout parameter to ConsumerNetworkClient constructor

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/KafkaGroupMasterElector.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/KafkaGroupMasterElector.java
@@ -147,7 +147,8 @@ public class KafkaGroupMasterElector implements MasterElector, SchemaRegistryReb
           metadata,
           time,
           retryBackoffMs,
-          clientConfig.getInt(CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG)
+          clientConfig.getInt(CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG),
+          Integer.MAX_VALUE
       );
       this.coordinator = new SchemaRegistryCoordinator(
           logContext,

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinatorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinatorTest.java
@@ -93,7 +93,7 @@ public class SchemaRegistryCoordinatorTest {
     this.metadata = new Metadata(0, Long.MAX_VALUE, true);
     this.metadata.update(cluster, Collections.<String>emptySet(), time.milliseconds());
     LogContext logContext = new LogContext();
-    this.consumerClient = new ConsumerNetworkClient(logContext, client, metadata, time, 100, 1000);
+    this.consumerClient = new ConsumerNetworkClient(logContext, client, metadata, time, 100, 1000, Integer.MAX_VALUE);
     this.metrics = new Metrics(time);
     this.rebalanceListener = new MockRebalanceListener();
 


### PR DESCRIPTION
This is due to an upstream change: https://github.com/apache/kafka/commit/7fe88e8bd9acedcb74a4b3e61440f61481b60711. Here is a link to the failing build: https://jenkins.confluent.io/job/test-cp-downstream-builds/1549/console.