### PR TITLE
Pass up subject & schema/version id errors from where they occur.

### DIFF
--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -56,7 +56,7 @@ paths:
         \ compatibility level for the subject (http:get:: /config/(string: subject)).\
         \ If this subject's compatibility level was never changed, then the global\
         \ compatibility level applies (http:get:: /config)."
-      operationId: "testCompatabilityBySubjectName"
+      operationId: "testCompatibilityBySubjectName"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
       - "application/vnd.schemaregistry+json"

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/VersionId.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/VersionId.java
@@ -32,10 +32,10 @@ public class VersionId {
       try {
         this.version = Integer.parseInt(version.trim());
       } catch (NumberFormatException nfe) {
-        throw new InvalidVersionException();
+        throw new InvalidVersionException(version);
       }
       if (this.version == -1) {
-        throw new InvalidVersionException();
+        throw new InvalidVersionException(version);
       }
       assertValidVersion();
     }
@@ -56,7 +56,7 @@ public class VersionId {
 
   private void assertValidVersion() throws InvalidVersionException {
     if (this.version <= 0 && this.version != -1) {
-      throw new InvalidVersionException();
+      throw new InvalidVersionException(String.valueOf(this.version));
     }
   }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/Errors.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/Errors.java
@@ -23,11 +23,12 @@ import io.confluent.rest.exceptions.RestNotFoundException;
 public class Errors {
 
   // HTTP 404
-  public static final String SUBJECT_NOT_FOUND_MESSAGE = "Subject not found.";
+  public static final String SUBJECT_NOT_FOUND_MESSAGE_FORMAT = "Subject '%s' not found.";
   public static final int SUBJECT_NOT_FOUND_ERROR_CODE = 40401;
-  public static final String VERSION_NOT_FOUND_MESSAGE = "Version not found.";
+  public static final String VERSION_NOT_FOUND_MESSAGE_FORMAT = "Version %s not found.";
   public static final int VERSION_NOT_FOUND_ERROR_CODE = 40402;
   public static final String SCHEMA_NOT_FOUND_MESSAGE = "Schema not found";
+  public static final String SCHEMA_NOT_FOUND_MESSAGE_FORMAT = "Schema %s not found";
   public static final int SCHEMA_NOT_FOUND_ERROR_CODE = 40403;
 
   // HTTP 409
@@ -47,16 +48,26 @@ public class Errors {
   public static final int UNKNOWN_MASTER_ERROR_CODE = 50004;
   // 50005 is used by the RestService to indicate a JSON Parse Error
 
-  public static RestException subjectNotFoundException() {
-    return new RestNotFoundException(SUBJECT_NOT_FOUND_MESSAGE, SUBJECT_NOT_FOUND_ERROR_CODE);
+  public static RestException subjectNotFoundException(String subject) {
+    return new RestNotFoundException(
+        String.format(SUBJECT_NOT_FOUND_MESSAGE_FORMAT, subject), SUBJECT_NOT_FOUND_ERROR_CODE);
   }
 
-  public static RestException versionNotFoundException() {
-    return new RestNotFoundException(VERSION_NOT_FOUND_MESSAGE, VERSION_NOT_FOUND_ERROR_CODE);
+  public static RestException versionNotFoundException(Integer id) {
+    return new RestNotFoundException(
+        String.format(VERSION_NOT_FOUND_MESSAGE_FORMAT, id), VERSION_NOT_FOUND_ERROR_CODE);
   }
 
   public static RestException schemaNotFoundException() {
     return new RestNotFoundException(SCHEMA_NOT_FOUND_MESSAGE, SCHEMA_NOT_FOUND_ERROR_CODE);
+  }
+
+  public static RestException schemaNotFoundException(Integer id) {
+    if (id == null) {
+      return schemaNotFoundException();
+    }
+    return new RestNotFoundException(
+        String.format(SCHEMA_NOT_FOUND_MESSAGE_FORMAT, id), SCHEMA_NOT_FOUND_ERROR_CODE);
   }
 
   public static RestIncompatibleAvroSchemaException incompatibleSchemaException(String message,
@@ -70,8 +81,8 @@ public class Errors {
     return new RestInvalidSchemaException(message);
   }
 
-  public static RestInvalidVersionException invalidVersionException() {
-    return new RestInvalidVersionException();
+  public static RestInvalidVersionException invalidVersionException(String version) {
+    return new RestInvalidVersionException(version);
   }
 
   public static RestException schemaRegistryException(String message, Throwable cause) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/RestInvalidVersionException.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/RestInvalidVersionException.java
@@ -24,13 +24,12 @@ import io.confluent.rest.exceptions.RestConstraintViolationException;
 public class RestInvalidVersionException extends RestConstraintViolationException {
 
   public static final int ERROR_CODE = Errors.INVALID_VERSION_ERROR_CODE;
+  public static final String INVALID_VERSION_MESSAGE_FORMAT = "The specified version '%s' "
+          + "is not a valid version id. "
+          + "Allowed values are between [1, 2^31-1] and the string \"latest\"";
 
-  public RestInvalidVersionException() {
-    this("The specified version is not a valid version id. Allowed values are between "
-         + "[1, 2^31-1] and the string \"latest\"");
+  public RestInvalidVersionException(String version) {
+    super(String.format(INVALID_VERSION_MESSAGE_FORMAT, version), ERROR_CODE);
   }
 
-  public RestInvalidVersionException(String message) {
-    super(message, ERROR_CODE);
-  }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -107,7 +107,7 @@ public class CompatibilityResource {
       //Don't check compatibility against deleted schema
       schemaForSpecifiedVersion = schemaRegistry.get(subject, versionId.getVersionId(), false);
     } catch (InvalidVersionException e) {
-      throw Errors.invalidVersionException();
+      throw Errors.invalidVersionException(e.getMessage());
     } catch (SchemaRegistryException e) {
       throw Errors.storeException("Error while retrieving schema for subject "
                                   + subject + " and version "
@@ -120,7 +120,7 @@ public class CompatibilityResource {
         compatibilityCheckResponse.setIsCompatible(isCompatible);
         asyncResponse.resume(compatibilityCheckResponse);
       } else {
-        throw Errors.versionNotFoundException();
+        throw Errors.versionNotFoundException(versionId.getVersionId());
       }
     } else {
       try {
@@ -145,15 +145,15 @@ public class CompatibilityResource {
     try {
       versionId = new VersionId(version);
     } catch (InvalidVersionException e) {
-      throw Errors.invalidVersionException();
+      throw Errors.invalidVersionException(e.getMessage());
     }
     return versionId;
   }
 
   private void registerWithError(final String subject, final String errorMessage) {
     try {
-      if (!schemaRegistry.hasSubjects(subject)) {
-        throw Errors.subjectNotFoundException();
+        if (!schemaRegistry.hasSubjects(subject)) {
+        throw Errors.subjectNotFoundException(subject);
       }
     } catch (SchemaRegistryStoreException e) {
       throw Errors.storeException(errorMessage, e);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -81,7 +81,7 @@ public class CompatibilityResource {
           + "Error code 42202 -- Invalid version"),
       @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store") })
   @PerformanceMetric("compatibility.subjects.versions.verify")
-  public void testCompatabilityBySubjectName(
+  public void testCompatibilityBySubjectName(
       final @Suspended AsyncResponse asyncResponse,
       final @HeaderParam("Content-Type") String contentType,
       final @HeaderParam("Accept") String accept,
@@ -152,7 +152,7 @@ public class CompatibilityResource {
 
   private void registerWithError(final String subject, final String errorMessage) {
     try {
-        if (!schemaRegistry.hasSubjects(subject)) {
+      if (!schemaRegistry.hasSubjects(subject)) {
         throw Errors.subjectNotFoundException(subject);
       }
     } catch (SchemaRegistryStoreException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -137,7 +137,7 @@ public class ConfigResource {
           ? schemaRegistry.getCompatibilityLevelInScope(subject)
           : schemaRegistry.getCompatibilityLevel(subject);
       if (compatibilityLevel == null) {
-        throw Errors.subjectNotFoundException();
+        throw Errors.subjectNotFoundException(subject);
       }
       config = new Config(compatibilityLevel.name);
     } catch (SchemaRegistryStoreException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
@@ -99,7 +99,7 @@ public class ModeResource {
     try {
       Mode mode = schemaRegistry.getMode(subject);
       if (mode == null) {
-        throw Errors.subjectNotFoundException();
+        throw Errors.subjectNotFoundException(subject);
       }
       return new ModeGetResponse(mode.name());
     } catch (SchemaRegistryException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
@@ -79,7 +79,7 @@ public class SchemasResource {
       throw Errors.schemaRegistryException(errorMessage, e);
     }
     if (schema == null) {
-      throw Errors.schemaNotFoundException();
+      throw Errors.schemaNotFoundException(id);
     }
     return schema;
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -98,23 +98,21 @@ public class SubjectVersionsResource {
     try {
       versionId = new VersionId(version);
     } catch (InvalidVersionException e) {
-      throw Errors.invalidVersionException();
+      throw Errors.invalidVersionException(e.getMessage());
     }
     Schema schema = null;
-    String errorMessage = null;
-    try {
-      schema = schemaRegistry.validateAndGetSchema(subject, versionId, false);
-    } catch (SchemaRegistryStoreException e) {
-      errorMessage =
-          "Error while retrieving schema for subject "
+    String errorMessage = "Error while retrieving schema for subject "
           + subject
           + " with version "
           + version
           + " from the schema registry";
+    try {
+      schema = schemaRegistry.validateAndGetSchema(subject, versionId, false);
+    } catch (SchemaRegistryStoreException e) {
       log.debug(errorMessage, e);
       throw Errors.storeException(errorMessage, e);
     } catch (InvalidVersionException e) {
-      throw Errors.invalidVersionException();
+      throw Errors.invalidVersionException(e.getMessage());
     } catch (SchemaRegistryException e) {
       throw Errors.schemaRegistryException(errorMessage, e);
     }
@@ -154,7 +152,7 @@ public class SubjectVersionsResource {
                           + " exists in the registry";
     try {
       if (!schemaRegistry.hasSubjects(subject)) {
-        throw Errors.subjectNotFoundException();
+        throw Errors.subjectNotFoundException(subject);
       }
     } catch (SchemaRegistryStoreException e) {
       throw Errors.storeException(errorMessage, e);
@@ -268,23 +266,22 @@ public class SubjectVersionsResource {
     try {
       versionId = new VersionId(version);
     } catch (InvalidVersionException e) {
-      throw Errors.invalidVersionException();
+      throw Errors.invalidVersionException(e.getMessage());
     }
     Schema schema = null;
-    String errorMessage = null;
+    String errorMessage =
+            "Error while retrieving schema for subject "
+            + subject
+            + " with version "
+            + version
+            + " from the schema registry";
     try {
       schema = schemaRegistry.validateAndGetSchema(subject, versionId, false);
     } catch (SchemaRegistryStoreException e) {
-      errorMessage =
-          "Error while retrieving schema for subject "
-          + subject
-          + " with version "
-          + version
-          + " from the schema registry";
       log.debug(errorMessage, e);
       throw Errors.storeException(errorMessage, e);
     } catch (InvalidVersionException e) {
-      throw Errors.invalidVersionException();
+      throw Errors.invalidVersionException(e.getMessage());
     } catch (SchemaRegistryException e) {
       throw Errors.schemaRegistryException(errorMessage, e);
     }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -90,7 +90,7 @@ public class SubjectsResource {
     io.confluent.kafka.schemaregistry.client.rest.entities.Schema matchingSchema = null;
     try {
       if (!schemaRegistry.hasSubjects(subject)) {
-        throw Errors.subjectNotFoundException();
+        throw Errors.subjectNotFoundException(subject);
       }
       matchingSchema =
           schemaRegistry.lookUpSchemaUnderSubject(subject, schema, lookupDeletedSchema);
@@ -140,7 +140,7 @@ public class SubjectsResource {
     List<Integer> deletedVersions;
     try {
       if (!schemaRegistry.hasSubjects(subject)) {
-        throw Errors.subjectNotFoundException();
+        throw Errors.subjectNotFoundException(subject);
       }
       Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
           headers, schemaRegistry.config().whitelistHeaders());

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -514,8 +514,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     } catch (StoreTimeoutException te) {
       throw new SchemaRegistryTimeoutException("Write to the Kafka store timed out while", te);
     } catch (StoreException e) {
-      throw new SchemaRegistryStoreException("Error while deleting the schema in the"
-                                             + " backend Kafka store", e);
+      throw new SchemaRegistryStoreException("Error while deleting the schema for subject '"
+                                            + subject + "' in the backend Kafka store", e);
     }
   }
 
@@ -742,12 +742,13 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
 
   public Schema validateAndGetSchema(String subject, VersionId versionId, boolean
       returnDeletedSchema) throws SchemaRegistryException {
-    Schema schema = this.get(subject, versionId.getVersionId(), returnDeletedSchema);
+    final int version = versionId.getVersionId();
+    Schema schema = this.get(subject, version, returnDeletedSchema);
     if (schema == null) {
       if (!this.hasSubjects(subject)) {
-        throw Errors.subjectNotFoundException();
+        throw Errors.subjectNotFoundException(subject);
       } else {
-        throw Errors.versionNotFoundException();
+        throw Errors.versionNotFoundException(version);
       }
     }
     return schema;


### PR DESCRIPTION
This error message isn't very informative. 

> `io.confluent.rest.exceptions.RestNotFoundException: Schema not found`

Would be more useful to see during serde interaction or other HTTP requests 

1. which schema ID is trying to be found
2. which subject it is trying to be found from
3. which version for that subject. 