### PR TITLE
Invalid compatibility message update to include three transitive states

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/InvalidCompatibilityException.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/InvalidCompatibilityException.java
@@ -21,8 +21,8 @@ public class InvalidCompatibilityException extends RestException {
   private static final int UNPROCESSABLE_ENTITY_STATUS_CODE = 422;
 
   public InvalidCompatibilityException() {
-    super("Invalid compatibility level. Valid values are none, backward, forward and full, " +
-                    "backward_transitive, forward_transitive, full_transitive",
+    super("Invalid compatibility level. Valid values are none, backward, forward and full, "
+                    + "backward_transitive, forward_transitive, full_transitive",
           UNPROCESSABLE_ENTITY_STATUS_CODE,
           UNPROCESSABLE_ENTITY_STATUS_CODE);
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/InvalidCompatibilityException.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/InvalidCompatibilityException.java
@@ -21,7 +21,8 @@ public class InvalidCompatibilityException extends RestException {
   private static final int UNPROCESSABLE_ENTITY_STATUS_CODE = 422;
 
   public InvalidCompatibilityException() {
-    super("Invalid compatibility level. Valid values are none, backward, forward and full",
+    super("Invalid compatibility level. Valid values are none, backward, forward and full, " +
+                    "backward_transitive, forward_transitive, full_transitive",
           UNPROCESSABLE_ENTITY_STATUS_CODE,
           UNPROCESSABLE_ENTITY_STATUS_CODE);
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/RestInvalidCompatibilityException.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/RestInvalidCompatibilityException.java
@@ -21,8 +21,8 @@ public class RestInvalidCompatibilityException extends RestConstraintViolationEx
   public static final int ERROR_CODE = Errors.INVALID_COMPATIBILITY_LEVEL_ERROR_CODE;
 
   public RestInvalidCompatibilityException() {
-    this("Invalid compatibility level. Valid values are none, backward, forward and full, " +
-            "backward_transitive, forward_transitive, full_transitive");
+    this("Invalid compatibility level. Valid values are none, backward, forward and full, "
+            + "backward_transitive, forward_transitive, full_transitive");
   }
 
   public RestInvalidCompatibilityException(String message) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/RestInvalidCompatibilityException.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/RestInvalidCompatibilityException.java
@@ -21,7 +21,8 @@ public class RestInvalidCompatibilityException extends RestConstraintViolationEx
   public static final int ERROR_CODE = Errors.INVALID_COMPATIBILITY_LEVEL_ERROR_CODE;
 
   public RestInvalidCompatibilityException() {
-    this("Invalid compatibility level. Valid values are none, backward, forward and full");
+    this("Invalid compatibility level. Valid values are none, backward, forward and full, " +
+            "backward_transitive, forward_transitive, full_transitive");
   }
 
   public RestInvalidCompatibilityException(String message) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/RestInvalidSchemaException.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/RestInvalidSchemaException.java
@@ -24,8 +24,8 @@ public class RestInvalidSchemaException extends RestConstraintViolationException
   public static final int ERROR_CODE = Errors.INVALID_SCHEMA_ERROR_CODE;
 
   public RestInvalidSchemaException() {
-    this("Invalid compatibility level. Valid values are none, backward, forward and full, " +
-            "backward_transitive, forward_transitive, full_transitive");
+    this("Invalid compatibility level. Valid values are none, backward, forward and full, "
+            + "backward_transitive, forward_transitive, full_transitive");
   }
 
   public RestInvalidSchemaException(String message) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/RestInvalidSchemaException.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/RestInvalidSchemaException.java
@@ -24,7 +24,8 @@ public class RestInvalidSchemaException extends RestConstraintViolationException
   public static final int ERROR_CODE = Errors.INVALID_SCHEMA_ERROR_CODE;
 
   public RestInvalidSchemaException() {
-    this("Invalid compatibility level. Valid values are none, backward, forward and full");
+    this("Invalid compatibility level. Valid values are none, backward, forward and full, " +
+            "backward_transitive, forward_transitive, full_transitive");
   }
 
   public RestInvalidSchemaException(String message) {


### PR DESCRIPTION
Currently, the invalid compatibility message is not consistent with the API - namely the omission of the three transitive states. (https://docs.confluent.io/current/schema-registry/docs/config.html#avro-compatibility-level). This changeset aims to bridge that gap.