### PR TITLE
Support HTTP authentication for Schema Registry

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -135,6 +135,11 @@ public class RestService {
       connection = (HttpURLConnection) url.openConnection();
       connection.setRequestMethod(method);
 
+      if (url.getUserInfo() != null) {
+        String basicAuth = "Basic " + javax.xml.bind.DatatypeConverter.printBase64Binary(url.getUserInfo().getBytes());
+        connection.setRequestProperty("Authorization", basicAuth);
+      }
+
       // connection.getResponseCode() implicitly calls getInputStream, so always set to true.
       // On the other hand, leaving this out breaks nothing.
       connection.setDoInput(true);

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -173,6 +173,8 @@ public class RestService {
         return result;
       } else if (responseCode == HttpURLConnection.HTTP_NO_CONTENT) {
         return null;
+      } else if (responseCode == HttpURLConnection.HTTP_UNAUTHORIZED) {
+        throw new RestClientException("Unauthorized", responseCode, responseCode);
       } else {
         InputStream es = connection.getErrorStream();
         ErrorMessage errorMessage;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -125,9 +125,9 @@ public class RestService {
                                 Map<String, String> requestProperties,
                                 TypeReference<T> responseFormat)
       throws IOException, RestClientException {
-    log.debug(String.format("Sending %s with input %s to %s",
+    log.debug(String.format("Sending %s with input %s to %s with properties %s",
                             method, requestBodyData == null ? "null" : new String(requestBodyData),
-                            requestUrl));
+                            requestUrl, requestProperties));
 
     HttpURLConnection connection = null;
     try {
@@ -163,6 +163,9 @@ public class RestService {
       }
 
       int responseCode = connection.getResponseCode();
+      log.debug(String.format("Response code: %s", responseCode));
+      log.debug(String.format("Response headers: %s", connection.getHeaderFields()));
+
       if (responseCode == HttpURLConnection.HTTP_OK) {
         InputStream is = connection.getInputStream();
         T result = jsonDeserializer.readValue(is, responseFormat);


### PR DESCRIPTION
When using the [Aiven](http://aiven.io) Kafka service, the Schema Registry requires authenticating with a username and password. This is not supported by the client.

This PR adds support for the authentication, along with logging of the relevant errors.