### PR TITLE
Docs for Subject Name Strategy and Basic Auth

### DIFF
--- a/docs/connect.rst
+++ b/docs/connect.rst
@@ -52,21 +52,27 @@ Configuration Options
   * Importance: low
 
 ``key.subject.name.strategy``
-  Determines how to construct the subject name under which the key schema is registered with the schema registry. By default, <topic>-key is used as subject.
+  Determines how to construct the subject name under which the key schema is registered with the schema registry.
+
+  Any implementation of ``io.confluent.kafka.serializers.subject.SubjectNameStrategy`` can be
+  specified. By default, <topic>-key is used as subject.
 
   * Type: class
   * Default: class io.confluent.kafka.serializers.subject.TopicNameStrategy
   * Importance: medium
 
 ``value.subject.name.strategy``
-  Determines how to construct the subject name under which the value schema is registered with the schema registry. By default, <topic>-value is used as subject.
+  Determines how to construct the subject name under which the value schema is registered with the schema registry.
+
+  Any implementation of ``io.confluent.kafka.serializers.subject.SubjectNameStrategy`` can be specified. By default, <topic>-value is used as subject.
 
   * Type: class
   * Default: class io.confluent.kafka.serializers.subject.TopicNameStrategy
   * Importance: medium
 
 ``basic.auth.credentials.source``
-  Specify how to pick the credentials for Basic uth header. The supported values are URL, USER_INFO and SASL_INHERIT
+  Specify how to pick the credentials for Basic Auth header. The supported values are URL,
+  USER_INFO and SASL_INHERIT
 
   * Type: string
   * Default: "URL"

--- a/docs/connect.rst
+++ b/docs/connect.rst
@@ -50,3 +50,31 @@ Configuration Options
   * Type: int
   * Default: 1000
   * Importance: low
+
+``key.subject.name.strategy``
+  Determines how to construct the subject name under which the key schema is registered with the schema registry. By default, <topic>-key is used as subject.
+
+  * Type: class
+  * Default: class io.confluent.kafka.serializers.subject.TopicNameStrategy
+  * Importance: medium
+
+``value.subject.name.strategy``
+  Determines how to construct the subject name under which the value schema is registered with the schema registry. By default, <topic>-value is used as subject.
+
+  * Type: class
+  * Default: class io.confluent.kafka.serializers.subject.TopicNameStrategy
+  * Importance: medium
+
+``basic.auth.credentials.source``
+  Specify how to pick the credentials for Basic uth header. The supported values are URL, USER_INFO and SASL_INHERIT
+
+  * Type: string
+  * Default: "URL"
+  * Importance: medium
+
+``schema.registry.basic.auth.user.info``
+  Specify the user info for Basic Auth in the form of {username}:{password}
+
+  * Type: password
+  * Default: ""
+  * Importance: medium

--- a/docs/serializer-formatter.rst
+++ b/docs/serializer-formatter.rst
@@ -127,21 +127,26 @@ not well formed.
 Subject Name Strategy
 ^^^^^^^^^^^^^^^^^^^^^
 
-By default, the KafkaAvroSerializer and KafkaAvroDeserializer default to using *<topicName>-Key*
+KafkaAvroSerializer and KafkaAvroDeserializer default to using *<topicName>-Key*
 and *<topicName>-value* as the corresponding subject name while registering or retrieving the
 schema.
 
 This behavior can be modified by using the following configs
 
 ``key.subject.name.strategy``
-  Determines how to construct the subject name under which the key schema is registered with the schema registry. By default, <topic>-key is used as subject.
+  Determines how to construct the subject name under which the key schema is registered with the
+  schema registry.
+
+  Any implementation of ``io.confluent.kafka.serializers.subject.SubjectNameStrategy`` can be specified. By default, <topic>-key is used as subject.
 
   * Type: class
   * Default: class io.confluent.kafka.serializers.subject.TopicNameStrategy
   * Importance: medium
 
 ``value.subject.name.strategy``
-  Determines how to construct the subject name under which the value schema is registered with the schema registry. By default, <topic>-value is used as subject.
+  Determines how to construct the subject name under which the value schema is registered with the schema registry.
+
+  Any implementation of ``io.confluent.kafka.serializers.subject.SubjectNameStrategy`` can be specified. By default, <topic>-value is used as subject.
 
   * Type: class
   * Default: class io.confluent.kafka.serializers.subject.TopicNameStrategy
@@ -176,7 +181,8 @@ Schema Registry supports ability to authenticate requests using Basic Auth heade
 the Basic Auth headers by setting the following configuration in your producer or consumer example
 
 ``basic.auth.credentials.source``
-  Specify how to pick the credentials for Basic uth header. The supported values are URL, USER_INFO and SASL_INHERIT
+  Specify how to pick the credentials for Basic Auth header. The supported values are URL,
+  USER_INFO and SASL_INHERIT
 
   * Type: string
   * Default: "URL"

--- a/docs/serializer-formatter.rst
+++ b/docs/serializer-formatter.rst
@@ -192,7 +192,7 @@ the Basic Auth headers by setting the following configuration in your producer o
 **URL** - The user info is configured as part of the ``schema.registry.url`` config in the
 form of ``http://<username>:<password>@sr-host:<sr-port>``
 
-**USER_INFO** - The User info is configured using the below configuration.
+**USER_INFO** - The user info is configured using the below configuration.
 ``schema.registry.basic.auth.user.info``
   Specify the user info for Basic Auth in the form of {username}:{password}
 
@@ -200,8 +200,8 @@ form of ``http://<username>:<password>@sr-host:<sr-port>``
   * Default: ""
   * Importance: medium
 
-**SASL_INHERIT** - If your Kafka client uses SASL SCRAM or SASL PLAIN to talk to the broker, you
-can use the same credentials to talk to your Schema Registry instance.
+**SASL_INHERIT** - Inherit the settings used by the Kafka client to communicate with the broker
+using SASL SCRAM or SASL PLAIN.
 
 Formatter
 ---------


### PR DESCRIPTION
Added docs for Subject Name Strategy and Basic Auth in Serializers and also cleaned up the example in Serializers to use New Consumer & Deserializer