### PR TITLE
Adding support for thrift and protobuf objects in Confluent's Schema Registry.

### DIFF
--- a/avro-serializer/pom.xml
+++ b/avro-serializer/pom.xml
@@ -14,6 +14,12 @@
     <packaging>jar</packaging>
     <name>kafka-avro-serializer</name>
 
+    <properties>
+        <avro.version>1.8.2</avro.version>
+        <protobuf.version>3.4.0</protobuf.version>
+        <thrift.version>0.10.0</thrift.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -25,6 +31,16 @@
             <artifactId>avro</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro-protobuf</artifactId>
+            <version>${avro.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry-client</artifactId>
         </dependency>
@@ -32,7 +48,17 @@
             <groupId>io.confluent</groupId>
             <artifactId>common-config</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+            <version>${thrift.version}</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro-thrift</artifactId>
+            <version>${avro.version}</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/avro-serializer/src/main/java/io/confluent/kafka/converters/GeneratedMessageToGenericRecord.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/converters/GeneratedMessageToGenericRecord.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2014 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.converters;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.GeneratedMessage;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+
+import java.util.Map;
+
+public class GeneratedMessageToGenericRecord {
+  public static GenericRecord convert(GeneratedMessage message, Schema schema) {
+    GenericRecord record = new GenericData.Record(schema);
+    for (Map.Entry<Descriptors.FieldDescriptor, Object> entry : message.getAllFields().entrySet()) {
+      String fieldName = entry.getKey().getName();
+      Object value = entry.getValue();
+      Schema fieldSchema = schema.getField(fieldName).schema();
+      setField(record, fieldName, value, fieldSchema);
+    }
+    return record;
+  }
+
+  private static void setField(GenericRecord record, String fieldName, Object value,
+                               Schema fieldSchema) {
+    Schema.Type type = fieldSchema.getType();
+    // TODO - handling nested types of maps and array
+    switch (type) {
+      case UNION:
+        Schema fschema = fieldSchema.getTypes().get(1); // TODO - iterate all types
+        setField(record, fieldName, value, fschema);
+        break;
+      case RECORD:
+        record.put(fieldName, GeneratedMessageToGenericRecord.convert(
+                (GeneratedMessage) value, fieldSchema));
+        break;
+      default:
+        record.put(fieldName, value);
+    }
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/converters/TBaseToGenericRecord.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/converters/TBaseToGenericRecord.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2014 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.converters;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.thrift.TBase;
+import org.apache.thrift.TFieldIdEnum;
+
+public class TBaseToGenericRecord {
+  public static GenericRecord convert(TBase message, Schema schema) {
+    GenericRecord record = new GenericData.Record(schema);
+    int index = 1;
+    TFieldIdEnum field = message.fieldForId(index);
+    while (field != null) {
+      String fieldName = field.getFieldName();
+      Object value = message.getFieldValue(field);
+      Schema fieldSchema = schema.getField(fieldName).schema();
+      setField(record, fieldName, value, fieldSchema);
+      index = index + 1;
+      field = message.fieldForId(index);
+    }
+    return record;
+  }
+
+  private static void setField(GenericRecord record, String fieldName, Object value,
+                               Schema fieldSchema) {
+    Schema.Type type = fieldSchema.getType();
+    // TODO - handling nested types of maps and array
+    switch (type) {
+      case UNION:
+        Schema fschema = fieldSchema.getTypes().get(1); // TODO - iterate all types
+        setField(record, fieldName, value, fschema);
+        break;
+      case RECORD:
+        record.put(fieldName, TBaseToGenericRecord.convert(
+                (TBase) value, fieldSchema));
+        break;
+      default:
+        record.put(fieldName, value);
+    }
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/io/GenericBinaryDecoder.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/io/GenericBinaryDecoder.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2014 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.io;
+
+import org.apache.avro.io.BinaryDecoder;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+public class GenericBinaryDecoder extends BinaryDecoder {
+  private byte[] bytes;
+  private int start;
+  private int length;
+
+  public GenericBinaryDecoder(byte[] bytes, int start, int length) {
+    this.bytes = bytes;
+    this.start = start;
+    this.length = length;
+  }
+
+  @Override
+  public ByteBuffer readBytes(ByteBuffer var1) throws IOException {
+    return ByteBuffer.wrap(Arrays.copyOfRange(bytes, start, start + length));
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/io/GenericBinaryEncoder.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/io/GenericBinaryEncoder.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2014 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.io;
+
+import org.apache.avro.io.BinaryEncoder;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class GenericBinaryEncoder extends BinaryEncoder {
+  private ByteArrayOutputStream out;
+
+  public GenericBinaryEncoder(ByteArrayOutputStream out) {
+    this.out = out;
+  }
+
+  @Override
+  protected void writeZero() throws IOException {
+
+  }
+
+  @Override
+  public int bytesBuffered() {
+    return 0;
+  }
+
+  @Override
+  public void writeBoolean(boolean b) throws IOException {
+
+  }
+
+  @Override
+  public void writeInt(int i) throws IOException {
+
+  }
+
+  @Override
+  public void writeLong(long l) throws IOException {
+
+  }
+
+  @Override
+  public void writeFloat(float v) throws IOException {
+
+  }
+
+  @Override
+  public void writeDouble(double v) throws IOException {
+
+  }
+
+  @Override
+  public void writeFixed(byte[] bytes, int i, int i1) throws IOException {
+    out.write(bytes, i, i1);
+  }
+
+  @Override
+  public void flush() throws IOException {
+
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/io/ProtobufReader.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/io/ProtobufReader.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2014 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.io;
+
+import org.apache.avro.Schema;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.Decoder;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class ProtobufReader implements DatumReader {
+  private Schema schema;
+
+  public ProtobufReader(Schema schema) {
+    this.schema = schema;
+  }
+
+  @Override
+  public void setSchema(Schema schema) {
+  }
+
+  @Override
+  public Object read(Object o, Decoder decoder) throws IOException {
+    Object instance;
+    try {
+      ByteArrayInputStream output = new ByteArrayInputStream(decoder.readBytes(null).array());
+      String className = schema.getNamespace() + schema.getName();
+      Class generatedMessageClass = Class.forName(className);
+      Method newBuilderMethod = generatedMessageClass.getMethod("newBuilder");
+      Object builder = newBuilderMethod.invoke(null);
+      Method mergeFromMethod = builder.getClass().getMethod("mergeFrom", InputStream.class);
+      mergeFromMethod.invoke(builder, output);
+      Method buildMethod = builder.getClass().getMethod("build");
+      instance = buildMethod.invoke(builder);
+    } catch (NoSuchMethodException | ClassNotFoundException
+        | IllegalAccessException | InvocationTargetException e) {
+      throw new IOException("Error reading protobuf object", e);
+    }
+    return instance;
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/io/ProtobufWriter.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/io/ProtobufWriter.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2014 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.io;
+
+import org.apache.avro.Schema;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.protobuf.ProtobufData;
+import org.apache.avro.protobuf.ProtobufDatumWriter;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
+
+public class ProtobufWriter<T> extends ProtobufDatumWriter<T> {
+
+  public ProtobufWriter(Class<T> c) {
+      super(ProtobufData.get().getSchema(c), ProtobufData.get());
+  }
+
+  @Override
+  protected void write(Schema schema, Object datum, Encoder out) throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    java.lang.reflect.Method method;
+    try {
+      method = datum.getClass().getMethod("writeTo", OutputStream.class);
+      method.invoke(datum, output);
+    } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+      throw new IOException("Error writing protobuf object", e);
+    }
+    out.writeBytes(output.toByteArray(), 0, output.toByteArray().length);
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/io/ThriftReader.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/io/ThriftReader.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2014 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.io;
+
+import org.apache.avro.Schema;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.Decoder;
+import org.apache.thrift.TBase;
+import org.apache.thrift.TDeserializer;
+import org.apache.thrift.TException;
+
+import java.io.IOException;
+
+public class ThriftReader implements DatumReader {
+  private Schema schema;
+
+  public ThriftReader(Schema schema) {
+    this.schema = schema;
+  }
+
+  @Override
+  public void setSchema(Schema schema) {
+  }
+
+  @Override
+  public Object read(Object o, Decoder decoder) throws IOException {
+    TDeserializer deserializer = new TDeserializer();
+    TBase instance;
+    try {
+      byte[] output = decoder.readBytes(null).array();
+      String className = schema.getFullName();
+      Class tbaseClass = Class.forName(className);
+      instance = (TBase) tbaseClass.newInstance();
+      deserializer.deserialize(instance, output);
+    } catch (TException | ClassNotFoundException | IllegalAccessException
+            | InstantiationException e) {
+      throw new IOException("Error reading thrift object", e);
+    }
+    return instance;
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/io/ThriftWriter.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/io/ThriftWriter.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2014 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.io;
+
+import org.apache.avro.Schema;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.thrift.ThriftData;
+import org.apache.avro.thrift.ThriftDatumWriter;
+import org.apache.thrift.TBase;
+import org.apache.thrift.TException;
+import org.apache.thrift.TSerializer;
+
+import java.io.IOException;
+
+public class ThriftWriter<T> extends ThriftDatumWriter<T> {
+
+  public ThriftWriter(Class<T> c) {
+    super(ThriftData.get().getSchema(c), ThriftData.get());
+  }
+
+  @Override
+  protected void write(Schema schema, Object datum, Encoder out) throws IOException {
+    byte[] output;
+    TSerializer serializer = new TSerializer();
+    try {
+      output = serializer.serialize((TBase) datum);
+    } catch (TException e) {
+      throw new IOException("Error writing thrift object", e);
+    }
+    out.writeBytes(output, 0, output.length);
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -36,8 +36,6 @@ import kafka.utils.VerifiableProperties;
 
 public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaAvroSerDe {
 
-  private final EncoderFactory encoderFactory = EncoderFactory.get();
-
   protected void configure(KafkaAvroSerializerConfig config) {
     configureClientProperties(config);
   }
@@ -78,17 +76,9 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaAvroSerDe
       if (object instanceof byte[]) {
         out.write((byte[]) object);
       } else {
-        BinaryEncoder encoder = encoderFactory.directBinaryEncoder(out, null);
-        DatumWriter<Object> writer;
-        Object
-            value =
-            object instanceof NonRecordContainer ? ((NonRecordContainer) object).getValue()
-                                                 : object;
-        if (value instanceof SpecificRecord) {
-          writer = new SpecificDatumWriter<>(schema);
-        } else {
-          writer = new GenericDatumWriter<>(schema);
-        }
+        BinaryEncoder encoder = getBinaryEncoder(out);
+        DatumWriter<Object> writer = getDatumWriter(object, schema);
+        Object value = getValue(object);
         writer.write(value, encoder);
         encoder.flush();
       }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaProtobufAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaProtobufAvroDeserializer.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafka.serializers;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.protobuf.ProtobufDatumReader;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.kafka.common.serialization.Deserializer;
+
+import java.util.Map;
+
+public class KafkaProtobufAvroDeserializer extends AbstractKafkaAvroDeserializer
+    implements Deserializer<Object> {
+
+  private boolean isKey;
+
+  /**
+   * Constructor used by Kafka consumer.
+   */
+  public KafkaProtobufAvroDeserializer() {
+
+  }
+
+  public KafkaProtobufAvroDeserializer(SchemaRegistryClient client) {
+    schemaRegistry = client;
+  }
+
+  public KafkaProtobufAvroDeserializer(SchemaRegistryClient client, Map<String, ?> props) {
+    schemaRegistry = client;
+    configure(deserializerConfig(props));
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    this.isKey = isKey;
+    configure(new KafkaAvroDeserializerConfig(configs));
+  }
+
+  @Override
+  public Object deserialize(String s, byte[] bytes) {
+    return deserialize(bytes);
+  }
+
+  /**
+   * Pass a reader schema to get an Avro projection
+   */
+  public Object deserialize(String s, byte[] bytes, Schema readerSchema) {
+    return deserialize(bytes, readerSchema);
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  protected DatumReader getDatumReader(Schema writerSchema, Schema readerSchema) {
+    if (readerSchema == null) {
+      return new ProtobufDatumReader(writerSchema);
+    }
+    return new ProtobufDatumReader(writerSchema, readerSchema);
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaProtobufAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaProtobufAvroSerializer.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2014 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.serializers;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import org.apache.avro.Schema;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.protobuf.ProtobufDatumReader;
+import org.apache.avro.protobuf.ProtobufDatumWriter;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.util.Map;
+
+public class KafkaProtobufAvroSerializer extends AbstractKafkaAvroSerializer
+        implements Serializer<Object> {
+
+  private boolean isKey;
+
+  /**
+   * Constructor used by Kafka producer.
+   */
+  public KafkaProtobufAvroSerializer() {
+
+  }
+
+  public KafkaProtobufAvroSerializer(SchemaRegistryClient client) {
+    schemaRegistry = client;
+  }
+
+  public KafkaProtobufAvroSerializer(SchemaRegistryClient client, Map<String, ?> props) {
+    schemaRegistry = client;
+    configure(serializerConfig(props));
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    this.isKey = isKey;
+    configure(new KafkaAvroSerializerConfig(configs));
+  }
+
+  @Override
+  public byte[] serialize(String topic, Object record) {
+    return serializeImpl(getSubjectName(topic, isKey), record);
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  protected Schema getSchema(Object object) {
+    return new ProtobufDatumReader<>(object.getClass()).getSchema();
+  }
+
+  @Override
+  protected DatumWriter getDatumWriter(Object value, Schema schema) {
+    return new ProtobufDatumWriter<>(value.getClass());
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaProtobufDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaProtobufDeserializer.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafka.serializers;
+
+import io.confluent.kafka.io.GenericBinaryDecoder;
+import io.confluent.kafka.io.ProtobufReader;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import org.apache.avro.Schema;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.kafka.common.serialization.Deserializer;
+
+import java.util.Map;
+
+public class KafkaProtobufDeserializer extends AbstractKafkaAvroDeserializer
+    implements Deserializer<Object> {
+
+  private boolean isKey;
+
+  /**
+   * Constructor used by Kafka consumer.
+   */
+  public KafkaProtobufDeserializer() {
+
+  }
+
+  public KafkaProtobufDeserializer(SchemaRegistryClient client) {
+    schemaRegistry = client;
+  }
+
+  public KafkaProtobufDeserializer(SchemaRegistryClient client, Map<String, ?> props) {
+    schemaRegistry = client;
+    configure(deserializerConfig(props));
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    this.isKey = isKey;
+    configure(new KafkaAvroDeserializerConfig(configs));
+  }
+
+  @Override
+  public Object deserialize(String s, byte[] bytes) {
+    return deserialize(bytes);
+  }
+
+  /**
+   * Pass a reader schema to get an Avro projection
+   */
+  public Object deserialize(String s, byte[] bytes, Schema readerSchema) {
+    return deserialize(bytes, readerSchema);
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  protected DatumReader getDatumReader(Schema writerSchema, Schema readerSchema) {
+    return new ProtobufReader(writerSchema);
+  }
+
+  @Override
+  protected BinaryDecoder getBinaryDecoder(byte[] bytes, int start, int length) {
+    return new GenericBinaryDecoder(bytes, start, length);
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaProtobufSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaProtobufSerializer.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2014 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.serializers;
+
+import io.confluent.kafka.io.GenericBinaryEncoder;
+import io.confluent.kafka.io.ProtobufWriter;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import org.apache.avro.Schema;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.protobuf.ProtobufDatumReader;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Map;
+
+public class KafkaProtobufSerializer extends AbstractKafkaAvroSerializer
+        implements Serializer<Object> {
+
+  private boolean isKey;
+
+  /**
+   * Constructor used by Kafka producer.
+   */
+  public KafkaProtobufSerializer() {
+
+  }
+
+  public KafkaProtobufSerializer(SchemaRegistryClient client) {
+    schemaRegistry = client;
+  }
+
+  public KafkaProtobufSerializer(SchemaRegistryClient client, Map<String, ?> props) {
+    schemaRegistry = client;
+    configure(serializerConfig(props));
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    this.isKey = isKey;
+    configure(new KafkaAvroSerializerConfig(configs));
+  }
+
+  @Override
+  public byte[] serialize(String topic, Object record) {
+    return serializeImpl(getSubjectName(topic, isKey), record);
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  protected Schema getSchema(Object object) {
+    return new ProtobufDatumReader<>(object.getClass()).getSchema();
+  }
+
+  @Override
+  protected DatumWriter getDatumWriter(Object value, Schema schema) {
+    return new ProtobufWriter<>(value.getClass());
+  }
+
+  @Override
+  protected BinaryEncoder getBinaryEncoder(ByteArrayOutputStream out) {
+    return new GenericBinaryEncoder(out);
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaThriftAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaThriftAvroDeserializer.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafka.serializers;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import org.apache.avro.Schema;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.thrift.ThriftDatumReader;
+import org.apache.kafka.common.serialization.Deserializer;
+
+import java.util.Map;
+
+public class KafkaThriftAvroDeserializer extends AbstractKafkaAvroDeserializer
+    implements Deserializer<Object> {
+
+  private boolean isKey;
+
+  /**
+   * Constructor used by Kafka consumer.
+   */
+  public KafkaThriftAvroDeserializer() {
+
+  }
+
+  public KafkaThriftAvroDeserializer(SchemaRegistryClient client) {
+    schemaRegistry = client;
+  }
+
+  public KafkaThriftAvroDeserializer(SchemaRegistryClient client, Map<String, ?> props) {
+    schemaRegistry = client;
+    configure(deserializerConfig(props));
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    this.isKey = isKey;
+    configure(new KafkaAvroDeserializerConfig(configs));
+  }
+
+  @Override
+  public Object deserialize(String s, byte[] bytes) {
+    return deserialize(bytes);
+  }
+
+  /**
+   * Pass a reader schema to get an Avro projection
+   */
+  public Object deserialize(String s, byte[] bytes, Schema readerSchema) {
+    return deserialize(bytes, readerSchema);
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  protected DatumReader getDatumReader(Schema writerSchema, Schema readerSchema) {
+    if (readerSchema == null) {
+      return new ThriftDatumReader(writerSchema);
+    }
+    return new ThriftDatumReader(writerSchema, readerSchema);
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaThriftAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaThriftAvroSerializer.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2014 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.serializers;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import org.apache.avro.Schema;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.thrift.ThriftDatumReader;
+import org.apache.avro.thrift.ThriftDatumWriter;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.util.Map;
+
+public class KafkaThriftAvroSerializer extends AbstractKafkaAvroSerializer
+        implements Serializer<Object> {
+
+  private boolean isKey;
+
+  /**
+   * Constructor used by Kafka producer.
+   */
+  public KafkaThriftAvroSerializer() {
+
+  }
+
+  public KafkaThriftAvroSerializer(SchemaRegistryClient client) {
+    schemaRegistry = client;
+  }
+
+  public KafkaThriftAvroSerializer(SchemaRegistryClient client, Map<String, ?> props) {
+    schemaRegistry = client;
+    configure(serializerConfig(props));
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    this.isKey = isKey;
+    configure(new KafkaAvroSerializerConfig(configs));
+  }
+
+  @Override
+  public byte[] serialize(String topic, Object record) {
+    return serializeImpl(getSubjectName(topic, isKey), record);
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  protected Schema getSchema(Object object) {
+    return new ThriftDatumReader<>(object.getClass()).getSchema();
+  }
+
+  @Override
+  protected DatumWriter getDatumWriter(Object value, Schema schema) {
+    return new ThriftDatumWriter<>(value.getClass());
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaThriftDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaThriftDeserializer.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafka.serializers;
+
+import io.confluent.kafka.io.GenericBinaryDecoder;
+import io.confluent.kafka.io.ThriftReader;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import org.apache.avro.Schema;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.kafka.common.serialization.Deserializer;
+
+import java.util.Map;
+
+public class KafkaThriftDeserializer extends AbstractKafkaAvroDeserializer
+    implements Deserializer<Object> {
+
+  private boolean isKey;
+
+  /**
+   * Constructor used by Kafka consumer.
+   */
+  public KafkaThriftDeserializer() {
+
+  }
+
+  public KafkaThriftDeserializer(SchemaRegistryClient client) {
+    schemaRegistry = client;
+  }
+
+  public KafkaThriftDeserializer(SchemaRegistryClient client, Map<String, ?> props) {
+    schemaRegistry = client;
+    configure(deserializerConfig(props));
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    this.isKey = isKey;
+    configure(new KafkaAvroDeserializerConfig(configs));
+  }
+
+  @Override
+  public Object deserialize(String s, byte[] bytes) {
+    return deserialize(bytes);
+  }
+
+  /**
+   * Pass a reader schema to get an Avro projection
+   */
+  public Object deserialize(String s, byte[] bytes, Schema readerSchema) {
+    return deserialize(bytes, readerSchema);
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  protected DatumReader getDatumReader(Schema writerSchema, Schema readerSchema) {
+    return new ThriftReader(writerSchema);
+  }
+
+  @Override
+  protected BinaryDecoder getBinaryDecoder(byte[] bytes, int start, int length) {
+    return new GenericBinaryDecoder(bytes, start, length);
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaThriftSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaThriftSerializer.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2014 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.serializers;
+
+import io.confluent.kafka.io.GenericBinaryEncoder;
+import io.confluent.kafka.io.ThriftWriter;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import org.apache.avro.Schema;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.thrift.ThriftDatumReader;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Map;
+
+public class KafkaThriftSerializer extends AbstractKafkaAvroSerializer
+        implements Serializer<Object> {
+
+  private boolean isKey;
+
+  /**
+   * Constructor used by Kafka producer.
+   */
+  public KafkaThriftSerializer() {
+
+  }
+
+  public KafkaThriftSerializer(SchemaRegistryClient client) {
+    schemaRegistry = client;
+  }
+
+  public KafkaThriftSerializer(SchemaRegistryClient client, Map<String, ?> props) {
+    schemaRegistry = client;
+    configure(serializerConfig(props));
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    this.isKey = isKey;
+    configure(new KafkaAvroSerializerConfig(configs));
+  }
+
+  @Override
+  public byte[] serialize(String topic, Object record) {
+    return serializeImpl(getSubjectName(topic, isKey), record);
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  protected Schema getSchema(Object object) {
+    return new ThriftDatumReader<>(object.getClass()).getSchema();
+  }
+
+  @Override
+  protected DatumWriter getDatumWriter(Object value, Schema schema) {
+    return new ThriftWriter<>(value.getClass());
+  }
+
+  @Override
+  protected BinaryEncoder getBinaryEncoder(ByteArrayOutputStream out) {
+    return new GenericBinaryEncoder(out);
+  }
+}


### PR DESCRIPTION
Here you can see my implementation to support thrift `org.apache.thrift.TBase` and protobuf `com.google.protobuf.GeneratedMessage` objects in Confluent's Schema Registry.
This implementation converts the originals schemata of the originals objects to Avro schemata for compatibility verification.

This is not "production ready", I just want to get your feedback on this solution (I tried to make the smallest change as possible).
In production we also need to:
* Use cache instead of reflection, I use reflection in some places in the code (it is possible to replace most of them with cache items).
* Decide on the packaging (Java) - maybe make a refactor in the code.
* ...

**You can find examples and more explanations in**:
https://github.com/akfak/examples/tree/master/avro-serializer

cc: @gwenshap