### PR TITLE
Support explicit names for non-string map schemas.

### DIFF
--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroConverterTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroConverterTest.java
@@ -39,10 +39,12 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDe;
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 // AvroConverter is a trivial combination of the serializers and the AvroData conversions, so
@@ -283,6 +285,31 @@ public class AvroConverterTest {
         AbstractKafkaAvroSerDeConfig.KEY_SUBJECT_NAME_STRATEGY, DeprecatedTestTopicNameStrategy.class.getName());
     avroConverter.configure(converterConfig, true);
     assertSameSchemaMultipleTopic(avroConverter, schemaRegistry, true);
+  }
+
+  @Test
+  public void testExplicitlyNamedNestedMapsWithNonStringKeys() {
+    final Schema schema = SchemaBuilder.map(
+        Schema.OPTIONAL_STRING_SCHEMA,
+        SchemaBuilder.map(
+            Schema.OPTIONAL_STRING_SCHEMA,
+            Schema.INT32_SCHEMA
+        ).name("foo.bar").build()
+    ).name("biz.baz").version(1).build();
+    final AvroConverter avroConverter = new AvroConverter(new MockSchemaRegistryClient());
+    avroConverter.configure(
+        Collections.singletonMap(
+            AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "localhost"
+        ),
+        false
+    );
+    final Object value = Collections.singletonMap("foo", Collections.singletonMap("bar", 1));
+
+    final byte[] bytes = avroConverter.fromConnectData("topic", schema, value);
+    final SchemaAndValue schemaAndValue = avroConverter.toConnectData("topic", bytes);
+
+    assertThat(schemaAndValue.schema(), equalTo(schema));
+    assertThat(schemaAndValue.value(), equalTo(value));
   }
 
   private void assertSameSchemaMultipleTopic(AvroConverter converter, SchemaRegistryClient schemaRegistry, boolean isKey) throws IOException, RestClientException {

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -62,7 +62,16 @@ import io.confluent.kafka.serializers.NonRecordContainer;
 
 import static io.confluent.connect.avro.AvroData.AVRO_TYPE_ENUM;
 import static io.confluent.connect.avro.AvroData.CONNECT_ENUM_DOC_PROP;
+import static io.confluent.connect.avro.AvroData.CONNECT_INTERNAL_TYPE_NAME;
+import static io.confluent.connect.avro.AvroData.MAP_ENTRY_TYPE_NAME;
+import static io.confluent.connect.avro.AvroData.CONNECT_NAME_PROP;
 import static io.confluent.connect.avro.AvroData.CONNECT_RECORD_DOC_PROP;
+import static io.confluent.connect.avro.AvroData.KEY_FIELD;
+import static io.confluent.connect.avro.AvroData.MAP_ENTRY_TYPE_NAME;
+import static io.confluent.connect.avro.AvroData.NAMESPACE;
+import static io.confluent.connect.avro.AvroData.VALUE_FIELD;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.*;
 
 public class AvroDataTest {
@@ -85,6 +94,22 @@ public class AvroDataTest {
     EPOCH_PLUS_TEN_THOUSAND_MILLIS.setTimeZone(TimeZone.getTimeZone("UTC"));
     EPOCH_PLUS_TEN_THOUSAND_MILLIS.add(Calendar.MILLISECOND, 10000);
   }
+
+  private static final Schema NAMED_MAP_SCHEMA =
+      SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.INT32_SCHEMA)
+          .name("foo.bar")
+          .build();
+  private static final org.apache.avro.Schema NAMED_AVRO_MAP_SCHEMA =
+      org.apache.avro.SchemaBuilder.array()
+          .prop(CONNECT_NAME_PROP, "foo.bar")
+          .items(
+              org.apache.avro.SchemaBuilder.record("foo.bar")
+                  .prop(CONNECT_INTERNAL_TYPE_NAME, MAP_ENTRY_TYPE_NAME)
+                  .fields()
+                  .optionalString(KEY_FIELD)
+                  .requiredInt(VALUE_FIELD)
+                  .endRecord()
+          );
 
   private AvroData avroData = new AvroData(2);
 
@@ -187,6 +212,49 @@ public class AvroDataTest {
     SchemaAndValue schemaAndValue = avroData.toConnectData(avroSchema, avroObj);
     checkNonRecordConversion(avroSchema, avroObj, schemaAndValue.schema(), schemaAndValue.value(),
         avroData);
+  }
+
+  @Test
+  public void testFromConnectMapWithStringKey() {
+    final Schema schema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA);
+    final org.apache.avro.Schema expected = org.apache.avro.SchemaBuilder.map()
+        .values(org.apache.avro.SchemaBuilder.builder().intType());
+    assertThat(avroData.fromConnectSchema(schema), equalTo(expected));
+  }
+
+  @Test
+  public void testFromConnectMapWithOptionalKey() {
+    final Schema schema = SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.INT32_SCHEMA);
+    final org.apache.avro.Schema expected = org.apache.avro.SchemaBuilder.array()
+        .items(
+            org.apache.avro.SchemaBuilder.record(NAMESPACE + "." + MAP_ENTRY_TYPE_NAME)
+                .fields()
+                .optionalString(KEY_FIELD)
+                .requiredInt(VALUE_FIELD)
+                .endRecord()
+        );
+
+    assertThat(avroData.fromConnectSchema(schema), equalTo(expected));
+  }
+
+  @Test
+  public void testFromConnectMapWithNonStringKey() {
+    final Schema schema = SchemaBuilder.map(Schema.INT32_SCHEMA, Schema.INT32_SCHEMA);
+    final org.apache.avro.Schema expected = org.apache.avro.SchemaBuilder.array()
+        .items(
+            org.apache.avro.SchemaBuilder.record(NAMESPACE + "." + MAP_ENTRY_TYPE_NAME)
+                .fields()
+                .requiredInt(KEY_FIELD)
+                .requiredInt(VALUE_FIELD)
+                .endRecord()
+        );
+
+    assertThat(avroData.fromConnectSchema(schema), equalTo(expected));
+  }
+
+  @Test
+  public void testFromNamedConnectMapWithNonStringKey() {
+    assertThat(avroData.fromConnectSchema(NAMED_MAP_SCHEMA), equalTo(NAMED_AVRO_MAP_SCHEMA));
   }
 
   @Test
@@ -1121,7 +1189,11 @@ public class AvroDataTest {
     assertEquals(new SchemaAndValue(schema, Collections.singletonMap((byte) 12, value)),
                  avroData.toConnectData(avroSchema, Arrays.asList(record)));
   }  
-  
+
+  @Test
+  public void testToConnectMapWithNamedSchema() {
+    assertThat(avroData.toConnectSchema(NAMED_AVRO_MAP_SCHEMA), equalTo(NAMED_MAP_SCHEMA));
+  }
   
   // Avro -> Connect: Avro types with no corresponding Connect type
 


### PR DESCRIPTION
This patch adds support for users of the schema api to explicitly set the
name for map schemas. The avro converter will then use this name for the
map entry type if it needs to serialize the map into a list of entry
records.