### PR TITLE
MINOR: Fix compilation errors due to changes in KAFKA-8284 (#6673)

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryCoordinator.java
@@ -77,8 +77,8 @@ final class SchemaRegistryCoordinator extends AbstractCoordinator implements Clo
           metrics,
           metricGrpPrefix,
           time,
-          retryBackoffMs,
-          true);
+          retryBackoffMs
+    );
     this.identity = identity;
     this.assignmentSnapshot = null;
     this.listener = listener;


### PR DESCRIPTION
[This Kafka PR](https://github.com/apache/kafka/pull/6673) changed the constructors for `AbstractCoordinator`; those changes are brought into Schema Registry by this PR.