### PR TITLE
Add support for basic auth in maven schema registry plugin

### DIFF
--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
@@ -18,6 +18,7 @@ package io.confluent.kafka.schemaregistry.maven;
 
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;
@@ -30,11 +31,14 @@ import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Collections;
 
 public abstract class SchemaRegistryMojo extends AbstractMojo {
 
   @Parameter(required = true)
   List<String> schemaRegistryUrls;
+  @Parameter
+  String basicAuthCredentialsSource;
   private SchemaRegistryClient client;
 
   void client(SchemaRegistryClient client) {
@@ -43,9 +47,15 @@ public abstract class SchemaRegistryMojo extends AbstractMojo {
 
   protected SchemaRegistryClient client() {
     if (null == this.client) {
-      this.client = new CachedSchemaRegistryClient(this.schemaRegistryUrls, 1000, null);
+      if (basicAuthCredentialsSource != null) {
+        this.client = new CachedSchemaRegistryClient(this.schemaRegistryUrls, 1000, Collections
+            .singletonMap(
+              SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE,
+              basicAuthCredentialsSource));
+      } else {
+        this.client = new CachedSchemaRegistryClient(this.schemaRegistryUrls, 1000, null);
+      }
     }
-
     return this.client;
   }
 


### PR DESCRIPTION
I can't figure out how to get this repo to build locally, but this is my best guess at a patch that will support basic auth in the maven schema registry plugin. Would be great to get thoughts from anyone with better knowledge of the repo.