### PR TITLE
Support reflection-based avro serialization

### DIFF
--- a/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/ConfigurationUtils.java
+++ b/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/ConfigurationUtils.java
@@ -40,4 +40,17 @@ class ConfigurationUtils {
     return specificAvroEnabledConfig;
   }
 
+  /**
+   * Enables the use of Avro Reflection.
+   *
+   * @param config the serializer/deserializer/serde configuration
+   * @return a copy of the configuration where the use of Avro Reflection is enabled
+   */
+  public static Map<String, Object> withReflectionAvroEnabled(final Map<String, ?> config) {
+    Map<String, Object> reflectionAvroEnabledConfig =
+            config == null ? new HashMap<String, Object>() : new HashMap<>(config);
+    reflectionAvroEnabledConfig.put(KafkaAvroDeserializerConfig.SCHEMA_REFLECTION_CONFIG, true);
+    return reflectionAvroEnabledConfig;
+  }
+
 }

--- a/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/ReflectionAvroDeserializer.java
+++ b/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/ReflectionAvroDeserializer.java
@@ -18,8 +18,8 @@ package io.confluent.kafka.streams.serdes.avro;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
-import java.lang.reflect.Type;
 import java.util.Map;
+import org.apache.avro.Schema;
 import org.apache.avro.reflect.ReflectData;
 import org.apache.kafka.common.annotation.InterfaceStability;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -38,10 +38,10 @@ import org.apache.kafka.common.serialization.Deserializer;
 public class ReflectionAvroDeserializer<T> implements Deserializer<T> {
 
   private final KafkaAvroDeserializer<T> inner;
-  private final Type type;
+  private final Schema schema;
 
   public ReflectionAvroDeserializer(Class<T> type) {
-    this.type = type;
+    this.schema = ReflectData.get().getSchema(type);
     this.inner = new KafkaAvroDeserializer<>();
   }
 
@@ -49,7 +49,7 @@ public class ReflectionAvroDeserializer<T> implements Deserializer<T> {
    * For testing purposes only.
    */
   ReflectionAvroDeserializer(final SchemaRegistryClient client, Class<T> type) {
-    this.type = type;
+    this.schema = ReflectData.get().getSchema(type);
     this.inner = new KafkaAvroDeserializer<>(client);
   }
 
@@ -63,7 +63,7 @@ public class ReflectionAvroDeserializer<T> implements Deserializer<T> {
 
   @Override
   public T deserialize(final String topic, final byte[] bytes) {
-    return inner.deserialize(topic, bytes, ReflectData.get().getSchema(type));
+    return inner.deserialize(topic, bytes, schema);
   }
 
   @Override

--- a/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/ReflectionAvroDeserializer.java
+++ b/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/ReflectionAvroDeserializer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.streams.serdes.avro;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import java.lang.reflect.Type;
+import java.util.Map;
+import org.apache.avro.reflect.ReflectData;
+import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.serialization.Deserializer;
+
+/**
+ * A schema-registry aware deserializer for reading data in "reflection Avro" format.
+ *
+ * <p>This deserializer assumes that the serialized data was written in the wire format defined at
+ * http://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html#wire-format. It
+ * requires access to a Confluent Schema Registry endpoint, which you must {@link
+ * ReflectionAvroDeserializer#configure(Map, boolean)} via the parameter "schema.registry.url".</p>
+ *
+ * <p>See {@link ReflectionAvroSerializer} for its serializer counterpart.</p>
+ */
+@InterfaceStability.Unstable
+public class ReflectionAvroDeserializer<T> implements Deserializer<T> {
+
+  private final KafkaAvroDeserializer<T> inner;
+  private final Type type;
+
+  public ReflectionAvroDeserializer(Class<T> type) {
+    this.type = type;
+    this.inner = new KafkaAvroDeserializer<>();
+  }
+
+  /**
+   * For testing purposes only.
+   */
+  ReflectionAvroDeserializer(final SchemaRegistryClient client, Class<T> type) {
+    this.type = type;
+    this.inner = new KafkaAvroDeserializer<>(client);
+  }
+
+  @Override
+  public void configure(final Map<String, ?> deserializerConfig,
+      final boolean isDeserializerForRecordKeys) {
+    inner.configure(
+        ConfigurationUtils.withReflectionAvroEnabled(deserializerConfig),
+        isDeserializerForRecordKeys);
+  }
+
+  @Override
+  public T deserialize(final String topic, final byte[] bytes) {
+    return inner.deserialize(topic, bytes, ReflectData.get().getSchema(type));
+  }
+
+  @Override
+  public void close() {
+    inner.close();
+  }
+
+}

--- a/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/ReflectionAvroSerde.java
+++ b/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/ReflectionAvroSerde.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.streams.serdes.avro;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import java.util.Map;
+import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+
+/**
+ * A schema-registry aware serde (serializer/deserializer) for Apache Kafka's Streams API that can
+ * be used for reading and writing data in "reflection Avro" format.  This serde's "generic Avro"
+ * counterpart is {@link GenericAvroSerde}.
+ *
+ * <p>This serde reads and writes data according to the wire format defined at
+ * http://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html#wire-format. It
+ * requires access to a Confluent Schema Registry endpoint, which you must {@link
+ * GenericAvroDeserializer#configure(Map, boolean)} via the parameter "schema.registry.url".</p>
+ *
+ * <p><strong>Usage</strong></p>
+ *
+ * <p>Example for configuring this serde as a Kafka Streams application's default serde for both
+ * record keys and record values:</p>
+ *
+ * <p>
+ * <pre>{@code
+ * Properties streamsConfiguration = new Properties();
+ * streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, ReflectionAvroSerde.class);
+ * streamsConfiguration.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, ReflectionAvroSerde.class);
+ * streamsConfiguration.put(
+ *     AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+ *     "http://confluent-schema-registry-server:8081/");
+ * }</pre>
+ * </p>
+ *
+ * <p>Example for explicitly overriding the application's default serdes (whatever they were
+ * configured to) so that only specific operations such as {@code KStream#to()} use this serde:</p>
+ *
+ * <p>
+ * <pre>{@code
+ * Serde<MyJavaClassGeneratedFromAvroSchema> reflectionAvroSerde = new ReflectionAvroSerde<>();
+ * boolean isKeySerde = false;
+ * reflectionAvroSerde.configure(
+ *     Collections.singletonMap(
+ *         AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+ *         "http://confluent-schema-registry-server:8081/"),
+ *     isKeySerde);
+ * KStream<String, MyJavaClassGeneratedFromAvroSchema> stream = ...;
+ * stream.to(Serdes.String(), reflectionAvroSerde, "my-output-topic");
+ * }</pre>
+ * </p>
+ */
+@InterfaceStability.Unstable
+public class ReflectionAvroSerde<T> implements Serde<T> {
+
+  private final Serde<T> inner;
+
+  public ReflectionAvroSerde(Class<T> type) {
+    inner = Serdes
+        .serdeFrom(new ReflectionAvroSerializer<>(), new ReflectionAvroDeserializer<>(type));
+  }
+
+  /**
+   * For testing purposes only.
+   */
+  public ReflectionAvroSerde(final SchemaRegistryClient client, Class<T> type) {
+    if (client == null) {
+      throw new IllegalArgumentException("schema registry client must not be null");
+    }
+    inner = Serdes.serdeFrom(
+        new ReflectionAvroSerializer<>(client),
+        new ReflectionAvroDeserializer<>(client, type));
+  }
+
+  @Override
+  public Serializer<T> serializer() {
+    return inner.serializer();
+  }
+
+  @Override
+  public Deserializer<T> deserializer() {
+    return inner.deserializer();
+  }
+
+  @Override
+  public void configure(final Map<String, ?> serdeConfig, final boolean isSerdeForRecordKeys) {
+    inner.serializer().configure(serdeConfig, isSerdeForRecordKeys);
+    inner.deserializer().configure(serdeConfig, isSerdeForRecordKeys);
+  }
+
+  @Override
+  public void close() {
+    inner.serializer().close();
+    inner.deserializer().close();
+  }
+
+}

--- a/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/ReflectionAvroSerializer.java
+++ b/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/ReflectionAvroSerializer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.streams.serdes.avro;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import java.util.Map;
+import org.apache.kafka.common.annotation.InterfaceStability;
+import org.apache.kafka.common.serialization.Serializer;
+
+/**
+ * A schema-registry aware serializer for writing data in "reflection Avro" format.
+ *
+ * <p>This serializer writes data in the wire format defined at
+ * http://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html#wire-format. It
+ * requires access to a Confluent Schema Registry endpoint, which you must {@link
+ * ReflectionAvroSerializer#configure(Map, boolean)} via the parameter "schema.registry.url".</p>
+ *
+ * <p>See {@link ReflectionAvroDeserializer} for its deserializer counterpart.</p>
+ */
+@InterfaceStability.Unstable
+public class ReflectionAvroSerializer<T> implements Serializer<T> {
+
+  private final KafkaAvroSerializer inner;
+
+  public ReflectionAvroSerializer() {
+    inner = new KafkaAvroSerializer();
+  }
+
+  /**
+   * For testing purposes only.
+   */
+  ReflectionAvroSerializer(final SchemaRegistryClient client) {
+    inner = new KafkaAvroSerializer(client);
+  }
+
+  @Override
+  public void configure(final Map<String, ?> serializerConfig,
+      final boolean isSerializerForRecordKeys) {
+    inner.configure(
+        ConfigurationUtils.withReflectionAvroEnabled(serializerConfig),
+        isSerializerForRecordKeys);
+  }
+
+  @Override
+  public byte[] serialize(final String topic, final T record) {
+    return inner.serialize(topic, record);
+  }
+
+  @Override
+  public void close() {
+    inner.close();
+  }
+
+}

--- a/avro-serde/src/test/java/io/confluent/kafka/example/Widget.java
+++ b/avro-serde/src/test/java/io/confluent/kafka/example/Widget.java
@@ -1,0 +1,40 @@
+package io.confluent.kafka.example;
+
+import java.util.Objects;
+
+public class Widget {
+
+  private String name;
+
+  public Widget() {
+  }
+
+  public Widget(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Widget widget = (Widget) o;
+    return name.equals(widget.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name);
+  }
+}

--- a/avro-serde/src/test/java/io/confluent/kafka/streams/serdes/avro/ReflectionAvroSerdeTest.java
+++ b/avro-serde/src/test/java/io/confluent/kafka/streams/serdes/avro/ReflectionAvroSerdeTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.streams.serdes.avro;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import io.confluent.kafka.example.Widget;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class ReflectionAvroSerdeTest {
+
+  private static final String ANY_TOPIC = "any-topic";
+
+  private static <T> ReflectionAvroSerde<T>
+  createConfiguredSerdeForRecordValues(Class<T> type) {
+    SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
+    ReflectionAvroSerde<T> serde = new ReflectionAvroSerde<>(schemaRegistryClient, type);
+    Map<String, Object> serdeConfig = new HashMap<>();
+    serdeConfig.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "fake");
+    serde.configure(serdeConfig, false);
+    return serde;
+  }
+
+  @Test
+  public void shouldRoundTripRecords() {
+    // Given
+    ReflectionAvroSerde<Widget> serde = createConfiguredSerdeForRecordValues(Widget.class);
+    Widget record = new Widget("alice");
+
+    // When
+    Widget roundtrippedRecord = serde.deserializer().deserialize(
+        ANY_TOPIC,
+        serde.serializer().serialize(ANY_TOPIC, record));
+
+    // Then
+    assertThat(roundtrippedRecord, equalTo(record));
+
+    // Cleanup
+    serde.close();
+  }
+
+  @Test
+  public void shouldRoundTripNullRecordsToNull() {
+    // Given
+    ReflectionAvroSerde<Widget> serde = createConfiguredSerdeForRecordValues(Widget.class);
+
+    // When
+    Widget roundtrippedRecord = serde.deserializer().deserialize(
+        ANY_TOPIC,
+        serde.serializer().serialize(ANY_TOPIC, null));
+
+    // Then
+    assertThat(roundtrippedRecord, nullValue());
+
+    // Cleanup
+    serde.close();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldFailWhenInstantiatedWithNullSchemaRegistryClient() {
+    new ReflectionAvroSerde<>(null, Widget.class);
+  }
+
+}

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -308,7 +308,8 @@ public abstract class AbstractKafkaAvroDeserializer<W> extends AbstractKafkaAvro
           } else {
             return result;
           }
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
+          // avro deserialization may throw AvroRuntimeException, NullPointerException, etc
           throw new SerializationException("Error deserializing Avro message for id "
               + schemaId, e);
         }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -16,22 +16,26 @@
 
 package io.confluent.kafka.serializers;
 
-import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import kafka.utils.VerifiableProperties;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DecoderFactory;
-import org.apache.avro.reflect.ReflectDatumReader;
+
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.kafka.common.errors.SerializationException;
+
+import org.apache.avro.reflect.ReflectDatumReader;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import kafka.utils.VerifiableProperties;
 
 public abstract class AbstractKafkaAvroDeserializer<W> extends AbstractKafkaAvroSerDe {
   private final DecoderFactory decoderFactory = DecoderFactory.get();

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -21,6 +21,7 @@ import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.reflect.ReflectDatumReader;
 import org.apache.avro.specific.SpecificData;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificRecord;
@@ -177,7 +178,12 @@ public abstract class AbstractKafkaAvroDeserializer<W> extends AbstractKafkaAvro
     boolean writerSchemaIsPrimitive =
         AvroSchemaUtils.getPrimitiveSchemas().values().contains(writerSchema);
     // do not use SpecificDatumReader if writerSchema is a primitive
-    if (useSpecificAvroReader && !writerSchemaIsPrimitive) {
+    if (useSchemaReflection && !writerSchemaIsPrimitive) {
+      if (readerSchema == null) {
+        throw new SerializationException("Reader schema cannot be null when using Avro schema reflection");
+      }
+      return new ReflectDatumReader<>(writerSchema, readerSchema);
+    } else if (useSpecificAvroReader && !writerSchemaIsPrimitive) {
       if (readerSchema == null) {
         readerSchema = getReaderSchema(writerSchema);
       }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
@@ -41,6 +41,7 @@ public abstract class AbstractKafkaAvroSerDe {
   protected SchemaRegistryClient schemaRegistry;
   protected Object keySubjectNameStrategy = new TopicNameStrategy();
   protected Object valueSubjectNameStrategy = new TopicNameStrategy();
+  protected boolean useSchemaReflection;
 
 
   protected void configureClientProperties(AbstractKafkaAvroSerDeConfig config) {
@@ -57,6 +58,7 @@ public abstract class AbstractKafkaAvroSerDe {
     }
     keySubjectNameStrategy = config.keySubjectNameStrategy();
     valueSubjectNameStrategy = config.valueSubjectNameStrategy();
+    useSchemaReflection = config.useSchemaReflection();
   }
 
   /**

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
@@ -93,6 +93,11 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
       "Determines how to construct the subject name under which the value schema is registered "
       + "with the schema registry. By default, <topic>-value is used as subject.";
 
+  public static final String SCHEMA_REFLECTION_CONFIG = "schema.reflection";
+  public static final boolean SCHEMA_REFLECTION_DEFAULT = false;
+  public static final String SCHEMA_REFLECTION_DOC =
+          "If true, uses the Avro reflection API when serializing/deserializing ";
+
   public static ConfigDef baseConfigDef() {
     return new ConfigDef()
         .define(SCHEMA_REGISTRY_URL_CONFIG, Type.LIST,
@@ -110,7 +115,10 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
         .define(KEY_SUBJECT_NAME_STRATEGY, Type.CLASS, KEY_SUBJECT_NAME_STRATEGY_DEFAULT,
                 Importance.MEDIUM, KEY_SUBJECT_NAME_STRATEGY_DOC)
         .define(VALUE_SUBJECT_NAME_STRATEGY, Type.CLASS, VALUE_SUBJECT_NAME_STRATEGY_DEFAULT,
-                Importance.MEDIUM, VALUE_SUBJECT_NAME_STRATEGY_DOC);
+                Importance.MEDIUM, VALUE_SUBJECT_NAME_STRATEGY_DOC)
+        .define(SCHEMA_REFLECTION_CONFIG, Type.BOOLEAN, SCHEMA_REFLECTION_DEFAULT,
+                Importance.LOW, SCHEMA_REFLECTION_DOC);
+
   }
 
   public AbstractKafkaAvroSerDeConfig(ConfigDef config, Map<?, ?> props) {
@@ -136,6 +144,8 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
   public Object valueSubjectNameStrategy() {
     return subjectNameStrategyInstance(VALUE_SUBJECT_NAME_STRATEGY);
   }
+
+  public boolean useSchemaReflection() { return this.getBoolean(SCHEMA_REFLECTION_CONFIG); }
   
   public Map<String, String> requestHeaders() {
     return originalsWithPrefix(REQUEST_HEADER_PREFIX).entrySet().stream()

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
@@ -145,7 +145,9 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
     return subjectNameStrategyInstance(VALUE_SUBJECT_NAME_STRATEGY);
   }
 
-  public boolean useSchemaReflection() { return this.getBoolean(SCHEMA_REFLECTION_CONFIG); }
+  public boolean useSchemaReflection() {
+    return this.getBoolean(SCHEMA_REFLECTION_CONFIG);
+  }
   
   public Map<String, String> requestHeaders() {
     return originalsWithPrefix(REQUEST_HEADER_PREFIX).entrySet().stream()

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -21,6 +21,7 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.reflect.ReflectDatumWriter;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.specific.SpecificRecord;
 import org.apache.kafka.common.errors.SerializationException;
@@ -64,7 +65,7 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaAvroSerDe
     String restClientErrorMsg = "";
     try {
       int id;
-      schema = AvroSchemaUtils.getSchema(object);
+      schema = AvroSchemaUtils.getSchema(object, useSchemaReflection);
       if (autoRegisterSchema) {
         restClientErrorMsg = "Error registering Avro schema: ";
         id = schemaRegistry.register(subject, schema);
@@ -86,6 +87,8 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaAvroSerDe
                                                  : object;
         if (value instanceof SpecificRecord) {
           writer = new SpecificDatumWriter<>(schema);
+        } else if (useSchemaReflection) {
+          writer = new ReflectDatumWriter<>(schema);
         } else {
           writer = new GenericDatumWriter<>(schema);
         }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AvroSchemaUtils.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AvroSchemaUtils.java
@@ -18,6 +18,8 @@ package io.confluent.kafka.serializers;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
+import org.apache.avro.reflect.ReflectData;
+import org.apache.kafka.common.errors.SerializationException;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -54,6 +56,10 @@ public class AvroSchemaUtils {
   }
 
   public static Schema getSchema(Object object) {
+    return getSchema(object, false);
+  }
+
+  public static Schema getSchema(Object object, boolean useReflection) {
     if (object == null) {
       return primitiveSchemas.get("Null");
     } else if (object instanceof Boolean) {
@@ -70,6 +76,13 @@ public class AvroSchemaUtils {
       return primitiveSchemas.get("String");
     } else if (object instanceof byte[]) {
       return primitiveSchemas.get("Bytes");
+    } else if (useReflection) {
+      Schema schema = ReflectData.get().getSchema(object.getClass());
+      if (schema == null) {
+        throw new SerializationException("Schema is null for object of class " + object.getClass().getCanonicalName());
+      } else {
+        return schema;
+      }
     } else if (object instanceof GenericContainer) {
       return ((GenericContainer) object).getSchema();
     } else {

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AvroSchemaUtils.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AvroSchemaUtils.java
@@ -79,7 +79,8 @@ public class AvroSchemaUtils {
     } else if (useReflection) {
       Schema schema = ReflectData.get().getSchema(object.getClass());
       if (schema == null) {
-        throw new SerializationException("Schema is null for object of class " + object.getClass().getCanonicalName());
+        throw new SerializationException("Schema is null for object of class "
+            + object.getClass().getCanonicalName());
       } else {
         return schema;
       }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
@@ -16,15 +16,13 @@
 
 package io.confluent.kafka.serializers;
 
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.kafka.common.serialization.Deserializer;
 
-import java.util.Map;
-
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-
-public class KafkaAvroDeserializer extends AbstractKafkaAvroDeserializer
-    implements Deserializer<Object> {
+public class KafkaAvroDeserializer<T> extends AbstractKafkaAvroDeserializer<T>
+    implements Deserializer<T> {
 
   private boolean isKey;
 
@@ -51,14 +49,14 @@ public class KafkaAvroDeserializer extends AbstractKafkaAvroDeserializer
   }
 
   @Override
-  public Object deserialize(String s, byte[] bytes) {
+  public T deserialize(String s, byte[] bytes) {
     return deserialize(bytes);
   }
 
   /**
    * Pass a reader schema to get an Avro projection
    */
-  public Object deserialize(String s, byte[] bytes, Schema readerSchema) {
+  public T deserialize(String s, byte[] bytes, Schema readerSchema) {
     return deserialize(bytes, readerSchema);
   }
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
@@ -16,10 +16,12 @@
 
 package io.confluent.kafka.serializers;
 
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.kafka.common.serialization.Deserializer;
+
+import java.util.Map;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 
 public class KafkaAvroDeserializer<T> extends AbstractKafkaAvroDeserializer<T>
     implements Deserializer<T> {

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
@@ -51,7 +51,8 @@ public class KafkaAvroSerializer extends AbstractKafkaAvroSerializer implements 
   @Override
   public byte[] serialize(String topic, Object record) {
     return serializeImpl(
-        getSubjectName(topic, isKey, record, AvroSchemaUtils.getSchema(record, useSchemaReflection)), record);
+        getSubjectName(topic, isKey, record,
+            AvroSchemaUtils.getSchema(record, useSchemaReflection)), record);
   }
 
   @Override

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
@@ -51,7 +51,7 @@ public class KafkaAvroSerializer extends AbstractKafkaAvroSerializer implements 
   @Override
   public byte[] serialize(String topic, Object record) {
     return serializeImpl(
-        getSubjectName(topic, isKey, record, AvroSchemaUtils.getSchema(record)), record);
+        getSubjectName(topic, isKey, record, AvroSchemaUtils.getSchema(record, useSchemaReflection)), record);
   }
 
   @Override

--- a/avro-serializer/src/test/java/io/confluent/kafka/example/ExtendedWidget.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/example/ExtendedWidget.java
@@ -1,0 +1,45 @@
+package io.confluent.kafka.example;
+
+import java.util.Objects;
+
+public class ExtendedWidget {
+    private String name;
+    private Integer age;
+
+    public ExtendedWidget() {}
+
+    public ExtendedWidget(String name, Integer age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getAge() {
+        return age;
+    }
+
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ExtendedWidget that = (ExtendedWidget) o;
+        return name.equals(that.name) &&
+                age.equals(that.age);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, age);
+    }
+}

--- a/avro-serializer/src/test/java/io/confluent/kafka/example/Widget.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/example/Widget.java
@@ -1,0 +1,33 @@
+package io.confluent.kafka.example;
+
+import java.util.Objects;
+
+public class Widget {
+    private String name;
+
+    public Widget() {}
+    public Widget(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Widget widget = (Widget) o;
+        return name.equals(widget.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+}

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -13,7 +13,7 @@
               files="SchemaRegistryCoordinator.java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(AbstractKafkaAvroDeserializer|AvroMessageReader|RestService|Errors|SchemaRegistryRestApplication|KafkaSchemaRegistry|KafkaStore|AvroData|KafkaGroupMasterElector).java"/>
+              files="(AbstractKafkaAvroDeserializer|AvroSchemaUtils|AvroMessageReader|RestService|Errors|SchemaRegistryRestApplication|KafkaSchemaRegistry|KafkaStore|AvroData|KafkaGroupMasterElector).java"/>
 
     <suppress checks="ClassFanOutComplexity"
               files="(RestService|KafkaSchemaRegistry|KafkaStore|KafkaStoreReaderThread|AvroData|KafkaGroupMasterElector).java"/>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -13,7 +13,7 @@
               files="SchemaRegistryCoordinator.java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(AbstractKafkaAvroDeserializer|AvroSchemaUtils|AvroMessageReader|RestService|Errors|SchemaRegistryRestApplication|KafkaSchemaRegistry|KafkaStore|AvroData|KafkaGroupMasterElector).java"/>
+              files="(AbstractKafkaAvroDeserializer|AvroMessageReader|RestService|Errors|SchemaRegistryRestApplication|KafkaSchemaRegistry|KafkaStore|AvroData|KafkaGroupMasterElector).java"/>
 
     <suppress checks="ClassFanOutComplexity"
               files="(RestService|KafkaSchemaRegistry|KafkaStore|KafkaStoreReaderThread|AvroData|KafkaGroupMasterElector).java"/>
@@ -22,7 +22,7 @@
               files="(Errors|AvroMessageReader).java"/>
 
     <suppress checks="CyclomaticComplexity"
-              files="(AbstractKafkaAvroDeserializer|CompatibilityResource|KafkaSchemaRegistry|KafkaStoreReaderThread|AvroData|DownloadSchemaRegistryMojo|AvroMessageFormatter|MockSchemaRegistryClient|SchemaRegistrySerializer|SubjectVersionsResource).java"/>
+              files="(AbstractKafkaAvroDeserializer|AvroSchemaUtils|CompatibilityResource|KafkaSchemaRegistry|KafkaStoreReaderThread|AvroData|DownloadSchemaRegistryMojo|AvroMessageFormatter|MockSchemaRegistryClient|SchemaRegistrySerializer|SubjectVersionsResource).java"/>
 
     <suppress checks="NPathComplexity"
               files="(AvroData|DownloadSchemaRegistryMojo|AvroMessageFormatter|KafkaSchemaRegistry).java"/>


### PR DESCRIPTION
This pull request attempts to address #385, to enable the use of Avro without requiring IDL/JSON/etc the associated code-generation build complexity and multi-project coupling.

Serialization is pretty straightforward, so I've added a configurable boolean flag to `AbstractKafkaAvroSerDe`, and added a boolean parameter to `AvroSchemaUtils.getSchema`.

Deserialization is as bit harder, so I've done some cleanup and refactoring of the existing `AbstractKafkaAvroDeserializer` codebase in order to support the use of reflection.  Current limitations (which require some review and discussion):

* A concrete class (i.e. the class to instantiate and populate with avro record fields) must be supplied to the `ReflectionAvroDeserializer` constructor (and therefore also to the constructor of `ReflectionAvroSerde`)
* As with any `Deserializer` implementation, only a single concrete type is supported per instance.

@MichaelDrogalis @ept @benstopford @miguno: any thoughts/feedback?