### PR TITLE
CPKAFKA-2963: Add BearerAuthCredentialProvider interface

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
@@ -68,6 +68,12 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
       "Specify how to pick the credentials for Basic Auth header. "
       + "The supported values are URL, USER_INFO and SASL_INHERIT";
 
+  public static final String BEARER_AUTH_CREDENTIALS_SOURCE = SchemaRegistryClientConfig
+          .BEARER_AUTH_CREDENTIALS_SOURCE;
+  public static final String BEARER_AUTH_CREDENTIALS_SOURCE_DEFAULT = "";
+  public static final String BEARER_AUTH_CREDENTIALS_SOURCE_DOC =
+          "Specify how to pick the credentials for Bearer Auth header. ";
+
   @Deprecated
   public static final String SCHEMA_REGISTRY_USER_INFO_CONFIG =
       SchemaRegistryClientConfig.SCHEMA_REGISTRY_USER_INFO_CONFIG;
@@ -78,6 +84,12 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
   public static final String USER_INFO_CONFIG =
       SchemaRegistryClientConfig.USER_INFO_CONFIG;
   public static final String USER_INFO_DEFAULT = "";
+
+  public static final String BEARER_AUTH_TOKEN_CONFIG = SchemaRegistryClientConfig
+          .BEARER_AUTH_TOKEN_CONFIG;
+  public static final String BEARER_AUTH_TOKEN_DEFAULT = "";
+  public static final String BEARER_AUTH_TOKEN_DOC =
+          "Specify the Bearer token to be used for authentication";
 
   public static final String KEY_SUBJECT_NAME_STRATEGY = "key.subject.name.strategy";
   public static final String KEY_SUBJECT_NAME_STRATEGY_DEFAULT =
@@ -103,10 +115,14 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
                 Importance.MEDIUM, AUTO_REGISTER_SCHEMAS_DOC)
         .define(BASIC_AUTH_CREDENTIALS_SOURCE, Type.STRING, BASIC_AUTH_CREDENTIALS_SOURCE_DEFAULT,
             Importance.MEDIUM, BASIC_AUTH_CREDENTIALS_SOURCE_DOC)
+        .define(BEARER_AUTH_CREDENTIALS_SOURCE, Type.STRING, BEARER_AUTH_CREDENTIALS_SOURCE_DEFAULT,
+                Importance.MEDIUM, BEARER_AUTH_CREDENTIALS_SOURCE_DOC)
         .define(SCHEMA_REGISTRY_USER_INFO_CONFIG, Type.PASSWORD, SCHEMA_REGISTRY_USER_INFO_DEFAULT,
                 Importance.MEDIUM, SCHEMA_REGISTRY_USER_INFO_DOC)
         .define(USER_INFO_CONFIG, Type.PASSWORD, USER_INFO_DEFAULT,
                 Importance.MEDIUM, SCHEMA_REGISTRY_USER_INFO_DOC)
+        .define(BEARER_AUTH_TOKEN_CONFIG, Type.PASSWORD, BEARER_AUTH_TOKEN_DEFAULT,
+                Importance.MEDIUM, BEARER_AUTH_TOKEN_DOC)
         .define(KEY_SUBJECT_NAME_STRATEGY, Type.CLASS, KEY_SUBJECT_NAME_STRATEGY_DEFAULT,
                 Importance.MEDIUM, KEY_SUBJECT_NAME_STRATEGY_DOC)
         .define(VALUE_SUBJECT_NAME_STRATEGY, Type.CLASS, VALUE_SUBJECT_NAME_STRATEGY_DEFAULT,

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
@@ -70,7 +70,7 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
 
   public static final String BEARER_AUTH_CREDENTIALS_SOURCE = SchemaRegistryClientConfig
           .BEARER_AUTH_CREDENTIALS_SOURCE;
-  public static final String BEARER_AUTH_CREDENTIALS_SOURCE_DEFAULT = "";
+  public static final String BEARER_AUTH_CREDENTIALS_SOURCE_DEFAULT = "STATIC_TOKEN";
   public static final String BEARER_AUTH_CREDENTIALS_SOURCE_DOC =
           "Specify how to pick the credentials for Bearer Auth header. ";
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -18,6 +18,9 @@ package io.confluent.kafka.schemaregistry.client;
 
 import java.util.Collections;
 import java.util.Objects;
+
+import io.confluent.kafka.schemaregistry.client.security.bearerauth.BearerAuthCredentialProvider;
+import io.confluent.kafka.schemaregistry.client.security.bearerauth.BearerAuthCredentialProviderFactory;
 import org.apache.avro.Schema;
 
 import java.io.IOException;
@@ -124,17 +127,29 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
     }
 
     if (configs != null) {
-      String credentialSourceConfig =
+      String basicCredentialsSource =
           (String) configs.get(SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE);
 
-      if (credentialSourceConfig != null && !credentialSourceConfig.isEmpty()) {
+      if (basicCredentialsSource != null && !basicCredentialsSource.isEmpty()) {
         BasicAuthCredentialProvider basicAuthCredentialProvider =
             BasicAuthCredentialProviderFactory.getBasicAuthCredentialProvider(
-                credentialSourceConfig,
+                basicCredentialsSource,
                 configs
             );
 
         restService.setBasicAuthCredentialProvider(basicAuthCredentialProvider);
+      }
+
+      String bearerCredentialsSource =
+          (String) configs.get(SchemaRegistryClientConfig.BEARER_AUTH_CREDENTIALS_SOURCE);
+
+      if (bearerCredentialsSource != null && !bearerCredentialsSource.isEmpty()) {
+        BearerAuthCredentialProvider bearerAuthCredentialProvider =
+            BearerAuthCredentialProviderFactory.getBearerAuthCredentialProvider(
+                bearerCredentialsSource,
+                configs
+            );
+        restService.setBearerAuthCredentialProvider(bearerAuthCredentialProvider);
       }
     }
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/basicauth/BasicAuthCredentialProviderFactory.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/basicauth/BasicAuthCredentialProviderFactory.java
@@ -26,8 +26,12 @@ public class BasicAuthCredentialProviderFactory {
       basicAuthCredentialProviderMap = new HashMap<>();
 
   static {
-    for (BasicAuthCredentialProvider basicAuthCredentialProvider
-        : ServiceLoader.load(BasicAuthCredentialProvider.class)) {
+    ServiceLoader<BasicAuthCredentialProvider> serviceLoader = ServiceLoader.load(
+        BasicAuthCredentialProvider.class,
+        BasicAuthCredentialProviderFactory.class.getClassLoader()
+    );
+
+    for (BasicAuthCredentialProvider basicAuthCredentialProvider : serviceLoader) {
       basicAuthCredentialProviderMap.put(
           basicAuthCredentialProvider.alias(),
           basicAuthCredentialProvider);

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProvider.java
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-package io.confluent.kafka.schemaregistry.client;
+package io.confluent.kafka.schemaregistry.client.security.bearerauth;
 
-public class SchemaRegistryClientConfig {
-  public static final String BASIC_AUTH_CREDENTIALS_SOURCE = "basic.auth.credentials.source";
-  @Deprecated
-  public static final String SCHEMA_REGISTRY_USER_INFO_CONFIG =
-      "schema.registry.basic.auth.user.info";
-  public static final String USER_INFO_CONFIG = "basic.auth.user.info";
+import org.apache.kafka.common.Configurable;
 
-  public static final String BEARER_AUTH_CREDENTIALS_SOURCE = "bearer.auth.credentials.source";
-  public static final String BEARER_AUTH_TOKEN_CONFIG = "bearer.auth.token";
+import java.net.URL;
+
+public interface BearerAuthCredentialProvider extends Configurable {
+  String alias();
+
+  String getBearerToken(URL url);
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProviderFactory.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProviderFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.client.security.bearerauth;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+public class BearerAuthCredentialProviderFactory {
+
+  public static final Map<String, BearerAuthCredentialProvider>
+      bearerAuthCredentialProviderMap = new HashMap<>();
+
+  static {
+    ServiceLoader<BearerAuthCredentialProvider> serviceLoader = ServiceLoader.load(
+        BearerAuthCredentialProvider.class,
+        BearerAuthCredentialProviderFactory.class.getClassLoader()
+    );
+
+    for (BearerAuthCredentialProvider bearerAuthCredentialProvider : serviceLoader) {
+      bearerAuthCredentialProviderMap.put(
+          bearerAuthCredentialProvider.alias(),
+          bearerAuthCredentialProvider);
+    }
+  }
+
+  public static BearerAuthCredentialProvider getBearerAuthCredentialProvider(
+      String bearerAuthCredentialSource,
+      Map<String, ?> configs) {
+    BearerAuthCredentialProvider bearerAuthCredentialProvider =
+        bearerAuthCredentialProviderMap.get(bearerAuthCredentialSource);
+    if (bearerAuthCredentialProvider != null) {
+      bearerAuthCredentialProvider.configure(configs);
+    }
+    return bearerAuthCredentialProvider;
+  }
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/StaticTokenCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/StaticTokenCredentialProvider.java
@@ -24,7 +24,7 @@ import java.util.Map;
 
 public class StaticTokenCredentialProvider implements BearerAuthCredentialProvider {
 
-  private String userInfo;
+  private String bearerToken;
 
   @Override
   public String alias() {
@@ -33,8 +33,8 @@ public class StaticTokenCredentialProvider implements BearerAuthCredentialProvid
 
   @Override
   public void configure(Map<String, ?> configs) {
-    userInfo = (String) configs.get(SchemaRegistryClientConfig.BEARER_AUTH_TOKEN_CONFIG);
-    if (userInfo != null && !userInfo.isEmpty()) {
+    bearerToken = (String) configs.get(SchemaRegistryClientConfig.BEARER_AUTH_TOKEN_CONFIG);
+    if (bearerToken != null && !bearerToken.isEmpty()) {
       return;
     }
 
@@ -48,6 +48,6 @@ public class StaticTokenCredentialProvider implements BearerAuthCredentialProvid
 
   @Override
   public String getBearerToken(URL url) {
-    return userInfo;
+    return bearerToken;
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/StaticTokenCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/StaticTokenCredentialProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.client.security.bearerauth;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
+import org.apache.kafka.common.config.ConfigException;
+
+import java.net.URL;
+import java.util.Map;
+
+public class StaticTokenCredentialProvider implements BearerAuthCredentialProvider {
+
+  private String userInfo;
+
+  @Override
+  public String alias() {
+    return "STATIC_TOKEN";
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    userInfo = (String) configs.get(SchemaRegistryClientConfig.BEARER_AUTH_TOKEN_CONFIG);
+    if (userInfo != null && !userInfo.isEmpty()) {
+      return;
+    }
+
+    throw new ConfigException(String.format(
+        "Token must be provided via %s config when %s is set to %s",
+        SchemaRegistryClientConfig.BEARER_AUTH_TOKEN_CONFIG,
+        SchemaRegistryClientConfig.BEARER_AUTH_CREDENTIALS_SOURCE,
+        alias()
+    ));
+  }
+
+  @Override
+  public String getBearerToken(URL url) {
+    return userInfo;
+  }
+}

--- a/client/src/main/resources/META-INF/services/io.confluent.kafka.schemaregistry.client.security.bearerauth.BearerAuthCredentialProvider
+++ b/client/src/main/resources/META-INF/services/io.confluent.kafka.schemaregistry.client.security.bearerauth.BearerAuthCredentialProvider
@@ -1,0 +1,1 @@
+io.confluent.kafka.schemaregistry.client.security.bearerauth.StaticTokenCredentialProvider

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/RestServiceTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/RestServiceTest.java
@@ -132,7 +132,7 @@ public class RestServiceTest {
 
 
   /*
-   * Test setBasicAuthRequestHeader (private method) indirectly through getAllSubjects.
+   * Test setBearerAuthRequestHeader (private method) indirectly through getAllSubjects.
    */
   @Test
   public void testSetBearerAuthRequestHeader() throws Exception {

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/RestServiceTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/RestServiceTest.java
@@ -32,6 +32,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
 import avro.shaded.com.google.common.collect.ImmutableMap;
+import io.confluent.kafka.schemaregistry.client.security.bearerauth.BearerAuthCredentialProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.annotation.Mock;
@@ -130,6 +131,56 @@ public class RestServiceTest {
   }
 
 
+  /*
+   * Test setBasicAuthRequestHeader (private method) indirectly through getAllSubjects.
+   */
+  @Test
+  public void testSetBearerAuthRequestHeader() throws Exception {
+    RestService restService = new RestService("http://localhost:8081");
+
+    BearerAuthCredentialProvider bearerAuthCredentialProvider = createMock(BearerAuthCredentialProvider.class);
+    restService.setBearerAuthCredentialProvider(bearerAuthCredentialProvider);
+
+    HttpURLConnection httpURLConnection = createNiceMock(HttpURLConnection.class);
+    InputStream inputStream = createNiceMock(InputStream.class);
+
+    expectNew(URL.class, anyString()).andReturn(url);
+    expect(url.openConnection()).andReturn(httpURLConnection);
+    expect(httpURLConnection.getURL()).andReturn(url);
+    expect(bearerAuthCredentialProvider.getBearerToken(anyObject(URL.class))).andReturn("auth-token");
+    expect(httpURLConnection.getResponseCode()).andReturn(HttpURLConnection.HTTP_OK);
+
+    // Make sure that the Authorization header is set with the correct value for "user:password"
+    httpURLConnection.setRequestProperty("Authorization", "Bearer auth-token");
+    expectLastCall().once();
+
+    expect(httpURLConnection.getInputStream()).andReturn(inputStream);
+
+    expect(inputStream.read((byte[]) anyObject(), anyInt(), anyInt()))
+            .andDelegateTo(new InputStream() {
+              @Override
+              public int read() {
+                return 0;
+              }
+
+              @Override
+              public int read(byte[] b, int off, int len) {
+                byte[] json = "[\"abc\"]".getBytes(StandardCharsets.UTF_8);
+                System.arraycopy(json, 0, b, 0, json.length);
+                return json.length;
+              }
+            }).anyTimes();
+
+    replay(URL.class, url);
+    replay(HttpURLConnection.class, httpURLConnection);
+    replay(bearerAuthCredentialProvider);
+    replay(InputStream.class, inputStream);
+
+    restService.getAllSubjects();
+
+    verify(httpURLConnection);
+  }
+  
   /*
  * Test setHttpHeaders (private method) indirectly through getAllSubjects.
  */

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProviderFactoryTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProviderFactoryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.client.security.bearerauth;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
+import org.apache.kafka.common.security.JaasUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.security.auth.login.Configuration;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class BearerAuthCredentialProviderFactoryTest {
+  private Map<String, String> CONFIG_MAP = new HashMap<>();
+
+  @Before
+  public void setup() throws IOException {
+    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_TOKEN_CONFIG, "user:password");
+    File jaasConfigFile = File.createTempFile("ks-jaas-",".conf");
+    jaasConfigFile.deleteOnExit();
+
+    System.setProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM,jaasConfigFile.getPath());
+
+    List<String> lines = new ArrayList<>();
+    lines.add("KafkaClient { org.apache.kafka.common.security.plain.PlainLoginModule required "
+            + "username=\"user\""
+            +" password=\"password\";};");
+    Files.write(jaasConfigFile.toPath(), lines, StandardCharsets.UTF_8);
+
+    Configuration.setConfiguration(null);
+  }
+
+  @Test
+  public void testSuccess() {
+    assertInstance(BearerAuthCredentialProviderFactory.getBearerAuthCredentialProvider(
+            "STATIC_TOKEN", CONFIG_MAP), StaticTokenCredentialProvider.class);
+  }
+
+  @Test
+  public void testUnknownProvider() {
+    Assert.assertNull(BearerAuthCredentialProviderFactory.getBearerAuthCredentialProvider(
+            "UNKNOWN", CONFIG_MAP));
+  }
+
+  public void assertInstance(BearerAuthCredentialProvider instance,
+                             Class<? extends BearerAuthCredentialProvider> klass) {
+    Assert.assertNotNull(instance);
+    Assert.assertEquals(klass, instance.getClass());
+  }
+}

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProviderFactoryTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProviderFactoryTest.java
@@ -17,19 +17,13 @@
 package io.confluent.kafka.schemaregistry.client.security.bearerauth;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
-import org.apache.kafka.common.security.JaasUtils;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.security.auth.login.Configuration;
-import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class BearerAuthCredentialProviderFactoryTest {
@@ -37,19 +31,7 @@ public class BearerAuthCredentialProviderFactoryTest {
 
   @Before
   public void setup() throws IOException {
-    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_TOKEN_CONFIG, "user:password");
-    File jaasConfigFile = File.createTempFile("ks-jaas-",".conf");
-    jaasConfigFile.deleteOnExit();
-
-    System.setProperty(JaasUtils.JAVA_LOGIN_CONFIG_PARAM,jaasConfigFile.getPath());
-
-    List<String> lines = new ArrayList<>();
-    lines.add("KafkaClient { org.apache.kafka.common.security.plain.PlainLoginModule required "
-            + "username=\"user\""
-            +" password=\"password\";};");
-    Files.write(jaasConfigFile.toPath(), lines, StandardCharsets.UTF_8);
-
-    Configuration.setConfiguration(null);
+    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_TOKEN_CONFIG, "auth-token");
   }
 
   @Test

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/StaticTokenCredentialProviderTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/StaticTokenCredentialProviderTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.client.security.bearerauth;
+
+import org.apache.kafka.common.config.ConfigException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
+
+public class StaticTokenCredentialProviderTest {
+
+  @Test
+  public void testBearerToken() throws MalformedURLException {
+    Map<String, Object> clientConfig = new HashMap<>();
+    clientConfig.put(SchemaRegistryClientConfig.BEARER_AUTH_TOKEN_CONFIG, "auth-token");
+    StaticTokenCredentialProvider provider = new StaticTokenCredentialProvider();
+    provider.configure(clientConfig);
+    Assert.assertEquals("auth-token", provider.getBearerToken(new URL("http://localhost")));
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testNulBearerToken() throws MalformedURLException {
+    Map<String, Object> clientConfig = new HashMap<>();
+    StaticTokenCredentialProvider provider = new StaticTokenCredentialProvider();
+    provider.configure(clientConfig);
+  }
+
+}


### PR DESCRIPTION
[Jira](https://confluentinc.atlassian.net/browse/CPKAFKA-2963), [one-pager](https://confluentinc.atlassian.net/wiki/spaces/PM/pages/897679748/One+Pager+-+Authentication+in+Schema+Registry+client+and+projects+that+utilize+it)

These changes add a `BearerAuthCredentialProvider` interface that behaves similarly to the `BasicAuthCredentialProvider` interface. It is loaded using the `ServiceLoader` mechanism and can be used to provide bearer token credentials that are then prefaced with `Bearer ` and used for the `Authorization` header in requests made to Schema Registry.

This should be manually tested before merging.