### PR TITLE
RestClient: Add timeout to HttpConnection

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -90,6 +90,9 @@ public class RestService {
       new TypeReference<List<Integer>>() {
       };
 
+  private static final int HTTP_CONNECT_TIMEOUT_MS = 60000;
+  private static final int HTTP_READ_TIMEOUT_MS = 60000;
+
   private static final int JSON_PARSE_ERROR_CODE = 50005;
   private static ObjectMapper jsonDeserializer = new ObjectMapper();
 
@@ -140,6 +143,9 @@ public class RestService {
     try {
       URL url = new URL(requestUrl);
       connection = (HttpURLConnection) url.openConnection();
+      
+      connection.setConnectTimeout(HTTP_CONNECT_TIMEOUT_MS);
+      connection.setReadTimeout(HTTP_READ_TIMEOUT_MS);
 
       setupSsl(connection);
       connection.setRequestMethod(method);


### PR DESCRIPTION
There is no implicit timeout on a httpconnection so if the network is disrupted the underlying socket will never close and remain open forever and cause the current thread to stall.

Make static, remove setters, increase timeouts