### PR TITLE
CC-3954: Use only Jackson 2 for serialization

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Config.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Config.java
@@ -16,13 +16,13 @@
 
 package io.confluent.kafka.schemaregistry.client.rest.entities;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class Config {
 
   private String compatibilityLevel;
 
-  public Config(@JsonProperty("compatibility") String compatibilityLevel) {
+  public Config(@JsonProperty("compatibilityLevel") String compatibilityLevel) {
     this.compatibilityLevel = compatibilityLevel;
   }
 
@@ -30,12 +30,12 @@ public class Config {
     compatibilityLevel = null;
   }
 
-  @JsonProperty("compatibility")
+  @JsonProperty("compatibilityLevel")
   public String getCompatibilityLevel() {
     return compatibilityLevel;
   }
 
-  @JsonProperty("compatibility")
+  @JsonProperty("compatibilityLevel")
   public void setCompatibilityLevel(String compatibilityLevel) {
     this.compatibilityLevel = compatibilityLevel;
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ClearSubjectKey.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ClearSubjectKey.java
@@ -16,7 +16,7 @@
 package io.confluent.kafka.schemaregistry.storage;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.hibernate.validator.constraints.NotEmpty;
 
 @JsonPropertyOrder(value = {"keytype", "subject", "magic"})

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigKey.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigKey.java
@@ -16,8 +16,7 @@
 package io.confluent.kafka.schemaregistry.storage;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 @JsonPropertyOrder(value = {"keytype", "subject", "magic"})
 public class ConfigKey extends SchemaRegistryKey {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
@@ -15,7 +15,7 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
 
@@ -23,7 +23,8 @@ public class ConfigValue implements SchemaRegistryValue {
 
   private AvroCompatibilityLevel compatibilityLevel;
 
-  public ConfigValue(@JsonProperty("compatibility") AvroCompatibilityLevel compatibilityLevel) {
+  public ConfigValue(@JsonProperty("compatibilityLevel")
+                     AvroCompatibilityLevel compatibilityLevel) {
     this.compatibilityLevel = compatibilityLevel;
   }
 
@@ -31,12 +32,12 @@ public class ConfigValue implements SchemaRegistryValue {
     compatibilityLevel = null;
   }
 
-  @JsonProperty("compatibility")
+  @JsonProperty("compatibilityLevel")
   public AvroCompatibilityLevel getCompatibilityLevel() {
     return compatibilityLevel;
   }
 
-  @JsonProperty("compatibility")
+  @JsonProperty("compatibilityLevel")
   public void setCompatibilityLevel(AvroCompatibilityLevel compatibilityLevel) {
     this.compatibilityLevel = compatibilityLevel;
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/DeleteSubjectKey.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/DeleteSubjectKey.java
@@ -16,8 +16,7 @@
 package io.confluent.kafka.schemaregistry.storage;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.hibernate.validator.constraints.NotEmpty;
 
 @JsonPropertyOrder(value = {"keytype", "subject", "magic"})

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ModeKey.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ModeKey.java
@@ -16,7 +16,7 @@
 package io.confluent.kafka.schemaregistry.storage;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import java.util.Objects;
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ModeValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ModeValue.java
@@ -15,7 +15,7 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
-import org.codehaus.jackson.annotate.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ModeValue implements SchemaRegistryValue {
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/NoopKey.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/NoopKey.java
@@ -15,7 +15,7 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 /**
  *

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaKey.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaKey.java
@@ -16,8 +16,7 @@
 package io.confluent.kafka.schemaregistry.storage;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import org.codehaus.jackson.annotate.JsonPropertyOrder;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.constraints.Min;


### PR DESCRIPTION
SR was importing old Jackson 1 packages, which are ignored when using Jackson 2.  This fix imports the new Jackson 2 packages.  For backward compatibility, we retain the field name
"compatibilityLevel".