### PR TITLE
Fix class loading issues for avro converter by reinstating io.confluent config classes

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
@@ -16,16 +16,15 @@
 
 package io.confluent.kafka.serializers;
 
-import org.apache.kafka.common.config.AbstractConfig;
-import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.config.ConfigDef.Importance;
-import org.apache.kafka.common.config.ConfigDef.Type;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import io.confluent.common.config.AbstractConfig;
+import io.confluent.common.config.ConfigDef;
+import io.confluent.common.config.ConfigDef.Importance;
+import io.confluent.common.config.ConfigDef.Type;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
 import io.confluent.kafka.serializers.subject.TopicNameStrategy;
 import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializerConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializerConfig.java
@@ -17,9 +17,9 @@
 package io.confluent.kafka.serializers;
 
 
-import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.config.ConfigDef.Importance;
-import org.apache.kafka.common.config.ConfigDef.Type;
+import io.confluent.common.config.ConfigDef;
+import io.confluent.common.config.ConfigDef.Importance;
+import io.confluent.common.config.ConfigDef.Type;
 
 import java.util.Map;
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializerConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializerConfig.java
@@ -16,7 +16,7 @@
 
 package io.confluent.kafka.serializers;
 
-import org.apache.kafka.common.config.ConfigDef;
+import io.confluent.common.config.ConfigDef;
 
 import java.util.Map;
 


### PR DESCRIPTION
Class loading isolation breaks for connector and the framework by just moving configs to org.apache.kafka package in avro converter.
Reinstating io.confluent config classes only for the avro converter. 