### PR TITLE
Update maven-plugin-plugin to fix out of bounds error in build

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -41,7 +41,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.3</version>
                 <configuration>
                     <goalPrefix>schema-registry</goalPrefix>
                 </configuration>


### PR DESCRIPTION
This fixes the following error which was causing the build to fail:
```
[INFO:2018-05-29 15:57:54,568]: [ERROR] Failed to execute goal org.apache.maven.plugins:maven-plugin-plugin:3.2:descriptor (default-descriptor) on project kafka-schema-registry-maven-plugin: Execution default-descriptor of goal org.apache.maven.plugins:maven-plugin-plugin:3.2:descriptor failed: 2925 -> [Help 1]
```
I reproduced this error locally and confirmed it was fixed by updating the maven-plugin-plugin version.