### PR TITLE
CC-2367 : Tombstone deleted schemakey if the same schema is registered again in the subject

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -87,6 +87,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
   private final SchemaRegistryConfig config;
   final Map<Integer, SchemaKey> guidToSchemaKey;
   final Map<MD5, SchemaIdAndSubjects> schemaHashToGuid;
+  final Map<Integer, List<SchemaKey>> guidToDeletedSchemaKeys;
   private final KafkaStore<SchemaRegistryKey, SchemaRegistryValue> kafkaStore;
   private final Serializer<SchemaRegistryKey, SchemaRegistryValue> serializer;
   private final SchemaRegistryIdentity myIdentity;
@@ -135,6 +136,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     this.defaultCompatibilityLevel = config.compatibilityType();
     this.guidToSchemaKey = new HashMap<Integer, SchemaKey>();
     this.schemaHashToGuid = new HashMap<MD5, SchemaIdAndSubjects>();
+    this.guidToDeletedSchemaKeys = new HashMap<>();
     Store store = new InMemoryStore<SchemaRegistryKey, SchemaRegistryValue>();
     kafkaStore =
         new KafkaStore<SchemaRegistryKey, SchemaRegistryValue>(

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -16,14 +16,15 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
+import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class KafkaStoreMessageHandler
     implements StoreUpdateHandler<SchemaRegistryKey, SchemaRegistryValue> {
@@ -31,11 +32,13 @@ public class KafkaStoreMessageHandler
   private static final Logger log = LoggerFactory.getLogger(KafkaStoreMessageHandler.class);
   private final KafkaSchemaRegistry schemaRegistry;
   private final Store store;
+  private final ExecutorService tombstoneExecutor;
 
   public KafkaStoreMessageHandler(KafkaSchemaRegistry schemaRegistry,
                                   Store store) {
     this.schemaRegistry = schemaRegistry;
     this.store = store;
+    this.tombstoneExecutor = Executors.newSingleThreadExecutor();
   }
 
   /**
@@ -66,6 +69,7 @@ public class KafkaStoreMessageHandler
         if (schemaValue != null) {
           schemaValue.setDeleted(true);
           this.store.put(schemaKey, schemaValue);
+          handleDeleteSchemaKey(schemaKey, schemaValue);
         }
       } catch (StoreException e) {
         log.error("Failed to delete subject in the local store");
@@ -76,16 +80,6 @@ public class KafkaStoreMessageHandler
   private void handleSchemaUpdate(SchemaKey schemaKey, SchemaValue schemaObj) {
     if (schemaObj != null) {
       schemaRegistry.guidToSchemaKey.put(schemaObj.getId(), schemaKey);
-
-      if (schemaObj.isDeleted()) {
-        schemaRegistry.guidToDeletedSchemaKeys
-            .computeIfAbsent(schemaObj.getId(), k -> new ArrayList<>()).add(schemaKey);
-      } else {
-        List<SchemaKey> schemaKeys = schemaRegistry.guidToDeletedSchemaKeys
-            .getOrDefault(schemaObj.getId(), Collections.emptyList());
-        schemaKeys.stream().filter(v -> v.getSubject().equals(schemaObj.getSubject()))
-            .forEach(k -> tombstoneSchemaKey(k));
-      }
 
       // Update the maximum id seen so far
       if (schemaRegistry.getMaxIdInKafkaStore() < schemaObj.getId()) {
@@ -99,14 +93,29 @@ public class KafkaStoreMessageHandler
       }
       schemaIdAndSubjects.addSubjectAndVersion(schemaKey.getSubject(), schemaKey.getVersion());
       schemaRegistry.schemaHashToGuid.put(md5, schemaIdAndSubjects);
+
+      if (schemaObj.isDeleted()) {
+        handleDeleteSchemaKey(schemaKey, schemaObj);
+      } else {
+        List<SchemaKey> schemaKeys = schemaRegistry.guidToDeletedSchemaKeys
+            .getOrDefault(schemaObj.getId(), Collections.emptyList());
+        schemaKeys.stream().filter(v -> v.getSubject().equals(schemaObj.getSubject()))
+            .forEach(k -> tombstoneExecutor.execute(() -> tombstoneSchemaKey(k)));
+      }
     }
+  }
+
+  private void handleDeleteSchemaKey(SchemaKey schemaKey, SchemaValue schemaValue) {
+    schemaRegistry.guidToDeletedSchemaKeys
+        .computeIfAbsent(schemaValue.getId(), k -> new ArrayList<>()).add(schemaKey);
   }
 
   private void tombstoneSchemaKey(SchemaKey schemaKey) {
     try {
       schemaRegistry.getKafkaStore().put(schemaKey, null);
+      log.debug("Tombstoned {}", schemaKey);
     } catch (StoreException e) {
-      log.error("Failed to tombstone {}", schemaKey);
+      log.error("Failed to tombstone {}", schemaKey, e);
     }
   }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -99,7 +99,7 @@ public class KafkaStoreMessageHandler
       // Whenever we encounter a new schema for a subject, we check to see if the same schema
       // (same id) was deleted for the subject ever. If so, we tombstone those delete keys.
       // This helps optimize the storage. The main reason we only allow soft deletes in SR is that
-      // consumers should be able to access teh schemas by id. This is guaranteed when teh schema is
+      // consumers should be able to access teh schemas by id. This is guaranteed when the schema is
       // re-registered again and hence we can tombstone the record.
       if (schemaObj.isDeleted()) {
         handleDeleteSchemaKey(schemaKey, schemaObj);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -99,7 +99,7 @@ public class KafkaStoreMessageHandler
       // Whenever we encounter a new schema for a subject, we check to see if the same schema
       // (same id) was deleted for the subject ever. If so, we tombstone those delete keys.
       // This helps optimize the storage. The main reason we only allow soft deletes in SR is that
-      // consumers should be able to access teh schemas by id. This is guaranteed when the schema is
+      // consumers should be able to access the schemas by id. This is guaranteed when the schema is
       // re-registered again and hence we can tombstone the record.
       if (schemaObj.isDeleted()) {
         handleDeleteSchemaKey(schemaKey, schemaObj);


### PR DESCRIPTION
Ability to tombstone old delete keys if the subject has the same schema registered again. This will help optimize on the storage when users typically do a delete & a register for health check purposes.

The notion of a delete is soft delete in SR today. The key that is stored in the storage has the delete flag. It also has the version.  When you register again with the same schema, while you might get the same id, the old keys still exist in the storage. The motivation of this PR is tombstone the old key so that we can optimize on storage.