### PR TITLE
Relicensing: Remove CCL from Avro Converter POM and use only Apache 2.0 license

### DIFF
--- a/avro-converter/pom.xml
+++ b/avro-converter/pom.xml
@@ -10,6 +10,14 @@
         <version>5.1.0-SNAPSHOT</version>
     </parent>
 
+    <licenses>
+            <license>
+            <name>Apache License 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
     <artifactId>kafka-connect-avro-converter</artifactId>
     <packaging>jar</packaging>
     <name>kafka-connect-avro-converter</name>


### PR DESCRIPTION
The POM is especially useful for this project since its `<licenses>` element affects archive files generated for use in Confluent Hub. As a result, we should make sure that its licenses are accurate.