### PR TITLE
CC-4015 : Clean up tombstones from internal caches

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
@@ -42,10 +42,7 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
   private final Map<Integer, List<SchemaKey>> guidToDeletedSchemaKeys;
 
   public InMemoryCache() {
-    this.store = new ConcurrentSkipListMap<>();
-    this.guidToSchemaKey = new ConcurrentHashMap<>();
-    this.schemaHashToGuid = new ConcurrentHashMap<>();
-    this.guidToDeletedSchemaKeys = new ConcurrentHashMap<>();
+    this(new ConcurrentSkipListMap<>());
   }
 
   public InMemoryCache(ConcurrentNavigableMap<K, V> store) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -727,6 +727,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
         return null;
       }
       schema = (SchemaValue) kafkaStore.get(subjectVersionKey);
+      if (schema == null) {
+        return null;
+      }
     } catch (StoreException e) {
       throw new SchemaRegistryStoreException(
           "Error while retrieving schema with id "
@@ -994,7 +997,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
       throws SchemaRegistryException {
     try {
       SchemaValue schemaValue = (SchemaValue) this.kafkaStore.get(new SchemaKey(subject, version));
-      return schemaValue.isDeleted();
+      return schemaValue == null || schemaValue.isDeleted();
     } catch (StoreException e) {
       throw new SchemaRegistryStoreException(
           "Error while retrieving schema from the backend Kafka"

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -149,6 +149,7 @@ public class KafkaStoreMessageHandler
           try {
             schemaRegistry.getKafkaStore().waitForInit();
             schemaRegistry.getKafkaStore().delete(schemaKey);
+            lookupCache.schemaTombstoned(schemaKey);
             log.debug("Tombstoned {}", schemaKey);
           } catch (InterruptedException e) {
             log.error("Interrupted while waiting for the tombstone thread to be initialized ", e);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThread.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThread.java
@@ -202,8 +202,9 @@ public class KafkaStoreReaderThread<K, V> extends ShutdownableThread {
                       null
                   );
                   producer.send(producerRecord);
+                  log.debug("Tombstoned invalid key {}", messageKey);
                 } catch (KafkaException ke) {
-                  log.warn("Failed to tombstone schema with duplicate ID", ke);
+                  log.warn("Failed to tombstone invalid key {}", messageKey, ke);
                 }
               }
             }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupCache.java
@@ -86,6 +86,13 @@ public interface LookupCache<K,V> extends Store<K,V> {
   void schemaDeleted(SchemaKey schemaKey, SchemaValue schemaValue);
 
   /**
+   * Callback that is invoked when a schema is tombstoned.
+   *
+   * @param schemaKey   the tombstoned SchemaKey; never {@code null}
+   */
+  void schemaTombstoned(SchemaKey schemaKey);
+
+  /**
    * Retrieves the config for a subject.
    *
    * @param subject the subject

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
@@ -405,8 +405,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
 
     assertTrue(inMemoryStore.get(inMemoryStore.schemaKeyById(id)).isDeleted());
 
-    inMemoryStore.replaceMatchingDeletedWithNonDeletedOrRemove(
-        inMemoryStore.store, s -> s.equals("subject2"));
+    inMemoryStore.replaceMatchingDeletedWithNonDeletedOrRemove(s -> s.equals("subject2"));
 
     SchemaValue newValue = inMemoryStore.get(inMemoryStore.schemaKeyById(id));
     assertEquals("subject", newValue.getSubject());

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
@@ -405,7 +405,8 @@ public class KafkaStoreTest extends ClusterTestHarness {
 
     assertTrue(inMemoryStore.get(inMemoryStore.schemaKeyById(id)).isDeleted());
 
-    inMemoryStore.replaceMatchingDeletedWithNonDeletedOrRemove(s -> s.equals("subject2"));
+    inMemoryStore.replaceMatchingDeletedWithNonDeletedOrRemove(
+        inMemoryStore.store, s -> s.equals("subject2"));
 
     SchemaValue newValue = inMemoryStore.get(inMemoryStore.schemaKeyById(id));
     assertEquals("subject", newValue.getSubject());


### PR DESCRIPTION
After tombstoning extraneous soft-deleted entries, remove said entries
from internal caches.  Also, added several defensive checks against null
entries when looking up schemas.