### PR TITLE
Log properly when Exception raised on SchemaRegistryRestApplication

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
@@ -62,8 +62,8 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
       );
       schemaRegistry.init();
     } catch (SchemaRegistryException e) {
-      onShutdown();
       log.error("Error starting the schema registry", e);
+      onShutdown();
       System.exit(1);
     }
 


### PR DESCRIPTION
When schemaRegistry.init() throws SchemaRegistryException, log the exception before onShutdown() is called.