### PR TITLE
Fixed https://github.com/confluentinc/kafka-connect-hdfs/issues/280

### DIFF
--- a/avro-converter/src/test/avro/Date.avsc
+++ b/avro-converter/src/test/avro/Date.avsc
@@ -1,0 +1,6 @@
+{
+  "type": "int",
+  "connect.name": "org.apache.kafka.connect.data.Date",
+  "connect.version": 1,
+  "logicalType": "date"
+}

--- a/avro-converter/src/test/avro/Decimal.avsc
+++ b/avro-converter/src/test/avro/Decimal.avsc
@@ -1,0 +1,12 @@
+{
+  "type": "bytes",
+  "scale": 2,
+  "precision": 64,
+  "connect.version": 1,
+  "connect.parameters": {
+    "scale": "2",
+    "connect.decimal.precision": "64"
+  },
+  "connect.name": "org.apache.kafka.connect.data.Decimal",
+  "logicalType": "decimal"
+}

--- a/avro-converter/src/test/avro/Time.avsc
+++ b/avro-converter/src/test/avro/Time.avsc
@@ -1,0 +1,6 @@
+{
+  "type": "int",
+  "connect.name": "org.apache.kafka.connect.data.Time",
+  "connect.version": 1,
+  "logicalType": "time-millis"
+}

--- a/avro-converter/src/test/avro/Timestamp.avsc
+++ b/avro-converter/src/test/avro/Timestamp.avsc
@@ -1,0 +1,6 @@
+{
+  "type": "long",
+  "connect.name": "org.apache.kafka.connect.data.Timestamp",
+  "connect.version": 1,
+  "logicalType": "timestamp-millis"
+}


### PR DESCRIPTION
This is a quick fix to a very subtle problem when using Kafka Connect Hdfs Parquet Sink with Schema Registry in order to convert avro logical types to parquet ones correctly. The proposed solution is temporary and eventually should be replaced with a robust one. However its development might be time consuming as the problem spans across multiple projects and it would be nice to have Parquet Sink working in the near future. 

Currently we are not able to decode Kafka Connect parquet output in case we are dealing with logical types as the info about logical types is wiped off.

parquet-mr/parquet-avro requires org.apache.avro.Schema object to have logicalType field set as it is used for proper parquet encoding. Then in the codebase of Schema Registry, we convert logical types programmatically putting info about logical types into props whereas logicalType field is expected to be assigned. We cannot assign programmatically logicalType field during conversion as its access modifier is 'default'. That's why I re-parse the schema immediately after logical type prop is put - parser method is the only place where logicalType field of org.apache.avro.Schema class is assigned.