### PR TITLE
CC-3803: Corrected support for handling defaults of logical schema types

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -990,7 +990,7 @@ public class AvroData {
       defaultVal = fieldSchema.defaultValue();
 
       // If this is a logical, convert to the primitive form for the Avro default value
-      defaultVal = fromLogical(fieldSchema, defaultVal);
+      defaultVal = toAvroLogical(fieldSchema, defaultVal);
 
       // Avro doesn't handle a few types that Connect uses, so convert those explicitly here
       if (defaultVal instanceof Byte) {
@@ -1018,7 +1018,7 @@ public class AvroData {
     fields.add(field);
   }
 
-  private static Object fromLogical(Schema schema, Object value) {
+  private static Object toAvroLogical(Schema schema, Object value) {
     if (schema != null && schema.name() != null) {
       LogicalTypeConverter logicalConverter = TO_AVRO_LOGICAL_CONVERTERS.get(schema.name());
       if (logicalConverter != null && value != null) {
@@ -1028,7 +1028,7 @@ public class AvroData {
     return value;
   }
 
-  private static Object toLogical(Schema schema, Object value) {
+  private static Object toConnectLogical(Schema schema, Object value) {
     if (schema != null && schema.name() != null) {
       LogicalTypeConverter logicalConverter = TO_CONNECT_LOGICAL_CONVERTERS.get(schema.name());
       if (logicalConverter != null && value != null) {
@@ -1047,7 +1047,7 @@ public class AvroData {
     try {
       // If this is a logical type, convert it from the convenient Java type to the underlying
       // serializeable format
-      Object defaultVal = fromLogical(schema, value);
+      Object defaultVal = toAvroLogical(schema, value);
 
       switch (schema.type()) {
         case INT8:
@@ -1787,7 +1787,7 @@ public class AvroData {
       ToConnectContext toConnectContext) {
     Object result = defaultValueFromAvroWithoutLogical(schema, avroSchema, value, toConnectContext);
     // If the schema is a logical type, convert the primitive Avro default into the logical form
-    return toLogical(schema, result);
+    return toConnectLogical(schema, result);
   }
 
   private Object defaultValueFromAvroWithoutLogical(Schema schema,


### PR DESCRIPTION
Used the logical converters before attempting to morph the default literals used in Connect schemas into the primitive form needed for setting defaults on Avro schemas, and vice versa when morphing the Avro schema defaults to the logical literals needed by Connect schemas. Added to an existing test case to add logical type fields with defaults.

As part of this, changed the parameters for Decimal to only include the `connect.decimal.precision` schema property when it is not the default of 64. This makes it more consistent with repeated conversion between Avro and Connect when the property may not be set unless needed. The `Schema.equals(...)` will fail when if the property is not always set exactly the same; with this change, schemas are exactly equal more of the time.

Also, because of how Avro reads in schemas from JSON, it is possible that some Avro schemas have defaults for binary schemas/fields that are textual-based literals rather than binary literals. This PR adds support for these while keeping the previous support for binary default literals.

Finally, corrected an error in how Map default literals are converted from Avro to Connect.

Fixes #833.
Fixes #983.
Fixes #695.