### PR TITLE
Define a property to deserialize as generic record when specific record class not found

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/exceptions/SpecificRecordClassNotFound.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/exceptions/SpecificRecordClassNotFound.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Confluent Inc.
+ * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/avro-serializer/src/main/java/io/confluent/kafka/exceptions/SpecificRecordClassNotFound.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/exceptions/SpecificRecordClassNotFound.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.kafka.exceptions;
 
 import org.apache.kafka.common.errors.SerializationException;

--- a/avro-serializer/src/main/java/io/confluent/kafka/exceptions/SpecificRecordClassNotFound.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/exceptions/SpecificRecordClassNotFound.java
@@ -1,0 +1,14 @@
+package io.confluent.kafka.exceptions;
+
+import org.apache.kafka.common.errors.SerializationException;
+
+/**
+ * Indicates that the SpecificRecord class was not found when SPECIFIC_AVRO_READER_CONFIG
+ * is enabled
+ */
+public class SpecificRecordClassNotFound extends SerializationException {
+
+  public SpecificRecordClassNotFound(String message) {
+    super(message);
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -16,13 +16,6 @@
 
 package io.confluent.kafka.serializers;
 
-import io.confluent.kafka.exceptions.SpecificRecordClassNotFound;
-import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import kafka.utils.VerifiableProperties;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.generic.GenericDatumReader;
@@ -34,6 +27,14 @@ import org.apache.avro.specific.SpecificRecord;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.SerializationException;
 import org.codehaus.jackson.node.JsonNodeFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import kafka.utils.VerifiableProperties;
 
 public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaAvroSerDe {
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -16,6 +16,7 @@
 
 package io.confluent.kafka.serializers;
 
+import io.confluent.kafka.exceptions.SpecificRecordClassNotFound;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.generic.GenericDatumReader;

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializerConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializerConfig.java
@@ -29,12 +29,26 @@ public class KafkaAvroDeserializerConfig extends AbstractKafkaAvroSerDeConfig {
   public static final String SPECIFIC_AVRO_READER_DOC =
       "If true, tries to look up the SpecificRecord class ";
 
+  public static final String SPECIFIC_AVRO_READER_UNKNOWN_AS_GENERIC_CONFIG = "specific.avro.reader.unknown.generic";
+  public static final boolean SPECIFIC_AVRO_READER_UNKNOWN_AS_GENERIC_DEFAULT = false;
+  public static final String SPECIFIC_AVRO_READER_UNKNOWN_AS_GENERIC_DOC =
+      "If true, deserialize as GenericRecord when SpecificRecord class not found ";
+
   private static ConfigDef config;
 
   static {
     config = baseConfigDef()
-        .define(SPECIFIC_AVRO_READER_CONFIG, Type.BOOLEAN, SPECIFIC_AVRO_READER_DEFAULT,
-                Importance.LOW, SPECIFIC_AVRO_READER_DOC);
+        .define(
+            SPECIFIC_AVRO_READER_CONFIG,
+            Type.BOOLEAN,
+            SPECIFIC_AVRO_READER_DEFAULT,
+            Importance.LOW,
+            SPECIFIC_AVRO_READER_DOC)
+        .define(SPECIFIC_AVRO_READER_UNKNOWN_AS_GENERIC_CONFIG,
+            Type.BOOLEAN,
+            SPECIFIC_AVRO_READER_UNKNOWN_AS_GENERIC_DEFAULT,
+            Importance.LOW,
+            SPECIFIC_AVRO_READER_UNKNOWN_AS_GENERIC_DOC);
   }
 
   public KafkaAvroDeserializerConfig(Map<?, ?> props) {

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializerConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializerConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015 Confluent Inc.
+ * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializerConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializerConfig.java
@@ -29,7 +29,8 @@ public class KafkaAvroDeserializerConfig extends AbstractKafkaAvroSerDeConfig {
   public static final String SPECIFIC_AVRO_READER_DOC =
       "If true, tries to look up the SpecificRecord class ";
 
-  public static final String SPECIFIC_AVRO_READER_UNKNOWN_AS_GENERIC_CONFIG = "specific.avro.reader.unknown.generic";
+  public static final String SPECIFIC_AVRO_READER_UNKNOWN_AS_GENERIC_CONFIG =
+      "specific.avro.reader.unknown.generic";
   public static final boolean SPECIFIC_AVRO_READER_UNKNOWN_AS_GENERIC_DEFAULT = false;
   public static final String SPECIFIC_AVRO_READER_UNKNOWN_AS_GENERIC_DOC =
       "If true, deserialize as GenericRecord when SpecificRecord class not found ";

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializerConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializerConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Confluent Inc.
+ * Copyright 2015 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
@@ -15,25 +15,6 @@
  */
 package io.confluent.kafka.serializers;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import avro.shaded.com.google.common.collect.ImmutableMap;
-import io.confluent.kafka.example.ExtendedUser;
-import io.confluent.kafka.example.User;
-import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-import io.confluent.kafka.serializers.subject.TopicRecordNameStrategy;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import kafka.utils.VerifiableProperties;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -41,6 +22,26 @@ import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.util.Utf8;
 import org.apache.kafka.common.errors.SerializationException;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import avro.shaded.com.google.common.collect.ImmutableMap;
+import io.confluent.kafka.example.ExtendedUser;
+import io.confluent.kafka.example.User;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import kafka.utils.VerifiableProperties;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class KafkaAvroSerializerTest {
 

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -13,7 +13,7 @@
               files="SchemaRegistryCoordinator.java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(AvroMessageReader|RestService|Errors|SchemaRegistryRestApplication|KafkaSchemaRegistry|KafkaStore|AvroData|KafkaGroupMasterElector).java"/>
+              files="(AvroMessageReader|RestService|Errors|SchemaRegistryRestApplication|KafkaSchemaRegistry|KafkaStore|AvroData|KafkaGroupMasterElector|AbstractKafkaAvroDeserializer).java"/>
 
     <suppress checks="ClassFanOutComplexity"
               files="(RestService|KafkaSchemaRegistry|KafkaStore|KafkaStoreReaderThread|AvroData|KafkaGroupMasterElector).java"/>


### PR DESCRIPTION
What was done:

* A new boolean property was created ```SPECIFIC_AVRO_READER_UNKNOWN_AS_GENERIC_CONFIG```. When is true, if ```SPECIFIC_AVRO_READER_CONFIG``` is enabled, it will deserialize as generic record if specific record class was not found.
* Throwing an specific serialization exception class when specific record class not found ( ```SpecificRecordClassNotFound```) to allow consumer to handle properly.

For more details: https://github.com/confluentinc/schema-registry/issues/791

