### PR TITLE
Add new constructor arg to `SchemaRegistryCoordinator` to fix the build

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinator.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafka.schemaregistry.masterelector.kafka;
 
+import java.util.Optional;
 import org.apache.kafka.clients.consumer.internals.AbstractCoordinator;
 import org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient;
 import org.apache.kafka.common.message.JoinGroupRequestData;
@@ -69,6 +70,7 @@ final class SchemaRegistryCoordinator extends AbstractCoordinator implements Clo
     super(logContext,
           client,
           groupId,
+          Optional.empty(),
           rebalanceTimeoutMs,
           sessionTimeoutMs,
           heartbeatIntervalMs,


### PR DESCRIPTION
Fix the SR build by adding the required new constructor arg, (Added upstream to Kafka).