### PR TITLE
CC-3732: Prevent SR from registering duplicate IDs

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -348,8 +348,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
         if (schemaId >= 0) {
           schema.setId(schemaId);
         } else {
-          while (guidToSchemaKey.containsKey(nextAvailableSchemaId)) {
-            nextAvailableSchemaId++;
+          if (guidToSchemaKey.containsKey(nextAvailableSchemaId)) {
+            throw new SchemaRegistryStoreException("Error while registering the schema due "
+                + "to generating an ID that is already in use.");
           }
           schema.setId(nextAvailableSchemaId);
           nextAvailableSchemaId++;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -26,13 +26,13 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import io.confluent.common.metrics.JmxReporter;
@@ -133,8 +133,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     this.initTimeout = config.getInt(SchemaRegistryConfig.KAFKASTORE_INIT_TIMEOUT_CONFIG);
     this.serializer = serializer;
     this.defaultCompatibilityLevel = config.compatibilityType();
-    this.guidToSchemaKey = new HashMap<Integer, SchemaKey>();
-    this.schemaHashToGuid = new HashMap<MD5, SchemaIdAndSubjects>();
+    this.guidToSchemaKey = new ConcurrentHashMap<>();
+    this.schemaHashToGuid = new ConcurrentHashMap<>();
     Store store = new InMemoryStore<SchemaRegistryKey, SchemaRegistryValue>();
     kafkaStore =
         new KafkaStore<SchemaRegistryKey, SchemaRegistryValue>(

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -348,6 +348,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
         if (schemaId >= 0) {
           schema.setId(schemaId);
         } else {
+          while (guidToSchemaKey.containsKey(nextAvailableSchemaId)) {
+            nextAvailableSchemaId++;
+          }
           schema.setId(nextAvailableSchemaId);
           nextAvailableSchemaId++;
         }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -87,7 +87,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
   private final SchemaRegistryConfig config;
   final Map<Integer, SchemaKey> guidToSchemaKey;
   final Map<MD5, SchemaIdAndSubjects> schemaHashToGuid;
-  private final KafkaStore<SchemaRegistryKey, SchemaRegistryValue> kafkaStore;
+  // visible for tests
+  final KafkaStore<SchemaRegistryKey, SchemaRegistryValue> kafkaStore;
   private final Serializer<SchemaRegistryKey, SchemaRegistryValue> serializer;
   private final SchemaRegistryIdentity myIdentity;
   private final Object masterLock = new Object();

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -130,7 +130,7 @@ public class KafkaStore<K, V> implements Store<K, V> {
     this.kafkaTopicReader =
         new KafkaStoreReaderThread<>(this.bootstrapBrokers, topic, groupId,
                                      this.storeUpdateHandler, serializer, this.localStore,
-                                     this.noopKey, this.config);
+                                     this.producer, this.noopKey, this.config);
     this.kafkaTopicReader.start();
 
     try {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -45,7 +45,14 @@ public class KafkaStoreMessageHandler
       SchemaValue schemaObj = (SchemaValue) value;
       if (schemaObj != null) {
         SchemaKey oldKey = schemaRegistry.guidToSchemaKey.get(schemaObj.getId());
-        if (!key.equals(oldKey)) {
+        SchemaValue oldSchema;
+        try {
+          oldSchema = (SchemaValue) store.get(oldKey);
+        } catch (StoreException e) {
+          log.error("Error while retrieving schema", e);
+          return false;
+        }
+        if (oldSchema != null && !oldSchema.equals(schemaObj.getSchema())) {
           log.error("Found a schema with duplicate ID {}", schemaObj.getId());
           return false;
         }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -44,7 +44,8 @@ public class KafkaStoreMessageHandler
     if (key.getKeyType() == SchemaRegistryKeyType.SCHEMA) {
       SchemaValue schemaObj = (SchemaValue) value;
       if (schemaObj != null) {
-        if (schemaRegistry.guidToSchemaKey.containsKey(schemaObj.getId())) {
+        SchemaKey oldKey = schemaRegistry.guidToSchemaKey.get(schemaObj.getId());
+        if (!key.equals(oldKey)) {
           log.error("Found a schema with duplicate ID {}", schemaObj.getId());
           return false;
         }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -53,7 +53,7 @@ public class KafkaStoreMessageHandler
             log.error("Error while retrieving schema", e);
             return false;
           }
-          if (oldSchema != null && !oldSchema.equals(schemaObj.getSchema())) {
+          if (oldSchema != null && !oldSchema.getSchema().equals(schemaObj.getSchema())) {
             log.error("Found a schema with duplicate ID {}", schemaObj.getId());
             return false;
           }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -45,16 +45,18 @@ public class KafkaStoreMessageHandler
       SchemaValue schemaObj = (SchemaValue) value;
       if (schemaObj != null) {
         SchemaKey oldKey = schemaRegistry.guidToSchemaKey.get(schemaObj.getId());
-        SchemaValue oldSchema;
-        try {
-          oldSchema = (SchemaValue) store.get(oldKey);
-        } catch (StoreException e) {
-          log.error("Error while retrieving schema", e);
-          return false;
-        }
-        if (oldSchema != null && !oldSchema.equals(schemaObj.getSchema())) {
-          log.error("Found a schema with duplicate ID {}", schemaObj.getId());
-          return false;
+        if (oldKey != null) {
+          SchemaValue oldSchema;
+          try {
+            oldSchema = (SchemaValue) store.get(oldKey);
+          } catch (StoreException e) {
+            log.error("Error while retrieving schema", e);
+            return false;
+          }
+          if (oldSchema != null && !oldSchema.equals(schemaObj.getSchema())) {
+            log.error("Found a schema with duplicate ID {}", schemaObj.getId());
+            return false;
+          }
         }
       }
     }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThread.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThread.java
@@ -179,12 +179,15 @@ public class KafkaStoreReaderThread<K, V> extends ShutdownableThread {
                       + ","
                       + message
                       + ") to the local store");
-            if (message == null) {
-              localStore.delete(messageKey);
-            } else {
-              localStore.put(messageKey, message);
+            boolean valid = this.storeUpdateHandler.validateUpdate(messageKey, message);
+            if (valid) {
+              if (message == null) {
+                localStore.delete(messageKey);
+              } else {
+                localStore.put(messageKey, message);
+              }
+              this.storeUpdateHandler.handleUpdate(messageKey, message);
             }
-            this.storeUpdateHandler.handleUpdate(messageKey, message);
             try {
               offsetUpdateLock.lock();
               offsetInSchemasTopic = record.offset();

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThread.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThread.java
@@ -199,7 +199,7 @@ public class KafkaStoreReaderThread<K, V> extends ShutdownableThread {
                     new ProducerRecord<byte[], byte[]>(topic, 0, record.key(), null);
                 producer.send(producerRecord);
               } catch (KafkaException ke) {
-                log.warn("Attempt to tombstone duplicate failed", ke);
+                log.warn("Failed to tombstone schema with duplicate ID", ke);
               }
             }
             try {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThread.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThread.java
@@ -23,6 +23,9 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.RecordTooLargeException;
@@ -65,6 +68,7 @@ public class KafkaStoreReaderThread<K, V> extends ShutdownableThread {
   private final ReentrantLock offsetUpdateLock;
   private final Condition offsetReachedThreshold;
   private Consumer<byte[], byte[]> consumer;
+  private final Producer<byte[], byte[]> producer;
   private long offsetInSchemasTopic = -1L;
   // Noop key is only used to help reliably determine last offset; reader thread ignores 
   // messages with this key
@@ -78,6 +82,7 @@ public class KafkaStoreReaderThread<K, V> extends ShutdownableThread {
                                 StoreUpdateHandler<K, V> storeUpdateHandler,
                                 Serializer<K, V> serializer,
                                 Store<K, V> localStore,
+                                Producer<byte[], byte[]> producer,
                                 K noopKey,
                                 SchemaRegistryConfig config) {
     super("kafka-store-reader-thread-" + topic, false);  // this thread is not interruptible
@@ -88,6 +93,7 @@ public class KafkaStoreReaderThread<K, V> extends ShutdownableThread {
     this.storeUpdateHandler = storeUpdateHandler;
     this.serializer = serializer;
     this.localStore = localStore;
+    this.producer = producer;
     this.noopKey = noopKey;
 
     KafkaStore.addSchemaRegistryConfigsToClientProperties(config, consumerProps);
@@ -187,6 +193,14 @@ public class KafkaStoreReaderThread<K, V> extends ShutdownableThread {
                 localStore.put(messageKey, message);
               }
               this.storeUpdateHandler.handleUpdate(messageKey, message);
+            } else {
+              try {
+                ProducerRecord<byte[], byte[]> producerRecord =
+                    new ProducerRecord<byte[], byte[]>(topic, 0, record.key(), null);
+                producer.send(producerRecord);
+              } catch (KafkaException ke) {
+                log.warn("Attempt to tombstone duplicate failed", ke);
+              }
             }
             try {
               offsetUpdateLock.lock();

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/StoreUpdateHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/StoreUpdateHandler.java
@@ -16,6 +16,8 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
+import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
+
 public interface StoreUpdateHandler<K, V> {
 
   /**
@@ -24,6 +26,6 @@ public interface StoreUpdateHandler<K, V> {
    * @param key   Key associated with the data
    * @param value Data written to the store
    */
-  public void handleUpdate(K key, V value);
+  public void handleUpdate(K key, V value) throws StoreException;
 
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/StoreUpdateHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/StoreUpdateHandler.java
@@ -16,9 +16,15 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
-import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
-
 public interface StoreUpdateHandler<K, V> {
+
+  /**
+   * Invoked before every new K,V pair written to the store
+   *
+   * @param key   Key associated with the data
+   * @param value Data written to the store
+   */
+  public boolean validateUpdate(K key, V value);
 
   /**
    * Invoked on every new K,V pair written to the store
@@ -26,6 +32,6 @@ public interface StoreUpdateHandler<K, V> {
    * @param key   Key associated with the data
    * @param value Data written to the store
    */
-  public void handleUpdate(K key, V value) throws StoreException;
+  public void handleUpdate(K key, V value);
 
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistryTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistryTest.java
@@ -19,12 +19,9 @@ import org.junit.Test;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Properties;
 
-import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
-import io.confluent.kafka.schemaregistry.storage.serialization.SchemaRegistrySerializer;
 
 import static org.junit.Assert.assertEquals;
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistryTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistryTest.java
@@ -19,9 +19,12 @@ import org.junit.Test;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Properties;
 
+import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
+import io.confluent.kafka.schemaregistry.storage.serialization.SchemaRegistrySerializer;
 
 import static org.junit.Assert.assertEquals;
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
@@ -28,7 +28,9 @@ import org.slf4j.LoggerFactory;
 import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreInitializationException;
+import io.confluent.kafka.schemaregistry.storage.serialization.SchemaRegistrySerializer;
 
+import java.util.Iterator;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
@@ -287,4 +289,61 @@ public class KafkaStoreTest extends ClusterTestHarness {
     StoreUtils.createAndInitKafkaStoreInstance(zkConnect, inMemoryStore, kafkaProps);
   }
 
+  @Test
+  public void testKafkaStoreMessageHandlerSameIdDifferentSchema() throws Exception {
+    Properties props = new Properties();
+    props.put(SchemaRegistryConfig.KAFKASTORE_CONNECTION_URL_CONFIG, zkConnect);
+    props.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG, ClusterTestHarness.KAFKASTORE_TOPIC);
+
+    SchemaRegistryConfig config = new SchemaRegistryConfig(props);
+    KafkaSchemaRegistry schemaRegistry = new KafkaSchemaRegistry(
+        config,
+        new SchemaRegistrySerializer()
+    );
+
+    KafkaStore<SchemaRegistryKey, SchemaRegistryValue> kafkaStore = schemaRegistry.kafkaStore;
+    kafkaStore.init();
+    int id = 100;
+    kafkaStore.put(new SchemaKey("subject", 1),
+        new SchemaValue("subject", 1, id, "schemaString", false)
+    );
+    kafkaStore.put(new SchemaKey("subject2", 1),
+        new SchemaValue("subject2", 1, id, "schemaString2", false)
+    );
+    int size = 0;
+    for (Iterator<SchemaRegistryKey> iter = kafkaStore.getAllKeys(); iter.hasNext(); ) {
+      size++;
+      iter.next();
+    }
+    assertEquals(1, size);
+  }
+
+  @Test
+  public void testKafkaStoreMessageHandlerSameIdSameSchema() throws Exception {
+    Properties props = new Properties();
+    props.put(SchemaRegistryConfig.KAFKASTORE_CONNECTION_URL_CONFIG, zkConnect);
+    props.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG, ClusterTestHarness.KAFKASTORE_TOPIC);
+
+    SchemaRegistryConfig config = new SchemaRegistryConfig(props);
+    KafkaSchemaRegistry schemaRegistry = new KafkaSchemaRegistry(
+        config,
+        new SchemaRegistrySerializer()
+    );
+
+    KafkaStore<SchemaRegistryKey, SchemaRegistryValue> kafkaStore = schemaRegistry.kafkaStore;
+    kafkaStore.init();
+    int id = 100;
+    kafkaStore.put(new SchemaKey("subject", 1),
+        new SchemaValue("subject", 1, id, "schemaString", false)
+    );
+    kafkaStore.put(new SchemaKey("subject2", 1),
+        new SchemaValue("subject2", 1, id, "schemaString", false)
+    );
+    int size = 0;
+    for (Iterator<SchemaRegistryKey> iter = kafkaStore.getAllKeys(); iter.hasNext(); ) {
+      size++;
+      iter.next();
+    }
+    assertEquals(2, size);
+  }
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/StringMessageHandler.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/StringMessageHandler.java
@@ -19,6 +19,16 @@ package io.confluent.kafka.schemaregistry.storage;
 public class StringMessageHandler implements StoreUpdateHandler<String, String> {
 
   /**
+   * Invoked before every new K,V pair written to the store
+   *
+   * @param key   Key associated with the data
+   * @param value Data written to the store
+   */
+  public boolean validateUpdate(String key, String value) {
+    return true;
+  }
+
+  /**
    * Invoked on every new K,V pair written to the store
    *
    * @param key   Key associated with the data


### PR DESCRIPTION
Here is a short summary of the new changes:

There are two means by which an instance of the Schema Registry (SR) will register new schemas.

1) Via the REST API.
2) Via consuming the _schemas topic, where new schemas are inserted by the master.

For 1), when the schema is new and we generate an ID for it (using either ZK or Kafka), we will now first check that the ID does not exist in our Map that is keyed by ID.

For 2), we now check if there is a different schema for the same ID, and if so, we will tombstone the schema so that the schema with the duplicate ID will eventually be removed during compaction.  If somehow check #1 failed (due to a race condition or multiple masters), then this check will still prevent the schema with the duplicate ID from being registered.