### PR TITLE
DOCS-1094 - Schema Registry docs: Add DescribeConfigs ACL requirement

### DIFF
--- a/docs/security.rst
+++ b/docs/security.rst
@@ -164,12 +164,18 @@ However, it will still be able to retrieve existing schemas from the |sr|, assum
 Authorizing Access to the Schemas Topic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you have enabled :ref:`Kafka authorization <kafka_authorization>`, you will need to grant the |sr|'s principal read and write access to the schemas topic.
+If you have enabled :ref:`Kafka authorization <kafka_authorization>`, you will
+need to grant the |sr|'s principal read and write access to the schemas topic,
+along with describe configuration access to verify that the topic exists.
 This ensures that only authorized users can make changes to the topic.
 
 .. sourcecode:: bash
 
      export KAFKA_OPTS="-Djava.security.auth.login.config=<path to JAAS conf file>"
+     
+     bin/kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add \
+                   --allow-principal 'User:<sr-principal>' --allow-host '*' \
+                   --operation DescribeConfigs --topic _schemas
 
      bin/kafka-acls --authorizer-properties zookeeper.connect=localhost:2181 --add \
                     --allow-principal 'User:<sr-principal>' --allow-host '*' \


### PR DESCRIPTION
## Description

- **Jira ticket:** https://confluentinc.atlassian.net/browse/DOCS-1094

- Added requirement for `DescribeConfigs` ACL on `_schema` topic (along with Read/Write access to the topic) to [Schema Registry docs](https://docs.confluent.io/current/schema-registry/docs/security.html#authorizing-access-to-the-schemas-topic)

## cc
@rajinisivaram

Signed-off-by: Victoria Bialas <vicky@confluent.io>