### PR TITLE
Fix issue when dealing with null default value for Array in a schema

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -1080,8 +1080,10 @@ public class AvroData {
           }
         case ARRAY: {
           ArrayNode array = JsonNodeFactory.instance.arrayNode();
-          for (Object elem : (Collection<Object>) defaultVal) {
-            array.add(defaultValueFromConnect(schema.valueSchema(), elem));
+          if (defaultVal != null) {
+            for (Object elem : (Collection<Object>) defaultVal) {
+              array.add(defaultValueFromConnect(schema.valueSchema(), elem));
+            }
           }
           return array;
         }


### PR DESCRIPTION
Let's say we have an Avro schema with the following field: 

```
{
  "name": "my_array",
  "type": [
    "null",
    {
      "type": "array",
      "items": "string"
    }
  ],
  "default": null
}
```

If the field is not set and the default `null` value is used, a NPE will be thrown when converting data back to Avro.

As this is a valid Avro schema, we should check that the default value for an array field is not null.