### PR TITLE
MINOR: method for additional configs before starting RestApp

### DIFF
--- a/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
@@ -72,6 +72,12 @@ public class RestApp {
     }
   }
 
+  /**
+   * This method must be called before calling {@code RestApp.start()}
+   * for the additional properties to take affect.
+   *
+   * @param props the additional properties to set
+   */
   public void addConfigs(Properties props) {
     prop.putAll(props);
   }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
@@ -18,7 +18,6 @@ package io.confluent.kafka.schemaregistry;
 
 import org.eclipse.jetty.server.Server;
 
-import java.util.Objects;
 import java.util.Properties;
 
 import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
@@ -74,7 +74,6 @@ public class RestApp {
   }
 
   public void addConfigs(Properties props) {
-    Objects.requireNonNull(props, "Additional properties can't be null");
     prop.putAll(props);
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
@@ -16,15 +16,15 @@
 package io.confluent.kafka.schemaregistry;
 
 
-import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import org.eclipse.jetty.server.Server;
 
 import java.util.Properties;
 
 import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
+import io.confluent.kafka.schemaregistry.client.rest.RestService;
+import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryRestApplication;
-import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
 import io.confluent.kafka.schemaregistry.zookeeper.SchemaRegistryIdentity;
 
@@ -69,6 +69,12 @@ public class RestApp {
     if (restServer != null) {
       restServer.stop();
       restServer.join();
+    }
+  }
+
+  public void addConfigs(Properties props) {
+    if(props != null) {
+      prop.putAll(props);
     }
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
@@ -18,6 +18,7 @@ package io.confluent.kafka.schemaregistry;
 
 import org.eclipse.jetty.server.Server;
 
+import java.util.Objects;
 import java.util.Properties;
 
 import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
@@ -73,9 +74,8 @@ public class RestApp {
   }
 
   public void addConfigs(Properties props) {
-    if(props != null) {
-      prop.putAll(props);
-    }
+    Objects.requireNonNull(props, "Additional properties can't be null");
+    prop.putAll(props);
   }
 
   public boolean isMaster() {


### PR DESCRIPTION
`kafka-streams-examples` makes heavy use of `RestApp` in tests and it would be helpful to have the ability to adjust or specify additional configs.