### PR TITLE
Fix exception string formatting in Avro converter

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
@@ -61,7 +61,7 @@ public class AvroConverter implements Converter {
     if (schemaRegistry == null) {
       schemaRegistry =
           new CachedSchemaRegistryClient(avroConverterConfig.getSchemaRegistryUrls(),
-              avroConverterConfig.getMaxSchemasPerSubject());
+                                         avroConverterConfig.getMaxSchemasPerSubject());
     }
 
     serializer = new Serializer(schemaRegistry);

--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
@@ -61,7 +61,7 @@ public class AvroConverter implements Converter {
     if (schemaRegistry == null) {
       schemaRegistry =
           new CachedSchemaRegistryClient(avroConverterConfig.getSchemaRegistryUrls(),
-                                         avroConverterConfig.getMaxSchemasPerSubject());
+              avroConverterConfig.getMaxSchemasPerSubject());
     }
 
     serializer = new Serializer(schemaRegistry);
@@ -74,7 +74,10 @@ public class AvroConverter implements Converter {
     try {
       return serializer.serialize(topic, isKey, avroData.fromConnectData(schema, value));
     } catch (SerializationException e) {
-      throw new DataException("Failed to serialize Avro data from topic %s :".format(topic), e);
+      throw new DataException(
+          String.format("Failed to serialize Avro data from topic %s :", topic),
+          e
+      );
     }
   }
 
@@ -90,11 +93,14 @@ public class AvroConverter implements Converter {
         return avroData.toConnectData(deserialized.getSchema(), ((NonRecordContainer) deserialized)
             .getValue());
       }
-      throw new DataException("Unsupported type returned during deserialization of topic %s "
-                                  .format(topic));
+      throw new DataException(
+          String.format("Unsupported type returned during deserialization of topic %s ", topic)
+      );
     } catch (SerializationException e) {
-      throw new DataException("Failed to deserialize data for topic %s to Avro: "
-                                  .format(topic), e);
+      throw new DataException(
+          String.format("Failed to deserialize data for topic %s to Avro: ", topic),
+          e
+      );
     }
   }
 


### PR DESCRIPTION
Replaces several instances of incorrect string formatting where `String.format(...)` was used as an instance method instead of a static method.