### PR TITLE
don't tombstone while kafka store is being initialized

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -387,6 +387,10 @@ public class KafkaStore<K, V> implements Store<K, V> {
     }
   }
 
+  public boolean initialized() {
+    return initialized.get();
+  }
+
   /**
    * For testing.
    */

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -145,7 +145,7 @@ public class KafkaStoreMessageHandler
   }
 
   private void tombstoneSchemaKey(SchemaKey schemaKey) {
-    if(schemaRegistry.getKafkaStore().initialized()) {
+    if (schemaRegistry.getKafkaStore().initialized()) {
       tombstoneExecutor.execute(() -> {
             try {
               schemaRegistry.getKafkaStore().waitForInit();

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -145,18 +145,20 @@ public class KafkaStoreMessageHandler
   }
 
   private void tombstoneSchemaKey(SchemaKey schemaKey) {
-    tombstoneExecutor.execute(() -> {
-          try {
-            schemaRegistry.getKafkaStore().waitForInit();
-            schemaRegistry.getKafkaStore().delete(schemaKey);
-            lookupCache.schemaTombstoned(schemaKey);
-            log.debug("Tombstoned {}", schemaKey);
-          } catch (InterruptedException e) {
-            log.error("Interrupted while waiting for the tombstone thread to be initialized ", e);
-          } catch (StoreException e) {
-            log.error("Failed to tombstone {}", schemaKey, e);
+    if(schemaRegistry.getKafkaStore().initialized()) {
+      tombstoneExecutor.execute(() -> {
+            try {
+              schemaRegistry.getKafkaStore().waitForInit();
+              schemaRegistry.getKafkaStore().delete(schemaKey);
+              lookupCache.schemaTombstoned(schemaKey);
+              log.debug("Tombstoned {}", schemaKey);
+            } catch (InterruptedException e) {
+              log.error("Interrupted while waiting for the tombstone thread to be initialized ", e);
+            } catch (StoreException e) {
+              log.error("Failed to tombstone {}", schemaKey, e);
+            }
           }
-        }
-    );
+      );
+    }
   }
 }


### PR DESCRIPTION
Currently, we tombstone deleted keys whenever we encounter a deleted schema object in the same subject. During startup, this could potentially lead to OOM errors as with each attempt we could end up adding the same tasks over and over again to the executor. Since tombstone is best effort, we could do it at the next event rather than queuing them during init.