### PR TITLE
CC-2156: Changed log message to avoid logging sensitive consumer configs

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThread.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThread.java
@@ -104,6 +104,7 @@ public class KafkaStoreReaderThread<K, V> extends ShutdownableThread {
             config.getString(SchemaRegistryConfig.KAFKASTORE_SECURITY_PROTOCOL_CONFIG));
     KafkaStore.addSecurityConfigsToClientProperties(config, consumerProps);
 
+    log.info("Kafka store reader thread starting consumer");
     this.consumer = new KafkaConsumer<>(consumerProps);
 
     // Include a few retries since topic creation may take some time to propagate and schema registry is often started
@@ -136,8 +137,7 @@ public class KafkaStoreReaderThread<K, V> extends ShutdownableThread {
 
     log.info("Initialized last consumed offset to " + offsetInSchemasTopic);
 
-    log.debug("Kafka store reader thread started with consumer properties " +
-              consumerProps.toString());
+    log.debug("Kafka store reader thread started");
   }
 
   @Override


### PR DESCRIPTION
The `KafkaConsumer` constructor instantiates a `ConsumerConfig`, which will properly log at INFO level all of the config properties, so logging them again is unnecessary.