### PR TITLE
MINOR: Update Metadata constructor to match changes in AK

### DIFF
--- a/core/src/test/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinatorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinatorTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.clients.MockClient;
 import org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
+import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractRequest;
@@ -90,7 +91,7 @@ public class SchemaRegistryCoordinatorTest {
   @Before
   public void setup() {
     this.time = new MockTime();
-    this.metadata = new Metadata(0, Long.MAX_VALUE, true);
+    this.metadata = new Metadata(0, Long.MAX_VALUE, new LogContext(), new ClusterResourceListeners());
     this.client = new MockClient(time, new MockClient.MockMetadataUpdater() {
       @Override
       public List<Node> fetchNodes() {


### PR DESCRIPTION
Downstream builds are failing and preventing update of Confluent Kafka.