### PR TITLE
Refactor SR to pull lookup datastructure to its own interface and Id Generation to its own interface

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/exceptions/IdGenerationException.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/exceptions/IdGenerationException.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 Confluent Inc.
+/*
+ * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,27 +12,25 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
-
-package io.confluent.kafka.schemaregistry.storage;
-
-/**
- * A range of schema IDs, from the first available ID to the inclusive upper bound.
  */
-public class SchemaIdRange {
-  private final int base;
-  private final int end;
 
-  public SchemaIdRange(int base, int end) {
-    this.base = base;
-    this.end = end;
+package io.confluent.kafka.schemaregistry.exceptions;
+
+public class IdGenerationException extends SchemaRegistryException {
+
+  public IdGenerationException(String message, Throwable cause) {
+    super(message, cause);
   }
 
-  public int base() {
-    return base;
+  public IdGenerationException(String message) {
+    super(message);
   }
 
-  public int end() {
-    return end;
+  public IdGenerationException(Throwable cause) {
+    super(cause);
+  }
+
+  public IdGenerationException() {
+    super();
   }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/id/IdGenerator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/id/IdGenerator.java
@@ -22,14 +22,41 @@ import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.storage.SchemaKey;
 import io.confluent.kafka.schemaregistry.storage.SchemaValue;
 
+/**
+ * Internal interface used for generating id while registering schema.
+ */
 public interface IdGenerator {
 
-  int id(String subject, Schema schema) throws IdGenerationException;
+  /**
+   * Provides the id for the schema.
+   *
+   * @param schema the schema being registered; never {@code null}
+   * @return the identifier for the schema; never {@code null}
+   * @throws IdGenerationException exception when id can't be generated
+   */
+  int id(Schema schema) throws IdGenerationException;
 
+  /**
+   * Configure the underlying generator.
+   *
+   * @param config Schema Registry Configs
+   */
   void configure(SchemaRegistryConfig config);
 
+  /**
+   * Initialize the underlying generator.
+   *
+   * @throws IdGenerationException exception when IdGenerator can't be initialized
+   */
   void init() throws IdGenerationException;
 
+  /**
+   * Callback method that is invoked when a schema is registered.
+   * IdGenerator implementation can optionally use this to update the next possible id.
+   *
+   * @param schemaKey the registered SchemaKey; never {@code null}
+   * @param schemaValue the registered SchemaValue; never {@code null}
+   */
   void schemaRegistered(SchemaKey schemaKey, SchemaValue schemaValue);
 
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/id/IdGenerator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/id/IdGenerator.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 Confluent Inc.
+/*
+ * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,20 +12,24 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
-
-package io.confluent.kafka.schemaregistry.storage;
-
-import io.confluent.kafka.schemaregistry.exceptions.IdGenerationException;
-import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException;
-import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryTimeoutException;
-
-/**
- * Internal interface for schema registry implementations. Used as a restricted interface for
- * MasterElectors to interact with.
  */
-public interface MasterAwareSchemaRegistry {
-  void setMaster(SchemaRegistryIdentity newMaster) throws SchemaRegistryTimeoutException,
-      SchemaRegistryStoreException, IdGenerationException;
+
+package io.confluent.kafka.schemaregistry.id;
+
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.exceptions.IdGenerationException;
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
+import io.confluent.kafka.schemaregistry.storage.SchemaKey;
+import io.confluent.kafka.schemaregistry.storage.SchemaValue;
+
+public interface IdGenerator {
+
+  int id(String subject, Schema schema) throws IdGenerationException;
+
+  void configure(SchemaRegistryConfig config);
+
+  void init() throws IdGenerationException;
+
+  void schemaRegistered(SchemaKey schemaKey, SchemaValue schemaValue);
 
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/id/IncrementalIdGenerator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/id/IncrementalIdGenerator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.id;
+
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.exceptions.IdGenerationException;
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
+import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
+import io.confluent.kafka.schemaregistry.storage.SchemaKey;
+import io.confluent.kafka.schemaregistry.storage.SchemaValue;
+
+public class IncrementalIdGenerator implements IdGenerator {
+
+  private int maxIdInKafkaStore = -1;
+
+  @Override
+  public int id(String subject, Schema schema) throws IdGenerationException {
+    int nextId = Math.max(
+        KafkaSchemaRegistry.MIN_VERSION,
+        maxIdInKafkaStore + 1
+    );
+    return nextId;
+  }
+
+  @Override
+  public void configure(SchemaRegistryConfig config) {
+
+  }
+
+  @Override
+  public void init() throws IdGenerationException {
+
+  }
+
+  @Override
+  public void schemaRegistered(SchemaKey schemaKey, SchemaValue schemaValue) {
+    if (maxIdInKafkaStore < schemaValue.getId()) {
+      maxIdInKafkaStore = schemaValue.getId();
+    }
+  }
+}

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/id/IncrementalIdGenerator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/id/IncrementalIdGenerator.java
@@ -28,7 +28,7 @@ public class IncrementalIdGenerator implements IdGenerator {
   private int maxIdInKafkaStore = -1;
 
   @Override
-  public int id(String subject, Schema schema) throws IdGenerationException {
+  public int id(Schema schema) throws IdGenerationException {
     int nextId = Math.max(
         KafkaSchemaRegistry.MIN_VERSION,
         maxIdInKafkaStore + 1

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/id/SchemaIdRange.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/id/SchemaIdRange.java
@@ -14,17 +14,25 @@
  * limitations under the License.
  **/
 
-package io.confluent.kafka.schemaregistry.storage;
+package io.confluent.kafka.schemaregistry.id;
 
-import io.confluent.kafka.schemaregistry.exceptions.IdGenerationException;
-import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryInitializationException;
-import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException;
-import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryTimeoutException;
+/**
+ * A range of schema IDs, from the first available ID to the inclusive upper bound.
+ */
+public class SchemaIdRange {
+  private final int base;
+  private final int end;
 
-public interface MasterElector {
+  public SchemaIdRange(int base, int end) {
+    this.base = base;
+    this.end = end;
+  }
 
-  void init() throws SchemaRegistryTimeoutException, SchemaRegistryStoreException,
-      SchemaRegistryInitializationException, IdGenerationException;
+  public int base() {
+    return base;
+  }
 
-  void close();
+  public int end() {
+    return end;
+  }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/id/ZookeeperIdGenerator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/id/ZookeeperIdGenerator.java
@@ -52,7 +52,7 @@ public class ZookeeperIdGenerator implements IdGenerator {
 
 
   @Override
-  public int id(String subject, Schema schema) throws IdGenerationException {
+  public int id(Schema schema) throws IdGenerationException {
     int id = nextAvailableSchemaId;
     nextAvailableSchemaId++;
     if (reachedEndOfIdBatch()) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/id/ZookeeperIdGenerator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/id/ZookeeperIdGenerator.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.id;
+
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.exceptions.IdGenerationException;
+import io.confluent.kafka.schemaregistry.masterelector.zookeeper.ZookeeperMasterElector;
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
+import io.confluent.kafka.schemaregistry.storage.SchemaKey;
+import io.confluent.kafka.schemaregistry.storage.SchemaValue;
+import kafka.utils.ZkUtils;
+import org.I0Itec.zkclient.exception.ZkNodeExistsException;
+import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Tuple2;
+
+
+public class ZookeeperIdGenerator implements IdGenerator {
+
+  public static final int ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE = 20;
+  public static final String ZOOKEEPER_SCHEMA_ID_COUNTER = "/schema_id_counter";
+  private static final Logger log = LoggerFactory.getLogger(ZookeeperMasterElector.class);
+  private static final int ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_WRITE_RETRY_BACKOFF_MS = 50;
+
+  private ZkUtils zkUtils;
+  // Hand out this id during the next schema registration. Indexed from 1.
+  private int nextAvailableSchemaId;
+  // Tracks the upper bound of the current id batch (inclusive). When nextAvailableSchemaId goes
+  // above this value, it's time to allocate a new batch of ids
+  private int idBatchInclusiveUpperBound;
+  // Track the largest id in the kafka store so far (-1 indicates none in the store)
+  // This is automatically updated by the KafkaStoreReaderThread every time a new Schema is added
+  // Used to ensure that any newly allocated batch of ids does not overlap
+  // with any id in the kafkastore. Primarily for bootstrapping the SchemaRegistry when
+  // data is already in the kafkastore.
+  private int maxIdInKafkaStore = -1;
+
+
+  @Override
+  public int id(String subject, Schema schema) throws IdGenerationException {
+    int id = nextAvailableSchemaId;
+    nextAvailableSchemaId++;
+    if (reachedEndOfIdBatch()) {
+      init();
+    }
+    return id;
+  }
+
+  @Override
+  public void configure(SchemaRegistryConfig config) {
+    this.zkUtils = config.zkUtils();
+  }
+
+  @Override
+  public void init() throws IdGenerationException {
+    SchemaIdRange nextRange = nextRange();
+    nextAvailableSchemaId = nextRange.base();
+    idBatchInclusiveUpperBound = nextRange.end();
+  }
+
+  @Override
+  public void schemaRegistered(SchemaKey schemaKey, SchemaValue schemaValue) {
+    if (maxIdInKafkaStore < schemaValue.getId()) {
+      maxIdInKafkaStore = schemaValue.getId();
+    }
+  }
+
+  private SchemaIdRange nextRange() throws IdGenerationException {
+    int base = nextSchemaIdCounterBatch();
+    return new SchemaIdRange(base, getInclusiveUpperBound(base));
+  }
+
+  /**
+   * Allocate and lock the next batch of schema ids. Signal a global lock over the next batch by
+   * writing the inclusive upper bound of the batch to ZooKeeper. I.e. the value stored in
+   * ZOOKEEPER_SCHEMA_ID_COUNTER in ZooKeeper indicates the current max allocated id for assignment.
+   *
+   * <p>When a schema registry server is initialized, kafka may have preexisting persistent
+   * schema -> id assignments, and zookeeper may have preexisting counter data.
+   * Therefore, when allocating the next batch of ids, it's necessary to ensure the entire new batch
+   * is greater than the greatest id in kafka and also greater than the previously recorded batch
+   * in zookeeper.
+   *
+   * <p>Return the first available id in the newly allocated batch of ids.
+   */
+  private Integer nextSchemaIdCounterBatch() throws IdGenerationException {
+    int nextIdBatchLowerBound = 1;
+
+    while (true) {
+
+      if (!zkUtils.zkClient().exists(ZOOKEEPER_SCHEMA_ID_COUNTER)) {
+        // create ZOOKEEPER_SCHEMA_ID_COUNTER if it already doesn't exist
+
+        try {
+          nextIdBatchLowerBound = getNextBatchLowerBoundFromKafkaStore();
+          int nextIdBatchUpperBound = getInclusiveUpperBound(nextIdBatchLowerBound);
+          zkUtils.createPersistentPath(ZOOKEEPER_SCHEMA_ID_COUNTER,
+              String.valueOf(nextIdBatchUpperBound),
+              zkUtils.defaultAcls(ZOOKEEPER_SCHEMA_ID_COUNTER));
+          return nextIdBatchLowerBound;
+        } catch (ZkNodeExistsException ignore) {
+          // A zombie master may have created this zk node after the initial existence check
+          // Ignore and try again
+        }
+      } else { // ZOOKEEPER_SCHEMA_ID_COUNTER exists
+
+        // read the latest counter value
+        final Tuple2<String, Stat> counterValue = zkUtils.readData(ZOOKEEPER_SCHEMA_ID_COUNTER);
+        final String counterData = counterValue._1();
+        final Stat counterStat = counterValue._2();
+        if (counterData == null) {
+          throw new IdGenerationException(
+              "Failed to read schema id counter " + ZOOKEEPER_SCHEMA_ID_COUNTER
+                  + " from zookeeper");
+        }
+
+        // Compute the lower bound of next id batch based on zk data and kafkastore data
+        int zkIdCounterValue = Integer.parseInt(counterData);
+        int zkNextIdBatchLowerBound = zkIdCounterValue + 1;
+        if (zkIdCounterValue % ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE != 0) {
+          // ZooKeeper id counter should be an integer multiple of id batch size in normal
+          // operation; handle corrupted/stale id counter data gracefully by bumping
+          // up to the next id batch
+
+          // fixedZkIdCounterValue is the smallest multiple of
+          // ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE greater than the bad zkIdCounterValue
+          int fixedZkIdCounterValue = ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE
+              * (1
+              + zkIdCounterValue
+              / ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE);
+          zkNextIdBatchLowerBound = fixedZkIdCounterValue + 1;
+
+          log.warn(
+              "Zookeeper schema id counter is not an integer multiple of id batch size."
+                  + " Zookeeper may have stale id counter data.\n"
+                  + "zk id counter: " + zkIdCounterValue + "\n"
+                  + "id batch size: " + ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE);
+        }
+        nextIdBatchLowerBound =
+            Math.max(zkNextIdBatchLowerBound, getNextBatchLowerBoundFromKafkaStore());
+        String
+            nextIdBatchUpperBound =
+            String.valueOf(getInclusiveUpperBound(nextIdBatchLowerBound));
+
+        // conditionally update the zookeeper path with the upper bound of the new id batch.
+        // newSchemaIdCounterDataVersion < 0 indicates a failed conditional update.
+        // Most probable cause is the existence of another master which tries to do the same
+        // counter batch allocation at the same time. If this happens, re-read the value and
+        // continue until one master is determined to be the zombie master.
+        // NOTE: The handling of multiple masters is still a TODO
+        int newSchemaIdCounterDataVersion =
+            (Integer) zkUtils.conditionalUpdatePersistentPath(
+                ZOOKEEPER_SCHEMA_ID_COUNTER,
+                nextIdBatchUpperBound,
+                counterStat.getVersion(),
+                null)._2();
+        if (newSchemaIdCounterDataVersion >= 0) {
+          break;
+        }
+      }
+      try {
+        // Wait a bit and attempt id batch allocation again
+        Thread.sleep(ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_WRITE_RETRY_BACKOFF_MS);
+      } catch (InterruptedException ignored) {
+        // ignored
+      }
+    }
+
+    return nextIdBatchLowerBound;
+  }
+
+  /**
+   * Return a minimum lower bound on the next batch of ids based on ids currently in the
+   * kafka store.
+   */
+  private int getNextBatchLowerBoundFromKafkaStore() {
+    if (maxIdInKafkaStore <= 0) {
+      return 1;
+    }
+
+    int nextBatchLowerBound = 1 + maxIdInKafkaStore / ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE;
+    return 1 + nextBatchLowerBound * ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE;
+  }
+
+  /**
+   * E.g. if inclusiveLowerBound is 61, and BATCH_SIZE is 20, the inclusiveUpperBound should be 80.
+   */
+  private int getInclusiveUpperBound(int inclusiveLowerBound) {
+    return inclusiveLowerBound + ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE - 1;
+  }
+
+  /**
+   * If true, it's time to allocate a new batch of ids with a call to nextSchemaIdCounterBatch()
+   */
+  private boolean reachedEndOfIdBatch() {
+    return nextAvailableSchemaId > idBatchInclusiveUpperBound;
+  }
+
+
+
+}

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/KafkaGroupMasterElector.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/KafkaGroupMasterElector.java
@@ -56,7 +56,6 @@ import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryTimeoutExcepti
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
 import io.confluent.kafka.schemaregistry.storage.MasterElector;
-import io.confluent.kafka.schemaregistry.storage.SchemaIdRange;
 import io.confluent.kafka.schemaregistry.storage.SchemaRegistryIdentity;
 
 public class KafkaGroupMasterElector implements MasterElector, SchemaRegistryRebalanceListener {
@@ -208,15 +207,6 @@ public class KafkaGroupMasterElector implements MasterElector, SchemaRegistryReb
     }
 
     log.debug("Schema registry group member initialized and joined group");
-  }
-
-  @Override
-  public SchemaIdRange nextRange() throws SchemaRegistryStoreException {
-    int nextId = Math.max(
-        KafkaSchemaRegistry.MIN_VERSION,
-        schemaRegistry.getMaxIdInKafkaStore() + 1
-    );
-    return new SchemaIdRange(nextId, nextId);
   }
 
   @Override

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/zookeeper/ZookeeperMasterElector.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/zookeeper/ZookeeperMasterElector.java
@@ -22,7 +22,6 @@ import org.I0Itec.zkclient.ZkClient;
 import org.I0Itec.zkclient.exception.ZkNoNodeException;
 import org.I0Itec.zkclient.exception.ZkNodeExistsException;
 import org.apache.zookeeper.Watcher;
-import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,22 +30,18 @@ import java.io.IOException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryInitializationException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryTimeoutException;
+import io.confluent.kafka.schemaregistry.exceptions.IdGenerationException;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException;
 import io.confluent.kafka.schemaregistry.storage.MasterElector;
-import io.confluent.kafka.schemaregistry.storage.SchemaIdRange;
 import io.confluent.kafka.schemaregistry.storage.MasterAwareSchemaRegistry;
 import io.confluent.kafka.schemaregistry.storage.SchemaRegistryIdentity;
 import kafka.utils.ZkUtils;
-import scala.Tuple2;
 
 public class ZookeeperMasterElector implements MasterElector {
 
   private static final Logger log = LoggerFactory.getLogger(ZookeeperMasterElector.class);
   private static final String MASTER_PATH = "/schema_registry_master";
-  public static final int ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE = 20;
-  public static final String ZOOKEEPER_SCHEMA_ID_COUNTER = "/schema_id_counter";
-  private static final int ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_WRITE_RETRY_BACKOFF_MS = 50;
 
   private final boolean isEligibleForMasterElection;
   private final ZkClient zkClient;
@@ -62,7 +57,7 @@ public class ZookeeperMasterElector implements MasterElector {
       throws SchemaRegistryStoreException {
 
     this.isEligibleForMasterElection = myIdentity.getMasterEligibility();
-    this.zkUtils = createZkNamespace(config);
+    this.zkUtils = config.zkUtils();
     this.zkClient = zkUtils.zkClient();
 
     this.myIdentity = myIdentity;
@@ -79,7 +74,7 @@ public class ZookeeperMasterElector implements MasterElector {
   }
 
   public void init() throws SchemaRegistryTimeoutException, SchemaRegistryStoreException,
-                            SchemaRegistryInitializationException {
+      SchemaRegistryInitializationException, IdGenerationException {
     if (isEligibleForMasterElection) {
       electMaster();
     } else {
@@ -93,8 +88,8 @@ public class ZookeeperMasterElector implements MasterElector {
   }
 
   public void electMaster() throws
-                            SchemaRegistryStoreException, SchemaRegistryTimeoutException,
-                            SchemaRegistryInitializationException {
+      SchemaRegistryStoreException, SchemaRegistryTimeoutException,
+      SchemaRegistryInitializationException, IdGenerationException {
     SchemaRegistryIdentity masterIdentity = null;
     try {
       zkUtils.createEphemeralPathExpectConflict(MASTER_PATH, myIdentityString,
@@ -109,7 +104,7 @@ public class ZookeeperMasterElector implements MasterElector {
 
   public void readCurrentMaster()
       throws SchemaRegistryTimeoutException, SchemaRegistryStoreException,
-             SchemaRegistryInitializationException {
+      SchemaRegistryInitializationException, IdGenerationException {
     SchemaRegistryIdentity masterIdentity = null;
     // If someone else has written the path, read the new master back
     try {
@@ -129,166 +124,6 @@ public class ZookeeperMasterElector implements MasterElector {
       throw new SchemaRegistryInitializationException("Invalid identity");
     }
     schemaRegistry.setMaster(masterIdentity);
-  }
-
-  public SchemaIdRange nextRange() throws SchemaRegistryStoreException {
-    int base = nextSchemaIdCounterBatch();
-    return new SchemaIdRange(base, getInclusiveUpperBound(base));
-  }
-
-  private ZkUtils createZkNamespace(SchemaRegistryConfig config) {
-    boolean zkAclsEnabled = config.checkZkAclConfig();
-    String schemaRegistryZkNamespace =
-        config.getString(SchemaRegistryConfig.SCHEMAREGISTRY_ZK_NAMESPACE);
-    String srClusterZkUrl = config.getString(SchemaRegistryConfig.KAFKASTORE_CONNECTION_URL_CONFIG);
-    int zkSessionTimeoutMs =
-        config.getInt(SchemaRegistryConfig.KAFKASTORE_ZK_SESSION_TIMEOUT_MS_CONFIG);
-
-    int kafkaNamespaceIndex = srClusterZkUrl.indexOf("/");
-    String zkConnForNamespaceCreation = kafkaNamespaceIndex > 0
-                                        ? srClusterZkUrl.substring(0, kafkaNamespaceIndex)
-                                        : srClusterZkUrl;
-
-    final String schemaRegistryNamespace = "/" + schemaRegistryZkNamespace;
-    final String schemaRegistryZkUrl = zkConnForNamespaceCreation + schemaRegistryNamespace;
-
-    ZkUtils zkUtilsForNamespaceCreation = ZkUtils.apply(
-        zkConnForNamespaceCreation,
-        zkSessionTimeoutMs, zkSessionTimeoutMs, zkAclsEnabled);
-    zkUtilsForNamespaceCreation.makeSurePersistentPathExists(
-        schemaRegistryNamespace,
-        zkUtilsForNamespaceCreation.defaultAcls(schemaRegistryNamespace));
-    log.info("Created schema registry namespace "
-             + zkConnForNamespaceCreation
-             + schemaRegistryNamespace);
-    zkUtilsForNamespaceCreation.close();
-    return ZkUtils.apply(
-        schemaRegistryZkUrl,
-        zkSessionTimeoutMs,
-        zkSessionTimeoutMs,
-        zkAclsEnabled
-    );
-  }
-
-  /**
-   * Allocate and lock the next batch of schema ids. Signal a global lock over the next batch by
-   * writing the inclusive upper bound of the batch to ZooKeeper. I.e. the value stored in
-   * ZOOKEEPER_SCHEMA_ID_COUNTER in ZooKeeper indicates the current max allocated id for assignment.
-   *
-   * <p>When a schema registry server is initialized, kafka may have preexisting persistent
-   * schema -> id assignments, and zookeeper may have preexisting counter data.
-   * Therefore, when allocating the next batch of ids, it's necessary to ensure the entire new batch
-   * is greater than the greatest id in kafka and also greater than the previously recorded batch
-   * in zookeeper.
-   *
-   * <p>Return the first available id in the newly allocated batch of ids.
-   */
-  private Integer nextSchemaIdCounterBatch() throws SchemaRegistryStoreException {
-    int nextIdBatchLowerBound = 1;
-
-    while (true) {
-
-      if (!zkUtils.zkClient().exists(ZOOKEEPER_SCHEMA_ID_COUNTER)) {
-        // create ZOOKEEPER_SCHEMA_ID_COUNTER if it already doesn't exist
-
-        try {
-          nextIdBatchLowerBound = getNextBatchLowerBoundFromKafkaStore();
-          int nextIdBatchUpperBound = getInclusiveUpperBound(nextIdBatchLowerBound);
-          zkUtils.createPersistentPath(ZOOKEEPER_SCHEMA_ID_COUNTER,
-                                       String.valueOf(nextIdBatchUpperBound),
-                                       zkUtils.defaultAcls(ZOOKEEPER_SCHEMA_ID_COUNTER));
-          return nextIdBatchLowerBound;
-        } catch (ZkNodeExistsException ignore) {
-          // A zombie master may have created this zk node after the initial existence check
-          // Ignore and try again
-        }
-      } else { // ZOOKEEPER_SCHEMA_ID_COUNTER exists
-
-        // read the latest counter value
-        final Tuple2<String, Stat> counterValue = zkUtils.readData(ZOOKEEPER_SCHEMA_ID_COUNTER);
-        final String counterData = counterValue._1();
-        final Stat counterStat = counterValue._2();
-        if (counterData == null) {
-          throw new SchemaRegistryStoreException(
-              "Failed to read schema id counter " + ZOOKEEPER_SCHEMA_ID_COUNTER
-              + " from zookeeper");
-        }
-
-        // Compute the lower bound of next id batch based on zk data and kafkastore data
-        int zkIdCounterValue = Integer.parseInt(counterData);
-        int zkNextIdBatchLowerBound = zkIdCounterValue + 1;
-        if (zkIdCounterValue % ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE != 0) {
-          // ZooKeeper id counter should be an integer multiple of id batch size in normal
-          // operation; handle corrupted/stale id counter data gracefully by bumping
-          // up to the next id batch
-
-          // fixedZkIdCounterValue is the smallest multiple of
-          // ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE greater than the bad zkIdCounterValue
-          int fixedZkIdCounterValue = ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE
-                                      * (1
-                                         + zkIdCounterValue
-                                           / ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE);
-          zkNextIdBatchLowerBound = fixedZkIdCounterValue + 1;
-
-          log.warn(
-              "Zookeeper schema id counter is not an integer multiple of id batch size."
-              + " Zookeeper may have stale id counter data.\n"
-              + "zk id counter: " + zkIdCounterValue + "\n"
-              + "id batch size: " + ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE);
-        }
-        nextIdBatchLowerBound =
-            Math.max(zkNextIdBatchLowerBound, getNextBatchLowerBoundFromKafkaStore());
-        String
-            nextIdBatchUpperBound =
-            String.valueOf(getInclusiveUpperBound(nextIdBatchLowerBound));
-
-        // conditionally update the zookeeper path with the upper bound of the new id batch.
-        // newSchemaIdCounterDataVersion < 0 indicates a failed conditional update.
-        // Most probable cause is the existence of another master which tries to do the same
-        // counter batch allocation at the same time. If this happens, re-read the value and
-        // continue until one master is determined to be the zombie master.
-        // NOTE: The handling of multiple masters is still a TODO
-        int newSchemaIdCounterDataVersion =
-            (Integer) zkUtils.conditionalUpdatePersistentPath(
-                ZOOKEEPER_SCHEMA_ID_COUNTER,
-                nextIdBatchUpperBound,
-                counterStat.getVersion(),
-                null)._2();
-        if (newSchemaIdCounterDataVersion >= 0) {
-          break;
-        }
-      }
-      try {
-        // Wait a bit and attempt id batch allocation again
-        Thread.sleep(ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_WRITE_RETRY_BACKOFF_MS);
-      } catch (InterruptedException ignored) {
-        // ignored
-      }
-    }
-
-    return nextIdBatchLowerBound;
-  }
-
-  /**
-   * Return a minimum lower bound on the next batch of ids based on ids currently in the
-   * kafka store.
-   */
-  private int getNextBatchLowerBoundFromKafkaStore() {
-    if (schemaRegistry.getMaxIdInKafkaStore() <= 0) {
-      return 1;
-    }
-
-    int
-        nextBatchLowerBound =
-        1 + schemaRegistry.getMaxIdInKafkaStore() / ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE;
-    return 1 + nextBatchLowerBound * ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE;
-  }
-
-  /**
-   * E.g. if inclusiveLowerBound is 61, and BATCH_SIZE is 20, the inclusiveUpperBound should be 80.
-   */
-  private int getInclusiveUpperBound(int inclusiveLowerBound) {
-    return inclusiveLowerBound + ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE - 1;
   }
 
   private class MasterChangeListener implements IZkDataListener {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
@@ -50,23 +50,28 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
 
   public SchemaRegistryRestApplication(SchemaRegistryConfig config) {
     super(config);
-
   }
 
-  @Override
-  public void setupResources(Configurable<?> config, SchemaRegistryConfig schemaRegistryConfig) {
+
+  protected KafkaSchemaRegistry initSchemaRegistry(SchemaRegistryConfig config) {
+    KafkaSchemaRegistry kafkaSchemaRegistry = null;
     try {
-      schemaRegistry = new KafkaSchemaRegistry(
-          schemaRegistryConfig,
+      kafkaSchemaRegistry = new KafkaSchemaRegistry(
+          config,
           new SchemaRegistrySerializer()
       );
-      schemaRegistry.init();
+      kafkaSchemaRegistry.init();
     } catch (SchemaRegistryException e) {
       log.error("Error starting the schema registry", e);
       onShutdown();
       System.exit(1);
     }
+    return kafkaSchemaRegistry;
+  }
 
+  @Override
+  public void setupResources(Configurable<?> config, SchemaRegistryConfig schemaRegistryConfig) {
+    schemaRegistry = initSchemaRegistry(schemaRegistryConfig);
     schemaRegistryResourceExtensions =
         schemaRegistryConfig.getConfiguredInstances(
             schemaRegistryConfig.definedResourceExtensionConfigName(),

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
@@ -33,13 +33,13 @@ import io.confluent.kafka.schemaregistry.storage.exceptions.StoreInitializationE
 /**
  * In-memory store based on maps
  */
-public class InMemoryStore<K, V> implements LookupStore<K, V> {
+public class InMemoryCache<K, V> implements LookupCache<K, V> {
   private final ConcurrentSkipListMap<K, V> store;
   private final Map<Integer, SchemaKey> guidToSchemaKey;
   private final Map<MD5, SchemaIdAndSubjects> schemaHashToGuid;
   private final Map<Integer, List<SchemaKey>> guidToDeletedSchemaKeys;
 
-  public InMemoryStore() {
+  public InMemoryCache() {
     store = new ConcurrentSkipListMap<K, V>();
     this.guidToSchemaKey = new HashMap<Integer, SchemaKey>();
     this.schemaHashToGuid = new HashMap<MD5, SchemaIdAndSubjects>();

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -156,7 +156,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
         this.serializer, lookupStore, new NoopKey());
   }
 
-  protected LookupStore lookupStore(){
+  protected LookupStore lookupStore() {
     return new InMemoryStore<SchemaRegistryKey, SchemaRegistryValue>();
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -315,10 +315,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
       kafkaStore.waitUntilKafkaReaderReachesLastOffset(kafkaStoreTimeoutMs);
 
       // see if the schema to be registered already exists
-      MD5 md5 = MD5.ofString(schema.getSchema());
       int schemaId = -1;
-      if (this.lookupStore.containsSchema(schema)) {
-        SchemaIdAndSubjects schemaIdAndSubjects = this.lookupStore.schemaIdAndSubjects(schema);
+      SchemaIdAndSubjects schemaIdAndSubjects = this.lookupStore.schemaIdAndSubjects(schema);
+      if (schemaIdAndSubjects != null) {
         if (schemaIdAndSubjects.hasSubject(subject)
             && !isSubjectVersionDeleted(subject, schemaIdAndSubjects.getVersion(subject))) {
           // return only if the schema was previously registered under the input subject
@@ -353,7 +352,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
         if (schemaId >= 0) {
           schema.setId(schemaId);
         } else {
-          schema.setId(idGenerator.id(subject, schema));
+          schema.setId(idGenerator.id(schema));
         }
 
         SchemaValue schemaValue = new SchemaValue(schema);
@@ -490,9 +489,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
   public Schema lookUpSchemaUnderSubject(String subject, Schema schema, boolean lookupDeletedSchema)
       throws SchemaRegistryException {
     canonicalizeSchema(schema);
-    if (this.lookupStore.containsSchema(schema)) {
-      SchemaIdAndSubjects schemaIdAndSubjects = this.lookupStore.schemaIdAndSubjects(schema);
-
+    SchemaIdAndSubjects schemaIdAndSubjects = this.lookupStore.schemaIdAndSubjects(schema);
+    if (schemaIdAndSubjects != null) {
       if (schemaIdAndSubjects.hasSubject(subject)
           && (lookupDeletedSchema || !isSubjectVersionDeleted(subject, schemaIdAndSubjects
           .getVersion(subject)))) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -16,12 +16,11 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
+import io.confluent.kafka.schemaregistry.id.IdGenerator;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -31,13 +30,16 @@ public class KafkaStoreMessageHandler
 
   private static final Logger log = LoggerFactory.getLogger(KafkaStoreMessageHandler.class);
   private final KafkaSchemaRegistry schemaRegistry;
-  private final Store store;
+  private final LookupStore store;
   private final ExecutorService tombstoneExecutor;
+  private IdGenerator idGenerator;
 
   public KafkaStoreMessageHandler(KafkaSchemaRegistry schemaRegistry,
-                                  Store store) {
+                                  LookupStore store,
+                                  IdGenerator idGenerator) {
     this.schemaRegistry = schemaRegistry;
     this.store = store;
+    this.idGenerator = idGenerator;
     this.tombstoneExecutor = Executors.newSingleThreadExecutor();
   }
 
@@ -68,8 +70,8 @@ public class KafkaStoreMessageHandler
         SchemaValue schemaValue = (SchemaValue) this.store.get(schemaKey);
         if (schemaValue != null) {
           schemaValue.setDeleted(true);
-          this.store.put(schemaKey, schemaValue);
-          handleDeleteSchemaKey(schemaKey, schemaValue);
+          store.put(schemaKey, schemaValue);
+          store.schemaDeleted(schemaKey, schemaValue);
         }
       } catch (StoreException e) {
         log.error("Failed to delete subject in the local store");
@@ -79,21 +81,6 @@ public class KafkaStoreMessageHandler
 
   private void handleSchemaUpdate(SchemaKey schemaKey, SchemaValue schemaObj) {
     if (schemaObj != null) {
-      schemaRegistry.guidToSchemaKey.put(schemaObj.getId(), schemaKey);
-
-      // Update the maximum id seen so far
-      if (schemaRegistry.getMaxIdInKafkaStore() < schemaObj.getId()) {
-        schemaRegistry.setMaxIdInKafkaStore(schemaObj.getId());
-      }
-
-      MD5 md5 = MD5.ofString(schemaObj.getSchema());
-      SchemaIdAndSubjects schemaIdAndSubjects = schemaRegistry.schemaHashToGuid.get(md5);
-      if (schemaIdAndSubjects == null) {
-        schemaIdAndSubjects = new SchemaIdAndSubjects(schemaObj.getId());
-      }
-      schemaIdAndSubjects.addSubjectAndVersion(schemaKey.getSubject(), schemaKey.getVersion());
-      schemaRegistry.schemaHashToGuid.put(md5, schemaIdAndSubjects);
-
       // If the schema is marked to be deleted, we store it in an internal datastructure
       // that holds all deleted schema keys for an id.
       // Whenever we encounter a new schema for a subject, we check to see if the same schema
@@ -102,19 +89,16 @@ public class KafkaStoreMessageHandler
       // consumers should be able to access the schemas by id. This is guaranteed when the schema is
       // re-registered again and hence we can tombstone the record.
       if (schemaObj.isDeleted()) {
-        handleDeleteSchemaKey(schemaKey, schemaObj);
+        this.store.schemaDeleted(schemaKey, schemaObj);
       } else {
-        List<SchemaKey> schemaKeys = schemaRegistry.guidToDeletedSchemaKeys
-            .getOrDefault(schemaObj.getId(), Collections.emptyList());
+        // Update the maximum id seen so far
+        idGenerator.schemaRegistered(schemaKey,schemaObj);
+        store.schemaRegistered(schemaKey, schemaObj);
+        List<SchemaKey> schemaKeys = store.deletedSchemaKeys(schemaObj);
         schemaKeys.stream().filter(v -> v.getSubject().equals(schemaObj.getSubject()))
             .forEach(this::tombstoneSchemaKey);
       }
     }
-  }
-
-  private void handleDeleteSchemaKey(SchemaKey schemaKey, SchemaValue schemaValue) {
-    schemaRegistry.guidToDeletedSchemaKeys
-        .computeIfAbsent(schemaValue.getId(), k -> new ArrayList<>()).add(schemaKey);
   }
 
   private void tombstoneSchemaKey(SchemaKey schemaKey) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupCache.java
@@ -22,11 +22,15 @@ import java.util.List;
 
 /**
  * Internal interface that provides various indexed methods that help lookup the underlying schemas.
+ * The interface has also callback methods for various schema lifecycle events like register,
+ * delete, etc. It is important to note that these callbacks block the corresponding API that
+ * lead to the callback. Hence sufficient care must be taken to ensure that the callbacks are
+ * light weight.
  *
  * @param <K> key of the store
  * @param <V> value of the store
  */
-public interface LookupStore<K,V> extends Store<K,V> {
+public interface LookupCache<K,V> extends Store<K,V> {
 
   /**
    * Provides SchemaIdAndSubjects associated with the schema.

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupStore.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2017 Confluent Inc.
+/*
+ * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,19 +12,25 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.kafka.schemaregistry.storage;
 
-import io.confluent.kafka.schemaregistry.exceptions.IdGenerationException;
-import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryInitializationException;
-import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException;
-import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryTimeoutException;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 
-public interface MasterElector {
+import java.util.List;
 
-  void init() throws SchemaRegistryTimeoutException, SchemaRegistryStoreException,
-      SchemaRegistryInitializationException, IdGenerationException;
+public interface LookupStore<K,V> extends Store<K,V> {
 
-  void close();
+  SchemaIdAndSubjects schemaIdAndSubjects(Schema schema);
+
+  boolean containsSchema(Schema schema);
+
+  SchemaKey schemaKeyById(Integer id);
+
+  List<SchemaKey> deletedSchemaKeys(SchemaValue schemaValue);
+
+  void schemaRegistered(SchemaKey schemaKey, SchemaValue schemaValue);
+
+  void schemaDeleted(SchemaKey schemaKey, SchemaValue schemaValue);
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupStore.java
@@ -20,17 +20,63 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 
 import java.util.List;
 
+/**
+ * Internal interface that provides various indexed methods that help lookup the underlying schemas.
+ *
+ * @param <K> key of the store
+ * @param <V> value of the store
+ */
 public interface LookupStore<K,V> extends Store<K,V> {
 
+  /**
+   * Provides SchemaIdAndSubjects associated with the schema.
+   *
+   * @param schema schema object; never {@code null}
+   * @return the schema id and subjects associated with the schema, null otherwise.
+   */
   SchemaIdAndSubjects schemaIdAndSubjects(Schema schema);
 
+  /**
+   * Checks is a schema is registered in any subject.
+   *
+   * @param schema schema object
+   * @return true if the schema is already registered else false
+   */
   boolean containsSchema(Schema schema);
 
+  /**
+   * Provides the {@link SchemaKey} for the provided schema id.
+   *
+   * @param id the schema id; never {@code null}
+   * @return the {@link SchemaKey} if found, otherwise null.
+   */
   SchemaKey schemaKeyById(Integer id);
 
+  /**
+   * Provides the list of {@link SchemaKey} that have been deleted for the registered {SchemaValue}
+   *
+   * @param schemaValue the SchemaValue being registered; never {@code null}
+   * @return the list of {@link SchemaKey} that have been marked to be deleted, can be null or empty
+   */
   List<SchemaKey> deletedSchemaKeys(SchemaValue schemaValue);
 
+  /**
+   * Callback that is invoked when a schema is registered.
+   * This can be used to update any internal data structure.
+   * This is invoked synchronously during register.
+   *
+   * @param schemaKey   the registered SchemaKey; never {@code null}
+   * @param schemaValue the registered SchemaValue; never {@code null}
+   */
   void schemaRegistered(SchemaKey schemaKey, SchemaValue schemaValue);
 
+  /**
+   * Callback that is invoked when a schema is deleted.
+   * This can be used to update any internal data structure.
+   * This is invoked synchronously during delete.
+   *
+   * @param schemaKey   the deleted SchemaKey; never {@code null}
+   * @param schemaValue the deleted SchemaValue; never {@code null}
+   */
   void schemaDeleted(SchemaKey schemaKey, SchemaValue schemaValue);
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
@@ -178,11 +178,15 @@ public abstract class ClusterTestHarness {
       schemaRegistryProps.put(SchemaRegistryConfig.LISTENERS_CONFIG, getSchemaRegistryProtocol() +
                                                                      "://0.0.0.0:"
                                                                      + schemaRegistryPort);
-      restApp = new RestApp(schemaRegistryPort, zkConnect, null, KAFKASTORE_TOPIC,
-                            compatibilityType, true, schemaRegistryProps);
-      restApp.start();
+      setupRestApp(schemaRegistryProps);
 
     }
+  }
+
+  protected void setupRestApp(Properties schemaRegistryProps) throws Exception {
+    restApp = new RestApp(schemaRegistryPort, zkConnect, null, KAFKASTORE_TOPIC,
+                          compatibilityType, true, schemaRegistryProps);
+    restApp.start();
   }
 
   protected Properties getSchemaRegistryProperties() {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/MasterElectorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/MasterElectorTest.java
@@ -35,8 +35,8 @@ import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.utils.TestUtils;
+import io.confluent.kafka.schemaregistry.id.ZookeeperIdGenerator;
 import io.confluent.kafka.schemaregistry.storage.SchemaRegistryIdentity;
-import io.confluent.kafka.schemaregistry.masterelector.zookeeper.ZookeeperMasterElector;
 
 import static io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel.FORWARD;
 import static io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel.NONE;
@@ -59,7 +59,7 @@ public class MasterElectorTest extends ClusterTestHarness {
         },
         {
             "zookeeper",
-            ZookeeperMasterElector.ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE
+            ZookeeperIdGenerator.ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE
         }
     });
   }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/masterelector/zookeeper/ZookeeperMasterElectorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/masterelector/zookeeper/ZookeeperMasterElectorTest.java
@@ -20,6 +20,7 @@ import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.RestApp;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.schemaregistry.id.ZookeeperIdGenerator;
 import io.confluent.kafka.schemaregistry.storage.serialization.ZkStringSerializer;
 import io.confluent.kafka.schemaregistry.utils.TestUtils;
 import org.I0Itec.zkclient.ZkClient;
@@ -37,9 +38,9 @@ import static org.junit.Assert.assertTrue;
 // covering all MasterElectors
 public class ZookeeperMasterElectorTest extends ClusterTestHarness {
   private static final int ID_BATCH_SIZE =
-      ZookeeperMasterElector.ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE;
+      ZookeeperIdGenerator.ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE;
   private static final String ZK_ID_COUNTER_PATH =
-      "/schema_registry" + ZookeeperMasterElector.ZOOKEEPER_SCHEMA_ID_COUNTER;
+      "/schema_registry" + ZookeeperIdGenerator.ZOOKEEPER_SCHEMA_ID_COUNTER;
 
   @Test
   /**

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
@@ -113,7 +113,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
 
   @Test
   public void testSimpleGetAfterFailure() throws Exception {
-    Store<String, String> inMemoryStore = new InMemoryStore<String, String>();
+    Store<String, String> inMemoryStore = new InMemoryCache<String, String>();
     KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(
         zkConnect,
         inMemoryStore
@@ -188,7 +188,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
 
   @Test
   public void testDeleteAfterRestart() throws Exception {
-    Store<String, String> inMemoryStore = new InMemoryStore<String, String>();
+    Store<String, String> inMemoryStore = new InMemoryCache<String, String>();
     KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(
         zkConnect,
         inMemoryStore
@@ -241,7 +241,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
 
   @Test
   public void testCustomGroupIdConfig() throws Exception {
-    Store<String, String> inMemoryStore = new InMemoryStore<String, String>();
+    Store<String, String> inMemoryStore = new InMemoryCache<String, String>();
     String groupId = "test-group-id";
     Properties props = new Properties();
     props.put(SchemaRegistryConfig.KAFKASTORE_GROUP_ID_CONFIG, groupId);
@@ -253,7 +253,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
 
   @Test
   public void testDefaultGroupIdConfig() throws Exception {
-    Store<String, String> inMemoryStore = new InMemoryStore<String, String>();
+    Store<String, String> inMemoryStore = new InMemoryCache<String, String>();
     Properties props = new Properties();
     KafkaStore kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(zkConnect, inMemoryStore, props);
 
@@ -268,7 +268,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
 
     AdminUtils.createTopic(zkUtils, SchemaRegistryConfig.DEFAULT_KAFKASTORE_TOPIC, 1, 1, topicProps, RackAwareMode.Enforced$.MODULE$);
 
-    Store<String, String> inMemoryStore = new InMemoryStore<String, String>();
+    Store<String, String> inMemoryStore = new InMemoryCache<String, String>();
 
     KafkaStore kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(zkConnect, inMemoryStore, kafkaProps);
   }
@@ -282,7 +282,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
     AdminUtils.createTopic(zkUtils, SchemaRegistryConfig.DEFAULT_KAFKASTORE_TOPIC, 3, 1,
                            topicProps, RackAwareMode.Enforced$.MODULE$);
 
-    Store<String, String> inMemoryStore = new InMemoryStore<String, String>();
+    Store<String, String> inMemoryStore = new InMemoryCache<String, String>();
 
     StoreUtils.createAndInitKafkaStoreInstance(zkConnect, inMemoryStore, kafkaProps);
   }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistryKeysTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistryKeysTest.java
@@ -174,7 +174,7 @@ public class SchemaRegistryKeysTest {
 
   private void testStoreKeyOrder(SchemaRegistryKey[] orderedKeys) {
     int numKeys = orderedKeys.length;
-    InMemoryStore<SchemaRegistryKey, String> store = new InMemoryStore<SchemaRegistryKey, String>();
+    InMemoryCache<SchemaRegistryKey, String> store = new InMemoryCache<SchemaRegistryKey, String>();
     while (--numKeys >= 0) {
       try {
         store.put(orderedKeys[numKeys], orderedKeys[numKeys].toString());

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/StoreUtils.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/StoreUtils.java
@@ -38,7 +38,7 @@ public class StoreUtils {
    */
   public static KafkaStore<String, String> createAndInitKafkaStoreInstance(String zkConnect)
       throws RestConfigException, StoreInitializationException, SchemaRegistryException {
-    Store<String, String> inMemoryStore = new InMemoryStore<String, String>();
+    Store<String, String> inMemoryStore = new InMemoryCache<String, String>();
     return createAndInitKafkaStoreInstance(zkConnect, inMemoryStore);
   }
   /**
@@ -67,7 +67,7 @@ public class StoreUtils {
 
     props.put(SchemaRegistryConfig.ZOOKEEPER_SET_ACL_CONFIG, false);
 
-    Store<String, String> inMemoryStore = new InMemoryStore<String, String>();
+    Store<String, String> inMemoryStore = new InMemoryCache<String, String>();
     return createAndInitKafkaStoreInstance(zkConnect, inMemoryStore, props);
   }
 
@@ -94,7 +94,7 @@ public class StoreUtils {
               ((Password) sslConfigs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG)).value());
     }
 
-    Store<String, String> inMemoryStore = new InMemoryStore<String, String>();
+    Store<String, String> inMemoryStore = new InMemoryCache<String, String>();
     return createAndInitKafkaStoreInstance(zkConnect, inMemoryStore, props);
   }
 


### PR DESCRIPTION
1. Moved all data structures used for various lookup under one new interface LookupStore
2. Moved Id generation to its own interface.

This PR is still WIP but wanted to gather some initial feedback on this refactoring. 