### PR TITLE
Return global config value if subjects' is not set, but subject exists

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -106,11 +106,19 @@ public class ConfigResource {
   @Path("/{subject}")
   @GET
   public Config getSubjectLevelConfig(@PathParam("subject") String subject) {
+    try {
+      if (!schemaRegistry.listSubjects().contains(subject)) {
+        throw Errors.subjectNotFoundException();
+      }
+    } catch (SchemaRegistryException e) {
+      throw Errors.schemaRegistryException("Failed to retrieve a list of all subjects"
+              + " from the registry", e);
+    }
     Config config = null;
     try {
       AvroCompatibilityLevel compatibilityLevel = schemaRegistry.getCompatibilityLevel(subject);
       if (compatibilityLevel == null) {
-        throw Errors.subjectNotFoundException();
+        compatibilityLevel = schemaRegistry.getCompatibilityLevel(null);
       }
       config = new Config(compatibilityLevel.name);
     } catch (SchemaRegistryStoreException e) {


### PR DESCRIPTION
Fix related to issue https://github.com/confluentinc/schema-registry/issues/215

With this fix behavior of the "GET /config/subject" endpoint becomes as the following:
- if subject exists and has a custom config value - then its custom value is returned
- if subject exists and doesn't have custom config value - then global config value is returned
- if subject doesn't exist - error with code 40401 "subject not found" is returned, with http response code of 404

Current behavior differs is case when subject exists, but doesn't have a custom compatibility config value - now 404 is returned in this case, which is not expected.