### PR TITLE
CC-4100: Forward whitelisted headers to master.

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -168,8 +168,8 @@ public class SchemaRegistryConfig extends RestConfig {
       "schema.registry.inter.instance.protocol";
   public static final String INTER_INSTANCE_PROTOCOL_CONFIG =
       "inter.instance.protocol";
-  private static final String SCHEMAREGISTRY_HEADERS_FORWARD_CONFIG =
-      "schema.registry.headers.forward";
+  private static final String INTER_INSTANCE_HEADERS_WHITELIST_CONFIG =
+      "inter.instance.headers.whitelist";
 
   protected static final String SCHEMAREGISTRY_GROUP_ID_DOC =
       "Use this setting to override the group.id for the Kafka group used when Kafka is used for "
@@ -316,9 +316,9 @@ public class SchemaRegistryConfig extends RestConfig {
       + "`ssl.truststore.` configs are used while making the call. The "
       + "schema.registry.inter.instance.protocol name is deprecated; prefer using "
       + "inter.instance.protocol instead.";
-  private static final String SCHEMAREGISTRY_HEADERS_FORWARD_DOC
-      = "A list of `http` headers to forward from slave to master, "
-      + "in addition to `Content-Type`, `Accept`, `Authorization`.";
+  private static final String INTER_INSTANCE_HEADERS_WHITELIST_DOC
+      = "A list of ``http`` headers to forward from slave to master, "
+      + "in addition to ``Content-Type``, ``Accept``, ``Authorization``.";
 
   private static final boolean ZOOKEEPER_SET_ACL_DEFAULT = false;
   private static final String COMPATIBILITY_DEFAULT = "backward";
@@ -363,8 +363,8 @@ public class SchemaRegistryConfig extends RestConfig {
     .define(SCHEMAREGISTRY_GROUP_ID_CONFIG, ConfigDef.Type.STRING, "schema-registry",
             ConfigDef.Importance.MEDIUM, SCHEMAREGISTRY_GROUP_ID_DOC
     )
-    .define(SCHEMAREGISTRY_HEADERS_FORWARD_CONFIG, ConfigDef.Type.LIST, "",
-        ConfigDef.Importance.LOW, SCHEMAREGISTRY_HEADERS_FORWARD_DOC)
+    .define(INTER_INSTANCE_HEADERS_WHITELIST_CONFIG, ConfigDef.Type.LIST, "",
+        ConfigDef.Importance.LOW, INTER_INSTANCE_HEADERS_WHITELIST_DOC)
     .define(KAFKASTORE_ZK_SESSION_TIMEOUT_MS_CONFIG, ConfigDef.Type.INT, 30000, atLeast(0),
             ConfigDef.Importance.LOW, KAFKASTORE_ZK_SESSION_TIMEOUT_MS_DOC
     )
@@ -705,8 +705,8 @@ public class SchemaRegistryConfig extends RestConfig {
     return zkUtils;
   }
 
-  public List<String> headersForward() {
-    return getList(SCHEMAREGISTRY_HEADERS_FORWARD_CONFIG);
+  public List<String> whitelistHeaders() {
+    return getList(INTER_INSTANCE_HEADERS_WHITELIST_CONFIG);
   }
 
   public static void main(String[] args) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -168,6 +168,8 @@ public class SchemaRegistryConfig extends RestConfig {
       "schema.registry.inter.instance.protocol";
   public static final String INTER_INSTANCE_PROTOCOL_CONFIG =
       "inter.instance.protocol";
+  private static final String SCHEMAREGISTRY_HEADERS_FORWARD_CONFIG =
+      "schema.registry.headers.forward";
 
   protected static final String SCHEMAREGISTRY_GROUP_ID_DOC =
       "Use this setting to override the group.id for the Kafka group used when Kafka is used for "
@@ -314,6 +316,9 @@ public class SchemaRegistryConfig extends RestConfig {
       + "`ssl.truststore.` configs are used while making the call. The "
       + "schema.registry.inter.instance.protocol name is deprecated; prefer using "
       + "inter.instance.protocol instead.";
+  private static final String SCHEMAREGISTRY_HEADERS_FORWARD_DOC
+      = "A list of `http` headers to forward from slave to master, "
+      + "in addition to `Content-Type`, `Accept`, `Authorization`.";
 
   private static final boolean ZOOKEEPER_SET_ACL_DEFAULT = false;
   private static final String COMPATIBILITY_DEFAULT = "backward";
@@ -358,6 +363,8 @@ public class SchemaRegistryConfig extends RestConfig {
     .define(SCHEMAREGISTRY_GROUP_ID_CONFIG, ConfigDef.Type.STRING, "schema-registry",
             ConfigDef.Importance.MEDIUM, SCHEMAREGISTRY_GROUP_ID_DOC
     )
+    .define(SCHEMAREGISTRY_HEADERS_FORWARD_CONFIG, ConfigDef.Type.LIST, "",
+        ConfigDef.Importance.LOW, SCHEMAREGISTRY_HEADERS_FORWARD_DOC)
     .define(KAFKASTORE_ZK_SESSION_TIMEOUT_MS_CONFIG, ConfigDef.Type.INT, 30000, atLeast(0),
             ConfigDef.Importance.LOW, KAFKASTORE_ZK_SESSION_TIMEOUT_MS_DOC
     )
@@ -696,6 +703,10 @@ public class SchemaRegistryConfig extends RestConfig {
       );
     }
     return zkUtils;
+  }
+
+  public List<String> headersForward() {
+    return getList(SCHEMAREGISTRY_HEADERS_FORWARD_CONFIG);
   }
 
   public static void main(String[] args) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
@@ -89,12 +89,12 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
             SchemaRegistryResourceExtension.class);
 
     config.register(RootResource.class);
-    config.register(new ConfigResource(schemaRegistry, schemaRegistryConfig));
-    config.register(new SubjectsResource(schemaRegistry, schemaRegistryConfig));
+    config.register(new ConfigResource(schemaRegistry));
+    config.register(new SubjectsResource(schemaRegistry));
     config.register(new SchemasResource(schemaRegistry));
-    config.register(new SubjectVersionsResource(schemaRegistry, schemaRegistryConfig));
+    config.register(new SubjectVersionsResource(schemaRegistry));
     config.register(new CompatibilityResource(schemaRegistry));
-    config.register(new ModeResource(schemaRegistry, schemaRegistryConfig));
+    config.register(new ModeResource(schemaRegistry));
 
     if (schemaRegistryResourceExtensions != null) {
       try {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
@@ -89,12 +89,12 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
             SchemaRegistryResourceExtension.class);
 
     config.register(RootResource.class);
-    config.register(new ConfigResource(schemaRegistry));
-    config.register(new SubjectsResource(schemaRegistry));
+    config.register(new ConfigResource(schemaRegistry, schemaRegistryConfig));
+    config.register(new SubjectsResource(schemaRegistry, schemaRegistryConfig));
     config.register(new SchemasResource(schemaRegistry));
-    config.register(new SubjectVersionsResource(schemaRegistry));
+    config.register(new SubjectVersionsResource(schemaRegistry, schemaRegistryConfig));
     config.register(new CompatibilityResource(schemaRegistry));
-    config.register(new ModeResource(schemaRegistry));
+    config.register(new ModeResource(schemaRegistry, schemaRegistryConfig));
 
     if (schemaRegistryResourceExtensions != null) {
       try {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -84,9 +84,6 @@ public class ConfigResource {
       throw new RestInvalidCompatibilityException();
     }
     try {
-      if (schemaRegistry.config() == null) {
-        throw Errors.schemaRegistryException("Schema registry configuration is null", null);
-      }
       Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
           headers, schemaRegistry.config().whitelistHeaders());
       schemaRegistry.updateConfigOrForward(subject, compatibilityLevel, headerProperties);
@@ -139,9 +136,6 @@ public class ConfigResource {
       throw new RestInvalidCompatibilityException();
     }
     try {
-      if (schemaRegistry.config() == null) {
-        throw Errors.schemaRegistryException("Schema registry configuration is null", null);
-      }
       Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
           headers, schemaRegistry.config().whitelistHeaders());
       schemaRegistry.updateConfigOrForward(null, compatibilityLevel, headerProperties);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -40,6 +40,7 @@ import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryRequestForwardingException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException;
 import io.confluent.kafka.schemaregistry.exceptions.UnknownMasterException;
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidCompatibilityException;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
@@ -57,9 +58,12 @@ public class ConfigResource {
   private final KafkaSchemaRegistry schemaRegistry;
 
   private final RequestHeaderBuilder requestHeaderBuilder = new RequestHeaderBuilder();
+  private final SchemaRegistryConfig config;
 
-  public ConfigResource(KafkaSchemaRegistry schemaRegistry) {
+  public ConfigResource(KafkaSchemaRegistry schemaRegistry,
+      SchemaRegistryConfig schemaRegistryConfig) {
     this.schemaRegistry = schemaRegistry;
+    this.config = schemaRegistryConfig;
   }
 
   @Path("/{subject}")
@@ -84,7 +88,10 @@ public class ConfigResource {
       throw new RestInvalidCompatibilityException();
     }
     try {
-      Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(headers);
+      Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
+          headers,
+          config
+      );
       schemaRegistry.updateConfigOrForward(subject, compatibilityLevel, headerProperties);
     } catch (OperationNotPermittedException e) {
       throw Errors.operationNotPermittedException(e.getMessage());
@@ -135,7 +142,8 @@ public class ConfigResource {
       throw new RestInvalidCompatibilityException();
     }
     try {
-      Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(headers);
+      Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(headers,
+          config);
       schemaRegistry.updateConfigOrForward(null, compatibilityLevel, headerProperties);
     } catch (OperationNotPermittedException e) {
       throw Errors.operationNotPermittedException(e.getMessage());

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -88,9 +88,7 @@ public class ConfigResource {
         throw Errors.schemaRegistryException("Schema registry configuration is null", null);
       }
       Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
-          headers,
-          schemaRegistry.config().whitelistHeaders()
-      );
+          headers, schemaRegistry.config().whitelistHeaders());
       schemaRegistry.updateConfigOrForward(subject, compatibilityLevel, headerProperties);
     } catch (OperationNotPermittedException e) {
       throw Errors.operationNotPermittedException(e.getMessage());
@@ -144,8 +142,8 @@ public class ConfigResource {
       if (schemaRegistry.config() == null) {
         throw Errors.schemaRegistryException("Schema registry configuration is null", null);
       }
-      Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(headers,
-          schemaRegistry.config().whitelistHeaders());
+      Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
+          headers, schemaRegistry.config().whitelistHeaders());
       schemaRegistry.updateConfigOrForward(null, compatibilityLevel, headerProperties);
     } catch (OperationNotPermittedException e) {
       throw Errors.operationNotPermittedException(e.getMessage());

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
@@ -38,6 +38,7 @@ import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryRequestForwardingException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException;
 import io.confluent.kafka.schemaregistry.exceptions.UnknownMasterException;
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidModeException;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
@@ -56,9 +57,12 @@ public class ModeResource {
   private final KafkaSchemaRegistry schemaRegistry;
 
   private final RequestHeaderBuilder requestHeaderBuilder = new RequestHeaderBuilder();
+  private final SchemaRegistryConfig config;
 
-  public ModeResource(KafkaSchemaRegistry schemaRegistry) {
+  public ModeResource(KafkaSchemaRegistry schemaRegistry,
+      SchemaRegistryConfig config) {
     this.schemaRegistry = schemaRegistry;
+    this.config = config;
   }
 
   @Path("/{subject}")
@@ -75,7 +79,10 @@ public class ModeResource {
       throw new RestInvalidModeException();
     }
     try {
-      Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(headers);
+      Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
+          headers,
+          config
+      );
       schemaRegistry.setModeOrForward(subject, mode, headerProperties);
     } catch (OperationNotPermittedException e) {
       throw Errors.operationNotPermittedException(e.getMessage());

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
@@ -79,9 +79,7 @@ public class ModeResource {
         throw Errors.schemaRegistryException("Schema registry configuration is null", null);
       }
       Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
-          headers,
-          schemaRegistry.config().whitelistHeaders()
-      );
+          headers, schemaRegistry.config().whitelistHeaders());
       schemaRegistry.setModeOrForward(subject, mode, headerProperties);
     } catch (OperationNotPermittedException e) {
       throw Errors.operationNotPermittedException(e.getMessage());

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
@@ -75,9 +75,6 @@ public class ModeResource {
       throw new RestInvalidModeException();
     }
     try {
-      if (schemaRegistry.config() == null) {
-        throw Errors.schemaRegistryException("Schema registry configuration is null", null);
-      }
       Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
           headers, schemaRegistry.config().whitelistHeaders());
       schemaRegistry.setModeOrForward(subject, mode, headerProperties);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/RequestHeaderBuilder.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/RequestHeaderBuilder.java
@@ -19,28 +19,30 @@ import org.eclipse.jetty.util.StringUtil;
 
 import javax.ws.rs.core.HttpHeaders;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-
-import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 
 public class RequestHeaderBuilder {
 
   public Map<String, String> buildRequestHeaders(
       HttpHeaders httpHeaders,
-      SchemaRegistryConfig config
+      List<String> whitelistedHeaders
   ) {
     Map<String, String> headerProperties = new HashMap<>();
     addStaticHeaders(headerProperties, httpHeaders);
-    addWhitelistedHeaders(headerProperties, httpHeaders, config);
+    addWhitelistedHeaders(headerProperties, httpHeaders, whitelistedHeaders);
     return headerProperties;
   }
 
   private void addWhitelistedHeaders(
       Map<String, String> headerProperties,
       HttpHeaders httpHeaders,
-      SchemaRegistryConfig config
+      List<String> whitelistedHeaders
   ) {
-    config.headersForward()
+    if (whitelistedHeaders == null) {
+      return;
+    }
+    whitelistedHeaders
         .stream()
         .forEach(headerToForward -> addIfNotEmpty(httpHeaders, headerProperties, headerToForward));
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/RequestHeaderBuilder.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/RequestHeaderBuilder.java
@@ -17,19 +17,38 @@ package io.confluent.kafka.schemaregistry.rest.resources;
 
 import org.eclipse.jetty.util.StringUtil;
 
+import javax.ws.rs.core.HttpHeaders;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.ws.rs.core.HttpHeaders;
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 
 public class RequestHeaderBuilder {
 
-  public Map<String, String> buildRequestHeaders(HttpHeaders httpHeaders) {
+  public Map<String, String> buildRequestHeaders(
+      HttpHeaders httpHeaders,
+      SchemaRegistryConfig config
+  ) {
     Map<String, String> headerProperties = new HashMap<>();
+    addStaticHeaders(headerProperties, httpHeaders);
+    addWhitelistedHeaders(headerProperties, httpHeaders, config);
+    return headerProperties;
+  }
+
+  private void addWhitelistedHeaders(
+      Map<String, String> headerProperties,
+      HttpHeaders httpHeaders,
+      SchemaRegistryConfig config
+  ) {
+    config.headersForward()
+        .stream()
+        .forEach(headerToForward -> addIfNotEmpty(httpHeaders, headerProperties, headerToForward));
+  }
+
+  private void addStaticHeaders(Map<String, String> headerProperties, HttpHeaders httpHeaders) {
     addIfNotEmpty(httpHeaders, headerProperties, "Content-Type");
     addIfNotEmpty(httpHeaders, headerProperties, "Accept");
     addIfNotEmpty(httpHeaders, headerProperties, "Authorization");
-    return headerProperties;
   }
 
   private void addIfNotEmpty(

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/RequestHeaderBuilder.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/RequestHeaderBuilder.java
@@ -39,12 +39,12 @@ public class RequestHeaderBuilder {
       HttpHeaders httpHeaders,
       List<String> whitelistedHeaders
   ) {
-    if (whitelistedHeaders == null) {
-      return;
+    if (whitelistedHeaders != null) {
+      whitelistedHeaders
+          .stream()
+          .forEach(
+              headerToForward -> addIfNotEmpty(httpHeaders, headerProperties, headerToForward));
     }
-    whitelistedHeaders
-        .stream()
-        .forEach(headerToForward -> addIfNotEmpty(httpHeaders, headerProperties, headerToForward));
   }
 
   private void addStaticHeaders(Map<String, String> headerProperties, HttpHeaders httpHeaders) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -155,10 +155,6 @@ public class SubjectVersionsResource {
                        @PathParam("subject") String subjectName,
                        @NotNull RegisterSchemaRequest request) {
 
-    if (schemaRegistry.config() == null) {
-      throw Errors.schemaRegistryException("Schema registry configuration is null", null);
-    }
-
     Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
         headers, schemaRegistry.config().whitelistHeaders());
 
@@ -228,9 +224,6 @@ public class SubjectVersionsResource {
       throw Errors.schemaRegistryException(errorMessage, e);
     }
     try {
-      if (schemaRegistry.config() == null) {
-        throw Errors.schemaRegistryException("Schema registry configuration is null", null);
-      }
       Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
           headers, schemaRegistry.config().whitelistHeaders());
       schemaRegistry.deleteSchemaVersionOrForward(headerProperties, subject, schema);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -160,9 +160,7 @@ public class SubjectVersionsResource {
     }
 
     Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
-        headers,
-        schemaRegistry.config().whitelistHeaders()
-    );
+        headers, schemaRegistry.config().whitelistHeaders());
 
     Schema schema = new Schema(
         subjectName,
@@ -234,9 +232,7 @@ public class SubjectVersionsResource {
         throw Errors.schemaRegistryException("Schema registry configuration is null", null);
       }
       Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
-          headers,
-          schemaRegistry.config().whitelistHeaders()
-      );
+          headers, schemaRegistry.config().whitelistHeaders());
       schemaRegistry.deleteSchemaVersionOrForward(headerProperties, subject, schema);
     } catch (SchemaRegistryTimeoutException e) {
       throw Errors.operationTimeoutException("Delete Schema Version operation timed out", e);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -49,6 +49,7 @@ import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryRequestForward
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryTimeoutException;
 import io.confluent.kafka.schemaregistry.exceptions.UnknownMasterException;
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.rest.VersionId;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
@@ -68,9 +69,11 @@ public class SubjectVersionsResource {
   private final KafkaSchemaRegistry schemaRegistry;
 
   private final RequestHeaderBuilder requestHeaderBuilder = new RequestHeaderBuilder();
+  private final SchemaRegistryConfig config;
 
-  public SubjectVersionsResource(KafkaSchemaRegistry registry) {
+  public SubjectVersionsResource(KafkaSchemaRegistry registry, SchemaRegistryConfig config) {
     this.schemaRegistry = registry;
+    this.config = config;
   }
 
   @GET
@@ -155,7 +158,10 @@ public class SubjectVersionsResource {
                        @PathParam("subject") String subjectName,
                        @NotNull RegisterSchemaRequest request) {
 
-    Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(headers);
+    Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
+        headers,
+        config
+    );
 
     Schema schema = new Schema(
         subjectName,
@@ -223,7 +229,8 @@ public class SubjectVersionsResource {
       throw Errors.schemaRegistryException(errorMessage, e);
     }
     try {
-      Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(headers);
+      Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(headers,
+          config);
       schemaRegistry.deleteSchemaVersionOrForward(headerProperties, subject, schema);
     } catch (SchemaRegistryTimeoutException e) {
       throw Errors.operationTimeoutException("Delete Schema Version operation timed out", e);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -119,8 +119,8 @@ public class SubjectsResource {
       if (schemaRegistry.config() == null) {
         throw Errors.schemaRegistryException("Schema registry configuration is null", null);
       }
-      Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(headers,
-          schemaRegistry.config().whitelistHeaders());
+      Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
+          headers, schemaRegistry.config().whitelistHeaders());
       deletedVersions = schemaRegistry.deleteSubjectOrForward(headerProperties, subject);
     } catch (SchemaRegistryException e) {
       throw Errors.schemaRegistryException("Error while deleting the subject " + subject,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -116,9 +116,6 @@ public class SubjectsResource {
       if (!schemaRegistry.listSubjects().contains(subject)) {
         throw Errors.subjectNotFoundException();
       }
-      if (schemaRegistry.config() == null) {
-        throw Errors.schemaRegistryException("Schema registry configuration is null", null);
-      }
       Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
           headers, schemaRegistry.config().whitelistHeaders());
       deletedVersions = schemaRegistry.deleteSubjectOrForward(headerProperties, subject);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -42,6 +42,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException;
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
 import io.confluent.rest.annotations.PerformanceMetric;
@@ -58,9 +59,12 @@ public class SubjectsResource {
   private static final Logger log = LoggerFactory.getLogger(SubjectsResource.class);
   private final KafkaSchemaRegistry schemaRegistry;
   private final RequestHeaderBuilder requestHeaderBuilder = new RequestHeaderBuilder();
+  private final SchemaRegistryConfig config;
 
-  public SubjectsResource(KafkaSchemaRegistry schemaRegistry) {
+  public SubjectsResource(KafkaSchemaRegistry schemaRegistry,
+      SchemaRegistryConfig config) {
     this.schemaRegistry = schemaRegistry;
+    this.config = config;
   }
 
   @POST
@@ -116,7 +120,8 @@ public class SubjectsResource {
       if (!schemaRegistry.listSubjects().contains(subject)) {
         throw Errors.subjectNotFoundException();
       }
-      Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(headers);
+      Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(headers,
+          config);
       deletedVersions = schemaRegistry.deleteSubjectOrForward(headerProperties, subject);
     } catch (SchemaRegistryException e) {
       throw Errors.schemaRegistryException("Error while deleting the subject " + subject,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -470,7 +470,6 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     }
   }
 
-
   public void deleteSchemaVersionOrForward(
       Map<String, String> headerProperties, String subject,
       Schema schema) throws SchemaRegistryException {
@@ -1007,6 +1006,11 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
           "Error while retrieving schema from the backend Kafka"
           + " store", e);
     }
+  }
+
+  @Override
+  public SchemaRegistryConfig config() {
+    return config;
   }
 
   public static class SchemeAndPort {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -113,6 +113,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
   public KafkaSchemaRegistry(SchemaRegistryConfig config,
                              Serializer<SchemaRegistryKey, SchemaRegistryValue> serializer)
       throws SchemaRegistryException {
+    if (config == null) {
+      throw new SchemaRegistryException("Schema registry configuration is null");
+    }
     this.config = config;
     String host = config.getString(SchemaRegistryConfig.HOST_NAME_CONFIG);
     SchemeAndPort schemeAndPort = getSchemeAndPortForIdentity(

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 
 public interface SchemaRegistry {
 
@@ -57,4 +58,6 @@ public interface SchemaRegistry {
   void close();
 
   void deleteSchemaVersion(String subject, Schema schema) throws SchemaRegistryException;
+
+  SchemaRegistryConfig config();
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RequestHeaderBuilderTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RequestHeaderBuilderTest.java
@@ -40,7 +40,8 @@ public class RequestHeaderBuilderTest {
     ));
 
     RequestHeaderBuilder requestHeaderBuilder = new RequestHeaderBuilder();
-    Map<String, String> requestProps = requestHeaderBuilder.buildRequestHeaders(httpHeaders, Collections.EMPTY_LIST);
+    Map<String, String> requestProps = requestHeaderBuilder.buildRequestHeaders(
+        httpHeaders, Collections.EMPTY_LIST);
     Assert.assertNotNull(requestProps);
     Assert.assertEquals("application/json", requestProps.get("Content-Type"));
     Assert.assertEquals("application/json", requestProps.get("Accept"));
@@ -64,7 +65,8 @@ public class RequestHeaderBuilderTest {
     ));
 
     RequestHeaderBuilder requestHeaderBuilder = new RequestHeaderBuilder();
-    Map<String, String> requestProps = requestHeaderBuilder.buildRequestHeaders(httpHeaders, Collections.EMPTY_LIST);
+    Map<String, String> requestProps = requestHeaderBuilder.buildRequestHeaders(
+        httpHeaders, Collections.EMPTY_LIST);
     Assert.assertNotNull(requestProps);
     Assert.assertEquals("application/json", requestProps.get("Content-Type"));
     Assert.assertEquals("application/json", requestProps.get("Accept"));
@@ -79,7 +81,8 @@ public class RequestHeaderBuilderTest {
         "Authorization", ""));
 
     RequestHeaderBuilder requestHeaderBuilder = new RequestHeaderBuilder();
-    Map<String, String> requestProps = requestHeaderBuilder.buildRequestHeaders(httpHeaders, Collections.EMPTY_LIST);
+    Map<String, String> requestProps = requestHeaderBuilder.buildRequestHeaders(
+        httpHeaders, Collections.EMPTY_LIST);
     Assert.assertNotNull(requestProps);
     Assert.assertEquals("application/json", requestProps.get("Content-Type"));
     Assert.assertEquals("application/json", requestProps.get("Accept"));
@@ -97,9 +100,7 @@ public class RequestHeaderBuilderTest {
 
     RequestHeaderBuilder requestHeaderBuilder = new RequestHeaderBuilder();
     Map<String, String> requestProps = requestHeaderBuilder.buildRequestHeaders(
-        httpHeaders,
-        Collections.singletonList("target-sr-cluster")
-    );
+        httpHeaders, Collections.singletonList("target-sr-cluster"));
     Assert.assertNotNull(requestProps);
     Assert.assertEquals("sr-xyz", requestProps.get("target-sr-cluster"));
     Assert.assertNull(requestProps.get("some-other-header"));
@@ -119,9 +120,7 @@ public class RequestHeaderBuilderTest {
 
     RequestHeaderBuilder requestHeaderBuilder = new RequestHeaderBuilder();
     Map<String, String> requestProps = requestHeaderBuilder.buildRequestHeaders(
-        httpHeaders,
-        headersForward
-    );
+        httpHeaders, headersForward);
     Assert.assertNotNull(requestProps);
     Assert.assertEquals("sr-xyz", requestProps.get("target-sr-cluster"));
     Assert.assertEquals("abc", requestProps.get("some-other-header"));
@@ -138,7 +137,8 @@ public class RequestHeaderBuilderTest {
     ));
 
     RequestHeaderBuilder requestHeaderBuilder = new RequestHeaderBuilder();
-    Map<String, String> requestProps = requestHeaderBuilder.buildRequestHeaders(httpHeaders, Collections.EMPTY_LIST);
+    Map<String, String> requestProps = requestHeaderBuilder.buildRequestHeaders(
+        httpHeaders, Collections.EMPTY_LIST);
     Assert.assertNotNull(requestProps);
     Assert.assertNull(requestProps.get("target-sr-cluster"));
     Assert.assertNull(requestProps.get("some-other-header"));
@@ -155,7 +155,8 @@ public class RequestHeaderBuilderTest {
     ));
 
     RequestHeaderBuilder requestHeaderBuilder = new RequestHeaderBuilder();
-    Map<String, String> requestProps = requestHeaderBuilder.buildRequestHeaders(httpHeaders, null);
+    Map<String, String> requestProps = requestHeaderBuilder.buildRequestHeaders(
+        httpHeaders, null);
     Assert.assertNotNull(requestProps);
     Assert.assertEquals("application/json", requestProps.get("Content-Type"));
     Assert.assertEquals("application/json", requestProps.get("Accept"));


### PR DESCRIPTION
This PR adds a new config, `schema.registry.headers.forward`.
When slave SR forwards request to master SR, all headers, defined in the config, will be forwarded along with headers, that are always being forwarded: `Content-Type`, `Accept`, `Authorization`.