### PR TITLE
Support explicit names for non-string map schemas.

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -85,6 +85,7 @@ public class AvroData {
   public static final String CONNECT_VERSION_PROP = "connect.version";
   public static final String CONNECT_DEFAULT_VALUE_PROP = "connect.default";
   public static final String CONNECT_PARAMETERS_PROP = "connect.parameters";
+  public static final String CONNECT_INTERNAL_TYPE_NAME = "connect.internal.type";
 
   public static final String CONNECT_TYPE_PROP = "connect.type";
 
@@ -836,8 +837,18 @@ public class AvroData {
         } else {
           // Special record name indicates format
           List<org.apache.avro.Schema.Field> fields = new ArrayList<>();
-          final org.apache.avro.Schema mapSchema = org.apache.avro.Schema.createRecord(
-              MAP_ENTRY_TYPE_NAME, null, namespace, false);
+          final org.apache.avro.Schema mapSchema;
+          if (schema.name() == null) {
+            mapSchema = org.apache.avro.Schema.createRecord(
+                MAP_ENTRY_TYPE_NAME,
+                null,
+                namespace,
+                false
+            );
+          } else {
+            mapSchema = org.apache.avro.Schema.createRecord(name, null, namespace, false);
+            mapSchema.addProp(CONNECT_INTERNAL_TYPE_NAME, MAP_ENTRY_TYPE_NAME);
+          }
           addAvroRecordField(
               fields,
               KEY_FIELD,
@@ -1133,6 +1144,20 @@ public class AvroData {
     }
   }
 
+  private boolean isMapEntry(final org.apache.avro.Schema elemSchema) {
+    if (!elemSchema.getType().equals(org.apache.avro.Schema.Type.RECORD)) {
+      return false;
+    }
+    if (NAMESPACE.equals(elemSchema.getNamespace())
+        && MAP_ENTRY_TYPE_NAME.equals(elemSchema.getName())) {
+      return true;
+    }
+    if (Objects.equals(elemSchema.getProp(CONNECT_INTERNAL_TYPE_NAME), MAP_ENTRY_TYPE_NAME)) {
+      return true;
+    }
+    return false;
+  }
+
   /**
    * Convert the given object, in Avro format, into a Connect data object.
    * @param avroSchema the Avro schema
@@ -1351,7 +1376,7 @@ public class AvroData {
           Schema valueSchema = schema.valueSchema();
           if (keySchema != null && keySchema.type() == Schema.Type.STRING && !keySchema
               .isOptional()) {
-            // String keys
+            // Non-optional string keys
             Map<CharSequence, Object> original = (Map<CharSequence, Object>) value;
             Map<CharSequence, Object> result = new HashMap<>(original.size());
             for (Map.Entry<CharSequence, Object> entry : original.entrySet()) {
@@ -1561,9 +1586,7 @@ public class AvroData {
       case ARRAY:
         org.apache.avro.Schema elemSchema = schema.getElementType();
         // Special case for custom encoding of non-string maps as list of key-value records
-        if (elemSchema.getType().equals(org.apache.avro.Schema.Type.RECORD)
-            && NAMESPACE.equals(elemSchema.getNamespace())
-            && MAP_ENTRY_TYPE_NAME.equals(elemSchema.getName())) {
+        if (isMapEntry(elemSchema)) {
           if (elemSchema.getFields().size() != 2
               || elemSchema.getField(KEY_FIELD) == null
               || elemSchema.getField(VALUE_FIELD) == null) {

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroConverterTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroConverterTest.java
@@ -39,10 +39,12 @@ import io.confluent.kafka.serializers.AbstractKafkaAvroSerDe;
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 // AvroConverter is a trivial combination of the serializers and the AvroData conversions, so
@@ -283,6 +285,31 @@ public class AvroConverterTest {
         AbstractKafkaAvroSerDeConfig.KEY_SUBJECT_NAME_STRATEGY, DeprecatedTestTopicNameStrategy.class.getName());
     avroConverter.configure(converterConfig, true);
     assertSameSchemaMultipleTopic(avroConverter, schemaRegistry, true);
+  }
+
+  @Test
+  public void testExplicitlyNamedNestedMapsWithNonStringKeys() {
+    final Schema schema = SchemaBuilder.map(
+        Schema.OPTIONAL_STRING_SCHEMA,
+        SchemaBuilder.map(
+            Schema.OPTIONAL_STRING_SCHEMA,
+            Schema.INT32_SCHEMA
+        ).name("foo.bar").build()
+    ).name("biz.baz").version(1).build();
+    final AvroConverter avroConverter = new AvroConverter(new MockSchemaRegistryClient());
+    avroConverter.configure(
+        Collections.singletonMap(
+            AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "localhost"
+        ),
+        false
+    );
+    final Object value = Collections.singletonMap("foo", Collections.singletonMap("bar", 1));
+
+    final byte[] bytes = avroConverter.fromConnectData("topic", schema, value);
+    final SchemaAndValue schemaAndValue = avroConverter.toConnectData("topic", bytes);
+
+    assertThat(schemaAndValue.schema(), equalTo(schema));
+    assertThat(schemaAndValue.value(), equalTo(value));
   }
 
   private void assertSameSchemaMultipleTopic(AvroConverter converter, SchemaRegistryClient schemaRegistry, boolean isKey) throws IOException, RestClientException {

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -66,7 +66,14 @@ import io.confluent.kafka.serializers.NonRecordContainer;
 
 import static io.confluent.connect.avro.AvroData.AVRO_TYPE_ENUM;
 import static io.confluent.connect.avro.AvroData.CONNECT_ENUM_DOC_PROP;
+import static io.confluent.connect.avro.AvroData.CONNECT_INTERNAL_TYPE_NAME;
+import static io.confluent.connect.avro.AvroData.MAP_ENTRY_TYPE_NAME;
+import static io.confluent.connect.avro.AvroData.CONNECT_NAME_PROP;
 import static io.confluent.connect.avro.AvroData.CONNECT_RECORD_DOC_PROP;
+import static io.confluent.connect.avro.AvroData.KEY_FIELD;
+import static io.confluent.connect.avro.AvroData.NAMESPACE;
+import static io.confluent.connect.avro.AvroData.VALUE_FIELD;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.*;
 
 public class AvroDataTest {
@@ -89,6 +96,22 @@ public class AvroDataTest {
     EPOCH_PLUS_TEN_THOUSAND_MILLIS.setTimeZone(TimeZone.getTimeZone("UTC"));
     EPOCH_PLUS_TEN_THOUSAND_MILLIS.add(Calendar.MILLISECOND, 10000);
   }
+
+  private static final Schema NAMED_MAP_SCHEMA =
+      SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.INT32_SCHEMA)
+          .name("foo.bar")
+          .build();
+  private static final org.apache.avro.Schema NAMED_AVRO_MAP_SCHEMA =
+      org.apache.avro.SchemaBuilder.array()
+          .prop(CONNECT_NAME_PROP, "foo.bar")
+          .items(
+              org.apache.avro.SchemaBuilder.record("foo.bar")
+                  .prop(CONNECT_INTERNAL_TYPE_NAME, MAP_ENTRY_TYPE_NAME)
+                  .fields()
+                  .optionalString(KEY_FIELD)
+                  .requiredInt(VALUE_FIELD)
+                  .endRecord()
+          );
 
   private AvroData avroData = new AvroData(2);
 
@@ -191,6 +214,49 @@ public class AvroDataTest {
     SchemaAndValue schemaAndValue = avroData.toConnectData(avroSchema, avroObj);
     checkNonRecordConversion(avroSchema, avroObj, schemaAndValue.schema(), schemaAndValue.value(),
         avroData);
+  }
+
+  @Test
+  public void testFromConnectMapWithStringKey() {
+    final Schema schema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA);
+    final org.apache.avro.Schema expected = org.apache.avro.SchemaBuilder.map()
+        .values(org.apache.avro.SchemaBuilder.builder().intType());
+    assertThat(avroData.fromConnectSchema(schema), equalTo(expected));
+  }
+
+  @Test
+  public void testFromConnectMapWithOptionalKey() {
+    final Schema schema = SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.INT32_SCHEMA);
+    final org.apache.avro.Schema expected = org.apache.avro.SchemaBuilder.array()
+        .items(
+            org.apache.avro.SchemaBuilder.record(NAMESPACE + "." + MAP_ENTRY_TYPE_NAME)
+                .fields()
+                .optionalString(KEY_FIELD)
+                .requiredInt(VALUE_FIELD)
+                .endRecord()
+        );
+
+    assertThat(avroData.fromConnectSchema(schema), equalTo(expected));
+  }
+
+  @Test
+  public void testFromConnectMapWithNonStringKey() {
+    final Schema schema = SchemaBuilder.map(Schema.INT32_SCHEMA, Schema.INT32_SCHEMA);
+    final org.apache.avro.Schema expected = org.apache.avro.SchemaBuilder.array()
+        .items(
+            org.apache.avro.SchemaBuilder.record(NAMESPACE + "." + MAP_ENTRY_TYPE_NAME)
+                .fields()
+                .requiredInt(KEY_FIELD)
+                .requiredInt(VALUE_FIELD)
+                .endRecord()
+        );
+
+    assertThat(avroData.fromConnectSchema(schema), equalTo(expected));
+  }
+
+  @Test
+  public void testFromNamedConnectMapWithNonStringKey() {
+    assertThat(avroData.fromConnectSchema(NAMED_MAP_SCHEMA), equalTo(NAMED_AVRO_MAP_SCHEMA));
   }
 
   @Test
@@ -1339,7 +1405,11 @@ public class AvroDataTest {
     assertEquals(new SchemaAndValue(schema, Collections.singletonMap((byte) 12, value)),
                  avroData.toConnectData(avroSchema, Arrays.asList(record)));
   }  
-  
+
+  @Test
+  public void testToConnectMapWithNamedSchema() {
+    assertThat(avroData.toConnectSchema(NAMED_AVRO_MAP_SCHEMA), equalTo(NAMED_MAP_SCHEMA));
+  }
   
   // Avro -> Connect: Avro types with no corresponding Connect type
 


### PR DESCRIPTION
This patch adds support for users of the schema api to explicitly set the
name for map schemas. The avro converter will then use this name for the
map entry type if it needs to serialize the map into a list of entry
records.