### PR TITLE
Don't store CONNECT_ENUM_DOC_PROP when null (#541,#544)

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -1450,7 +1450,9 @@ public class AvroData {
       case ENUM:
         // enums are unwrapped to strings and the original enum is not preserved
         builder = SchemaBuilder.string();
-        builder.parameter(CONNECT_ENUM_DOC_PROP, schema.getDoc());
+        if (schema.getDoc() != null) {
+          builder.parameter(CONNECT_ENUM_DOC_PROP, schema.getDoc());
+        }
         builder.parameter(AVRO_TYPE_ENUM, schema.getFullName());
         for (String enumSymbol : schema.getEnumSymbols()) {
           builder.parameter(AVRO_TYPE_ENUM + "." + enumSymbol, enumSymbol);
@@ -1539,11 +1541,13 @@ public class AvroData {
       while (paramIt.hasNext()) {
         Map.Entry<String, JsonNode> field = paramIt.next();
         JsonNode jsonValue = field.getValue();
-        if (!jsonValue.isTextual()) {
-          throw new DataException("Expected schema parameter values to be strings but found: "
-                                  + jsonValue);
+        if (!jsonValue.isNull()) {
+          if (!jsonValue.isTextual()) {
+            throw new DataException("Expected schema parameter values to be strings but found: "
+                    + jsonValue);
+          }
+          builder.parameter(field.getKey(), jsonValue.getTextValue());
         }
-        builder.parameter(field.getKey(), jsonValue.getTextValue());
       }
     }
 

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -1277,7 +1277,6 @@ public class AvroDataTest {
     org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.builder()
         .enumeration("TestEnum").symbols("foo", "bar", "baz");
     SchemaBuilder builder = SchemaBuilder.string().name("TestEnum");
-    builder.parameter(CONNECT_ENUM_DOC_PROP, null);
     builder.parameter(AVRO_TYPE_ENUM, "TestEnum");
     for(String enumSymbol : new String[]{"foo", "bar", "baz"}) {
       builder.parameter(AVRO_TYPE_ENUM+"."+enumSymbol, enumSymbol);


### PR DESCRIPTION
This patch has 2 purposes:
 - prevent from storing CONNECT_ENUM_DOC_PROP when the value is null
 - skip null parameters that are expected to be strings. This is necessary in order to
   process files generated before this patch.