### PR TITLE
Do not return -1 from register call in Mock

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -83,14 +83,15 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
       if (schemaId == null) {
         id = id >= 0 ? id : ids.incrementAndGet();
         schemaIdCache.put(schema, id);
+        schemaId = id;
       } else if (id >= 0 && id != schemaId) {
         throw new IllegalStateException("Schema already registered with id "
             + schemaId + " instead of input id " + id);
       }
-      idSchemaMap.put(id, schema);
+      idSchemaMap.put(schemaId, schema);
       idCache.put(subject, idSchemaMap);
       generateVersion(subject, schema);
-      return id;
+      return schemaId;
     } else {
       throw new RestClientException("Schema Not Found", 404, 404001);
     }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -81,9 +81,8 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
     if (registerRequest) {
       Integer schemaId = schemaIdCache.get(schema);
       if (schemaId == null) {
-        id = id >= 0 ? id : ids.incrementAndGet();
-        schemaIdCache.put(schema, id);
-        schemaId = id;
+        schemaId = id >= 0 ? id : ids.incrementAndGet();
+        schemaIdCache.put(schema, schemaId);
       } else if (id >= 0 && id != schemaId) {
         throw new IllegalStateException("Schema already registered with id "
             + schemaId + " instead of input id " + id);


### PR DESCRIPTION
The `MockSchemaRegistryClient.register(subject, schema)` method will currently incorrectly return `-1` if the schema is already registered, rather than the id at which its registered.

This PR makes the mock return the registered id.