### PR TITLE
MINOR: check that previous schema is not deleted

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -53,7 +53,9 @@ public class KafkaStoreMessageHandler
             log.error("Error while retrieving schema", e);
             return false;
           }
-          if (oldSchema != null && !oldSchema.getSchema().equals(schemaObj.getSchema())) {
+          if (oldSchema != null
+              && !oldSchema.isDeleted()
+              && !oldSchema.getSchema().equals(schemaObj.getSchema())) {
             log.error("Found a schema with duplicate ID {}", schemaObj.getId());
             return false;
           }


### PR DESCRIPTION
This check is not strictly necessary, although provides a defensive check should we allow re-registering schemas with the same id.