### PR TITLE
Added delete subject and delete version  to schema registry client.

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -269,6 +269,9 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   @Override
   public List<Integer> deleteSubject(Map<String, String> requestProperties, String subject)
       throws IOException, RestClientException {
+    versionCache.remove(subject);
+    idCache.remove(subject);
+    schemaCache.remove(subject);
     return restService.deleteSubject(requestProperties, subject);
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -262,6 +262,29 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
+  public List<Integer> deleteSubject(String subject) throws IOException, RestClientException {
+    return deleteSubject(restService.DEFAULT_REQUEST_PROPERTIES, subject);
+  }
+
+  @Override
+  public List<Integer> deleteSubject(Map<String, String> requestProperties, String subject)
+      throws IOException, RestClientException {
+    return restService.deleteSubject(requestProperties, subject);
+  }
+
+  @Override
+  public Integer deleteSchemaVersion(String subject, String version)
+      throws IOException, RestClientException {
+    return deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject, version);
+  }
+
+  @Override
+  public Integer deleteSchemaVersion(Map<String, String> requestProperties, String subject,
+                                     String version) throws IOException, RestClientException {
+    return restService.deleteSchemaVersion(requestProperties, subject, version);
+  }
+
+  @Override
   public boolean testCompatibility(String subject, Schema schema)
       throws IOException, RestClientException {
     return restService.testCompatibility(schema.toString(), subject, "latest");

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -287,6 +287,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
       String subject,
       String version)
       throws IOException, RestClientException {
+    versionCache.get(subject).values().remove(Integer.valueOf(version));
     return restService.deleteSchemaVersion(requestProperties, subject, version);
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -279,8 +279,11 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
-  public Integer deleteSchemaVersion(Map<String, String> requestProperties, String subject,
-                                     String version) throws IOException, RestClientException {
+  public Integer deleteSchemaVersion(
+      Map<String, String> requestProperties,
+      String subject,
+      String version)
+      throws IOException, RestClientException {
     return restService.deleteSchemaVersion(requestProperties, subject, version);
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -304,7 +304,7 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
       String version)
       throws IOException, RestClientException {
     if (versionCache.containsKey(subject)) {
-      versionCache.get(subject).remove(version);
+      versionCache.get(subject).values().remove(Integer.valueOf(version));
       return 0;
     }
     return -1;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -281,10 +281,11 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
-  public List<Integer> deleteSubject(Map<String, String> requestProperties, String subject)
+  public List<Integer> deleteSubject(
+      Map<String, String> requestProperties,
+      String subject)
       throws IOException, RestClientException {
     schemaCache.remove(subject);
-    idCache.remove(subject);
     versionCache.remove(subject);
     compatibilityCache.remove(subject);
     return Arrays.asList(0);
@@ -297,8 +298,11 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
-  public Integer deleteSchemaVersion(Map<String, String> requestProperties, String subject,
-                                     String version) throws IOException, RestClientException {
+  public Integer deleteSchemaVersion(
+      Map<String, String> requestProperties,
+      String subject,
+      String version)
+      throws IOException, RestClientException {
     if (versionCache.containsKey(subject)) {
       versionCache.get(subject).remove(version);
       return 0;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -20,6 +20,7 @@ import org.apache.avro.Schema;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -272,5 +273,36 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
   @Override
   public int getId(String subject, Schema schema) throws IOException, RestClientException {
     return getIdFromRegistry(subject, schema, false);
+  }
+
+  @Override
+  public List<Integer> deleteSubject(String subject) throws IOException, RestClientException {
+    return deleteSubject(null, subject);
+  }
+
+  @Override
+  public List<Integer> deleteSubject(Map<String, String> requestProperties, String subject)
+      throws IOException, RestClientException {
+    schemaCache.remove(subject);
+    idCache.remove(subject);
+    versionCache.remove(subject);
+    compatibilityCache.remove(subject);
+    return Arrays.asList(0);
+  }
+
+  @Override
+  public Integer deleteSchemaVersion(String subject, String version)
+      throws IOException, RestClientException {
+    return deleteSchemaVersion(null, subject, version);
+  }
+
+  @Override
+  public Integer deleteSchemaVersion(Map<String, String> requestProperties, String subject,
+                                     String version) throws IOException, RestClientException {
+    if (versionCache.containsKey(subject)) {
+      versionCache.get(subject).remove(version);
+      return 0;
+    }
+    return -1;
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -21,6 +21,7 @@ import org.apache.avro.Schema;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 
@@ -59,4 +60,20 @@ public interface SchemaRegistryClient {
   public Collection<String> getAllSubjects() throws IOException, RestClientException;
 
   int getId(String subject, Schema schema) throws IOException, RestClientException;
+
+  public List<Integer> deleteSubject(String subject) throws IOException, RestClientException;
+
+  public List<Integer> deleteSubject(
+      Map<String, String> requestProperties,
+      String subject
+  ) throws IOException, RestClientException;
+
+  public Integer deleteSchemaVersion(String subject, String version) throws IOException,
+                                                                            RestClientException;
+
+  public Integer deleteSchemaVersion(
+      Map<String, String> requestProperties,
+      String subject,
+      String version
+  ) throws IOException, RestClientException;
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -65,15 +65,16 @@ public interface SchemaRegistryClient {
 
   public List<Integer> deleteSubject(
       Map<String, String> requestProperties,
-      String subject
-  ) throws IOException, RestClientException;
+      String subject)
+      throws IOException, RestClientException;
 
-  public Integer deleteSchemaVersion(String subject, String version) throws IOException,
-                                                                            RestClientException;
+  public Integer deleteSchemaVersion(String subject,
+                                     String version)
+      throws IOException, RestClientException;
 
   public Integer deleteSchemaVersion(
       Map<String, String> requestProperties,
       String subject,
-      String version
-  ) throws IOException, RestClientException;
+      String version)
+      throws IOException, RestClientException;
 }

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
@@ -19,11 +19,13 @@ import org.apache.avro.Schema;
 import org.easymock.EasyMock;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
 
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
 
+import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.eq;
@@ -31,6 +33,7 @@ import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 public class CachedSchemaRegistryClientTest {
@@ -196,6 +199,78 @@ public class CachedSchemaRegistryClientTest {
     // These two should be cached now
     assertEquals(avroSchema, client.getBySubjectAndId(subjectOne, id));
     assertEquals(avroSchema, client.getBySubjectAndId(subjectTwo, id));
+
+    verify(restService);
+  }
+
+
+  @Test
+  public void testDeleteSchemaCache() throws Exception {
+    RestService restService = createMock(RestService.class);
+    CachedSchemaRegistryClient client = new CachedSchemaRegistryClient(restService, 20, new
+        HashMap<String, Object>());
+
+    String schema = "{\"type\": \"record\", \"name\": \"Blah\", \"fields\": [{ \"name\": \"name\", \"type\": \"string\" }]}";
+    Schema avroSchema = new Schema.Parser().parse(schema);
+
+    String subject = "foo";
+    int id = 25;
+
+    EasyMock.reset(restService);
+    // Expect one call to register schema
+    expect(restService.registerSchema(anyString(), eq(subject)))
+        .andReturn(id);
+
+    expect(restService.deleteSubject(RestService.DEFAULT_REQUEST_PROPERTIES, subject))
+        .andReturn(Arrays.asList(0));
+
+    replay(restService);
+
+    assertEquals(id, client.register(subject, avroSchema));
+    assertEquals(id, client.register(subject, avroSchema)); // hit the cache
+
+    assertEquals(Arrays.asList(0), client.deleteSubject(subject));
+
+    verify(restService);
+  }
+
+  @Test
+  public void testDeleteVersionCache() throws Exception {
+    RestService restService = createMock(RestService.class);
+    CachedSchemaRegistryClient client = new CachedSchemaRegistryClient(restService, 20,  new
+        HashMap<String, Object>());
+
+    String schema = "{\"type\": \"record\", \"name\": \"Blah\", \"fields\": [{ \"name\": \"name\", \"type\": \"string\" }]}";
+    Schema avroSchema = new Schema.Parser().parse(schema);
+
+    String subject = "foo";
+    int id = 25;
+    int version = 7;
+
+    EasyMock.reset(restService);
+
+    expect(restService.registerSchema(anyString(), eq(subject)))
+        .andReturn(id);
+
+    // Expect only one call to lookup the subject (the rest should hit the cache)
+    expect(restService.lookUpSubjectVersion(anyString(), eq(subject), eq(true)))
+        .andReturn(new io.confluent.kafka.schemaregistry.client.rest.entities.Schema(subject,
+                                                                                     version,
+                                                                                     id,
+                                                                                     schema));
+
+    expect(restService.deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES,
+                                           subject,
+                                           String.valueOf(version)))
+        .andReturn(0);
+
+    replay(restService);
+
+    assertEquals(id, client.register(subject, avroSchema));
+    assertEquals(version, client.getVersion(subject, avroSchema));
+    assertEquals(version, client.getVersion(subject, avroSchema)); // hit the cache
+
+    assertEquals(Integer.valueOf(0), client.deleteSchemaVersion(subject, String.valueOf(version)));
 
     verify(restService);
   }


### PR DESCRIPTION
The SchemaRegistyClient did not have methods for deleting subject and deleting version. This PR adds these methods to the client.