### PR TITLE
Update Slack Channel subscription on pre-master branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
 common {
-  slackChannel = '#clients-eng'
+  slackChannel = '#connect-eng'
   upstreamProjects = 'confluentinc/rest-utils'
 }


### PR DESCRIPTION
Although the current Jenkinsfile is correct on mater the older branches still reflect the `#clients-eng` subscription.  The idea here is to commit to 3.3.x then propagate the changes upwards