### PR TITLE
Make the AbstractKafkaAvroSerDe Serializable

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDe.java
@@ -33,7 +33,7 @@ import io.confluent.kafka.serializers.subject.TopicNameStrategy;
 /**
  * Common fields and helper methods for both the serializer and the deserializer.
  */
-public abstract class AbstractKafkaAvroSerDe {
+public abstract class AbstractKafkaAvroSerDe implements Serializable {
 
   protected static final byte MAGIC_BYTE = 0x0;
   protected static final int idSize = 4;


### PR DESCRIPTION
For our Flink job the SchemaRegistryClient is part of a task, and we would like to be able to Serialize this class and send it to the TaskManagers.