### PR TITLE
issue#629: endpoint to return schema literal

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -423,12 +424,12 @@ public class RestService {
   }
 
   public Schema getLatestVersion(Map<String, String> requestProperties,
-            String subject)
-            throws IOException, RestClientException {
+                                 String subject)
+      throws IOException, RestClientException {
     String path = String.format("/subjects/%s/versions/latest", subject);
 
     Schema response = httpRequest(path, "GET", null, requestProperties,
-                GET_SCHEMA_BY_VERSION_RESPONSE_TYPE);
+                                  GET_SCHEMA_BY_VERSION_RESPONSE_TYPE);
     return response;
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -18,8 +18,8 @@ package io.confluent.kafka.schemaregistry.client.rest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,6 +64,9 @@ public class RestService {
       };
   private static final TypeReference<SchemaString> GET_SCHEMA_BY_ID_RESPONSE_TYPE =
       new TypeReference<SchemaString>() {
+      };
+  private static final TypeReference<JsonNode> GET_SCHEMA_ONLY_BY_VERSION_RESPONSE_TYPE =
+      new TypeReference<JsonNode>() {
       };
   private static final TypeReference<Schema> GET_SCHEMA_BY_VERSION_RESPONSE_TYPE =
       new TypeReference<Schema>() {
@@ -420,13 +423,31 @@ public class RestService {
   }
 
   public Schema getLatestVersion(Map<String, String> requestProperties,
-                                 String subject)
-      throws IOException, RestClientException {
+            String subject)
+            throws IOException, RestClientException {
     String path = String.format("/subjects/%s/versions/latest", subject);
 
     Schema response = httpRequest(path, "GET", null, requestProperties,
-                                  GET_SCHEMA_BY_VERSION_RESPONSE_TYPE);
+                GET_SCHEMA_BY_VERSION_RESPONSE_TYPE);
     return response;
+  }
+
+  public String getVersionSchemaOnly(String subject, int version)
+            throws IOException, RestClientException {
+    String path = String.format("/subjects/%s/versions/%d/schema", subject, version);
+
+    JsonNode response = httpRequest(path, "GET", null, DEFAULT_REQUEST_PROPERTIES,
+            GET_SCHEMA_ONLY_BY_VERSION_RESPONSE_TYPE);
+    return response.toString();
+  }
+
+  public String getLatestVersionSchemaOnly(String subject)
+            throws IOException, RestClientException {
+    String path = String.format("/subjects/%s/versions/latest/schema", subject);
+
+    JsonNode response = httpRequest(path, "GET", null, DEFAULT_REQUEST_PROPERTIES,
+            GET_SCHEMA_ONLY_BY_VERSION_RESPONSE_TYPE);
+    return response.toString();
   }
 
   public List<Integer> getAllVersions(String subject)

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -106,6 +106,14 @@ public class SubjectVersionsResource {
   }
 
   @GET
+  @Path("/{version}/schema")
+  @PerformanceMetric("subjects.versions.get-schema.only")
+  public String getSchemaOnly(@PathParam("subject") String subject,
+                              @PathParam("version") String version) {
+    return getSchema(subject, version).getSchema();
+  }
+
+  @GET
   @PerformanceMetric("subjects.versions.list")
   public List<Integer> list(@PathParam("subject") String subject) {
     // check if subject exists. If not, throw 404

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -25,7 +25,6 @@ import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientExcept
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidVersionException;
 import io.confluent.kafka.schemaregistry.utils.TestUtils;
-
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -393,6 +392,29 @@ public class RestApiTest extends ClusterTestHarness {
     assertEquals("Latest schema should be the same as version 2",
                  schemas.get(1),
                  restApp.restClient.getLatestVersion(subject).getSchema());
+  }
+
+  @Test
+  public void testGetLatestVersionSchemaOnly() throws Exception {
+    List<String> schemas = TestUtils.getRandomCanonicalAvroString(2);
+    String subject = "test";
+    TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(0), 1, subject);
+    TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(1), 2, subject);
+
+    assertEquals("Latest schema should be the same as version 2",
+                 schemas.get(1),
+                 restApp.restClient.getLatestVersionSchemaOnly(subject));
+  }
+
+  @Test
+  public void testGetVersionSchemaOnly() throws Exception {
+    List<String> schemas = TestUtils.getRandomCanonicalAvroString(1);
+    String subject = "test";
+    TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(0), 1, subject);
+
+    assertEquals("Latest schema should be the same as version 1",
+                schemas.get(0),
+                restApp.restClient.getVersionSchemaOnly(subject, 1));
   }
 
   @Test

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -25,6 +25,7 @@ import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientExcept
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidVersionException;
 import io.confluent.kafka.schemaregistry.utils.TestUtils;
+
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -412,7 +413,7 @@ public class RestApiTest extends ClusterTestHarness {
     String subject = "test";
     TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(0), 1, subject);
 
-    assertEquals("Latest schema should be the same as version 1",
+    assertEquals("Retrieved schema should be the same as version 1",
                 schemas.get(0),
                 restApp.restClient.getVersionSchemaOnly(subject, 1));
   }

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -236,6 +236,40 @@ The subjects resource provides a list of all registered subjects in your schema 
         "schema": "{\"type\": \"string\"}"
       }
 
+.. http:get:: /subjects/(string: subject)/versions/(versionId: version)/schema
+
+   Get the avro schema for the specified version of this subject. The unescaped schema only is returned.
+
+   :param string subject: Name of the subject
+   :param versionId version: Version of the schema to be returned. Valid values for versionId are between [1,2^31-1] or the string "latest". "latest" returns the last registered schema under the specified subject. Note that there may be a new latest schema that gets registered right after this request is served.
+
+   :>json string schema: The Avro schema string (unescaped)
+
+   :statuscode 404:
+      * Error code 40401 -- Subject not found
+      * Error code 40402 -- Version not found
+   :statuscode 422:
+      * Error code 42202 -- Invalid version
+   :statuscode 500:
+      * Error code 50001 -- Error in the backend data store
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+      GET /subjects/test/versions/1/schema HTTP/1.1
+      Host: schemaregistry.example.com
+      Accept: application/vnd.schemaregistry.v1+json, application/vnd.schemaregistry+json, application/json
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/vnd.schemaregistry.v1+json
+
+      {"type": "string"}
+
 .. http:post:: /subjects/(string: subject)/versions
 
    Register a new schema under the specified subject. If successfully registered, this returns the unique identifier of this schema in the registry. The returned identifier should be used to retrieve this schema from the schemas resource and is different from the schema's version which is associated with the subject.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,9 @@ Changelog
 Version 3.4.0
 -------------
 
+* `PR-686 <https://github.com/confluentinc/schema-registry/pull/686>` - Added REST endpoint to return the unescaped Avro schema
+  for a specific subject and version. 
+
 Upgrade Notes
 ^^^^^^^^^^^^^
 

--- a/docs/monitoring.rst
+++ b/docs/monitoring.rst
@@ -97,6 +97,7 @@ endpoint name ``brokers.list`` with the metric name ``request-rate`` to get
   ``subjects.get-schema``                    ``POST /subjects/{subject}``
   ``subjects.list``                          ``GET /subjects``
   ``subjects.versions.get-schema``           ``GET /subjects/{subject}/versions/{version}``
+  ``subjects.versions.get-schema.only``      ``GET /subjects/{subject}/versions/{version}/schema``
   ``subjects.versions.list``                 ``GET /subjects/{subject}/versions``
   ``subjects.versions.register``             ``POST /subjects/{subject}/versions``
   ========================================== =======================================================


### PR DESCRIPTION
PR for #629 & #381 

This PR is to create an endpoint to return the avro schema as a string literal for integration with Hive.  

I ran into an issue where the String being returned was fine with Hive, but the ObjectMapper used in the RestService#sendHttpRequest assumes every payload returned is a json object. The object mapper wasn't able to correctly parse the returned String. Because it couldn't be escaped the json parser interpreted the contents as being a json response, but was using the StringDeserializer, which couldn't handle it. I just wound up with these exceptions:
```
com.fasterxml.jackson.databind.JsonMappingException: Can not deserialize instance of java.lang.String out of START_OBJECT token
 at [Source: sun.net.www.protocol.http.HttpURLConnection$HttpInputStream@65bdd558; line: 1, column: 1]
	at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:270)
	at com.fasterxml.jackson.databind.DeserializationContext.reportMappingException(DeserializationContext.java:1234)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1122)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1075)
```
If I escaped the returned string, then the object mapper was happy but would break Hive. So, I went with checking the content type and if it is `text/plain` to just read it as a string and bypass the object mapper. I'm open to other ideas if there is a better way to handle this.  