### PR TITLE
CC-1958: Verify configs if createTopic fails because topic already exists

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -214,7 +214,8 @@ public class KafkaStore<K, V> implements Store<K, V> {
           .get(initTimeout, TimeUnit.MILLISECONDS);
     } catch (ExecutionException e) {
       if (e.getCause() instanceof TopicExistsException) {
-        // This is ok.
+        // If topic already exists, ensure that it is configured correctly.
+        verifySchemaTopic(admin);
       } else {
         throw e;
       }


### PR DESCRIPTION
If we call "describeTopics" immediately after "createTopics" in admin client, the newly created topic does not show up. But, attempting to recreate the topic will throw a TopicExistsException. Currently, we swallow the exception. This PR changes this behavior to verify the configuration of this topic. 

Signed-off-by: Arjun Satish <arjun@confluent.io>