### PR TITLE
MINOR: Fix description for Avro Converter in kafka-connect-maven-plugin config

### DIFF
--- a/avro-converter/pom.xml
+++ b/avro-converter/pom.xml
@@ -99,10 +99,9 @@
                         <configuration>
                             <title>Kafka Connect Avro Converter</title>
                             <documentationUrl>https://docs.confluent.io/current/schema-registry/docs/connect.html</documentationUrl>
-                            <description><![CDATA[
-                                The Kafka Connect Avro Converter integrates with <a href="https://docs.confluent.io/current/schema-registry/docs/intro.html">
-                                to convert data for Kafka Connect to and from Avro format.
-                            ]]></description>
+                            <description>
+                                <![CDATA[The Kafka Connect Avro Converter integrates with <a href="https://docs.confluent.io/current/schema-registry/docs/intro.html">Schema Registry</a> to convert data for Kafka Connect to and from Avro format.]]>
+                            </description>
                             <sourceUrl>https://github.com/confluentinc/schema-registry</sourceUrl>
                             
                             <supportProviderName>Confluent, Inc.</supportProviderName>


### PR DESCRIPTION
The description somehow got mangled and currently contains an unmatched `<a>` tag; this change fixes that.