### PR TITLE
CC-2024 : Fix schema not found issue

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -149,7 +149,8 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaAvroSer
         // schema registry's ordering (which is implicit by auto-registration time rather than
         // explicit from the Connector).
         String subject = getSubjectName(topic, isKey, result);
-        Integer version = schemaRegistry.getVersion(subject, schema);
+        Schema subjectSchema = schemaRegistry.getBySubjectAndId(subject, id);
+        Integer version = schemaRegistry.getVersion(subject, subjectSchema);
         if (schema.getType() == Schema.Type.UNION) {
           // Can't set additional properties on a union schema since it's just a list, so set it
           // on the first non-null entry


### PR DESCRIPTION
Since we add metadata, we need schemas to cached by subject. The recent change took away the by subject cache. This will do that again when we need schema versions. This happens when multiple topics have the same schema in a connector.