### PR TITLE
Make CachedSchemaRegistryClient thread-safe

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -16,6 +16,8 @@
 
 package io.confluent.kafka.schemaregistry.client;
 
+import java.util.Collections;
+import java.util.Objects;
 import org.apache.avro.Schema;
 
 import java.io.IOException;
@@ -34,6 +36,9 @@ import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientExcept
 import io.confluent.kafka.schemaregistry.client.security.basicauth.BasicAuthCredentialProvider;
 import io.confluent.kafka.schemaregistry.client.security.basicauth.BasicAuthCredentialProviderFactory;
 
+/**
+ * Thread-safe Schema Registry Client with client side caching.
+ */
 public class CachedSchemaRegistryClient implements SchemaRegistryClient {
 
   private final RestService restService;
@@ -88,9 +93,6 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
     configureRestService(configs);
   }
 
-
-
-
   private void configureRestService(Map<String, ?> configs) {
     if (configs != null) {
 
@@ -136,25 +138,22 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   @Override
   public synchronized int register(String subject, Schema schema)
       throws IOException, RestClientException {
-    Map<Schema, Integer> schemaIdMap;
-    if (schemaCache.containsKey(subject)) {
-      schemaIdMap = schemaCache.get(subject);
-    } else {
-      schemaIdMap = new IdentityHashMap<Schema, Integer>();
-      schemaCache.put(subject, schemaIdMap);
+    final Map<Schema, Integer> schemaIdMap =
+        schemaCache.computeIfAbsent(subject, k -> new IdentityHashMap<>());
+
+    final Integer cachedId = schemaIdMap.get(schema);
+    if (cachedId != null) {
+      return cachedId;
     }
 
-    if (schemaIdMap.containsKey(schema)) {
-      return schemaIdMap.get(schema);
-    } else {
-      if (schemaIdMap.size() >= identityMapCapacity) {
-        throw new IllegalStateException("Too many schema objects created for " + subject + "!");
-      }
-      int id = registerAndGetId(subject, schema);
-      schemaIdMap.put(schema, id);
-      idCache.get(null).put(id, schema);
-      return id;
+    if (schemaIdMap.size() >= identityMapCapacity) {
+      throw new IllegalStateException("Too many schema objects created for " + subject + "!");
     }
+
+    final int retrievedId = registerAndGetId(subject, schema);
+    schemaIdMap.put(schema, retrievedId);
+    idCache.get(null).put(retrievedId, schema);
+    return retrievedId;
   }
 
   @Override
@@ -177,21 +176,17 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   public synchronized Schema getBySubjectAndId(String subject, int id)
       throws IOException, RestClientException {
 
-    Map<Integer, Schema> idSchemaMap;
-    if (idCache.containsKey(subject)) {
-      idSchemaMap = idCache.get(subject);
-    } else {
-      idSchemaMap = new HashMap<Integer, Schema>();
-      idCache.put(subject, idSchemaMap);
+    final Map<Integer, Schema> idSchemaMap = idCache
+        .computeIfAbsent(subject, k -> new HashMap<>());
+
+    final Schema cachedSchema = idSchemaMap.get(id);
+    if (cachedSchema != null) {
+      return cachedSchema;
     }
 
-    if (idSchemaMap.containsKey(id)) {
-      return idSchemaMap.get(id);
-    } else {
-      Schema schema = getSchemaByIdFromRegistry(id);
-      idSchemaMap.put(id, schema);
-      return schema;
-    }
+    final Schema retrievedSchema = getSchemaByIdFromRegistry(id);
+    idSchemaMap.put(id, retrievedSchema);
+    return retrievedSchema;
   }
 
   @Override
@@ -218,24 +213,21 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   @Override
   public synchronized int getVersion(String subject, Schema schema)
       throws IOException, RestClientException {
-    Map<Schema, Integer> schemaVersionMap;
-    if (versionCache.containsKey(subject)) {
-      schemaVersionMap = versionCache.get(subject);
-    } else {
-      schemaVersionMap = new IdentityHashMap();
-      versionCache.put(subject, schemaVersionMap);
+    final Map<Schema, Integer> schemaVersionMap =
+        versionCache.computeIfAbsent(subject, k -> new IdentityHashMap<>());
+
+    final Integer cachedVersion = schemaVersionMap.get(schema);
+    if (cachedVersion != null) {
+      return cachedVersion;
     }
 
-    if (schemaVersionMap.containsKey(schema)) {
-      return schemaVersionMap.get(schema);
-    } else {
-      if (schemaVersionMap.size() >= identityMapCapacity) {
-        throw new IllegalStateException("Too many schema objects created for " + subject + "!");
-      }
-      int version = getVersionFromRegistry(subject, schema);
-      schemaVersionMap.put(schema, version);
-      return version;
+    if (schemaVersionMap.size() >= identityMapCapacity) {
+      throw new IllegalStateException("Too many schema objects created for " + subject + "!");
     }
+
+    final int retrievedVersion = getVersionFromRegistry(subject, schema);
+    schemaVersionMap.put(schema, retrievedVersion);
+    return retrievedVersion;
   }
 
   @Override
@@ -247,25 +239,22 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   @Override
   public synchronized int getId(String subject, Schema schema)
       throws IOException, RestClientException {
-    Map<Schema, Integer> schemaIdMap;
-    if (schemaCache.containsKey(subject)) {
-      schemaIdMap = schemaCache.get(subject);
-    } else {
-      schemaIdMap = new IdentityHashMap();
-      schemaCache.put(subject, schemaIdMap);
+    final Map<Schema, Integer> schemaIdMap =
+        schemaCache.computeIfAbsent(subject, k -> new IdentityHashMap<>());
+
+    final Integer cachedId = schemaIdMap.get(schema);
+    if (cachedId != null) {
+      return cachedId;
     }
 
-    if (schemaIdMap.containsKey(schema)) {
-      return schemaIdMap.get(schema);
-    } else {
-      if (schemaIdMap.size() >= identityMapCapacity) {
-        throw new IllegalStateException("Too many schema objects created for " + subject + "!");
-      }
-      int id = getIdFromRegistry(subject, schema);
-      schemaIdMap.put(schema, id);
-      idCache.get(null).put(id, schema);
-      return id;
+    if (schemaIdMap.size() >= identityMapCapacity) {
+      throw new IllegalStateException("Too many schema objects created for " + subject + "!");
     }
+
+    final int retrievedId = getIdFromRegistry(subject, schema);
+    schemaIdMap.put(schema, retrievedId);
+    idCache.get(null).put(retrievedId, schema);
+    return retrievedId;
   }
 
   @Override
@@ -274,8 +263,10 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
-  public List<Integer> deleteSubject(Map<String, String> requestProperties, String subject)
+  public synchronized List<Integer> deleteSubject(
+      Map<String, String> requestProperties, String subject)
       throws IOException, RestClientException {
+    Objects.requireNonNull(subject, "subject");
     versionCache.remove(subject);
     idCache.remove(subject);
     schemaCache.remove(subject);
@@ -289,12 +280,16 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
-  public Integer deleteSchemaVersion(
+  public synchronized Integer deleteSchemaVersion(
       Map<String, String> requestProperties,
       String subject,
       String version)
       throws IOException, RestClientException {
-    versionCache.get(subject).values().remove(Integer.valueOf(version));
+    versionCache
+        .getOrDefault(subject, Collections.emptyMap())
+        .values()
+        .remove(Integer.valueOf(version));
+
     return restService.deleteSchemaVersion(requestProperties, subject, version);
   }
 

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
@@ -15,18 +15,9 @@
  */
 package io.confluent.kafka.schemaregistry.client;
 
-import org.apache.avro.Schema;
-import org.easymock.EasyMock;
-import org.junit.Test;
-
-import java.util.HashMap;
-import java.util.Arrays;
-
-import io.confluent.kafka.schemaregistry.client.rest.RestService;
-import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
-
+import static org.easymock.EasyMock.anyBoolean;
 import static org.easymock.EasyMock.anyString;
-import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
@@ -34,66 +25,75 @@ import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import io.confluent.kafka.schemaregistry.client.rest.RestService;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.stream.IntStream;
+import org.apache.avro.Schema;
+import org.junit.Before;
+import org.junit.Test;
+
 public class CachedSchemaRegistryClientTest {
+
+  private static final int IDENTITY_MAP_CAPACITY = 5;
+  private static final String SCHEMA_STR_0 = avroSchemaString(0);
+  private static final Schema AVRO_SCHEMA_0 = avroSchema(0);
+  private static final String SUBJECT_0 = "foo";
+  private static final int ID_25 = 25;
+  private static final io.confluent.kafka.schemaregistry.client.rest.entities.Schema SCHEMA_DETAILS
+      = new io.confluent.kafka.schemaregistry.client.rest.entities.Schema(
+          SUBJECT_0, 7, ID_25, SCHEMA_STR_0);
+
+  private RestService restService;
+  private CachedSchemaRegistryClient client;
+
+  @Before
+  public void setUp() {
+    restService = createNiceMock(RestService.class);
+
+    client = new CachedSchemaRegistryClient(restService, IDENTITY_MAP_CAPACITY, new HashMap<>());
+  }
 
   @Test
   public void testRegisterSchemaCache() throws Exception {
-    RestService restService = createMock(RestService.class);
-    CachedSchemaRegistryClient client = new CachedSchemaRegistryClient(restService, 20, new
-        HashMap<String, Object>());
-
-    String schema = "{\"type\": \"record\", \"name\": \"Blah\", \"fields\": [{ \"name\": \"name\", \"type\": \"string\" }]}";
-    Schema avroSchema = new Schema.Parser().parse(schema);
-
-    String subject = "foo";
-    int id = 25;
-
-    EasyMock.reset(restService);
     // Expect one call to register schema
-    expect(restService.registerSchema(anyString(), eq(subject)))
-            .andReturn(id);
+    expect(restService.registerSchema(anyString(), eq(SUBJECT_0)))
+        .andReturn(ID_25)
+        .once();
 
     replay(restService);
 
-    assertEquals(id, client.register(subject, avroSchema));
-    assertEquals(id, client.register(subject, avroSchema)); // hit the cache
+    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0));
+    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0)); // hit the cache
 
     verify(restService);
   }
 
   @Test
   public void testRegisterOverCapacity() throws Exception {
-    RestService restService = createMock(RestService.class);
-    CachedSchemaRegistryClient client = new CachedSchemaRegistryClient(restService, 1,  new
-        HashMap<String, Object>()); //
-    // capacity is just one
-
-    String schema1 = "{\"type\": \"record\", \"name\": \"Blah\", \"fields\": [{ \"name\": \"name\", \"type\": \"string\" }]}";
-    Schema avroSchema1 = new Schema.Parser().parse(schema1);
-
-    String schema2 = "{\"type\": \"record\", \"name\": \"Blah\", \"fields\": [" +
-            "{ \"name\": \"name\", \"type\": \"string\" }," +
-            "{ \"name\": \"blah\", \"type\": \"string\" }" +
-            "]}";
-    Schema avroSchema2 = new Schema.Parser().parse(schema2);
-
-
-    String subject = "foo";
-    int id = 25;
-
-    EasyMock.reset(restService);
-    // Expect one call to register schema (the second one will fail)
-    expect(restService.registerSchema(anyString(), eq(subject)))
-            .andReturn(id);
+    expect(restService.registerSchema(anyString(), anyString()))
+        .andReturn(ID_25)
+        .andReturn(26)
+        .andReturn(27)
+        .andReturn(28)
+        .andReturn(29);
 
     replay(restService);
 
-    assertEquals(id, client.register(subject, avroSchema1));
+    for (int i = 0; i != IDENTITY_MAP_CAPACITY; ++i) {
+      client.register(SUBJECT_0, avroSchema(i));  // Each one results in new id.
+    }
+
     try {
       // This call should exceed the identityMapCapacity
-      assertEquals(id, client.register(subject, avroSchema2));
+      client.register(SUBJECT_0, avroSchema(IDENTITY_MAP_CAPACITY));
       fail();
     } catch (IllegalStateException e) {
+      //
     }
 
     verify(restService);
@@ -101,174 +101,183 @@ public class CachedSchemaRegistryClientTest {
 
   @Test
   public void testIdCache() throws Exception {
-    RestService restService = createMock(RestService.class);
-    CachedSchemaRegistryClient client = new CachedSchemaRegistryClient(restService, 20,  new
-        HashMap<String, Object>());
-
-    String schema = "{\"type\": \"record\", \"name\": \"Blah\", \"fields\": [{ \"name\": \"name\", \"type\": \"string\" }]}";
-    Schema avroSchema = new Schema.Parser().parse(schema);
-
-    String subject = "foo";
-    int id = 25;
-
-    EasyMock.reset(restService);
-
-    expect(restService.registerSchema(anyString(), eq(subject)))
-            .andReturn(id);
+    expect(restService.registerSchema(anyString(), eq(SUBJECT_0)))
+        .andReturn(ID_25);
 
     // Expect only one call to getId (the rest should hit the cache)
-    expect(restService.getId(id))
-            .andReturn(new SchemaString(schema));
+    expect(restService.getId(ID_25))
+        .andReturn(new SchemaString(SCHEMA_STR_0));
 
     replay(restService);
 
-    assertEquals(id, client.register(subject, avroSchema));
-    assertEquals(avroSchema, client.getBySubjectAndId(subject, id));
-    assertEquals(avroSchema, client.getBySubjectAndId(subject, id)); // hit the cache
+    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0));
+    assertEquals(AVRO_SCHEMA_0, client.getBySubjectAndId(SUBJECT_0, ID_25));
+    assertEquals(AVRO_SCHEMA_0, client.getBySubjectAndId(SUBJECT_0, ID_25)); // hit the cache
 
     verify(restService);
   }
 
   @Test
   public void testVersionCache() throws Exception {
-    RestService restService = createMock(RestService.class);
-    CachedSchemaRegistryClient client = new CachedSchemaRegistryClient(restService, 20,  new
-        HashMap<String, Object>());
-
-    String schema = "{\"type\": \"record\", \"name\": \"Blah\", \"fields\": [{ \"name\": \"name\", \"type\": \"string\" }]}";
-    Schema avroSchema = new Schema.Parser().parse(schema);
-
-    String subject = "foo";
-    int id = 25;
     int version = 7;
 
-    EasyMock.reset(restService);
-
-    expect(restService.registerSchema(anyString(), eq(subject)))
-            .andReturn(id);
+    expect(restService.registerSchema(anyString(), eq(SUBJECT_0)))
+        .andReturn(ID_25);
 
     // Expect only one call to lookup the subject (the rest should hit the cache)
-    expect(restService.lookUpSubjectVersion(anyString(), eq(subject), eq(true)))
-            .andReturn(new io.confluent.kafka.schemaregistry.client.rest.entities.Schema(subject, version, id, schema));
+    expect(restService.lookUpSubjectVersion(anyString(), eq(SUBJECT_0), eq(true)))
+        .andReturn(
+            new io.confluent.kafka.schemaregistry.client.rest.entities.Schema(SUBJECT_0, version,
+                ID_25, SCHEMA_STR_0));
 
     replay(restService);
 
-    assertEquals(id, client.register(subject, avroSchema));
-    assertEquals(version, client.getVersion(subject, avroSchema));
-    assertEquals(version, client.getVersion(subject, avroSchema)); // hit the cache
+    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0));
+    assertEquals(version, client.getVersion(SUBJECT_0, AVRO_SCHEMA_0));
+    assertEquals(version, client.getVersion(SUBJECT_0, AVRO_SCHEMA_0)); // hit the cache
 
     verify(restService);
   }
 
   @Test
   public void testIdenticalSchemas() throws Exception {
-    RestService restService = createMock(RestService.class);
-    CachedSchemaRegistryClient client =
-        new CachedSchemaRegistryClient(restService, 20, new HashMap<String, Object>());
-
-    String schema = "{\"type\": \"record\", \"name\": \"Blah\", \"fields\": [{ \"name\": \"name\", \"type\": \"string\" }]}";
-    Schema avroSchema = new Schema.Parser().parse(schema);
-    SchemaString schemaStringOne = new SchemaString(schema);
-    SchemaString schemaStringTwo = new SchemaString(schema);
+    SchemaString schemaStringOne = new SchemaString(SCHEMA_STR_0);
+    SchemaString schemaStringTwo = new SchemaString(SCHEMA_STR_0);
 
     String subjectOne = "subjectOne";
     String subjectTwo = "subjectTwo";
-    int id = 25;
 
-    EasyMock.reset(restService);
     expect(restService.registerSchema(anyString(), eq(subjectOne)))
-            .andReturn(id);
+        .andReturn(ID_25);
     expect(restService.registerSchema(anyString(), eq(subjectTwo)))
-            .andReturn(id);
+        .andReturn(ID_25);
 
-    expect(restService.getId(eq(id)))
+    expect(restService.getId(eq(ID_25)))
             .andReturn(schemaStringOne);
-    expect(restService.getId(eq(id)))
+    expect(restService.getId(eq(ID_25)))
             .andReturn(schemaStringTwo);
 
     replay(restService);
 
     // Make sure they still get the same ID
-    assertEquals(id, client.register(subjectOne, avroSchema));
-    assertEquals(id, client.register(subjectTwo, avroSchema));
+    assertEquals(ID_25, client.register(subjectOne, AVRO_SCHEMA_0));
+    assertEquals(ID_25, client.register(subjectTwo, AVRO_SCHEMA_0));
     // Neither of these two schemas should be cached yet
-    assertEquals(avroSchema, client.getBySubjectAndId(subjectOne, id));
-    assertEquals(avroSchema, client.getBySubjectAndId(subjectTwo, id));
+    assertEquals(AVRO_SCHEMA_0, client.getBySubjectAndId(subjectOne, ID_25));
+    assertEquals(AVRO_SCHEMA_0, client.getBySubjectAndId(subjectTwo, ID_25));
     // These two should be cached now
-    assertEquals(avroSchema, client.getBySubjectAndId(subjectOne, id));
-    assertEquals(avroSchema, client.getBySubjectAndId(subjectTwo, id));
+    assertEquals(AVRO_SCHEMA_0, client.getBySubjectAndId(subjectOne, ID_25));
+    assertEquals(AVRO_SCHEMA_0, client.getBySubjectAndId(subjectTwo, ID_25));
 
     verify(restService);
   }
 
   @Test
   public void testDeleteSchemaCache() throws Exception {
-    RestService restService = createMock(RestService.class);
-    CachedSchemaRegistryClient client = new CachedSchemaRegistryClient(restService, 20, new
-        HashMap<String, Object>());
+    expect(restService.registerSchema(anyString(), eq(SUBJECT_0)))
+        .andReturn(ID_25)
+        .once();
 
-    String schema = "{\"type\": \"record\", \"name\": \"Blah\", \"fields\": [{ \"name\": \"name\", \"type\": \"string\" }]}";
-    Schema avroSchema = new Schema.Parser().parse(schema);
-
-    String subject = "foo";
-    int id = 25;
-
-    EasyMock.reset(restService);
-    // Expect one call to register schema
-    expect(restService.registerSchema(anyString(), eq(subject)))
-        .andReturn(id);
-
-    expect(restService.deleteSubject(RestService.DEFAULT_REQUEST_PROPERTIES, subject))
+    expect(restService.deleteSubject(RestService.DEFAULT_REQUEST_PROPERTIES, SUBJECT_0))
         .andReturn(Arrays.asList(0));
 
     replay(restService);
 
-    assertEquals(id, client.register(subject, avroSchema));
-    assertEquals(id, client.register(subject, avroSchema)); // hit the cache
+    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0));
+    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0)); // hit the cache
 
-    assertEquals(Arrays.asList(0), client.deleteSubject(subject));
+    assertEquals(Arrays.asList(0), client.deleteSubject(SUBJECT_0));
 
     verify(restService);
   }
 
   @Test
   public void testDeleteVersionCache() throws Exception {
-    RestService restService = createMock(RestService.class);
-    CachedSchemaRegistryClient client = new CachedSchemaRegistryClient(restService, 20,  new
-        HashMap<String, Object>());
-
-    String schema = "{\"type\": \"record\", \"name\": \"Blah\", \"fields\": [{ \"name\": \"name\", \"type\": \"string\" }]}";
-    Schema avroSchema = new Schema.Parser().parse(schema);
-
-    String subject = "foo";
-    int id = 25;
     int version = 7;
 
-    EasyMock.reset(restService);
-
-    expect(restService.registerSchema(anyString(), eq(subject)))
-        .andReturn(id);
+    expect(restService.registerSchema(anyString(), eq(SUBJECT_0)))
+        .andReturn(ID_25);
 
     // Expect only one call to lookup the subject (the rest should hit the cache)
-    expect(restService.lookUpSubjectVersion(anyString(), eq(subject), eq(true)))
-        .andReturn(new io.confluent.kafka.schemaregistry.client.rest.entities.Schema(subject,
+    expect(restService.lookUpSubjectVersion(anyString(), eq(SUBJECT_0), eq(true)))
+        .andReturn(new io.confluent.kafka.schemaregistry.client.rest.entities.Schema(SUBJECT_0,
                                                                                      version,
-                                                                                     id,
-                                                                                     schema));
+            ID_25,
+            SCHEMA_STR_0));
 
     expect(restService.deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES,
-                                           subject,
+        SUBJECT_0,
                                            String.valueOf(version)))
         .andReturn(0);
 
     replay(restService);
 
-    assertEquals(id, client.register(subject, avroSchema));
-    assertEquals(version, client.getVersion(subject, avroSchema));
-    assertEquals(version, client.getVersion(subject, avroSchema)); // hit the cache
+    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0));
+    assertEquals(version, client.getVersion(SUBJECT_0, AVRO_SCHEMA_0));
+    assertEquals(version, client.getVersion(SUBJECT_0, AVRO_SCHEMA_0)); // hit the cache
 
-    assertEquals(Integer.valueOf(0), client.deleteSchemaVersion(subject, String.valueOf(version)));
+    assertEquals(Integer.valueOf(0),
+        client.deleteSchemaVersion(SUBJECT_0, String.valueOf(version)));
 
     verify(restService);
+  }
+
+  @Test
+  public void testDeleteVersionNotInVersionCache() throws Exception {
+    expect(client.deleteSchemaVersion(Collections.emptyMap(), SUBJECT_0, "0"))
+        .andReturn(10);
+
+    replay(restService);
+
+    final Integer result = client.deleteSchemaVersion(Collections.emptyMap(), SUBJECT_0, "0");
+
+    assertEquals((Integer)10, result);
+    verify(restService);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testDeleteNullSubjectThrows() throws Exception {
+    client.deleteSubject(null);
+  }
+
+  @Test
+  public void testThreadSafe() throws Exception {
+    expect(restService.registerSchema(anyString(), eq(SUBJECT_0)))
+        .andReturn(ID_25)
+        .anyTimes();
+
+    expect(restService.getId(ID_25))
+        .andReturn(new SchemaString(SCHEMA_STR_0))
+        .anyTimes();
+
+    expect(restService.lookUpSubjectVersion(eq(AVRO_SCHEMA_0.toString()), eq(SUBJECT_0), anyBoolean()))
+        .andReturn(SCHEMA_DETAILS)
+        .anyTimes();
+
+    replay(restService);
+
+    IntStream.range(0, 1_000)
+        .parallel()
+        .forEach(idx -> {
+          try {
+            final int id = client.register(SUBJECT_0, AVRO_SCHEMA_0);
+            final int version = client.getVersion(SUBJECT_0, AVRO_SCHEMA_0);
+            client.getId(SUBJECT_0, AVRO_SCHEMA_0);
+            client.getBySubjectAndId(SUBJECT_0, id);
+            client.deleteSchemaVersion(SUBJECT_0, String.valueOf(version));
+            client.deleteSubject(SUBJECT_0);
+          } catch (final IOException | RestClientException e) {
+            //
+          }
+        });
+  }
+
+  private static Schema avroSchema(final int i) {
+    return new Schema.Parser().parse(avroSchemaString(i));
+  }
+
+  private static String avroSchemaString(final int i) {
+    return "{\"type\": \"record\", \"name\": \"Blah" + i + "\", "
+        + "\"fields\": [{ \"name\": \"name\", \"type\": \"string\" }]}";
   }
 }

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
@@ -267,7 +267,7 @@ public class CachedSchemaRegistryClientTest {
             client.deleteSchemaVersion(SUBJECT_0, String.valueOf(version));
             client.deleteSubject(SUBJECT_0);
           } catch (final IOException | RestClientException e) {
-            //
+            throw new RuntimeException(e);
           }
         });
   }


### PR DESCRIPTION
Found and fixed a couple of thread-safety issues with `CachedSchemaRegistryClient`.

While I was in there I also added a test to check for thread safety issues and moved away from the 'double lookup pattern' e.g.

```java
if (someMap.contains(key)) {
   v = someMap.get(key);
} else {
   ... do something
}
```

Which can be simplified to a single look up:

```java
v = someMap.get(key);
if (v == null) {
   ... do something
}
```
