### PR TITLE
Issue #704 - Make Serde constructors public

### DIFF
--- a/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/GenericAvroSerde.java
+++ b/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/GenericAvroSerde.java
@@ -83,7 +83,7 @@ public class GenericAvroSerde implements Serde<GenericRecord> {
   /**
    * For testing purposes only.
    */
-  GenericAvroSerde(final SchemaRegistryClient client) {
+  public GenericAvroSerde(final SchemaRegistryClient client) {
     if (client == null) {
       throw new IllegalArgumentException("schema registry client must not be null");
     }

--- a/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/SpecificAvroSerde.java
+++ b/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/SpecificAvroSerde.java
@@ -83,7 +83,7 @@ public class SpecificAvroSerde<T extends org.apache.avro.specific.SpecificRecord
   /**
    * For testing purposes only.
    */
-  SpecificAvroSerde(final SchemaRegistryClient client) {
+  public SpecificAvroSerde(final SchemaRegistryClient client) {
     if (client == null) {
       throw new IllegalArgumentException("schema registry client must not be null");
     }


### PR DESCRIPTION
Currently the constructors for `GenericAvroSerde` and `SpecificAvroSerde` that take a `SchemaRegistryClient` argument are package-private. This means they're not readily available to use from unit tests for developers outside of Confluent.

I'm using the `KStreamTestDriver` to implement some property-based tests against our Avro based Kafka Streams topologies. This works great, but I had to add a helper method in the `io.confluent.kafka.streams.serdes.avro` package to use `MockSchemaRegistryClient`. This lets me run the tests without having to start a Schema Registry instance.

Once the internal Kafka test tools are more widely used, I would expect many more developers would wish to be able to use `MockSchemaRegistryClient` in their tests.