### PR TITLE
Update SchemaRegistryCoordinator to use generated protocol classes

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinator.java
@@ -18,6 +18,7 @@ package io.confluent.kafka.schemaregistry.masterelector.kafka;
 import org.apache.kafka.clients.consumer.internals.AbstractCoordinator;
 import org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient;
 import org.apache.kafka.common.message.JoinGroupRequestData;
+import org.apache.kafka.common.message.JoinGroupResponseData;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
@@ -30,6 +31,7 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -141,15 +143,15 @@ final class SchemaRegistryCoordinator extends AbstractCoordinator implements Clo
   protected Map<String, ByteBuffer> performAssignment(
       String kafkaLeaderId, // Kafka group "leader" who does assignment, *not* the SR master
       String protocol,
-      Map<String, ByteBuffer> allMemberMetadata
+      List<JoinGroupResponseData.JoinGroupResponseMember> allMemberMetadata
   ) {
     log.debug("Performing assignment");
 
     Map<String, SchemaRegistryIdentity> memberConfigs = new HashMap<>();
-    for (Map.Entry<String, ByteBuffer> entry : allMemberMetadata.entrySet()) {
+    for (JoinGroupResponseData.JoinGroupResponseMember entry : allMemberMetadata) {
       SchemaRegistryIdentity identity
-          = SchemaRegistryProtocol.deserializeMetadata(entry.getValue());
-      memberConfigs.put(entry.getKey(), identity);
+          = SchemaRegistryProtocol.deserializeMetadata(ByteBuffer.wrap(entry.metadata()));
+      memberConfigs.put(entry.memberId(), identity);
     }
 
     log.debug("Member information: {}", memberConfigs);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinator.java
@@ -19,7 +19,6 @@ import org.apache.kafka.clients.consumer.internals.AbstractCoordinator;
 import org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient;
 import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.common.metrics.Metrics;
-import org.apache.kafka.common.requests.JoinGroupRequest;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.common.utils.Timer;
@@ -28,11 +27,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.nio.ByteBuffer;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinator.java
@@ -17,6 +17,7 @@ package io.confluent.kafka.schemaregistry.masterelector.kafka;
 
 import org.apache.kafka.clients.consumer.internals.AbstractCoordinator;
 import org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient;
+import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.requests.JoinGroupRequest;
 import org.apache.kafka.common.utils.LogContext;
@@ -27,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -119,11 +121,12 @@ final class SchemaRegistryCoordinator extends AbstractCoordinator implements Clo
   }
 
   @Override
-  public List<JoinGroupRequest.ProtocolMetadata> metadata() {
+  public JoinGroupRequestData.JoinGroupRequestProtocolSet metadata() {
     ByteBuffer metadata = SchemaRegistryProtocol.serializeMetadata(identity);
-    return Collections.singletonList(
-        new JoinGroupRequest.ProtocolMetadata(SR_SUBPROTOCOL_V0, metadata)
-    );
+    return new JoinGroupRequestData.JoinGroupRequestProtocolSet(
+            Collections.singletonList(new JoinGroupRequestData.JoinGroupRequestProtocol()
+                    .setName(SR_SUBPROTOCOL_V0)
+                    .setMetadata(metadata.array())).iterator());
   }
 
   @Override

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinatorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinatorTest.java
@@ -22,13 +22,12 @@ import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
 import org.apache.kafka.common.message.JoinGroupRequestData;
+import org.apache.kafka.common.message.JoinGroupResponseData;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractRequest;
 import org.apache.kafka.common.requests.FindCoordinatorResponse;
-import org.apache.kafka.common.requests.JoinGroupRequest.ProtocolMetadata;
 import org.apache.kafka.common.requests.JoinGroupResponse;
-import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.requests.SyncGroupRequest;
 import org.apache.kafka.common.requests.SyncGroupResponse;
 import org.apache.kafka.common.utils.LogContext;
@@ -307,14 +306,21 @@ public class SchemaRegistryCoordinatorTest {
       Map<String, SchemaRegistryIdentity> memberMasterEligibility,
       Errors error
   ) {
-    Map<String, ByteBuffer> metadata = new HashMap<>();
+    List<JoinGroupResponseData.JoinGroupResponseMember> metadata = new ArrayList<>();
     for (Map.Entry<String, SchemaRegistryIdentity> configStateEntry : memberMasterEligibility.entrySet()) {
       SchemaRegistryIdentity memberIdentity = configStateEntry.getValue();
       ByteBuffer buf = SchemaRegistryProtocol.serializeMetadata(memberIdentity);
-      metadata.put(configStateEntry.getKey(), buf);
+      metadata.add(new JoinGroupResponseData.JoinGroupResponseMember()
+          .setMemberId(configStateEntry.getKey())
+          .setMetadata(buf.array()));
     }
-    return new JoinGroupResponse(error, generationId, SchemaRegistryCoordinator
-        .SR_SUBPROTOCOL_V0, memberId, memberId, metadata);
+    return new JoinGroupResponse(new JoinGroupResponseData()
+            .setErrorCode(error.code())
+            .setGenerationId(generationId)
+            .setProtocolName(SchemaRegistryCoordinator.SR_SUBPROTOCOL_V0)
+            .setMemberId(memberId)
+            .setLeader(memberId)
+            .setMembers(metadata));
   }
 
   private JoinGroupResponse joinGroupFollowerResponse(
@@ -323,13 +329,13 @@ public class SchemaRegistryCoordinatorTest {
       String leaderId,
       Errors error
   ) {
-    return new JoinGroupResponse(
-        error,
-        generationId,
-        SchemaRegistryCoordinator.SR_SUBPROTOCOL_V0,
-        memberId,
-        leaderId,
-        Collections.<String, ByteBuffer>emptyMap()
+    return new JoinGroupResponse(new JoinGroupResponseData()
+        .setErrorCode(error.code())
+        .setGenerationId(generationId)
+        .setProtocolName(SchemaRegistryCoordinator.SR_SUBPROTOCOL_V0)
+        .setMemberId(memberId)
+        .setLeader(leaderId)
+        .setMembers(Collections.emptyList())
     );
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinatorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinatorTest.java
@@ -21,6 +21,7 @@ import org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient;
 import org.apache.kafka.common.Cluster;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.internals.ClusterResourceListeners;
+import org.apache.kafka.common.message.JoinGroupRequestData;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.protocol.Errors;
 import org.apache.kafka.common.requests.AbstractRequest;
@@ -140,13 +141,13 @@ public class SchemaRegistryCoordinatorTest {
 
   @Test
   public void testMetadata() {
-    List<ProtocolMetadata> serialized = coordinator.metadata();
+    JoinGroupRequestData.JoinGroupRequestProtocolSet serialized = coordinator.metadata();
     assertEquals(1, serialized.size());
 
-    ProtocolMetadata defaultMetadata = serialized.get(0);
+    JoinGroupRequestData.JoinGroupRequestProtocol defaultMetadata = serialized.iterator().next();
     assertEquals(SchemaRegistryCoordinator.SR_SUBPROTOCOL_V0, defaultMetadata.name());
     SchemaRegistryIdentity state
-        = SchemaRegistryProtocol.deserializeMetadata(defaultMetadata.metadata());
+        = SchemaRegistryProtocol.deserializeMetadata(ByteBuffer.wrap(defaultMetadata.metadata()));
     assertEquals(LEADER_INFO, state);
   }
 


### PR DESCRIPTION
This patch updates SchemaRegistryCoordinator to consume this change made to the AbstractCoordinator interface in Apache Kafka: https://github.com/apache/kafka/commit/8406f3624d8f99b614eb7171b71fae8b0e663dcb