### PR TITLE
MINOR: Add request headers for Avro converter and (de-)serializer

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
@@ -61,9 +61,12 @@ public class AvroConverter implements Converter {
     AvroConverterConfig avroConverterConfig = new AvroConverterConfig(configs);
 
     if (schemaRegistry == null) {
-      schemaRegistry =
-          new CachedSchemaRegistryClient(avroConverterConfig.getSchemaRegistryUrls(),
-                                         avroConverterConfig.getMaxSchemasPerSubject(), configs);
+      schemaRegistry = new CachedSchemaRegistryClient(
+          avroConverterConfig.getSchemaRegistryUrls(),
+          avroConverterConfig.getMaxSchemasPerSubject(),
+          configs,
+          avroConverterConfig.requestHeaders()
+      );
     }
 
     serializer = new Serializer(configs, schemaRegistry);

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
@@ -50,7 +50,12 @@ public abstract class AbstractKafkaAvroSerDe {
       int maxSchemaObject = config.getMaxSchemasPerSubject();
       Map<String, Object> originals = config.originalsWithPrefix("");
       if (null == schemaRegistry) {
-        schemaRegistry = new CachedSchemaRegistryClient(urls, maxSchemaObject, originals);
+        schemaRegistry = new CachedSchemaRegistryClient(
+            urls,
+            maxSchemaObject,
+            originals,
+            config.requestHeaders()
+        );
       }
       keySubjectNameStrategy = config.keySubjectNameStrategy();
       valueSubjectNameStrategy = config.valueSubjectNameStrategy();

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
@@ -18,6 +18,8 @@ package io.confluent.kafka.serializers;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import io.confluent.common.config.AbstractConfig;
 import io.confluent.common.config.ConfigDef;
@@ -32,6 +34,15 @@ import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
  * defaults.
  */
 public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
+
+  /**
+   * Configurations beginning with this prefix can be used to specify headers to include in requests
+   * made to Schema Registry. For example, to include an {@code Authorization} header with a value
+   * of {@code Bearer NjksNDIw}, use the following configuration:
+   * 
+   * <p>{@code request.header.Authorization=Bearer NjksNDIw}
+   */
+  public static final String REQUEST_HEADER_PREFIX = "request.header.";
 
   public static final String SCHEMA_REGISTRY_URL_CONFIG = "schema.registry.url";
   public static final String
@@ -123,6 +134,11 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
 
   public Object valueSubjectNameStrategy() {
     return subjectNameStrategyInstance(VALUE_SUBJECT_NAME_STRATEGY);
+  }
+  
+  public Map<String, String> requestHeaders() {
+    return originalsWithPrefix(REQUEST_HEADER_PREFIX).entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, entry -> Objects.toString(entry.getValue())));
   }
 
   private Object subjectNameStrategyInstance(String config) {


### PR DESCRIPTION
The changes here allow request headers for underlying schema registry clients to be configured for the Avro converter, serializer, and deserializer via a `request.header.` prefix.

For example, to specify an `Authorization` header with a value of `Bearer NjksNDIw`, you would use the following configuration:
```properties
request.header.Authorization=Bearer NjksNDIw
```