### PR TITLE
New (key|value).multi.type option for Avro serialization

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
@@ -106,7 +106,7 @@ public class AvroConverter implements Converter {
     }
 
     public byte[] serialize(String topic, boolean isKey, Object value) {
-      return serializeImpl(getSubjectName(topic, isKey), value);
+      return serializeImpl(getSubjectName(topic, isKey, value), value);
     }
   }
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -118,7 +118,7 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaAvroSer
     try {
       ByteBuffer buffer = getByteBuffer(payload);
       id = buffer.getInt();
-      String subject = includeSchemaAndVersion ? getSubjectName(topic, isKey) : null;
+      String subject = includeSchemaAndVersion ? getSubjectName(topic, isKey, null) : null;
       Schema schema = schemaRegistry.getBySubjectAndId(subject, id);
       int length = buffer.limit() - 1 - idSize;
       final Object result;

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
@@ -31,6 +31,7 @@ import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.serializers.subject.SubjectNameStrategy;
+import io.confluent.kafka.serializers.subject.TopicNameStrategy;
 
 /**
  * Common fields and helper methods for both the serializer and the deserializer.
@@ -42,8 +43,8 @@ public abstract class AbstractKafkaAvroSerDe {
 
   private static final Map<String, Schema> primitiveSchemas;
   protected SchemaRegistryClient schemaRegistry;
-  protected SubjectNameStrategy keySubjectNameStrategy;
-  protected SubjectNameStrategy valueSubjectNameStrategy;
+  protected SubjectNameStrategy keySubjectNameStrategy = new TopicNameStrategy();
+  protected SubjectNameStrategy valueSubjectNameStrategy = new TopicNameStrategy();
 
   static {
     Schema.Parser parser = new Schema.Parser();
@@ -86,11 +87,7 @@ public abstract class AbstractKafkaAvroSerDe {
    * Get the subject name for the given topic and value type.
    */
   protected String getSubjectName(String topic, boolean isKey, Object value) {
-    // Null is passed through unserialized, since it has special meaning in
-    // log-compacted Kafka topics.
-    if (value == null) {
-      return null;
-    } else if (isKey) {
+    if (isKey) {
       return keySubjectNameStrategy.getSubjectName(topic, isKey, value);
     } else {
       return valueSubjectNameStrategy.getSubjectName(topic, isKey, value);

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
@@ -25,6 +25,8 @@ import io.confluent.common.config.ConfigDef.Importance;
 import io.confluent.common.config.ConfigDef.Type;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
 import io.confluent.kafka.schemaregistry.client.security.basicauth.BasicAuthCredentialSource;
+import io.confluent.kafka.serializers.subject.SubjectNameStrategy;
+import io.confluent.kafka.serializers.subject.TopicNameStrategy;
 
 /**
  * Base class for configs for serializers and deserializers, defining a few common configs and
@@ -62,13 +64,15 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
       "Specify the user info for Basic Auth in the form of {username}:{password}";
 
   public static final String KEY_SUBJECT_NAME_STRATEGY = "key.subject.name.strategy";
-  public static final String KEY_SUBJECT_NAME_STRATEGY_DEFAULT = "topic-key";
+  public static final String KEY_SUBJECT_NAME_STRATEGY_DEFAULT =
+      TopicNameStrategy.class.getName();
   public static final String KEY_SUBJECT_NAME_STRATEGY_DOC =
       "Determines how to construct the subject name under which the key schema is registered "
       + "with the schema registry";
 
   public static final String VALUE_SUBJECT_NAME_STRATEGY = "value.subject.name.strategy";
-  public static final String VALUE_SUBJECT_NAME_STRATEGY_DEFAULT = "topic-value";
+  public static final String VALUE_SUBJECT_NAME_STRATEGY_DEFAULT =
+      TopicNameStrategy.class.getName();
   public static final String VALUE_SUBJECT_NAME_STRATEGY_DOC =
       "Determines how to construct the subject name under which the value schema is registered "
       + "with the schema registry";
@@ -86,9 +90,9 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
             Importance.MEDIUM, BASIC_AUTH_CREDENTIALS_SOURCE_DOC)
         .define(SCHEMA_REGISTRY_USER_INFO_CONFIG, Type.PASSWORD, SCHEMA_REGISTRY_USER_INFO_DEFAULT,
             Importance.MEDIUM, SCHEMA_REGISTRY_USER_INFO_DOC)
-        .define(KEY_SUBJECT_NAME_STRATEGY, Type.STRING, KEY_SUBJECT_NAME_STRATEGY_DEFAULT,
+        .define(KEY_SUBJECT_NAME_STRATEGY, Type.CLASS, KEY_SUBJECT_NAME_STRATEGY_DEFAULT,
                 Importance.MEDIUM, KEY_SUBJECT_NAME_STRATEGY_DOC)
-        .define(VALUE_SUBJECT_NAME_STRATEGY, Type.STRING, VALUE_SUBJECT_NAME_STRATEGY_DEFAULT,
+        .define(VALUE_SUBJECT_NAME_STRATEGY, Type.CLASS, VALUE_SUBJECT_NAME_STRATEGY_DEFAULT,
                 Importance.MEDIUM, VALUE_SUBJECT_NAME_STRATEGY_DOC);
   }
 
@@ -108,11 +112,11 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
     return this.getBoolean(AUTO_REGISTER_SCHEMAS);
   }
 
-  public String keySubjectNameStrategy() {
-    return this.getString(KEY_SUBJECT_NAME_STRATEGY);
+  public SubjectNameStrategy keySubjectNameStrategy() {
+    return this.getConfiguredInstance(KEY_SUBJECT_NAME_STRATEGY, SubjectNameStrategy.class);
   }
 
-  public String valueSubjectNameStrategy() {
-    return this.getString(VALUE_SUBJECT_NAME_STRATEGY);
+  public SubjectNameStrategy valueSubjectNameStrategy() {
+    return this.getConfiguredInstance(VALUE_SUBJECT_NAME_STRATEGY, SubjectNameStrategy.class);
   }
 }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
@@ -61,17 +61,17 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
   public static final String SCHEMA_REGISTRY_USER_INFO_DOC =
       "Specify the user info for Basic Auth in the form of {username}:{password}";
 
-  public static final String KEY_MULTI_TYPE = "key.multi.type";
-  public static final boolean KEY_MULTI_TYPE_DEFAULT = false;
-  public static final String KEY_MULTI_TYPE_DOC =
-      "If true, the keys of messages in the topic may contain a mixture of "
-      + "different Avro record types.";
+  public static final String KEY_SUBJECT_NAME_STRATEGY = "key.subject.name.strategy";
+  public static final String KEY_SUBJECT_NAME_STRATEGY_DEFAULT = "topic-key";
+  public static final String KEY_SUBJECT_NAME_STRATEGY_DOC =
+      "Determines how to construct the subject name under which the key schema is registered "
+      + "with the schema registry";
 
-  public static final String VALUE_MULTI_TYPE = "value.multi.type";
-  public static final boolean VALUE_MULTI_TYPE_DEFAULT = false;
-  public static final String VALUE_MULTI_TYPE_DOC =
-      "If true, the values of messages in the topic may contain a mixture of "
-      + "different Avro record types.";
+  public static final String VALUE_SUBJECT_NAME_STRATEGY = "value.subject.name.strategy";
+  public static final String VALUE_SUBJECT_NAME_STRATEGY_DEFAULT = "topic-value";
+  public static final String VALUE_SUBJECT_NAME_STRATEGY_DOC =
+      "Determines how to construct the subject name under which the value schema is registered "
+      + "with the schema registry";
 
   public static ConfigDef baseConfigDef() {
     return new ConfigDef()
@@ -86,10 +86,10 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
             Importance.MEDIUM, BASIC_AUTH_CREDENTIALS_SOURCE_DOC)
         .define(SCHEMA_REGISTRY_USER_INFO_CONFIG, Type.PASSWORD, SCHEMA_REGISTRY_USER_INFO_DEFAULT,
             Importance.MEDIUM, SCHEMA_REGISTRY_USER_INFO_DOC)
-        .define(KEY_MULTI_TYPE, Type.BOOLEAN, KEY_MULTI_TYPE_DEFAULT,
-                Importance.MEDIUM, KEY_MULTI_TYPE_DOC)
-        .define(VALUE_MULTI_TYPE, Type.BOOLEAN, VALUE_MULTI_TYPE_DEFAULT,
-                Importance.MEDIUM, VALUE_MULTI_TYPE_DOC);
+        .define(KEY_SUBJECT_NAME_STRATEGY, Type.STRING, KEY_SUBJECT_NAME_STRATEGY_DEFAULT,
+                Importance.MEDIUM, KEY_SUBJECT_NAME_STRATEGY_DOC)
+        .define(VALUE_SUBJECT_NAME_STRATEGY, Type.STRING, VALUE_SUBJECT_NAME_STRATEGY_DEFAULT,
+                Importance.MEDIUM, VALUE_SUBJECT_NAME_STRATEGY_DOC);
   }
 
   public AbstractKafkaAvroSerDeConfig(ConfigDef config, Map<?, ?> props) {
@@ -108,11 +108,11 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
     return this.getBoolean(AUTO_REGISTER_SCHEMAS);
   }
 
-  public boolean keyMultiType() {
-    return this.getBoolean(KEY_MULTI_TYPE);
+  public String keySubjectNameStrategy() {
+    return this.getString(KEY_SUBJECT_NAME_STRATEGY);
   }
 
-  public boolean valueMultiType() {
-    return this.getBoolean(VALUE_MULTI_TYPE);
+  public String valueSubjectNameStrategy() {
+    return this.getString(VALUE_SUBJECT_NAME_STRATEGY);
   }
 }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
@@ -68,14 +68,14 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
       TopicNameStrategy.class.getName();
   public static final String KEY_SUBJECT_NAME_STRATEGY_DOC =
       "Determines how to construct the subject name under which the key schema is registered "
-      + "with the schema registry";
+      + "with the schema registry. By default, <topic>-key is used as subject.";
 
   public static final String VALUE_SUBJECT_NAME_STRATEGY = "value.subject.name.strategy";
   public static final String VALUE_SUBJECT_NAME_STRATEGY_DEFAULT =
       TopicNameStrategy.class.getName();
   public static final String VALUE_SUBJECT_NAME_STRATEGY_DOC =
       "Determines how to construct the subject name under which the value schema is registered "
-      + "with the schema registry";
+      + "with the schema registry. By default, <topic>-value is used as subject.";
 
   public static ConfigDef baseConfigDef() {
     return new ConfigDef()

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
@@ -61,6 +61,17 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
   public static final String SCHEMA_REGISTRY_USER_INFO_DOC =
       "Specify the user info for Basic Auth in the form of {username}:{password}";
 
+  public static final String KEY_MULTI_TYPE = "key.multi.type";
+  public static final boolean KEY_MULTI_TYPE_DEFAULT = false;
+  public static final String KEY_MULTI_TYPE_DOC =
+      "If true, the keys of messages in the topic may contain a mixture of "
+      + "different Avro record types.";
+
+  public static final String VALUE_MULTI_TYPE = "value.multi.type";
+  public static final boolean VALUE_MULTI_TYPE_DEFAULT = false;
+  public static final String VALUE_MULTI_TYPE_DOC =
+      "If true, the values of messages in the topic may contain a mixture of "
+      + "different Avro record types.";
 
   public static ConfigDef baseConfigDef() {
     return new ConfigDef()
@@ -74,7 +85,11 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
             ConfigDef.ValidString.in(BasicAuthCredentialSource.NAMES),
             Importance.MEDIUM, BASIC_AUTH_CREDENTIALS_SOURCE_DOC)
         .define(SCHEMA_REGISTRY_USER_INFO_CONFIG, Type.PASSWORD, SCHEMA_REGISTRY_USER_INFO_DEFAULT,
-            Importance.MEDIUM, SCHEMA_REGISTRY_USER_INFO_DOC);
+            Importance.MEDIUM, SCHEMA_REGISTRY_USER_INFO_DOC)
+        .define(KEY_MULTI_TYPE, Type.BOOLEAN, KEY_MULTI_TYPE_DEFAULT,
+                Importance.MEDIUM, KEY_MULTI_TYPE_DOC)
+        .define(VALUE_MULTI_TYPE, Type.BOOLEAN, VALUE_MULTI_TYPE_DEFAULT,
+                Importance.MEDIUM, VALUE_MULTI_TYPE_DOC);
   }
 
   public AbstractKafkaAvroSerDeConfig(ConfigDef config, Map<?, ?> props) {
@@ -93,4 +108,11 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
     return this.getBoolean(AUTO_REGISTER_SCHEMAS);
   }
 
+  public boolean keyMultiType() {
+    return this.getBoolean(KEY_MULTI_TYPE);
+  }
+
+  public boolean valueMultiType() {
+    return this.getBoolean(VALUE_MULTI_TYPE);
+  }
 }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
@@ -50,7 +50,7 @@ public class KafkaAvroSerializer extends AbstractKafkaAvroSerializer implements 
 
   @Override
   public byte[] serialize(String topic, Object record) {
-    return serializeImpl(getSubjectName(topic, isKey), record);
+    return serializeImpl(getSubjectName(topic, isKey, record), record);
   }
 
   @Override

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/RecordNameStrategy.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/RecordNameStrategy.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafka.serializers.subject;
+
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericContainer;
+import org.apache.kafka.common.errors.SerializationException;
+import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+
+/**
+ * For any Avro record type that is published to Kafka, registers the schema
+ * in the registry under the fully-qualified record name (regardless of the
+ * topic). This strategy allows a topic to contain a mixture of different
+ * record types, since no intra-topic compatibility checking is performed.
+ * Instead, checks compatibility of any occurrences of the same record name
+ * across <em>all</em> topics.
+ */
+public class RecordNameStrategy implements SubjectNameStrategy {
+
+  @Override
+  public void configure(Map<String, ?> config) {
+  }
+
+  @Override
+  public String getSubjectName(String topic, boolean isKey, Object value) {
+    return getRecordName(value, isKey);
+  }
+
+  /**
+   * If the value is an Avro record type, returns its fully-qualified name.
+   * Otherwise throws an error.
+   */
+  protected String getRecordName(Object value, boolean isKey) {
+    if (value instanceof GenericContainer) {
+      Schema schema = ((GenericContainer) value).getSchema();
+      if (schema.getType() == Schema.Type.RECORD) {
+        return schema.getFullName();
+      }
+    }
+
+    // isKey is only used to produce more helpful error messages
+    if (isKey) {
+      throw new SerializationException("In configuration "
+          + AbstractKafkaAvroSerDeConfig.KEY_SUBJECT_NAME_STRATEGY + " = "
+          + getClass().getName() + ", the message key must only be an Avro record");
+    } else {
+      throw new SerializationException("In configuration "
+          + AbstractKafkaAvroSerDeConfig.VALUE_SUBJECT_NAME_STRATEGY + " = "
+          + getClass().getName() + ", the message value must only be an Avro record");
+    }
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/RecordNameStrategy.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/RecordNameStrategy.java
@@ -38,6 +38,12 @@ public class RecordNameStrategy implements SubjectNameStrategy {
 
   @Override
   public String getSubjectName(String topic, boolean isKey, Object value) {
+    // Null is passed through unserialized, since it has special meaning in
+    // log-compacted Kafka topics.
+    if (value == null) {
+      return null;
+    }
+
     return getRecordName(value, isKey);
   }
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/SubjectNameStrategy.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/SubjectNameStrategy.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafka.serializers.subject;
+
+import io.confluent.common.Configurable;
+
+/**
+ * A {@link SubjectNameStrategy} is used by the Avro serializer to determine
+ * the subject name under which the event record schemas should be registered
+ * in the schema registry. The default is {@link TopicNameStrategy}.
+ */
+public interface SubjectNameStrategy extends Configurable {
+
+  /**
+   * For a given topic and message, returns the subject name under which the
+   * schema should be registered in the schema registry.
+   *
+   * @param topic The Kafka topic name to which the message is being published.
+   * @param isKey True when encoding a message key, false for a message value.
+   * @param value The value to be published in the message.
+   * @return The subject name under which the schema should be registered.
+   */
+  String getSubjectName(String topic, boolean isKey, Object value);
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/TopicNameStrategy.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/TopicNameStrategy.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafka.serializers.subject;
+
+import java.util.Map;
+
+/**
+ * Default {@link SubjectNameStrategy}: for any messages published to
+ * &lt;topic&gt;, the schema of the message key is registered under
+ * the subject name &lt;topic&gt;-key, and the message value is registered
+ * under the subject name &lt;topic&gt;-value.
+ */
+public class TopicNameStrategy implements SubjectNameStrategy {
+
+  @Override
+  public void configure(Map<String, ?> config) {
+  }
+
+  @Override
+  public String getSubjectName(String topic, boolean isKey, Object value) {
+    return isKey ? topic + "-key" : topic + "-value";
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/TopicRecordNameStrategy.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/TopicRecordNameStrategy.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafka.serializers.subject;
+
+/**
+ * For any Avro record type that is published to Kafka topic &lt;topic&gt;,
+ * registers the schema in the registry under the subject name
+ * &lt;topic&gt;-&lt;recordName&gt;, where &lt;recordName&gt; is the
+ * fully-qualified Avro record name. This strategy allows a topic to contain
+ * a mixture of different record types, since no intra-topic compatibility
+ * checking is performed. Moreover, different topics may contain mutually
+ * incompatible versions of the same record name, since the compatibility
+ * check is scoped to a particular record name within a particular topic.
+ */
+public class TopicRecordNameStrategy extends RecordNameStrategy {
+
+  @Override
+  public String getSubjectName(String topic, boolean isKey, Object value) {
+    return topic + "-" + getRecordName(value, isKey);
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/TopicRecordNameStrategy.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/TopicRecordNameStrategy.java
@@ -30,6 +30,12 @@ public class TopicRecordNameStrategy extends RecordNameStrategy {
 
   @Override
   public String getSubjectName(String topic, boolean isKey, Object value) {
+    // Null is passed through unserialized, since it has special meaning in
+    // log-compacted Kafka topics.
+    if (value == null) {
+      return null;
+    }
+
     return topic + "-" + getRecordName(value, isKey);
   }
 }

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
@@ -34,6 +34,7 @@ import io.confluent.kafka.example.User;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.serializers.subject.TopicRecordNameStrategy;
 import kafka.utils.VerifiableProperties;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -208,7 +209,7 @@ public class KafkaAvroSerializerTest {
         KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG,
         "bogus",
         KafkaAvroSerializerConfig.VALUE_SUBJECT_NAME_STRATEGY,
-        "topic-type"
+        TopicRecordNameStrategy.class.getName()
     );
     avroSerializer.configure(configs, false);
     IndexedRecord record1 = createAvroRecord();
@@ -227,7 +228,7 @@ public class KafkaAvroSerializerTest {
         KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG,
         "bogus",
         KafkaAvroSerializerConfig.VALUE_SUBJECT_NAME_STRATEGY,
-        "topic-type"
+        TopicRecordNameStrategy.class.getName()
     );
     avroSerializer.configure(configs, false);
     avroSerializer.serialize(topic, "a string should not be allowed");

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
@@ -207,16 +207,16 @@ public class KafkaAvroSerializerTest {
     Map configs = ImmutableMap.of(
         KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG,
         "bogus",
-        KafkaAvroSerializerConfig.VALUE_MULTI_TYPE,
-        true
+        KafkaAvroSerializerConfig.VALUE_SUBJECT_NAME_STRATEGY,
+        "topic-type"
     );
     avroSerializer.configure(configs, false);
     IndexedRecord record1 = createAvroRecord();
     IndexedRecord record2 = createAccountRecord();
     byte[] bytes1 = avroSerializer.serialize(topic, record1);
     byte[] bytes2 = avroSerializer.serialize(topic, record2);
-    assertNotNull(schemaRegistry.getLatestSchemaMetadata("example.avro.User"));
-    assertNotNull(schemaRegistry.getLatestSchemaMetadata("example.avro.Account"));
+    assertNotNull(schemaRegistry.getLatestSchemaMetadata(topic + "-example.avro.User"));
+    assertNotNull(schemaRegistry.getLatestSchemaMetadata(topic + "-example.avro.Account"));
     assertEquals(record1, avroDeserializer.deserialize(topic, bytes1));
     assertEquals(record2, avroDeserializer.deserialize(topic, bytes2));
   }
@@ -226,8 +226,8 @@ public class KafkaAvroSerializerTest {
     Map configs = ImmutableMap.of(
         KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG,
         "bogus",
-        KafkaAvroSerializerConfig.VALUE_MULTI_TYPE,
-        true
+        KafkaAvroSerializerConfig.VALUE_SUBJECT_NAME_STRATEGY,
+        "topic-type"
     );
     avroSerializer.configure(configs, false);
     avroSerializer.serialize(topic, "a string should not be allowed");


### PR DESCRIPTION
In some situations, an application needs to store events of several different types in the same Kafka topic. In particular, when developing a data model in an Event Sourcing style, you might have several kinds of event that affect the state of an entity. For example, for a customer entity there may be `customerCreated`, `customerAddressChanged`, `customerEnquiryReceived`, `customerInvoicePaid`, etc. events, and the application may require that those events are always read in the same order. Thus, they need to go in the same Kafka partition (to maintain ordering).

The Avro schema registry currently assumes a 1:1 mapping between Kafka topics and Avro schemas, making it difficult to support scenarios like the one above. Users who want several event types in the same topic currently either have to put them in one big Avro union (which works, but gets unwieldy very quickly), or turn off the registry's schema compatibility checking (which would be unfortunate, since the compatibility check is very valuable).

This patch introduces two new boolean config settings, `key.multi.type` and `value.multi.type`. When set to true, they allow the key (or value, respectively) of a message to be *any* Avro record type. The schema of the type is stored in the schema registry as usual; however, instead of
using `<topic>-key` or `<topic>-value` as subject, the fully-qualified name of the record type is used as subject.

This has the effect that a Kafka producer will happily accept any mixture of Avro record types and publish them to the same topic. Since the schema registry's ID for a schema is globally unique, the binary message encoding does not need to change, and consumers also handle the mixture of record types without change. When a schema is changed, the registry checks compatibility with previous schemas of the same fully-qualified type name; different record types can be evolved independently without any interference.