### PR TITLE
MINOR: Add info on "request.header." configuration prefix to docs

### DIFF
--- a/docs/connect.rst
+++ b/docs/connect.rst
@@ -84,3 +84,10 @@ Configuration Options
   * Type: password
   * Default: ""
   * Importance: medium
+  
+Additional headers can be specified by using a prefix of ``request.header.``. For example, to specify ``Authorization`` and ``From`` headers with respective values of ``Bearer NjksNDIw`` and ``jsmith@confluent.io``, use the following configuration:
+
+.. sourcecode:: bash
+
+    request.header.Authorization=Bearer NjksNDIw
+    request.header.From=jsmith@confluent.io


### PR DESCRIPTION
Should have been added as part of https://github.com/confluentinc/schema-registry/pull/1059 but I forgot that we still host Schema Registry docs in the repo itself as opposed to our global docs repo.