### PR TITLE
CC-4091: Enable reregistration of schema with different ID

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
@@ -226,7 +226,9 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
 
     // Delete from non-store structures first as they rely on the store
     schemaHashToGuid.values().forEach(v -> v.removeIf(matchDeleted));
+    schemaHashToGuid.entrySet().removeIf(e -> e.getValue().isEmpty());
     guidToDeletedSchemaKeys.values().forEach(v -> v.removeIf(matchDeleted));
+    guidToDeletedSchemaKeys.entrySet().removeIf(e -> e.getValue().isEmpty());
 
     // Delete from store later as the previous deletions rely on the store
     store.entrySet().removeIf(e -> {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaIdAndSubjects.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaIdAndSubjects.java
@@ -53,6 +53,10 @@ public class SchemaIdAndSubjects {
     return this.id;
   }
 
+  public boolean isEmpty() {
+    return subjectsAndVersions.isEmpty();
+  }
+
   public SchemaKey findAny(Predicate<SchemaKey> filter) {
     return subjectsAndVersions.entrySet().stream()
         .map(e -> new SchemaKey(e.getKey(), e.getValue()))

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiModeTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiModeTest.java
@@ -16,6 +16,8 @@ package io.confluent.kafka.schemaregistry.rest;
 
 import org.junit.Test;
 
+import java.util.Collections;
+
 import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
 import io.confluent.kafka.schemaregistry.avro.AvroUtils;
@@ -148,5 +150,37 @@ public class RestApiModeTest extends ClusterTestHarness {
           RestConstraintViolationException.DEFAULT_ERROR_CODE,
           e.getStatus());
     }
+  }
+
+  @Test
+  public void testRegisterSchemaWithDifferentIdAfterImport() throws Exception {
+    String subject = "testSubject";
+    String mode = "READWRITE";
+
+    // set mode to read write
+    assertEquals(
+        mode,
+        restApp.restClient.setMode(mode).getMode());
+
+    int expectedIdSchema1 = 1;
+    assertEquals("Registering without id should succeed",
+        expectedIdSchema1,
+        restApp.restClient.registerSchema(SCHEMA_STRING, subject));
+
+    // delete subject so we can switch to import mode
+    restApp.restClient.deleteSubject(Collections.emptyMap(), subject);
+
+    mode = "IMPORT";
+
+    // set mode to import
+    assertEquals(
+        mode,
+        restApp.restClient.setMode(mode).getMode());
+
+    // register same schema with different id
+    expectedIdSchema1 = 2;
+    assertEquals("Registering with id should succeed",
+        expectedIdSchema1,
+        restApp.restClient.registerSchema(SCHEMA_STRING, subject, 1, expectedIdSchema1));
   }
 }


### PR DESCRIPTION
This fixes the following scenario:
1. Register a schema
2. Delete all schemas
3. Set SR to import mode
4. Register the exact same schema as in step 1, but with a different ID.