### PR TITLE
CC-2769: Correct getBytes to not rely on default charset.

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageFormatter.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageFormatter.java
@@ -131,7 +131,7 @@ public class AvroMessageFormatter extends AbstractKafkaAvroDeserializer
       }
     }
     if (props.containsKey("schema.id.separator")) {
-      idSeparator = props.getProperty("schema.id.separator").getBytes();
+      idSeparator = props.getProperty("schema.id.separator").getBytes(StandardCharsets.UTF_8);
     }
   }
 


### PR DESCRIPTION
Missed this findbugs error due to changes on older branches with less stringent findbugs rules being were pint merged onto branches with more stringent findbugs rules.