### PR TITLE
DOCS-1440 - Remove CP install from SR lefthand TOC

### DIFF
--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -3,13 +3,22 @@
 Installing and Configuring |sr|
 ===============================
 
-|sr| is a component of |cp| and is installed along with the |cp| bundle.
+|sr| is a component of |cp| and is :ref:`installed <installation>` along with the |cp| bundle.
+
+
+- :ref:`Install Confluent Platform (including Schema Registry) <installation>`
+- :ref:`cloud-install-schema-registry`
+- :ref:`schemaregistry_config`
+- :ref:`schema-registry-prod`
+- :ref:`schemaregistry_migrate`
 
 .. toctree::
     :maxdepth: 1
+    :hidden:
 
-    Install Confluent Platform (including Schema Registry) <../../../installation/index>
     ../../../cloud/connect/schema-reg-cloud-config
     config
     deployment
+    migrate
+
         


### PR DESCRIPTION
Removes CP installation from SR lefthand TOC. This fixes issue with multiple nested headings opening at once, when installation topics are selected.

![image](https://user-images.githubusercontent.com/11722533/55031523-0528e680-4fcc-11e9-8276-1546ec829325.png)
