### PR TITLE
CC-3741 - Remove use of IdentityHashMap

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
@@ -21,6 +21,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.serializers.AbstractKafkaAvroDeserializer;
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerializer;
 import io.confluent.kafka.serializers.AvroSchemaUtils;
+import io.confluent.kafka.serializers.GenericContainerWithVersion;
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
 import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
 import io.confluent.kafka.serializers.NonRecordContainer;
@@ -82,14 +83,18 @@ public class AvroConverter implements Converter {
   @Override
   public SchemaAndValue toConnectData(String topic, byte[] value) {
     try {
-      GenericContainer deserialized = deserializer.deserialize(topic, isKey, value);
-      if (deserialized == null) {
+      GenericContainerWithVersion containerWithVersion =
+          deserializer.deserialize(topic, isKey, value);
+      if (containerWithVersion == null) {
         return SchemaAndValue.NULL;
-      } else if (deserialized instanceof IndexedRecord) {
-        return avroData.toConnectData(deserialized.getSchema(), deserialized);
+      }
+      GenericContainer deserialized = containerWithVersion.getContainer();
+      Integer version = containerWithVersion.getVersion();
+      if (deserialized instanceof IndexedRecord) {
+        return avroData.toConnectData(deserialized.getSchema(), deserialized, version);
       } else if (deserialized instanceof NonRecordContainer) {
-        return avroData.toConnectData(deserialized.getSchema(), ((NonRecordContainer) deserialized)
-            .getValue());
+        return avroData.toConnectData(
+            deserialized.getSchema(), ((NonRecordContainer) deserialized).getValue(), version);
       }
       throw new DataException("Unsupported type returned during deserialization of topic %s "
                                   .format(topic));
@@ -130,7 +135,7 @@ public class AvroConverter implements Converter {
       configure(new KafkaAvroDeserializerConfig(configs));
     }
 
-    public GenericContainer deserialize(String topic, boolean isKey, byte[] payload) {
+    public GenericContainerWithVersion deserialize(String topic, boolean isKey, byte[] payload) {
       return deserializeWithSchemaAndVersion(topic, isKey, payload);
     }
   }

--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
@@ -88,8 +88,8 @@ public class AvroConverter implements Converter {
       if (containerWithVersion == null) {
         return SchemaAndValue.NULL;
       }
-      GenericContainer deserialized = containerWithVersion.getContainer();
-      Integer version = containerWithVersion.getVersion();
+      GenericContainer deserialized = containerWithVersion.container();
+      Integer version = containerWithVersion.version();
       if (deserialized instanceof IndexedRecord) {
         return avroData.toConnectData(deserialized.getSchema(), deserialized, version);
       } else if (deserialized instanceof NonRecordContainer) {

--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -1115,12 +1115,23 @@ public class AvroData {
   }
 
   /**
-   * Convert the given object, in Avro format, into an Connect data object.
+   * Convert the given object, in Avro format, into a Connect data object.
+   * @param avroSchema the Avro schema
+   * @param value the value to convert into a Connect data object
+   * @return the Connect schema and value
    */
   public SchemaAndValue toConnectData(org.apache.avro.Schema avroSchema, Object value) {
     return toConnectData(avroSchema, value, null);
   }
 
+  /**
+   * Convert the given object, in Avro format, into a Connect data object.
+   * @param avroSchema the Avro schema
+   * @param value the value to convert into a Connect data object
+   * @param version the version to set on the Connect schema if the avroSchema does not have a
+   *     property named "connect.version", may be null
+   * @return the Connect schema and value
+   */
   public SchemaAndValue toConnectData(org.apache.avro.Schema avroSchema, Object value,
                                       Integer version) {
     if (value == null) {
@@ -1634,7 +1645,7 @@ public class AvroData {
     }
 
     // Included Kafka Connect version takes priority, fall back to schema registry version
-    int versionInt = -1;
+    int versionInt = -1;  // A valid version must be a positive integer (assumed throughout SR)
     JsonNode versionNode = schema.getJsonProp(CONNECT_VERSION_PROP);
     if (versionNode != null) {
       if (!versionNode.isIntegralNumber()) {

--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -312,11 +312,11 @@ public class AvroData {
       this.version = version;
     }
 
-    public org.apache.avro.Schema getSchema() {
+    public org.apache.avro.Schema schema() {
       return schema;
     }
 
-    public Integer getVersion() {
+    public Integer version() {
       return version;
     }
 

--- a/avro-serde/src/test/java/io/confluent/kafka/streams/serdes/avro/AvroUtils.java
+++ b/avro-serde/src/test/java/io/confluent/kafka/streams/serdes/avro/AvroUtils.java
@@ -21,6 +21,9 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class AvroUtils {
 
   private static IndexedRecord createAvroRecord() {

--- a/avro-serde/src/test/java/io/confluent/kafka/streams/serdes/avro/AvroUtils.java
+++ b/avro-serde/src/test/java/io/confluent/kafka/streams/serdes/avro/AvroUtils.java
@@ -21,9 +21,6 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class AvroUtils {
 
   private static IndexedRecord createAvroRecord() {

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/GenericContainerWithVersion.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/GenericContainerWithVersion.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.serializers;
+
+import org.apache.avro.generic.GenericContainer;
+
+import java.util.Objects;
+
+/**
+ * Wrapper for all non-record types that includes the schema for the data.
+ */
+public class GenericContainerWithVersion {
+
+  private final GenericContainer container;
+  private final Integer version;
+
+  public GenericContainerWithVersion(GenericContainer container, Integer version) {
+    this.container = container;
+    this.version = version;
+  }
+
+  public GenericContainer getContainer() {
+    return container;
+  }
+
+  public Integer getVersion() {
+    return version;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    GenericContainerWithVersion that = (GenericContainerWithVersion) o;
+    return Objects.equals(container, that.container) && Objects.equals(version, that.version);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(container, version);
+  }
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/GenericContainerWithVersion.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/GenericContainerWithVersion.java
@@ -33,11 +33,11 @@ public class GenericContainerWithVersion {
     this.version = version;
   }
 
-  public GenericContainer getContainer() {
+  public GenericContainer container() {
     return container;
   }
 
-  public Integer getVersion() {
+  public Integer version() {
     return version;
   }
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/GenericContainerWithVersion.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/GenericContainerWithVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,12 @@ import org.apache.avro.generic.GenericContainer;
 import java.util.Objects;
 
 /**
- * Wrapper for GenericContainer along with a version number.
+ * Wrapper for GenericContainer along with a version number, which may be null.
+ *
+ * <p>The version is typically the version of the Avro schema of the GenericContainer in the context
+ * of a subject.  The version is used to set the version on the Connect Schema that is
+ * derived from the Avro schema, but only if the Avro schema does not have a property named
+ * "connect.version", which takes precedence over the version here.
  */
 public class GenericContainerWithVersion {
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/GenericContainerWithVersion.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/GenericContainerWithVersion.java
@@ -21,7 +21,7 @@ import org.apache.avro.generic.GenericContainer;
 import java.util.Objects;
 
 /**
- * Wrapper for all non-record types that includes the schema for the data.
+ * Wrapper for GenericContainer along with a version number.
  */
 public class GenericContainerWithVersion {
 

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializerTest.java
@@ -72,7 +72,7 @@ public class AbstractKafkaAvroDeserializerTest {
     schemaRegistry.register(subject, avroRecord.getSchema());
     byte[] bytes = avroSerializer.serialize(topic, avroRecord);
     IndexedRecord deserialized
-        = (IndexedRecord) deserializer.deserializeWithSchemaAndVersion(topic, false, bytes);
+        = (IndexedRecord) deserializer.deserializeWithSchemaAndVersion(topic, false, bytes).getContainer();
 
     assertThat(deserialized.getSchema(), sameInstance(avroRecord.getSchema()));
   }
@@ -121,19 +121,13 @@ public class AbstractKafkaAvroDeserializerTest {
     int version = schemaRegistry.register("topic", avroRecord.getSchema());
     byte[] bytes = avroSerializer.serialize("topic", avroRecord);
 
-    IndexedRecord deserialized
-        = (IndexedRecord) deserializer.deserializeWithSchemaAndVersion(
+    GenericContainerWithVersion genericContainerWithVersion
+        = (GenericContainerWithVersion) deserializer.deserializeWithSchemaAndVersion(
             "topic", false, bytes);
 
-    org.apache.avro.Schema avroSchema = deserialized.getSchema();
-    assertThat(
-        avroSchema.getObjectProp(
-            AbstractKafkaAvroDeserializer.SCHEMA_REGISTRY_SCHEMA_VERSION_PROP),
-        instanceOf(Integer.class));
-    assertThat(
-        (Integer) avroSchema.getObjectProp(
-            AbstractKafkaAvroDeserializer.SCHEMA_REGISTRY_SCHEMA_VERSION_PROP),
-        equalTo(version));
+    org.apache.avro.Schema avroSchema = genericContainerWithVersion.getContainer().getSchema();
+    Integer schemaVersion = genericContainerWithVersion.getVersion();
+    assertThat(schemaVersion, equalTo(version));
   }
 
   @Test
@@ -142,12 +136,12 @@ public class AbstractKafkaAvroDeserializerTest {
     byte[] bytes = avroSerializer.serialize("topic", avroRecord);
     IndexedRecord deserialized1
         = (IndexedRecord) deserializer.deserializeWithSchemaAndVersion(
-            "topic", false, bytes);
+            "topic", false, bytes).getContainer();
     int hashCode = deserialized1.getSchema().hashCode();
 
     IndexedRecord deserialized2
         = (IndexedRecord) deserializer.deserializeWithSchemaAndVersion(
-        "topic", false, bytes);
+        "topic", false, bytes).getContainer();
 
     assertThat(deserialized1.getSchema(), sameInstance(deserialized2.getSchema()));
     org.apache.avro.Schema avroSchema = deserialized2.getSchema();

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializerTest.java
@@ -1,7 +1,6 @@
 package io.confluent.kafka.serializers;
 
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 
@@ -72,7 +71,7 @@ public class AbstractKafkaAvroDeserializerTest {
     schemaRegistry.register(subject, avroRecord.getSchema());
     byte[] bytes = avroSerializer.serialize(topic, avroRecord);
     IndexedRecord deserialized
-        = (IndexedRecord) deserializer.deserializeWithSchemaAndVersion(topic, false, bytes).getContainer();
+        = (IndexedRecord) deserializer.deserializeWithSchemaAndVersion(topic, false, bytes).container();
 
     assertThat(deserialized.getSchema(), sameInstance(avroRecord.getSchema()));
   }
@@ -125,8 +124,8 @@ public class AbstractKafkaAvroDeserializerTest {
         = (GenericContainerWithVersion) deserializer.deserializeWithSchemaAndVersion(
             "topic", false, bytes);
 
-    org.apache.avro.Schema avroSchema = genericContainerWithVersion.getContainer().getSchema();
-    Integer schemaVersion = genericContainerWithVersion.getVersion();
+    org.apache.avro.Schema avroSchema = genericContainerWithVersion.container().getSchema();
+    Integer schemaVersion = genericContainerWithVersion.version();
     assertThat(schemaVersion, equalTo(version));
   }
 
@@ -136,12 +135,12 @@ public class AbstractKafkaAvroDeserializerTest {
     byte[] bytes = avroSerializer.serialize("topic", avroRecord);
     IndexedRecord deserialized1
         = (IndexedRecord) deserializer.deserializeWithSchemaAndVersion(
-            "topic", false, bytes).getContainer();
+            "topic", false, bytes).container();
     int hashCode = deserialized1.getSchema().hashCode();
 
     IndexedRecord deserialized2
         = (IndexedRecord) deserializer.deserializeWithSchemaAndVersion(
-        "topic", false, bytes).getContainer();
+        "topic", false, bytes).container();
 
     assertThat(deserialized1.getSchema(), sameInstance(deserialized2.getSchema()));
     org.apache.avro.Schema avroSchema = deserialized2.getSchema();

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -13,7 +13,7 @@
               files="SchemaRegistryCoordinator.java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(AvroMessageReader|RestService|Errors|SchemaRegistryRestApplication|KafkaSchemaRegistry|KafkaStore|AvroData|KafkaGroupMasterElector).java"/>
+              files="(AbstractKafkaAvroDeserializer|AvroMessageReader|RestService|Errors|SchemaRegistryRestApplication|KafkaSchemaRegistry|KafkaStore|AvroData|KafkaGroupMasterElector).java"/>
 
     <suppress checks="ClassFanOutComplexity"
               files="(RestService|KafkaSchemaRegistry|KafkaStore|KafkaStoreReaderThread|AvroData|KafkaGroupMasterElector).java"/>

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -23,7 +23,6 @@ import org.apache.avro.Schema;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -142,7 +141,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   public synchronized int register(String subject, Schema schema)
       throws IOException, RestClientException {
     final Map<Schema, Integer> schemaIdMap =
-        schemaCache.computeIfAbsent(subject, k -> new IdentityHashMap<>());
+        schemaCache.computeIfAbsent(subject, k -> new HashMap<>());
 
     final Integer cachedId = schemaIdMap.get(schema);
     if (cachedId != null) {
@@ -217,7 +216,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   public synchronized int getVersion(String subject, Schema schema)
       throws IOException, RestClientException {
     final Map<Schema, Integer> schemaVersionMap =
-        versionCache.computeIfAbsent(subject, k -> new IdentityHashMap<>());
+        versionCache.computeIfAbsent(subject, k -> new HashMap<>());
 
     final Integer cachedVersion = schemaVersionMap.get(schema);
     if (cachedVersion != null) {
@@ -243,7 +242,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   public synchronized int getId(String subject, Schema schema)
       throws IOException, RestClientException {
     final Map<Schema, Integer> schemaIdMap =
-        schemaCache.computeIfAbsent(subject, k -> new IdentityHashMap<>());
+        schemaCache.computeIfAbsent(subject, k -> new HashMap<>());
 
     final Integer cachedId = schemaIdMap.get(schema);
     if (cachedId != null) {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -91,7 +90,7 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
     Map<Schema, Integer> schemaVersionMap;
     int currentVersion;
     if (versions.isEmpty()) {
-      schemaVersionMap = new IdentityHashMap<Schema, Integer>();
+      schemaVersionMap = new HashMap<Schema, Integer>();
       currentVersion = 1;
     } else {
       schemaVersionMap = versionCache.get(subject);
@@ -128,7 +127,7 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
     if (schemaCache.containsKey(subject)) {
       schemaIdMap = schemaCache.get(subject);
     } else {
-      schemaIdMap = new IdentityHashMap<Schema, Integer>();
+      schemaIdMap = new HashMap<Schema, Integer>();
       schemaCache.put(subject, schemaIdMap);
     }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/tools/SchemaRegistryClientPerformance.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/tools/SchemaRegistryClientPerformance.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License; you may not use this file
+ * except in compliance with the License.  You may obtain a copy of the License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.tools;
+
+import org.apache.avro.Schema;
+
+import java.io.IOException;
+
+import io.confluent.common.utils.AbstractPerformanceTest;
+import io.confluent.common.utils.PerformanceStats;
+import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.RestService;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+
+public class SchemaRegistryClientPerformance extends AbstractPerformanceTest {
+
+  long targetRegisteredSchemas;
+  long targetSchemasPerSec;
+  String baseUrl;
+  RestService restService;
+  String subject;
+  long registeredSchemas = 0;
+  long successfullyRegisteredSchemas = 0;
+
+  CachedSchemaRegistryClient client;
+
+  public static void main(String[] args) throws Exception {
+
+    if (args.length < 4) {
+      System.out.println(
+          "Usage: java " + SchemaRegistryClientPerformance.class.getName() + " schema_registry_url"
+          + " subject num_schemas target_schemas_per_sec"
+      );
+      System.exit(1);
+    }
+
+    String baseUrl = args[0];
+    String subject = args[1];
+    int numSchemas = Integer.parseInt(args[2]);
+    int targetSchemasPerSec = Integer.parseInt(args[3]);
+
+    SchemaRegistryClientPerformance perf =
+        new SchemaRegistryClientPerformance(baseUrl, subject, numSchemas, targetSchemasPerSec);
+    perf.run(targetSchemasPerSec);
+    perf.close();
+  }
+
+  public SchemaRegistryClientPerformance(String baseUrl, String subject, long numSchemas,
+                                         long targetSchemasPerSec) throws Exception {
+    super(numSchemas);
+    this.baseUrl = baseUrl;
+    this.restService = new RestService(baseUrl);
+    this.subject = subject;
+    this.targetRegisteredSchemas = numSchemas;
+    this.targetSchemasPerSec = targetSchemasPerSec;
+
+    client = new CachedSchemaRegistryClient(restService, Integer.MAX_VALUE);
+    // No compatibility verification
+    client.updateCompatibility(null, AvroCompatibilityLevel.NONE.name);
+  }
+
+  // sequential schema maker
+  private static Schema makeSchema(long num) {
+    String schemaString = "{\"type\":\"record\","
+                          + "\"name\":\"myrecord\","
+                          + "\"fields\":"
+                          + "[{\"type\":\"string\",\"name\":"
+                          + "\"f" + num + "\"}]}";
+    Schema.Parser parser1 = new Schema.Parser();
+    Schema schema = parser1.parse(schemaString);
+    return schema;
+  }
+
+  @Override
+  protected void doIteration(PerformanceStats.Callback cb) {
+    Schema schema = makeSchema(this.registeredSchemas);
+
+    try {
+      client.register(this.subject, schema);
+      int id = client.getId(this.subject, schema);
+      int version = client.getVersion(this.subject, schema);
+      successfullyRegisteredSchemas++;
+    } catch (IOException e) {
+      System.out.println("Problem registering schema: " + e.getMessage());
+    } catch (RestClientException e) {
+      System.out.println("Problem registering schema: " + e.getMessage());
+    }
+
+    registeredSchemas++;
+    cb.onCompletion(1, 0);
+  }
+
+  protected void close() {
+    // We can see some failures due to things like timeouts, but we want it to be obvious
+    // if there are too many failures (indicating a real underlying problem). 1% is an arbitrarily
+    // chosen limit.
+    if (successfullyRegisteredSchemas / (double) targetRegisteredSchemas < 0.99) {
+      throw new RuntimeException("Too many schema registration errors: "
+                                 + successfullyRegisteredSchemas
+                                 + " registered successfully out of " + targetRegisteredSchemas
+                                 + " attempted");
+    }
+  }
+
+  @Override
+  protected boolean finished(int iteration) {
+    return this.targetRegisteredSchemas == this.registeredSchemas;
+  }
+
+  @Override
+  protected boolean runningFast(int iteration, float elapsed) {
+    return iteration / elapsed > targetSchemasPerSec;
+  }
+}
+


### PR DESCRIPTION
There are 2 reasons why we currently use IdentityHashMap:

1. Performance
2. Avro schemas are used as keys, and we mutate them by adding a version property.  An IdentityHashMap allows for mutable keys.

Regarding #1 (performance), the real gain is by having the client use the same object reference with the CachedSchemaRegistryClient.  If a client does not use the same object reference, then a new Map entry is created, which can eventually lead to "Too many schema objects".  Our clients use the same object reference, but customers often do not.

If we replace the IdentityHashMap with HashMap, clients that use the same object reference will still be performant.  This is because the Avro schema class caches its hashcode, and its equals method will first check for reference equality.  

If we replace the IdentityHashMap with HashMap, clients that do NOT use the same object reference will not be as performant, however, they will correctly get the same lookup from the Map and will not continue adding new entries to the Map (thus more likely averting "Too many schema objects").

Regarding #2 (mutable keys), the fact that we store the version on the schema is somewhat of a hack.  The version can vary by subject, so there is not really a unique version per schema.  A cleaner solution would be to not store the version on the schema, but to pass it along with the schema so that the schema does not have to be mutated.  

