### PR TITLE
Add ?pretty URL extension. Add /schemas/ids/:id/schema

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -284,7 +285,6 @@ public class RestService {
     return lookUpSubjectVersion(DEFAULT_REQUEST_PROPERTIES, request, subject, lookupDeletedSchema);
   }
 
-
   public Schema lookUpSubjectVersion(Map<String, String> requestProperties,
                                      RegisterSchemaRequest registerSchemaRequest,
                                      String subject,
@@ -442,20 +442,43 @@ public class RestService {
 
   public String getVersionSchemaOnly(String subject, int version)
             throws IOException, RestClientException {
-    String path = String.format("/subjects/%s/versions/%d/schema", subject, version);
+    return getVersionSchemaOnly(subject, version, false);
+  }
 
+  public String getVersionSchemaOnly(String subject, int version, boolean pretty)
+          throws IOException, RestClientException {
+    String path = String.format(
+            "/subjects/%s/versions/%d/schema?pretty=%s", subject, version, pretty);
+
+    jsonDeserializer.configure(SerializationFeature.INDENT_OUTPUT, pretty);
     JsonNode response = httpRequest(path, "GET", null, DEFAULT_REQUEST_PROPERTIES,
             GET_SCHEMA_ONLY_BY_VERSION_RESPONSE_TYPE);
-    return response.toString();
+
+    return jsonDeserializer.writeValueAsString(response);
   }
 
   public String getLatestVersionSchemaOnly(String subject)
             throws IOException, RestClientException {
-    String path = String.format("/subjects/%s/versions/latest/schema", subject);
+    return getLatestVersionSchemaOnly(subject, false);
+  }
 
+  public String getLatestVersionSchemaOnly(String subject, boolean pretty)
+          throws IOException, RestClientException {
+    String path = String.format("/subjects/%s/versions/latest/schema?pretty=%s", subject, pretty);
+
+    jsonDeserializer.configure(SerializationFeature.INDENT_OUTPUT, pretty);
     JsonNode response = httpRequest(path, "GET", null, DEFAULT_REQUEST_PROPERTIES,
             GET_SCHEMA_ONLY_BY_VERSION_RESPONSE_TYPE);
-    return response.toString();
+    return jsonDeserializer.writeValueAsString(response);
+  }
+
+  public String getIdSchemaOnly(int id, boolean pretty) throws IOException, RestClientException {
+    String path = String.format("/schemas/ids/%d/schema?pretty=%s", id, pretty);
+
+    jsonDeserializer.configure(SerializationFeature.INDENT_OUTPUT, pretty);
+    JsonNode response = httpRequest(path, "GET", null, DEFAULT_REQUEST_PROPERTIES,
+            GET_SCHEMA_ONLY_BY_VERSION_RESPONSE_TYPE);
+    return jsonDeserializer.writeValueAsString(response);
   }
 
   public List<Integer> getAllVersions(String subject)

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaString.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaString.java
@@ -17,7 +17,9 @@
 package io.confluent.kafka.schemaregistry.client.rest.entities;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 
 import java.io.IOException;
 
@@ -47,7 +49,15 @@ public class SchemaString {
     this.schemaString = schemaString;
   }
 
-  public String toJson() throws IOException {
+  public String toJson(boolean pretty) throws IOException {
     return new ObjectMapper().writeValueAsString(this);
+  }
+
+  public String schemaStringToJson(boolean pretty) throws IOException {
+    ObjectMapper om = new ObjectMapper();
+    // Need to parse the schema first before applying indent feature
+    JsonNode json = om.readValue(this.schemaString, JsonNode.class);
+    return om.configure(SerializationFeature.INDENT_OUTPUT, pretty)
+            .writeValueAsString(json);
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/utils/UrlParser.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/utils/UrlParser.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.client.rest.utils;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * This class exposes functions to parse a {@link java.net.URL}.
+ */
+public class UrlParser {
+
+  private final URL url;
+
+  public UrlParser(URL url) {
+    if (url == null || url.toString().isEmpty()) {
+      throw new IllegalArgumentException("Expected at least one URL to be passed in constructor");
+    }
+    this.url = url;
+  }
+
+  public UrlParser(String url) throws MalformedURLException {
+    this(new URL(url));
+  }
+
+  /**
+   * Inspects a multi-value map for a key set to "true" or empty
+   * @return true if the first map entry for key is (key, "true") or (key, "")
+   */
+  public boolean hasBooleanQueryParam(String key) {
+    Map<String, List<String>> queryParams = getQueryParams();
+    if (queryParams == null || queryParams.size() == 0) {
+      return false;
+    }
+    boolean hasKey = queryParams.containsKey(key);
+    List<String> values = queryParams.get(key);
+    String value = values != null && values.size() > 0 ? values.get(0) : "";
+    if (hasKey && value.isEmpty()) { // for example: http://host:port?pretty
+      return true;
+    } else if (!Boolean.valueOf(value)) {
+      return false;
+    }
+    return "true".equals(value);
+  }
+
+  public Map<String, List<String>> getQueryParams() {
+    return UrlParser.getQueryParams(this.url);
+  }
+
+  /**
+   * Parses the query parameters from a URL and returns them as a multi-value Map
+   * @param url {@link java.net.URL} to extract query parameters from
+   * @return A multi-value map. Each key can potentially have many values.
+   */
+  public static Map<String, List<String>> getQueryParams(URL url) {
+    Map<String, List<String>> queryMap = new HashMap<>();
+    if (url.getQuery() != null) {
+      queryMap = Pattern.compile("&").splitAsStream(url.getQuery())
+              .map(s -> Arrays.copyOf(s.split("="), 2))
+              .collect(groupingBy(s -> s[0],
+                      mapping(s -> s[1] == null ? "" : s[1], toList())));
+    }
+    return queryMap;
+  }
+
+}

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/utils/UrlParserTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/utils/UrlParserTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.kafka.schemaregistry.client.rest.utils;
+
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toList;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+
+public class UrlParserTest {
+
+  public static final String QUERY_PARAM_DELETED = "deleted";
+  public static final String QUERY_PARAM_PRETTY = "pretty";
+
+  private String getFirstValue(Map<String, List<String>> m, String key) {
+    return m.containsKey(key) ? m.get(key).get(0) : null;
+  }
+
+  @Test
+  public void test_get_query_params() {
+    try {
+      UrlParser p = new UrlParser("http://foo.com");
+      assertEquals(0, p.getQueryParams().size());
+
+      p = new UrlParser("http://foo.com?pretty");
+      assertEquals(1, p.getQueryParams().size());
+
+      p = new UrlParser("http://foo.com?deleted=true&pretty=false");
+      assertEquals(2, p.getQueryParams().size());
+    } catch (MalformedURLException e) {
+      // no-op
+    }
+  }
+
+  @Test
+  public void verify_pretty_url_parsers() {
+    String[] prettyUrls = {
+            "http://foo.com?pretty=true",
+            "http://foo.com?pretty",
+            "http://foo.com?pretty=false&deleted=true",
+            "http://foo.com?deleted=false&pretty",
+            "http://foo.com?prety=true",
+    };
+
+    List<UrlParser> parsers = Arrays.stream(prettyUrls).map(u -> {
+      try {
+        return new UrlParser(u);
+      } catch (MalformedURLException e) {
+        // no-op
+      }
+      return null;
+    }).collect(toList());
+
+    List<Map<String, List<String>>> queryParams = parsers.stream()
+            .map(UrlParser::getQueryParams).collect(toList());
+
+    assertEquals("true", getFirstValue(queryParams.get(0), QUERY_PARAM_PRETTY));
+    assertEquals("", getFirstValue(queryParams.get(1), QUERY_PARAM_PRETTY));
+    assertTrue(parsers.get(1).hasBooleanQueryParam(QUERY_PARAM_PRETTY));
+
+    assertEquals("false", getFirstValue(queryParams.get(2), QUERY_PARAM_PRETTY));
+    assertEquals("true", getFirstValue(queryParams.get(2), QUERY_PARAM_DELETED));
+
+    assertEquals("false", getFirstValue(queryParams.get(3), QUERY_PARAM_DELETED));
+    assertEquals("", getFirstValue(queryParams.get(3), QUERY_PARAM_PRETTY));
+
+    assertFalse(parsers.get(4).hasBooleanQueryParam(QUERY_PARAM_PRETTY));
+  }
+
+}

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
@@ -27,6 +27,7 @@ import javax.ws.rs.core.Configurable;
 
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.rest.extensions.SchemaRegistryResourceExtension;
+import io.confluent.kafka.schemaregistry.rest.extensions.PrettyQueryExtension;
 import io.confluent.kafka.schemaregistry.rest.resources.CompatibilityResource;
 import io.confluent.kafka.schemaregistry.rest.resources.ConfigResource;
 import io.confluent.kafka.schemaregistry.rest.resources.RootResource;
@@ -37,6 +38,8 @@ import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
 import io.confluent.kafka.schemaregistry.storage.serialization.SchemaRegistrySerializer;
 import io.confluent.rest.Application;
 import io.confluent.rest.RestConfigException;
+
+import static io.confluent.kafka.schemaregistry.rest.extensions.PrettyQueryExtension.QUERY_PARAM_PRETTY;
 
 public class SchemaRegistryRestApplication extends Application<SchemaRegistryConfig> {
 
@@ -78,6 +81,15 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
     config.register(new SchemasResource(schemaRegistry));
     config.register(new SubjectVersionsResource(schemaRegistry));
     config.register(new CompatibilityResource(schemaRegistry));
+
+    try {
+      new PrettyQueryExtension()
+              .register(config, schemaRegistryConfig, schemaRegistry);
+    } catch (SchemaRegistryException e) {
+      log.error(String.format(
+              "Error registering ?%s query resource extension. Starting up without it",
+              QUERY_PARAM_PRETTY), e);
+    }
 
     if (schemaRegistryResourceExtensions != null) {
       try {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/extensions/PrettyQueryExtension.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/extensions/PrettyQueryExtension.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rest.extensions;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.jaxrs.cfg.EndpointConfigBase;
+import com.fasterxml.jackson.jaxrs.cfg.ObjectWriterInjector;
+import com.fasterxml.jackson.jaxrs.cfg.ObjectWriterModifier;
+import io.confluent.kafka.schemaregistry.client.rest.utils.UrlParser;
+import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
+import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.core.Configurable;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+import java.io.IOException;
+import java.net.MalformedURLException;
+
+/**
+ * A {@link SchemaRegistryResourceExtension} that intercepts all requests and injects an
+ * {@link com.fasterxml.jackson.databind.ObjectWriter} to pretty-print any returned objects using
+ * Jackson's {@link com.fasterxml.jackson.databind.ObjectMapper}.
+ * <p></p>
+ * Adding a boolean query parameter of {@code ?pretty} to the URL will enable the
+ * {@link SerializationFeature#INDENT_OUTPUT} feature.
+ */
+public class PrettyQueryExtension implements SchemaRegistryResourceExtension {
+
+  private static final Logger log =
+          LoggerFactory.getLogger(PrettyQueryExtension.class);
+
+  public static final String QUERY_PARAM_PRETTY = "pretty";
+
+  @Override
+  public void register(
+          Configurable<?> config,
+          SchemaRegistryConfig schemaRegistryConfig,
+          SchemaRegistry schemaRegistry
+  ) throws SchemaRegistryException {
+    log.trace("Configuring Responses to accept ?{}=true QueryParams", QUERY_PARAM_PRETTY);
+    config.register(new ContainerResponseFilter() {
+      @Override
+      public void filter(
+              ContainerRequestContext requestContext,
+              ContainerResponseContext responseContext
+      ) throws IOException {
+        if (hasPrettyQueryParam(requestContext.getUriInfo())) {
+          log.trace("Injecting Indenting ObjectWriter");
+          ObjectWriterInjector.set(new IndentingModifier(true));
+        }
+      }
+    });
+  }
+
+  public static boolean hasPrettyQueryParam(UriInfo uriInfo) {
+    try {
+      return new UrlParser(uriInfo.getRequestUri().toURL())
+              .hasBooleanQueryParam(QUERY_PARAM_PRETTY);
+    } catch (MalformedURLException e) {
+      log.error("Malformed URL", e);
+      return false;
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+
+  }
+
+  public static class IndentingModifier extends ObjectWriterModifier {
+
+    private final boolean indent;
+
+    public IndentingModifier(boolean indent) {
+      this.indent = indent;
+    }
+
+    @Override
+    public ObjectWriter modify(
+            EndpointConfigBase<?> endpointConfigBase,
+            MultivaluedMap<String, Object> multivaluedMap,
+            Object o,
+            ObjectWriter objectWriter,
+            JsonGenerator jsonGenerator
+    ) throws IOException {
+      if (indent) {
+        return objectWriter.withFeatures(SerializationFeature.INDENT_OUTPUT);
+      }
+      return objectWriter;
+    }
+  }
+}

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/PrettyPrintedSchemaTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/PrettyPrintedSchemaTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import io.confluent.kafka.schemaregistry.ClusterTestHarness;
+import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
+import io.confluent.kafka.schemaregistry.avro.AvroUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+@RunWith(Parameterized.class)
+public class PrettyPrintedSchemaTest extends ClusterTestHarness {
+
+    @Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {SchemaRegistryConfig.RESOURCE_EXTENSION_CONFIG},
+                {SchemaRegistryConfig.SCHEMAREGISTRY_RESOURCE_EXTENSION_CONFIG}
+        });
+    }
+
+    @Parameter
+    public String resourceExtensionConfigName;
+
+    public PrettyPrintedSchemaTest() {
+        super(1, true, AvroCompatibilityLevel.BACKWARD.name);
+    }
+
+    String prettySchemaString1 = "{\n"+
+            "  \"type\" : \"record\",\n"+
+            "  \"name\" : \"myrecord\",\n"+
+            "  \"fields\" : [ {\n"+
+            "    \"name\" : \"f1\",\n"+
+            "    \"type\" : \"string\"\n"+
+            "  } ]\n"+
+            "}";
+
+    String schemaString1 = AvroUtils.parseSchema(prettySchemaString1).canonicalString;
+
+    private void comparePrettySchemas(String prettySchema, String s) {
+        assertNotEquals(
+                String.format("%s: Record schema should not be the same after prettified", s),
+                schemaString1,
+                prettySchema);
+        assertEquals(
+                String.format("%s: Record schema should be prettified", s),
+                prettySchemaString1,
+                prettySchema);
+    }
+
+    @Test
+    public void testPrettyVersion() throws Exception {
+        String subject = "testSubject";
+
+        int expectedIdSchema1 = 1;
+        assertEquals(
+                "Registering should succeed",
+                expectedIdSchema1,
+                restApp.restClient.registerSchema(schemaString1, subject)
+        );
+
+        String prettySchema = restApp.restClient.getVersionSchemaOnly(subject, expectedIdSchema1, false);
+        assertEquals(
+                "Record schema should be unaffected",
+                schemaString1,
+                prettySchema);
+
+        prettySchema = restApp.restClient.getVersionSchemaOnly(subject, expectedIdSchema1, true);
+        comparePrettySchemas(prettySchema, "v"+expectedIdSchema1);
+
+        prettySchema = restApp.restClient.getLatestVersionSchemaOnly(subject, true);
+        comparePrettySchemas(prettySchema, "latest");
+    }
+
+    @Test
+    public void testPrettyIdSchema() throws Exception {
+        String subject = "testSubject";
+
+        int expectedIdSchema1 = 1;
+        assertEquals(
+                "Registering should succeed",
+                expectedIdSchema1,
+                restApp.restClient.registerSchema(schemaString1, subject)
+        );
+
+        String prettySchema = restApp.restClient.getIdSchemaOnly(expectedIdSchema1, false);
+        assertEquals(
+                "Record schema should not be prettified",
+                schemaString1,
+                prettySchema);
+
+        prettySchema = restApp.restClient.getIdSchemaOnly(expectedIdSchema1, true);
+        comparePrettySchemas(prettySchema, "v"+expectedIdSchema1);
+    }
+
+}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -48,6 +48,10 @@ The server also supports content negotiation, so you may include multiple, weigh
 which can be useful when, for example, a new version of the API is preferred but
 you cannot be certain it is available yet.
 
+.. note::
+
+      All URLs support an optional ``pretty`` boolean query parameter to pretty-print the JSON responses. See the :ref:`usage documentation<schemaregistry_using>` for examples. The formatted responses shown below are only for readability.
+
 Errors
 ^^^^^^
 
@@ -99,6 +103,38 @@ Schemas
 
       {
         "schema": "{\"type\": \"string\"}"
+      }
+
+.. http:get:: /schemas/ids/{int: id}/schema
+
+   Get and parse the inner schema string identified by the input ID.
+
+   :param int id: the globally unique identifier of the schema
+
+         :>json string schema: Schema string identified by the ID
+
+         :statuscode 404:
+            * Error code 40403 -- Schema not found
+         :statuscode 500:
+            * Error code 50001 -- Error in the backend datastore
+
+         **Example request**:
+
+   .. sourcecode:: http
+
+      GET /schemas/ids/1/schema HTTP/1.1
+      Host: schemaregistry.example.com
+      Accept: application/vnd.schemaregistry.v1+json, application/vnd.schemaregistry+json, application/json
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+      HTTP/1.1 200 OK
+      Content-Type: application/vnd.schemaregistry.v1+json
+
+      {
+        "type": "string"
       }
 
 Subjects
@@ -268,14 +304,16 @@ The subjects resource provides a list of all registered subjects in your |sr|. A
       HTTP/1.1 200 OK
       Content-Type: application/vnd.schemaregistry.v1+json
 
-      {"type": "string"}
+      {
+        "type": "string"
+      }
 
 .. http:post:: /subjects/(string: subject)/versions
 
    Register a new schema under the specified subject. If successfully registered, this returns the unique identifier of this schema in the registry. The returned identifier should be used to retrieve this schema from the schemas resource and is different from the schema's version which is associated with the subject.
    If the same schema is registered under a different subject, the same identifier will be returned. However, the version of the schema may be different under different subjects.
 
-   A schema should be compatible with the previously registered schema or schemas (if there are any) as per the configured compatibility level. The configured compatibility level can be obtained by issuing a ``GET http:get:: /config/(string: subject)``. If that returns null, then ``GET http:get:: /config``
+   A schema should be compatible with the previously registered schema or schemas (if there are any) as per the configured compatibility level. The configured compatibility level can be obtained by issuing a ``GET /config/(string: subject)``. If that returns null, then ``GET /config``
 
    When there are multiple instances of |sr| running in the same cluster, the schema registration request will be forwarded to one of the instances designated as the master. If the master is not available, the client will get an error code indicating that the forwarding has failed.
 
@@ -439,7 +477,7 @@ The compatibility resource allows the user to test schemas for compatibility aga
 
 .. http:post:: /compatibility/subjects/(string: subject)/versions/(versionId: version)
 
-   Test input schema against a particular version of a subject's schema for compatibility. Note that the compatibility level applied for the check is the configured compatibility level for the subject (``http:get:: /config/(string: subject)``). If this subject's compatibility level was never changed, then the global compatibility level applies (``http:get:: /config``).
+   Test input schema against a particular version of a subject's schema for compatibility. Note that the compatibility level applied for the check is the configured compatibility level for the subject (``GET /config/(string: subject)``). If this subject's compatibility level was never changed, then the global compatibility level applies (``GET /config``).
 
    :param string subject: Subject of the schema version against which compatibility is to be tested
    :param versionId version: Version of the subject's schema against which compatibility is to be tested. Valid values for versionId are between [1,2^31-1] or the string "latest". "latest" checks compatibility of the input schema with the last registered schema under the specified subject

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -56,6 +56,8 @@ Common |sr| Usage Examples
 
 These examples use curl commands to interact with the |sr| :ref:`API <schemaregistry_api>`.
 
+All URLs support an optional ``pretty`` boolean query parameter to pretty-print the JSON responses. Examples are added below for readability.
+
 -------------------------------------------------------------------
 Registering a New Version of a Schema Under the Subject "Kafka-key"
 -------------------------------------------------------------------
@@ -64,22 +66,25 @@ Registering a New Version of a Schema Under the Subject "Kafka-key"
 
       curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" \
         --data '{"schema": "{\"type\": \"string\"}"}' \
-        http://localhost:8081/subjects/Kafka-key/versions
-      {"id":1}
-
+        http://localhost:8081/subjects/Kafka-key/versions?pretty
+      {
+        "id" : 1
+      }
 
 ---------------------------------------------------------------------
 Registering a New Version of a Schema Under the Subject "Kafka-value"
 ---------------------------------------------------------------------
 
+Note we can use both ``?pretty`` and ``?pretty=true`` to format the output.
 
 .. sourcecode:: bash
 
       curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" \
         --data '{"schema": "{\"type\": \"string\"}"}' \
-         http://localhost:8081/subjects/Kafka-value/versions
-      {"id":1}
-
+         http://localhost:8081/subjects/Kafka-value/versions?pretty=true
+      {
+        "id" : 1
+      }
 
 --------------------
 Listing All Subjects
@@ -97,8 +102,21 @@ Fetching a Schema by Globally Unique ID 1
 
 .. sourcecode:: bash
 
-      curl -X GET http://localhost:8081/schemas/ids/1
-      {"schema":"\"string\""}
+      curl -X GET http://localhost:8081/schemas/ids/1?pretty
+      {
+        "schema" : "\"string\""
+      }
+
+--------------------------------------------------
+Fetching the Schema String by Globally Unique ID 1
+--------------------------------------------------
+
+While not a good example, a more complex record will be pretty-printed.
+
+.. sourcecode:: bash
+
+      curl -X GET http://localhost:8081/schemas/ids/1/schema?pretty
+      "string"
 
 ----------------------------------------------------------------------
 Listing All Schema Versions Registered Under the Subject "Kafka-value"
@@ -115,8 +133,24 @@ Fetch Version 1 of the Schema Registered Under Subject "Kafka-value"
 
 .. sourcecode:: bash
 
-      curl -X GET http://localhost:8081/subjects/Kafka-value/versions/1
-      {"subject":"Kafka-value","version":1,"id":1,"schema":"\"string\""}
+      curl -X GET http://localhost:8081/subjects/Kafka-value/versions/1?pretty
+      {
+        "subject" : "Kafka-value",
+        "version" : 1,
+        "id" : 1,
+        "schema" : "\"string\""
+      }
+
+-------------------------------------------------------------
+Fetch Version 1 ``schema`` String Under Subject "Kafka-value"
+-------------------------------------------------------------
+
+While not a good example, a more complex record will be pretty-printed.
+
+.. sourcecode:: bash
+
+      curl -X GET http://localhost:8081/subjects/Kafka-value/versions/1/schema?pretty
+      "string"
 
 -----------------------------------------------------------------------
 Deleting Version 1 of the Schema Registered Under Subject "Kafka-value"
@@ -135,8 +169,10 @@ Registering the Same Schema Under the Subject "Kafka-value"
 
       curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" \
         --data '{"schema": "{\"type\": \"string\"}"}' \
-         http://localhost:8081/subjects/Kafka-value/versions
-      {"id":1}
+         http://localhost:8081/subjects/Kafka-value/versions?pretty
+      {
+        "id" : 1
+      }
 
 ------------------------------------------------------------------------
 Deleting the Most Recently Registered Schema Under Subject "Kafka-value"
@@ -155,8 +191,10 @@ Registering the Same Schema Under the Subject "Kafka-value"
 
       curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" \
         --data '{"schema": "{\"type\": \"string\"}"}' \
-         http://localhost:8081/subjects/Kafka-value/versions
-      {"id":1}
+         http://localhost:8081/subjects/Kafka-value/versions?pretty
+      {
+        "id" : 1
+      }
 
 -------------------------------------------------
 Fetching the Schema Again by Globally Unique ID 1
@@ -164,19 +202,26 @@ Fetching the Schema Again by Globally Unique ID 1
 
 .. sourcecode:: bash
 
-      curl -X GET http://localhost:8081/schemas/ids/1
-      {"schema":"\"string\""}
+      curl -X GET http://localhost:8081/schemas/ids/1?pretty
+      {
+        "schema" : "\"string\""
+      }
 
-------------------------------------------------------------
-Checking if a Schema Is Registered Under Subject "Kafka-key"
-------------------------------------------------------------
+--------------------------------------------------------------
+Checking if a Schema Is Registered Under Subject "Kafka-value"
+--------------------------------------------------------------
 
 .. sourcecode:: bash
 
       curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" \
         --data '{"schema": "{\"type\": \"string\"}"}' \
-        http://localhost:8081/subjects/Kafka-key
-      {"subject":"Kafka-key","version":3,"id":1,"schema":"\"string\""}
+        http://localhost:8081/subjects/Kafka-value?pretty
+      {
+        "subject" : "Kafka-value",
+        "version" : 3,
+        "id" : 1,
+        "schema" : "\"string\""
+      }
 
 ------------------------------------------------------------------------------------
 Testing Compatibility of a Schema with the Latest Schema Under Subject "Kafka-value"
@@ -186,8 +231,10 @@ Testing Compatibility of a Schema with the Latest Schema Under Subject "Kafka-va
 
       curl -X POST -H "Content-Type: application/vnd.schemaregistry.v1+json" \
         --data '{"schema": "{\"type\": \"string\"}"}' \
-        http://localhost:8081/compatibility/subjects/Kafka-value/versions/latest
-      {"is_compatible":true}
+        http://localhost:8081/compatibility/subjects/Kafka-value/versions/latest?pretty
+      {
+        "is_compatible" : true
+      }
 
 ----------------------------
 Getting the Top Level Config
@@ -195,8 +242,10 @@ Getting the Top Level Config
 
 .. sourcecode:: bash
 
-      curl -X GET http://localhost:8081/config
-      {"compatibilityLevel":"BACKWARD"}
+      curl -X GET http://localhost:8081/config?pretty
+      {
+        "compatibilityLevel" : "BACKWARD"
+      }
 
 --------------------------------------------
 Updating Compatibility Requirements Globally
@@ -206,8 +255,10 @@ Updating Compatibility Requirements Globally
 
       curl -X PUT -H "Content-Type: application/vnd.schemaregistry.v1+json" \
         --data '{"compatibility": "NONE"}' \
-        http://localhost:8081/config
-      {"compatibility":"NONE"}
+        http://localhost:8081/config?pretty
+      {
+        "compatibility" : "NONE"
+      }
 
 -------------------------------------------------------------------
 Updating Compatibility Requirements Under the Subject "Kafka-value"
@@ -217,8 +268,10 @@ Updating Compatibility Requirements Under the Subject "Kafka-value"
 
       curl -X PUT -H "Content-Type: application/vnd.schemaregistry.v1+json" \
         --data '{"compatibility": "BACKWARD"}' \
-        http://localhost:8081/config/Kafka-value
-      {"compatibility":"BACKWARD"}
+        http://localhost:8081/config/Kafka-value?pretty
+      {
+        "compatibility" : "BACKWARD"
+      }
 
 -----------------------------------------------------------------------
 Deleting All Schema Versions Registered Under the Subject "Kafka-value"


### PR DESCRIPTION
Enhancements over 
- #686
- Fixes ==> #629 
- Closes ==> #381

Utilize the `SchemaRegistryResourceExtension` class to inject Jackson's `ObjectMapper` & `PrettyPrinter`. 

No longer do we have to use CLI pipes into `jq` / `python -m json.tool` to format outputs from the CLI!!

## Example

Not only do GET's work, but also POSTs. I've went over the `using` document to update the entire page. 

Without `?pretty`

```bash
$ curl -X GET http://localhost:8081/subjects/LogLine-value/versions/1/schema
{"type":"record","name":"LogLine","namespace":"JavaSessionize.avro","fields":[{"name":"ip","type":"string"},{"name":"timestamp","type":"long"},{"name":"url","type":"string"},{"name":"referrer","type":"string"},{"name":"useragent","type":"string"},{"name":"sessionid","type":["null","int"],"default":null}]}
```

And with

```bash
$ curl -X GET http://localhost:8081/subjects/LogLine-value/versions/1/schema?pretty
{
  "type" : "record",
  "name" : "LogLine",
  "namespace" : "JavaSessionize.avro",
  "fields" : [ {
    "name" : "ip",
    "type" : "string"
  }, {
    "name" : "timestamp",
    "type" : "long"
  }, {
    "name" : "url",
    "type" : "string"
  }, {
    "name" : "referrer",
    "type" : "string"
  }, {
    "name" : "useragent",
    "type" : "string"
  }, {
    "name" : "sessionid",
    "type" : [ "null", "int" ],
    "default" : null
  } ]
}
```

## Details 

1. Added new URL for `/schemas/ids/:id/schema`, which was missing from #686. 

2. Updated the `RestClient` methods that returned `String` type because the other object types are handled by the `PrettyQueryExtension` class.  

3. Added a `UrlParser` that for now is used to parse out query parameters.   

4. Updated documentation ==> Closes #847