### PR TITLE
MINOR: do not try to validate schema deletes

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -43,7 +43,7 @@ public class KafkaStoreMessageHandler
   public boolean validateUpdate(SchemaRegistryKey key, SchemaRegistryValue value) {
     if (key.getKeyType() == SchemaRegistryKeyType.SCHEMA) {
       SchemaValue schemaObj = (SchemaValue) value;
-      if (schemaObj != null) {
+      if (schemaObj != null && !schemaObj.isDeleted()) {
         SchemaKey oldKey = schemaRegistry.guidToSchemaKey.get(schemaObj.getId());
         if (oldKey != null) {
           SchemaValue oldSchema;


### PR DESCRIPTION
Validating schema deletes should be fine, but it's best not to as we only really care about validating newly registered schemas.