### PR TITLE
CC-2441 : Add Cyclic schema support

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -1074,9 +1074,7 @@ public class AvroData {
     if (value == null) {
       return null;
     }
-    ToConnectContext toConnectContext = new ToConnectContext(
-        new IdentityHashMap<>(),
-        new HashSet<>());
+    ToConnectContext toConnectContext = new ToConnectContext();
     Schema schema = (avroSchema.equals(ANYTHING_SCHEMA))
         ? null
         : toConnectSchema(avroSchema, toConnectContext);
@@ -1352,8 +1350,7 @@ public class AvroData {
   }
 
   public Schema toConnectSchema(org.apache.avro.Schema schema) {
-    return toConnectSchema(
-        schema, new ToConnectContext(new IdentityHashMap<>(), new HashSet<>()));
+    return toConnectSchema(schema, new ToConnectContext());
   }
 
 
@@ -2007,13 +2004,12 @@ public class AvroData {
     private final Set<org.apache.avro.Schema> detectedCycles;
 
     /**
-     * @param cycleReferences map that holds connect Schema references to resolve cycles
-     * @param detectedCycles  avro schemas that have been detected to have cycles
+     * cycleReferences - map that holds connect Schema references to resolve cycles
+     * detectedCycles - avro schemas that have been detected to have cycles
      */
-    private ToConnectContext(Map<org.apache.avro.Schema, CyclicSchemaWrapper> cycleReferences,
-                             Set<org.apache.avro.Schema> detectedCycles) {
-      this.cycleReferences = cycleReferences;
-      this.detectedCycles = detectedCycles;
+    private ToConnectContext() {
+      this.cycleReferences = new IdentityHashMap<>();
+      this.detectedCycles = new HashSet<>();
     }
   }
 

--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -1074,7 +1074,9 @@ public class AvroData {
     if (value == null) {
       return null;
     }
-    ToConnectContext toConnectContext = new ToConnectContext(new IdentityHashMap<>(), new HashSet<>());
+    ToConnectContext toConnectContext = new ToConnectContext(
+        new IdentityHashMap<>(),
+        new HashSet<>());
     Schema schema = (avroSchema.equals(ANYTHING_SCHEMA))
         ? null
         : toConnectSchema(avroSchema, toConnectContext);

--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -1699,7 +1699,7 @@ public class AvroData {
       Map<org.apache.avro.Schema, CyclicSchemaWrapper> toConnectCycles,
       org.apache.avro.Schema memberSchema,
       boolean optional) {
-    return new CyclicSchemaWrapper(toConnectCycles.get(memberSchema).schemaBuilder(), optional);
+    return new CyclicSchemaWrapper(toConnectCycles.get(memberSchema).schema(), optional);
   }
 
   private Object defaultValueFromAvro(
@@ -1949,25 +1949,21 @@ public class AvroData {
 
   private class CyclicSchemaWrapper implements Schema {
 
-    private SchemaBuilder schemaBuilder;
+    private Schema schema;
     private boolean optional;
 
-    public CyclicSchemaWrapper(SchemaBuilder schemaBuilder) {
-      this(schemaBuilder, schemaBuilder.isOptional());
+    public CyclicSchemaWrapper(Schema schema) {
+      this(schema, schema.isOptional());
     }
 
-    public CyclicSchemaWrapper(SchemaBuilder schemaBuilder, boolean optional) {
-      this.schemaBuilder = schemaBuilder;
+    public CyclicSchemaWrapper(Schema schema, boolean optional) {
+      this.schema = schema;
       this.optional = optional;
-    }
-
-    public SchemaBuilder schemaBuilder() {
-      return schemaBuilder;
     }
 
     @Override
     public Type type() {
-      return schemaBuilder.type();
+      return schema.type();
     }
 
     @Override
@@ -1977,52 +1973,52 @@ public class AvroData {
 
     @Override
     public Object defaultValue() {
-      return schemaBuilder.defaultValue();
+      return schema.defaultValue();
     }
 
     @Override
     public String name() {
-      return schemaBuilder.name();
+      return schema.name();
     }
 
     @Override
     public Integer version() {
-      return schemaBuilder.version();
+      return schema.version();
     }
 
     @Override
     public String doc() {
-      return schemaBuilder.doc();
+      return schema.doc();
     }
 
     @Override
     public Map<String, String> parameters() {
-      return schemaBuilder.parameters();
+      return schema.parameters();
     }
 
     @Override
     public Schema keySchema() {
-      return schemaBuilder.keySchema();
+      return schema.keySchema();
     }
 
     @Override
     public Schema valueSchema() {
-      return schemaBuilder.valueSchema();
+      return schema.valueSchema();
     }
 
     @Override
     public List<Field> fields() {
-      return schemaBuilder.fields();
+      return schema.fields();
     }
 
     @Override
     public Field field(String s) {
-      return schemaBuilder.field(s);
+      return schema.field(s);
     }
 
     @Override
     public Schema schema() {
-      return schemaBuilder.schema();
+      return schema;
     }
 
   }

--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -16,8 +16,6 @@
 
 package io.confluent.connect.avro;
 
-import io.confluent.kafka.serializers.AbstractKafkaAvroDeserializer;
-import io.confluent.kafka.serializers.NonRecordContainer;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericEnumSymbol;
@@ -60,6 +58,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+
+import io.confluent.kafka.serializers.AbstractKafkaAvroDeserializer;
+import io.confluent.kafka.serializers.NonRecordContainer;
 
 
 /**
@@ -700,9 +701,9 @@ public class AvroData {
    * <p>This is different to the global schema cache which is used to hold/cache fully resolved
    * schemas used to avoid re-resolving when presented with the same source schema.
    */
-  private org.apache.avro.Schema fromConnectSchema(
-      Schema schema,
-      FromConnectContext fromConnectContext, boolean ignoreOptional) {
+  public org.apache.avro.Schema fromConnectSchema(Schema schema,
+                                                  FromConnectContext fromConnectContext,
+                                                  boolean ignoreOptional) {
     if (schema == null) {
       return ANYTHING_SCHEMA;
     }
@@ -1350,9 +1351,7 @@ public class AvroData {
 
   public Schema toConnectSchema(org.apache.avro.Schema schema) {
     return toConnectSchema(
-        schema,
-        new ToConnectContext(new IdentityHashMap<>(), new HashSet<>())
-    );
+        schema, new ToConnectContext(new IdentityHashMap<>(), new HashSet<>()));
   }
 
 
@@ -1686,11 +1685,10 @@ public class AvroData {
     return new CyclicSchemaWrapper(toConnectCycles.get(memberSchema).schema(), optional);
   }
 
-  private Object defaultValueFromAvro(
-      Schema schema,
-      org.apache.avro.Schema avroSchema,
-      Object value,
-      ToConnectContext toConnectContext) {
+  private Object defaultValueFromAvro(Schema schema,
+                                      org.apache.avro.Schema avroSchema,
+                                      Object value,
+                                      ToConnectContext toConnectContext) {
     // The type will be JsonNode if this default was pulled from a Connect default field, or an
     // Object if it's the actual Avro-specified default. If it's a regular Java object, we can
     // use our existing conversion tools.

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AdditionalAvroDataTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AdditionalAvroDataTest.java
@@ -3,6 +3,8 @@ package io.confluent.connect.avro;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 
 import io.test.avro.core.AvroMessage;
 import io.test.avro.doc.DocTestRecord;
@@ -44,7 +46,8 @@ public class AdditionalAvroDataTest
     {
         Schema avroSchema = new Parser().parse(new File("src/test/avro/DocTestRecord.avsc"));
 
-        org.apache.kafka.connect.data.Schema connectSchema = avroData.toConnectSchema(avroSchema);
+        org.apache.kafka.connect.data.Schema connectSchema = avroData.toConnectSchema(avroSchema,
+            new HashMap<>(), new HashSet<>());
 
         Schema outputAvroSchema = avroData.fromConnectSchema(connectSchema);
 
@@ -70,7 +73,7 @@ public class AdditionalAvroDataTest
         // Here is a schema complex union schema
         Schema avroSchema = new Parser().parse(new File("src/test/avro/AvroMessage.avsc"));
 
-        org.apache.kafka.connect.data.Schema connectSchema = avroData.toConnectSchema(avroSchema);
+        org.apache.kafka.connect.data.Schema connectSchema = avroData.toConnectSchema(avroSchema, new HashMap<>(), new HashSet<>());
 
         Schema outputAvroSchema = avroData.fromConnectSchema(connectSchema);
 
@@ -159,7 +162,7 @@ public class AdditionalAvroDataTest
         GenericData.Record nestedRecord = new GenericRecordBuilder(myImpl1Schema).set("data", "mydata").build();
         GenericData.Record obj = new GenericRecordBuilder(myAvroObjectSchema).set("obj", nestedRecord).build();
 
-        org.apache.kafka.connect.data.Schema connectSchema = avroData.toConnectSchema(myAvroObjectSchema);
+        org.apache.kafka.connect.data.Schema connectSchema = avroData.toConnectSchema(myAvroObjectSchema, new HashMap<>(), new HashSet<>());
         SchemaAndValue schemaAndValue = avroData.toConnectData(myAvroObjectSchema, obj);
         Object o = avroData.fromConnectData(schemaAndValue.schema(), schemaAndValue.value());
         Assert.assertEquals(obj ,o);

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AdditionalAvroDataTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AdditionalAvroDataTest.java
@@ -44,8 +44,7 @@ public class AdditionalAvroDataTest
     {
         Schema avroSchema = new Parser().parse(new File("src/test/avro/DocTestRecord.avsc"));
 
-        org.apache.kafka.connect.data.Schema connectSchema = avroData.toConnectSchema(avroSchema
-        );
+        org.apache.kafka.connect.data.Schema connectSchema = avroData.toConnectSchema(avroSchema);
 
         Schema outputAvroSchema = avroData.fromConnectSchema(connectSchema);
 

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AdditionalAvroDataTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AdditionalAvroDataTest.java
@@ -3,8 +3,6 @@ package io.confluent.connect.avro;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
 
 import io.test.avro.core.AvroMessage;
 import io.test.avro.doc.DocTestRecord;
@@ -46,8 +44,8 @@ public class AdditionalAvroDataTest
     {
         Schema avroSchema = new Parser().parse(new File("src/test/avro/DocTestRecord.avsc"));
 
-        org.apache.kafka.connect.data.Schema connectSchema = avroData.toConnectSchema(avroSchema,
-            new HashMap<>(), new HashSet<>());
+        org.apache.kafka.connect.data.Schema connectSchema = avroData.toConnectSchema(avroSchema
+        );
 
         Schema outputAvroSchema = avroData.fromConnectSchema(connectSchema);
 
@@ -73,7 +71,7 @@ public class AdditionalAvroDataTest
         // Here is a schema complex union schema
         Schema avroSchema = new Parser().parse(new File("src/test/avro/AvroMessage.avsc"));
 
-        org.apache.kafka.connect.data.Schema connectSchema = avroData.toConnectSchema(avroSchema, new HashMap<>(), new HashSet<>());
+        org.apache.kafka.connect.data.Schema connectSchema = avroData.toConnectSchema(avroSchema);
 
         Schema outputAvroSchema = avroData.fromConnectSchema(connectSchema);
 
@@ -162,7 +160,7 @@ public class AdditionalAvroDataTest
         GenericData.Record nestedRecord = new GenericRecordBuilder(myImpl1Schema).set("data", "mydata").build();
         GenericData.Record obj = new GenericRecordBuilder(myAvroObjectSchema).set("obj", nestedRecord).build();
 
-        org.apache.kafka.connect.data.Schema connectSchema = avroData.toConnectSchema(myAvroObjectSchema, new HashMap<>(), new HashSet<>());
+        org.apache.kafka.connect.data.Schema connectSchema = avroData.toConnectSchema(myAvroObjectSchema);
         SchemaAndValue schemaAndValue = avroData.toConnectData(myAvroObjectSchema, obj);
         Object o = avroData.fromConnectData(schemaAndValue.schema(), schemaAndValue.value());
         Assert.assertEquals(obj ,o);

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -16,12 +16,9 @@
 
 package io.confluent.connect.avro;
 
-import avro.shaded.com.google.common.collect.ImmutableMap;
 import com.connect.avro.EnumUnion;
 import com.connect.avro.UserType;
-import foo.bar.EnumTest;
-import foo.bar.Kind;
-import io.confluent.kafka.serializers.NonRecordContainer;
+
 import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -58,15 +55,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
+import avro.shaded.com.google.common.collect.ImmutableMap;
+import foo.bar.EnumTest;
+import foo.bar.Kind;
+import io.confluent.kafka.serializers.NonRecordContainer;
+
 import static io.confluent.connect.avro.AvroData.AVRO_TYPE_ENUM;
 import static io.confluent.connect.avro.AvroData.CONNECT_ENUM_DOC_PROP;
 import static io.confluent.connect.avro.AvroData.CONNECT_RECORD_DOC_PROP;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class AvroDataTest {
   private static final int TEST_SCALE = 2;

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -39,4 +39,7 @@
     <suppress checks="MethodLength"
               files="SchemaRegistryConfig.java"/>
 
+    <suppress checks="BooleanExpressionComplexity"
+              files="AvroData.java"/>
+
 </suppressions>


### PR DESCRIPTION
Adds support for Cyclic Schemas. Uses the fact that SchemaBuilder also implements Schema. Creates a wrapper CyclicSchema so that we can manage the optionality for different types of cycles. Also, we don't want to change the optionality on actual Struct that we are referring to. Keeps track of cycles and detected cycles while doing toConnectSchema. We want to use the reference only when it's a true cycle.