### PR TITLE
CC-3616:wait in tombstone thread until the store is initialized

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -16,6 +16,14 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
+import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
+import io.confluent.kafka.schemaregistry.storage.exceptions.SerializationException;
+import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
+import io.confluent.kafka.schemaregistry.storage.exceptions.StoreInitializationException;
+import io.confluent.kafka.schemaregistry.storage.exceptions.StoreTimeoutException;
+import io.confluent.kafka.schemaregistry.storage.serialization.Serializer;
+import io.confluent.rest.RestConfig;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.Config;
@@ -43,15 +51,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
-import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
-import io.confluent.kafka.schemaregistry.storage.exceptions.SerializationException;
-import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
-import io.confluent.kafka.schemaregistry.storage.exceptions.StoreInitializationException;
-import io.confluent.kafka.schemaregistry.storage.exceptions.StoreTimeoutException;
-import io.confluent.kafka.schemaregistry.storage.serialization.Serializer;
-import io.confluent.rest.RestConfig;
 
 public class KafkaStore<K, V> implements Store<K, V> {
 
@@ -380,7 +379,9 @@ public class KafkaStore<K, V> implements Store<K, V> {
   }
 
   public void waitForInit() throws InterruptedException {
-    initLatch.await();
+    if (initLatch.getCount() > 0) {
+      initLatch.await();
+    }
   }
 
   /**

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -16,14 +16,6 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
-import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
-import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
-import io.confluent.kafka.schemaregistry.storage.exceptions.SerializationException;
-import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
-import io.confluent.kafka.schemaregistry.storage.exceptions.StoreInitializationException;
-import io.confluent.kafka.schemaregistry.storage.exceptions.StoreTimeoutException;
-import io.confluent.kafka.schemaregistry.storage.serialization.Serializer;
-import io.confluent.rest.RestConfig;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.Config;
@@ -51,6 +43,15 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
+import io.confluent.kafka.schemaregistry.storage.exceptions.SerializationException;
+import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
+import io.confluent.kafka.schemaregistry.storage.exceptions.StoreInitializationException;
+import io.confluent.kafka.schemaregistry.storage.exceptions.StoreTimeoutException;
+import io.confluent.kafka.schemaregistry.storage.serialization.Serializer;
+import io.confluent.rest.RestConfig;
 
 public class KafkaStore<K, V> implements Store<K, V> {
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -376,6 +376,10 @@ public class KafkaStore<K, V> implements Store<K, V> {
     log.debug("Kafka store shut down complete");
   }
 
+  public boolean isInitialized() {
+    return initialized.get();
+  }
+
   /**
    * For testing.
    */

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -22,8 +22,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 public class KafkaStoreMessageHandler
     implements StoreUpdateHandler<SchemaRegistryKey, SchemaRegistryValue> {
@@ -104,9 +106,7 @@ public class KafkaStoreMessageHandler
   private void tombstoneSchemaKey(SchemaKey schemaKey) {
     tombstoneExecutor.execute(() -> {
           try {
-            while (!schemaRegistry.getKafkaStore().isInitialized()) {
-              Thread.sleep(1000);
-            }
+            schemaRegistry.getKafkaStore().waitForInit();
             schemaRegistry.getKafkaStore().put(schemaKey, null);
             log.debug("Tombstoned {}", schemaKey);
           } catch (InterruptedException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -22,10 +22,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 public class KafkaStoreMessageHandler
     implements StoreUpdateHandler<SchemaRegistryKey, SchemaRegistryValue> {


### PR DESCRIPTION
The tombstone executor would fail during startup if it finds any uncompacted/unprocessed records to be tombstoned since the store wouldn't have been initialized. The fix waits for the store to be initialized.