### PR TITLE
CC-4056:  Pass id/version when slave forwards register requests

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -430,7 +430,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
       } else {
         // forward registering request to the master
         if (masterIdentity != null) {
-          return forwardRegisterRequestToMaster(subject, schema.getSchema(), headerProperties);
+          return forwardRegisterRequestToMaster(subject, schema, headerProperties);
         } else {
           throw new UnknownMasterException("Register schema request failed since master is "
                                            + "unknown");
@@ -568,13 +568,15 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     }
   }
 
-  private int forwardRegisterRequestToMaster(String subject, String schemaString,
+  private int forwardRegisterRequestToMaster(String subject, Schema schema,
                                              Map<String, String> headerProperties)
       throws SchemaRegistryRequestForwardingException {
-    UrlList baseUrl = masterRestService.getBaseUrls();
+    final UrlList baseUrl = masterRestService.getBaseUrls();
 
     RegisterSchemaRequest registerSchemaRequest = new RegisterSchemaRequest();
-    registerSchemaRequest.setSchema(schemaString);
+    registerSchemaRequest.setSchema(schema.getSchema());
+    registerSchemaRequest.setVersion(schema.getVersion());
+    registerSchemaRequest.setId(schema.getId());
     log.debug(String.format("Forwarding registering schema request %s to %s",
                             registerSchemaRequest, baseUrl));
     try {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/MasterElectorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/MasterElectorTest.java
@@ -518,8 +518,8 @@ public class MasterElectorTest extends ClusterTestHarness {
     List<Integer> ids = new ArrayList<Integer>();
     Properties props = new Properties();
     props.setProperty(SchemaRegistryConfig.MODE_MUTABILITY, "true");
-    int newId = 1;
-    int newVersion = 1;
+    int newId = 100000;
+    int newVersion = 100;
 
     Set<RestApp> slaveApps = new HashSet<RestApp>();
     RestApp aSlave = null;
@@ -571,7 +571,8 @@ public class MasterElectorTest extends ClusterTestHarness {
         ids.add(aMaster.restClient.registerSchema(schema, subject, newVersion++, newId++));
       }
     } catch (RestClientException e) {
-      fail("It should be possible to register schemas when a master cluster is present.");
+      fail("It should be possible to register schemas when a master cluster is present. "
+          + "Error: " + e.getMessage());
     }
 
     // Try to register to a slave cluster node - should succeed


### PR DESCRIPTION
Pass the id and version when a slave forward register requests to the master.  Otherwise an error results for register requests that go to the slave during schema migration.