### PR TITLE
CC-3429 - Check if version prop already set for UNION schema

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -162,8 +162,7 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaAvroSer
           // on the first non-null entry
           for (Schema memberSchema : schema.getTypes()) {
             if (memberSchema.getType() != Schema.Type.NULL) {
-              memberSchema.addProp(SCHEMA_REGISTRY_SCHEMA_VERSION_PROP,
-                                   JsonNodeFactory.instance.numberNode(version));
+              setVersionProp(memberSchema, version);
               break;
             }
           }


### PR DESCRIPTION
When setting the version on a non-UNION schema, we first check if the version is already set. The same check needs to happen for UNION schemas.

Customer's stack trace:
```
Caused by: org.apache.kafka.common.errors.SerializationException: Error deserializing Avro message for id 53
Caused by: org.apache.avro.AvroRuntimeException: Can't overwrite property: schema.registry.schema.version
at org.apache.avro.JsonProperties.addProp(JsonProperties.java:187)
at org.apache.avro.Schema.addProp(Schema.java:134)
at io.confluent.kafka.serializers.AbstractKafkaAvroDeserializer.deserialize(AbstractKafkaAvroDeserializer.java:165)
at io.confluent.kafka.serializers.AbstractKafkaAvroDeserializer.deserializeWithSchemaAndVersion(AbstractKafkaAvroDeserializer.java:195)
at io.confluent.connect.avro.AvroConverter$Deserializer.deserialize(AvroConverter.java:132)
at io.confluent.connect.avro.AvroConverter.toConnectData(AvroConverter.java:84)
at org.apache.kafka.connect.runtime.WorkerSinkTask.lambda$convertAndTransformRecord$1(WorkerSinkTask.java:513)
at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execAndRetry(RetryWithToleranceOperator.java:128)
at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execAndHandleError(RetryWithToleranceOperator.java:162)
at org.apache.kafka.connect.runtime.errors.RetryWithToleranceOperator.execute(RetryWithToleranceOperator.java:104)
at org.apache.kafka.connect.runtime.WorkerSinkTask.convertAndTransformRecord(WorkerSinkTask.java:513)
at org.apache.kafka.connect.runtime.WorkerSinkTask.convertMessages(WorkerSinkTask.java:490)
at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:321)
at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:225)
at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:193)
at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:175)
at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:219)
at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
at java.lang.Thread.run(Thread.java:748)
[2018-11-26 14:30:02,982] DEBUG [Consumer clientId=consumer-8, groupId=connect-karo_all_data-hdfs-prod] Resuming partitions karo_cpo_ok3_data-9
[2018-11-26 14:30:02,982] ERROR WorkerSinkTask{id=karo_all_data-hdfs-prod-3}
Task is being killed and will not recover until manually restarted (org.apache.kafka.connect.runtime.WorkerTask)
```