### PR TITLE
CC-3930: Only send version/id if not null

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -22,7 +22,7 @@
               files="(Errors|AvroMessageReader).java"/>
 
     <suppress checks="CyclomaticComplexity"
-              files="(AbstractKafkaAvroDeserializer|CompatibilityResource|KafkaSchemaRegistry|KafkaStoreReaderThread|AvroData|DownloadSchemaRegistryMojo|AvroMessageFormatter|MockSchemaRegistryClient|SchemaRegistrySerializer).java"/>
+              files="(AbstractKafkaAvroDeserializer|CompatibilityResource|KafkaSchemaRegistry|KafkaStoreReaderThread|AvroData|DownloadSchemaRegistryMojo|AvroMessageFormatter|MockSchemaRegistryClient|SchemaRegistrySerializer|SubjectVersionsResource).java"/>
 
     <suppress checks="NPathComplexity"
               files="(AvroData|DownloadSchemaRegistryMojo|AvroMessageFormatter|KafkaSchemaRegistry).java"/>

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaRequest.java
@@ -16,24 +16,18 @@
 
 package io.confluent.kafka.schemaregistry.client.rest.entities.requests;
 
-import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.ser.FilterProvider;
-import com.fasterxml.jackson.databind.ser.PropertyWriter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
-import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 
 import java.io.IOException;
 import java.util.Objects;
 
-@JsonFilter("registerFilter")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class RegisterSchemaRequest {
 
-  private int version = 0;
-  private int id = -1;
+  private Integer version;
+  private Integer id;
   private String schema;
 
   public static RegisterSchemaRequest fromJson(String json) throws IOException {
@@ -41,22 +35,22 @@ public class RegisterSchemaRequest {
   }
 
   @JsonProperty("version")
-  public int getVersion() {
+  public Integer getVersion() {
     return this.version;
   }
 
   @JsonProperty("version")
-  public void setVersion(int version) {
+  public void setVersion(Integer version) {
     this.version = version;
   }
 
   @JsonProperty("id")
-  public int getId() {
+  public Integer getId() {
     return this.id;
   }
 
   @JsonProperty("id")
-  public void setId(int id) {
+  public void setId(Integer id) {
     this.id = id;
   }
 
@@ -79,7 +73,9 @@ public class RegisterSchemaRequest {
       return false;
     }
     RegisterSchemaRequest that = (RegisterSchemaRequest) o;
-    return version == that.version && id == that.id && Objects.equals(schema, that.schema);
+    return Objects.equals(version, that.version)
+        && Objects.equals(id, that.id)
+        && Objects.equals(schema, that.schema);
   }
 
   @Override
@@ -91,10 +87,10 @@ public class RegisterSchemaRequest {
   public String toString() {
     StringBuilder buf = new StringBuilder();
     buf.append("{");
-    if (version > 0) {
+    if (version != null) {
       buf.append("version=").append(version).append(", ");
     }
-    if (id >= 0) {
+    if (id != null) {
       buf.append("id=").append(id).append(", ");
     }
     buf.append("schema=").append(schema).append("}");
@@ -102,33 +98,7 @@ public class RegisterSchemaRequest {
   }
 
   public String toJson() throws IOException {
-    FilterProvider filters = new SimpleFilterProvider()
-        .addFilter("registerFilter", new RegisterFilter());
-    return new ObjectMapper().writer(filters).writeValueAsString(this);
-  }
-
-  private static class RegisterFilter extends SimpleBeanPropertyFilter {
-    @Override
-    public void serializeAsField(
-        Object pojo,
-        JsonGenerator jgen,
-        SerializerProvider provider,
-        PropertyWriter writer
-    ) throws Exception {
-      if (writer.getName().equals("version")) {
-        int version = ((RegisterSchemaRequest) pojo).getVersion();
-        if (version >= 1) {
-          writer.serializeAsField(pojo, jgen, provider);
-        }
-      } else if (writer.getName().equals("id")) {
-        int id = ((RegisterSchemaRequest) pojo).getId();
-        if (id >= 0) {
-          writer.serializeAsField(pojo, jgen, provider);
-        }
-      } else {
-        writer.serializeAsField(pojo, jgen, provider);
-      }
-    }
+    return new ObjectMapper().writeValueAsString(this);
   }
 
 }

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaRequestTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaRequestTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.kafka.schemaregistry.client.rest.entities.requests;
+
+import org.junit.Test;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class RegisterSchemaRequestTest {
+
+  @Test
+  public void buildRegisterSchemaRequest() throws Exception {
+
+    RegisterSchemaRequest request = new RegisterSchemaRequest();
+    request.setSchema("string");
+    request.setId(100);
+    request.setVersion(10);
+
+    assertEquals("{\"version\":10,\"id\":100,\"schema\":\"string\"}", request.toJson());
+  }
+
+  @Test
+  public void buildRegisterSchemaRequestWithoutId() throws Exception {
+
+    RegisterSchemaRequest request = new RegisterSchemaRequest();
+    request.setSchema("string");
+    request.setVersion(10);
+
+    assertEquals("{\"version\":10,\"schema\":\"string\"}", request.toJson());
+  }
+
+  @Test
+  public void buildRegisterSchemaRequestWithoutVersion() throws Exception {
+
+    RegisterSchemaRequest request = new RegisterSchemaRequest();
+    request.setSchema("string");
+    request.setId(100);
+
+    assertEquals("{\"id\":100,\"schema\":\"string\"}", request.toJson());
+  }
+
+  @Test
+  public void buildRegisterSchemaRequestWithoutIdOrVersion() throws Exception {
+
+    RegisterSchemaRequest request = new RegisterSchemaRequest();
+    request.setSchema("string");
+
+    assertEquals("{\"schema\":\"string\"}", request.toJson());
+  }
+}

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -159,8 +159,8 @@ public class SubjectVersionsResource {
 
     Schema schema = new Schema(
         subjectName,
-        request.getVersion(),
-        request.getId(),
+        request.getVersion() != null ? request.getVersion() : 0,
+        request.getId() != null ? request.getId() : -1,
         request.getSchema()
     );
     int id;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -72,7 +72,7 @@ public class SubjectsResource {
                                            lookupDeletedSchema,
                                        @NotNull RegisterSchemaRequest request) {
     // returns version if the schema exists. Otherwise returns 404
-    Schema schema = new Schema(subject, 0, 0, request.getSchema());
+    Schema schema = new Schema(subject, 0, -1, request.getSchema());
     io.confluent.kafka.schemaregistry.client.rest.entities.Schema matchingSchema = null;
     try {
       if (!schemaRegistry.listSubjects().contains(subject)) {


### PR DESCRIPTION
This addresses a compatibility issue introduced by augmenting the SR register API.  This fix will ensure that 5.2+ clients can still interoperate with pre-5.2 SR servers.  The version and ID will only be sent in the REST request if they are not set to null.