### PR TITLE
Updating Metadata parameters for compilation with latest Kafka trunk

### DIFF
--- a/core/src/test/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinatorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinatorTest.java
@@ -34,6 +34,7 @@ import org.apache.kafka.common.utils.MockTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.test.TestUtils;
 import org.junit.After;
+import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -89,8 +90,10 @@ public class SchemaRegistryCoordinatorTest {
 
   @Before
   public void setup() {
+    LogContext logContext = new LogContext();
     this.time = new MockTime();
-    this.metadata = new Metadata(0, Long.MAX_VALUE, true);
+    ClusterResourceListeners clusterResourceListeners = new ClusterResourceListeners();
+    this.metadata = new Metadata(0, Long.MAX_VALUE, logContext, clusterResourceListeners);
     this.client = new MockClient(time, new MockClient.MockMetadataUpdater() {
       @Override
       public List<Node> fetchNodes() {
@@ -108,7 +111,6 @@ public class SchemaRegistryCoordinatorTest {
       }
     });
 
-    LogContext logContext = new LogContext();
     this.consumerClient = new ConsumerNetworkClient(logContext, client, metadata, time, 100, 1000, Integer.MAX_VALUE);
     this.metrics = new Metrics(time);
     this.rebalanceListener = new MockRebalanceListener();


### PR DESCRIPTION
When building with the latest Kafka build, the console shows errors due to the updated class initialisation parameters in  `...kafka.clients.Metadata.java`, as follows:

```
[ERROR] /home/kafka/projects/schema-registry/core/src/main/java/io/confluent/kafka/schemaregistry/mastere
lector/kafka/KafkaGroupMasterElector.java:[109,23] constructor Metadata in class org.apache.kafka.clients
.Metadata cannot be applied to given types;                                                              
[ERROR]   required: long,long,org.apache.kafka.common.utils.LogContext,org.apache.kafka.common.internals.
ClusterResourceListeners                                                                                 
[ERROR]   found: long,java.lang.Long,boolean                                                             
[ERROR]   reason: actual and formal argument lists differ in length 
```

This error is due to [the update signature](https://github.com/axbaretto/kafka/blob/master/clients/src/main/java/org/apache/kafka/clients/Metadata.java), which is as follows:

``` Java
    public Metadata(long refreshBackoffMs,
                    long metadataExpireMs,
                    LogContext logContext,
                    ClusterResourceListeners clusterResourceListeners) {
        //...
```

The change required minor modifications, which included:
* Adding the imports for `...kafka.common.internals.ClusterResourceListeners`
* Moving `logContext` initialisation before Metadata initialisation
* Adding empty ClusterResourceListeners object
