### PR TITLE
MINOR: Adjust to upstream changes in AK

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/KafkaGroupMasterElector.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/KafkaGroupMasterElector.java
@@ -306,9 +306,9 @@ public class KafkaGroupMasterElector implements MasterElector, SchemaRegistryReb
     // Do final cleanup
     AtomicReference<Throwable> firstException = new AtomicReference<Throwable>();
     this.stopped.set(true);
-    ClientUtils.closeQuietly(coordinator, "coordinator", firstException);
-    ClientUtils.closeQuietly(metrics, "consumer metrics", firstException);
-    ClientUtils.closeQuietly(client, "consumer network client", firstException);
+    closeQuietly(coordinator, "coordinator", firstException);
+    closeQuietly(metrics, "consumer metrics", firstException);
+    closeQuietly(client, "consumer network client", firstException);
     AppInfoParser.unregisterAppInfo(JMX_PREFIX, clientId, metrics);
     if (firstException.get() != null && !swallowException) {
       throw new KafkaException(
@@ -317,6 +317,20 @@ public class KafkaGroupMasterElector implements MasterElector, SchemaRegistryReb
       );
     } else {
       log.debug("The schema registry group member has stopped.");
+    }
+  }
+
+  private static void closeQuietly(AutoCloseable closeable,
+                                   String name,
+                                   AtomicReference<Throwable> firstException
+  ) {
+    if (closeable != null) {
+      try {
+        closeable.close();
+      } catch (Throwable t) {
+        firstException.compareAndSet(null, t);
+        log.error("Failed to close {} with type {}", name, closeable.getClass().getName(), t);
+      }
     }
   }
 }


### PR DESCRIPTION
AK changes can be found https://github.com/apache/kafka/commit/6ca899e56d451eef04e81b0f4d88bdb10f3cf4b3 and https://github.com/apache/kafka/pull/6402, which were backported to the AK 2.0 branch.

Similar to #1110 that was applied only to `master`, except this duplicates the `closeQuietly(…)` method to avoid these kinds of changes in the future.