### PR TITLE
HUB-13: Fix source URL for Avro Converter

### DIFF
--- a/avro-converter/pom.xml
+++ b/avro-converter/pom.xml
@@ -103,6 +103,7 @@
                                 The Kafka Connect Avro Converter integrates with <a href="https://docs.confluent.io/current/schema-registry/docs/intro.html">
                                 to convert data for Kafka Connect to and from Avro format.
                             ]]></description>
+                            <sourceUrl>https://github.com/confluentinc/schema-registry</sourceUrl>
                             
                             <supportProviderName>Confluent, Inc.</supportProviderName>
                             <supportSummary>Confluent supports the Avro Converter alongside community members as part of its Confluent Platform open source offering.</supportSummary>


### PR DESCRIPTION
[JIRA](https://confluentinc.atlassian.net/browse/HUB-13)

The default `<sourceUrl>` field doesn't work well with submodules. This may warrant fixing in the Maven plugin, but for now we can just add it manually to the Avro Converter.