### PR TITLE
Fix a couple of issues with avro converter performance

### DIFF
--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroConverterTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroConverterTest.java
@@ -274,7 +274,6 @@ public class AvroConverterTest {
     assertSameSchemaMultipleTopic(avroConverter, schemaRegistry, false);
   }
 
-
   @Test
   public void testSameSchemaMultipleTopicWithDeprecatedSubjectNameStrategyForKey() throws IOException, RestClientException {
     SchemaRegistryClient schemaRegistry = new MockSchemaRegistryClient();
@@ -329,5 +328,4 @@ public class AvroConverterTest {
     converted2 = converter.toConnectData("topic2", serializedRecord2);
     assertEquals(2L, (long) converted2.schema().version());
   }
-
 }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -16,6 +16,7 @@
 
 package io.confluent.kafka.serializers;
 
+import java.util.Objects;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.generic.GenericDatumReader;
@@ -167,8 +168,7 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaAvroSer
             }
           }
         } else {
-          schema.addProp(SCHEMA_REGISTRY_SCHEMA_VERSION_PROP,
-                         JsonNodeFactory.instance.numberNode(version));
+          setVersionProp(schema, version);
         }
         if (schema.getType().equals(Schema.Type.RECORD)) {
           return result;
@@ -208,6 +208,16 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaAvroSer
     return isDeprecatedSubjectNameStrategy(isKey)
         ? null
         : getSubjectName(topic, isKey, null, schemaFromRegistry);
+  }
+
+  private void setVersionProp(Schema schema, int version) {
+    // Only set the property if it isn't already set. Setting the property resets
+    // the hashcode, which can lead to an expensive hashcode computation in the caller
+    if (!Objects.equals(schema.getObjectProp(SCHEMA_REGISTRY_SCHEMA_VERSION_PROP), version)) {
+      schema.addProp(
+          SCHEMA_REGISTRY_SCHEMA_VERSION_PROP,
+          JsonNodeFactory.instance.numberNode(version));
+    }
   }
 
   private Schema schemaForDeserialize(int id,
@@ -279,5 +289,4 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaAvroSer
     }
     return readerSchema;
   }
-
 }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
@@ -74,8 +74,9 @@ public abstract class AbstractKafkaAvroSerDe {
 
   protected boolean isDeprecatedSubjectNameStrategy(boolean isKey) {
     Object subjectNameStrategy = subjectNameStrategy(isKey);
-    return subjectNameStrategy
-        instanceof io.confluent.kafka.serializers.subject.SubjectNameStrategy;
+    return !(
+        subjectNameStrategy
+            instanceof io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy);
   }
 
   private Object subjectNameStrategy(boolean isKey) {

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializerTest.java
@@ -1,6 +1,7 @@
 package io.confluent.kafka.serializers;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 
@@ -127,6 +128,10 @@ public class AbstractKafkaAvroDeserializerTest {
     org.apache.avro.Schema avroSchema = deserialized.getSchema();
     assertThat(
         avroSchema.getObjectProp(
+            AbstractKafkaAvroDeserializer.SCHEMA_REGISTRY_SCHEMA_VERSION_PROP),
+        instanceOf(Integer.class));
+    assertThat(
+        (Integer) avroSchema.getObjectProp(
             AbstractKafkaAvroDeserializer.SCHEMA_REGISTRY_SCHEMA_VERSION_PROP),
         equalTo(version));
   }

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializerTest.java
@@ -1,0 +1,151 @@
+package io.confluent.kafka.serializers;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
+import avro.shaded.com.google.common.collect.ImmutableMap;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.serializers.subject.RecordNameStrategy;
+import io.confluent.kafka.serializers.subject.TopicNameStrategy;
+import io.confluent.kafka.serializers.subject.TopicRecordNameStrategy;
+import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AbstractKafkaAvroDeserializerTest {
+  private Map<String, ?> defaultConfigs;
+  private SchemaRegistryClient schemaRegistry;
+  private KafkaAvroSerializer avroSerializer;
+  private Deserializer deserializer;
+
+  @Before
+  public void setUp() {
+    defaultConfigs = ImmutableMap.of(
+        KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "bogus");
+    schemaRegistry = new MockSchemaRegistryClient();
+    avroSerializer = new KafkaAvroSerializer(schemaRegistry, defaultConfigs);
+    deserializer = new Deserializer(schemaRegistry);
+  }
+
+  private static class Deserializer extends AbstractKafkaAvroDeserializer {
+    Deserializer(SchemaRegistryClient schemaRegistry) {
+      this.schemaRegistry = schemaRegistry;
+    }
+  }
+
+  private IndexedRecord createAvroRecord() {
+    String userSchema = "{\"namespace\": \"example.avro\", \"type\": \"record\", " +
+        "\"name\": \"User\"," +
+        "\"fields\": [{\"name\": \"name\", \"type\": \"string\"}]}";
+    Schema.Parser parser = new Schema.Parser();
+    Schema schema = parser.parse(userSchema);
+    GenericRecord avroRecord = new GenericData.Record(schema);
+    avroRecord.put("name", "testUser");
+    return avroRecord;
+  }
+
+  public void assertSchemaNotCopiedWhenDeserializedWithVersion(
+      String topic,
+      SubjectNameStrategy<Schema> subjectNameStrategy) throws IOException, RestClientException {
+    Map configs = ImmutableMap.builder()
+        .putAll(defaultConfigs)
+        .put(KafkaAvroSerializerConfig.AUTO_REGISTER_SCHEMAS, false)
+        .put(
+            AbstractKafkaAvroSerDeConfig.VALUE_SUBJECT_NAME_STRATEGY,
+            subjectNameStrategy.getClass())
+        .build();
+    IndexedRecord avroRecord = createAvroRecord();
+    String subject = subjectNameStrategy.subjectName(topic, false, avroRecord.getSchema());
+    avroSerializer.configure(configs, false);
+    deserializer.configure(new KafkaAvroDeserializerConfig(configs));
+    schemaRegistry.register(subject, avroRecord.getSchema());
+    byte[] bytes = avroSerializer.serialize(topic, avroRecord);
+    IndexedRecord deserialized
+        = (IndexedRecord) deserializer.deserializeWithSchemaAndVersion(topic, false, bytes);
+
+    assertThat(deserialized.getSchema(), sameInstance(avroRecord.getSchema()));
+  }
+
+  @Test
+  public void testSchemaNotCopiedForTopicNameStrategy() throws IOException, RestClientException {
+    assertSchemaNotCopiedWhenDeserializedWithVersion(
+        "test-topic",
+        new TopicNameStrategy()
+    );
+  }
+
+  @Test
+  public void testSchemaNotCopiedForRecordNameStrategy()
+      throws IOException, RestClientException {
+    assertSchemaNotCopiedWhenDeserializedWithVersion(
+        "test-topic",
+        new RecordNameStrategy()
+    );
+  }
+
+  @Test
+  public void testSchemaNotCopiedForTopicRecordNameStrategy()
+      throws IOException, RestClientException {
+    assertSchemaNotCopiedWhenDeserializedWithVersion(
+        "test-topic",
+        new TopicRecordNameStrategy()
+    );
+  }
+
+  private int getSchemaInternalHashCode(org.apache.avro.Schema avroSchema)
+      throws NoSuchFieldException, IllegalAccessException {
+    Field hashCodeField = org.apache.avro.Schema.class.getDeclaredField("hashCode");
+    boolean accessible = hashCodeField.isAccessible();
+    hashCodeField.setAccessible(true);
+    try {
+      return (int) hashCodeField.get(avroSchema);
+    } finally {
+      hashCodeField.setAccessible(accessible);
+    }
+  }
+
+  @Test
+  public void testSchemaVersionSet() throws IOException, RestClientException {
+    IndexedRecord avroRecord = createAvroRecord();
+    int version = schemaRegistry.register("topic", avroRecord.getSchema());
+    byte[] bytes = avroSerializer.serialize("topic", avroRecord);
+
+    IndexedRecord deserialized
+        = (IndexedRecord) deserializer.deserializeWithSchemaAndVersion(
+            "topic", false, bytes);
+
+    org.apache.avro.Schema avroSchema = deserialized.getSchema();
+    assertThat(
+        avroSchema.getObjectProp(
+            AbstractKafkaAvroDeserializer.SCHEMA_REGISTRY_SCHEMA_VERSION_PROP),
+        equalTo(version));
+  }
+
+  @Test
+  public void testHashCodeNotReset() throws NoSuchFieldException, IllegalAccessException {
+    IndexedRecord avroRecord = createAvroRecord();
+    byte[] bytes = avroSerializer.serialize("topic", avroRecord);
+    IndexedRecord deserialized1
+        = (IndexedRecord) deserializer.deserializeWithSchemaAndVersion(
+            "topic", false, bytes);
+    int hashCode = deserialized1.getSchema().hashCode();
+
+    IndexedRecord deserialized2
+        = (IndexedRecord) deserializer.deserializeWithSchemaAndVersion(
+        "topic", false, bytes);
+
+    assertThat(deserialized1.getSchema(), sameInstance(deserialized2.getSchema()));
+    org.apache.avro.Schema avroSchema = deserialized2.getSchema();
+    assertThat(getSchemaInternalHashCode(avroSchema), equalTo(hashCode));
+  }
+}


### PR DESCRIPTION
AbstractKafkaAvroDeserializer copies the schema if the subject name strategy
implements the deprecated interface. All the available strategies implement
both the deprecated and new interfaces, and therefore the schema is copied
on every call to toConnectData, which is very expensive. This patch changes
the deprecation check to return true if the strategy does not implement the
new interface.

AbstractKafkaAvroDeserializer always sets the version property when used by
the converter. This resets the hash code inside the avro schema, which is
completely unnecessary in most cases where the property has already been set.
Computing the hash code for the schema can be expensive, so we want to avoid
doing so. To prevent this check whether the version is set before calling
addProp.