### PR TITLE
MINOR: Tweak Kafka Connect Maven Plugin details

### DIFF
--- a/avro-converter/pom.xml
+++ b/avro-converter/pom.xml
@@ -63,6 +63,42 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>io.confluent</groupId>
+                <artifactId>kafka-connect-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>kafka-connect</goal>
+                        </goals>
+                        <configuration>
+                            <title>Kafka Connect Avro Converter</title>
+                            <description>
+                                <![CDATA[The Kafka Connect Avro Converter integrates with <a href="https://docs.confluent.io/current/schema-registry/docs/intro.html">Schema Registry</a> to convert data for Kafka Connect to and from Avro format.]]>
+                            </description>
+
+                            <dockerNamespace>confluentinc</dockerNamespace>
+                            <dockerName>cp-kafka-connect</dockerName>
+                            <dockerTag>${project.version}</dockerTag>
+                            
+                            <componentTypes>
+                                <componentType>converter</componentType>
+                            </componentTypes>
+                            
+                            <tags>
+                                <tag>avro</tag>
+                                <tag>schema registry</tag>
+                            </tags>
+                            
+                            <kafkaConnectApi>false</kafkaConnectApi>
+                            <singleMessageTransforms>false</singleMessageTransforms>
+                            <supportedEncodings>
+                                <supportedEncoding>avro</supportedEncoding>
+                            </supportedEncodings>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.avro</groupId>
                 <artifactId>avro-maven-plugin</artifactId>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <exec-maven-plugin.version>1.2.1</exec-maven-plugin.version>
         <podam.version>6.0.2.RELEASE</podam.version>
+        <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
     </properties>
 
     <repositories>
@@ -123,6 +124,26 @@
     <build>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>io.confluent</groupId>
+                    <artifactId>kafka-connect-maven-plugin</artifactId>
+                    <version>${kafka.connect.maven.plugin.version}</version>
+                    <configuration>
+                        <documentationUrl>https://docs.confluent.io/${project.version}/schema-registry/docs/connect.html</documentationUrl>
+                        <sourceUrl>https://github.com/confluentinc/schema-registry</sourceUrl>
+                        
+                        <supportProviderName>${project.organization.name}</supportProviderName>
+                        <supportSummary>Confluent supports the Avro Converter alongside community members as part of its Confluent Platform open source offering.</supportSummary>
+                        <supportUrl>https://docs.confluent.io/current/</supportUrl>
+                        <supportLogo>logos/confluent.png</supportLogo>
+                        
+                        <ownerUsername>confluentinc</ownerUsername>
+                        <ownerType>organization</ownerType>
+                        <ownerName>${project.organization.name}</ownerName>
+                        <ownerUrl>https://confluent.io/</ownerUrl>
+                        <ownerLogo>logos/confluent.png</ownerLogo>
+                    </configuration>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.avro</groupId>
                     <artifactId>avro-maven-plugin</artifactId>


### PR DESCRIPTION
This will align the configuration for the Kafka Connect Maven Plugin with the configuration proposed in https://github.com/confluentinc/schema-registry/pull/906; otherwise, future 4.0.x, 4.1.x, and 5.0.x releases wouldn't contain the changes included in there as well.