### PR TITLE
MINOR: Replace IndentifyHashMap from MockSchemaRegistryClient

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -91,7 +90,7 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
     Map<Schema, Integer> schemaVersionMap;
     int currentVersion;
     if (versions.isEmpty()) {
-      schemaVersionMap = new IdentityHashMap<Schema, Integer>();
+      schemaVersionMap = new HashMap<Schema, Integer>();
       currentVersion = 1;
     } else {
       schemaVersionMap = versionCache.get(subject);
@@ -128,7 +127,7 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
     if (schemaCache.containsKey(subject)) {
       schemaIdMap = schemaCache.get(subject);
     } else {
-      schemaIdMap = new IdentityHashMap<Schema, Integer>();
+      schemaIdMap = new HashMap<Schema, Integer>();
       schemaCache.put(subject, schemaIdMap);
     }
 


### PR DESCRIPTION
After https://github.com/confluentinc/schema-registry/pull/856
identify hash map does not work in mocked SR client class anymore