### PR TITLE
KafkaGroupMasterElector update call site to include time

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/KafkaGroupMasterElector.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/KafkaGroupMasterElector.java
@@ -121,7 +121,7 @@ public class KafkaGroupMasterElector implements MasterElector, SchemaRegistryReb
       this.metadata.update(Cluster.bootstrap(addresses), Collections.<String>emptySet(), 0);
       String metricGrpPrefix = "kafka.schema.registry";
 
-      ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(clientConfig);
+      ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(clientConfig, time);
       long maxIdleMs = clientConfig.getLong(CommonClientConfigs.CONNECTIONS_MAX_IDLE_MS_CONFIG);
 
       String groupId = config.getString(SchemaRegistryConfig.SCHEMAREGISTRY_GROUP_ID_CONFIG);


### PR DESCRIPTION
 ClientUtils.createChannelBuilder second parameter is missing `time` value captured above in the code block. 

Code built from master of all other dependencies for kafka, commons, rest-utils.

Tests pass after patching. 
