### PR TITLE
CC-2674: Point to the right checkstyle suppression file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <exec-maven-plugin.version>1.2.1</exec-maven-plugin.version>
         <podam.version>6.0.2.RELEASE</podam.version>
+        <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Not sure if we some changes were made to how we do checkstyle, but it looks like this repo has been looking in the wrong place for its checkstyle suppressions. Updating it so builds pass.

edit: this change broke the path https://github.com/confluentinc/rest-utils/pull/114/files

Signed-off-by: Arjun Satish <arjun@confluent.io>