### PR TITLE
CC-4062: Fix NPE caused after _schemas topic is compacted

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
@@ -273,10 +273,7 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
   private SchemaKey getNonDeletedSchemaKey(String schema) {
     MD5 md5 = MD5.ofString(schema);
     SchemaIdAndSubjects keys = schemaHashToGuid.get(md5);
-    if (keys == null) {
-      return null;
-    }
-    return keys.findAny(key -> {
+    return keys == null ? null : keys.findAny(key -> {
       SchemaValue value = (SchemaValue) store.get(key);
       // The value returned from the store should not be null since we clean up caches
       // after tombstoning, but we still check defensively

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
@@ -267,6 +267,9 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
   private SchemaKey getNonDeletedSchemaKey(String schema) {
     MD5 md5 = MD5.ofString(schema);
     SchemaIdAndSubjects keys = schemaHashToGuid.get(md5);
+    if (keys == null) {
+      return null;
+    }
     return keys.findAny(key -> {
       SchemaValue value = (SchemaValue) store.get(key);
       // The value returned from the store should not be null since we clean up caches

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
@@ -411,4 +411,19 @@ public class KafkaStoreTest extends ClusterTestHarness {
     assertEquals("subject", newValue.getSubject());
     assertFalse(newValue.isDeleted());
   }
+
+  @Test
+  public void testReplaceDeletedWithNonDeletedAfterCompaction() throws Exception {
+    InMemoryCache<SchemaKey, SchemaValue> inMemoryStore = new InMemoryCache<>();
+
+    int id = 100;
+    SchemaKey schemaKey = new SchemaKey("subject", 1);
+    SchemaValue schemaValue = new SchemaValue("subject", 1, id, "schemaString", true);
+
+    // After a compaction, the schema will not be registered but only deleted
+    inMemoryStore.put(schemaKey, schemaValue);
+    inMemoryStore.schemaDeleted(schemaKey, schemaValue);
+
+    inMemoryStore.replaceMatchingDeletedWithNonDeletedOrRemove(s -> s.equals("subject"));
+  }
 }


### PR DESCRIPTION
When a compaction occurs, a deleted schema will not first be registered. This means that when Schema Registry is restarted, the schema is never registered with the `schemaHashToGuid` cache. This causes an NPE, which then causes the Kafka store reader thread to stop.