### PR TITLE
Add config for mock registry in avro serdes

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
@@ -16,17 +16,20 @@
 
 package io.confluent.kafka.serializers;
 
-import java.util.List;
-import java.util.Map;
-
 import io.confluent.common.config.AbstractConfig;
 import io.confluent.common.config.ConfigDef;
 import io.confluent.common.config.ConfigDef.Importance;
 import io.confluent.common.config.ConfigDef.Type;
+import io.confluent.common.config.ConfigException;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
 import io.confluent.kafka.schemaregistry.client.security.basicauth.BasicAuthCredentialSource;
+import io.confluent.kafka.schemaregistry.testutil.MockSchemaRegistry;
 import io.confluent.kafka.serializers.subject.TopicNameStrategy;
 import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Base class for configs for serializers and deserializers, defining a few common configs and
@@ -34,11 +37,17 @@ import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
  */
 public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
 
+  public static final String MOCK_SCHEMA_REGISTRY_SCOPE_CONFIG = "mock.schema.registry.scope";
+  public static final String MOCK_SCHEMA_REGISTRY_SCOPE_DOC =
+      "For testing, a scope name to use to get a mock client from MockSchemaRegistry"
+      + "instead of an actual connection to Schema Registry. "
+      + "Either mock.schema.registry.scope or schema.registry.url is required.";
+
   public static final String SCHEMA_REGISTRY_URL_CONFIG = "schema.registry.url";
-  public static final String
-      SCHEMA_REGISTRY_URL_DOC =
+  public static final String SCHEMA_REGISTRY_URL_DOC =
       "Comma-separated list of URLs for schema registry instances that can be used to register "
-      + "or look up schemas.";
+      + "or look up schemas. "
+      + "Either schema.registry.url or mock.schema.registry.scope is required.";
 
   public static final String MAX_SCHEMAS_PER_SUBJECT_CONFIG = "max.schemas.per.subject";
   public static final int MAX_SCHEMAS_PER_SUBJECT_DEFAULT = 1000;
@@ -79,7 +88,9 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
 
   public static ConfigDef baseConfigDef() {
     return new ConfigDef()
-        .define(SCHEMA_REGISTRY_URL_CONFIG, Type.LIST,
+        .defineAlternative("registry", MOCK_SCHEMA_REGISTRY_SCOPE_CONFIG, Type.STRING, null,
+                Importance.LOW, MOCK_SCHEMA_REGISTRY_SCOPE_DOC)
+        .defineAlternative("registry", SCHEMA_REGISTRY_URL_CONFIG, Type.LIST, null,
                 Importance.HIGH, SCHEMA_REGISTRY_URL_DOC)
         .define(MAX_SCHEMAS_PER_SUBJECT_CONFIG, Type.INT, MAX_SCHEMAS_PER_SUBJECT_DEFAULT,
                 Importance.LOW, MAX_SCHEMAS_PER_SUBJECT_DOC)
@@ -105,7 +116,37 @@ public class AbstractKafkaAvroSerDeConfig extends AbstractConfig {
   }
 
   public List<String> getSchemaRegistryUrls() {
-    return this.getList(SCHEMA_REGISTRY_URL_CONFIG);
+    if (hasMockRegistry()) {
+      return null;
+    } else {
+      return this.getList(SCHEMA_REGISTRY_URL_CONFIG);
+    }
+  }
+
+  public SchemaRegistryClient getMockSchemaRegistryClient() {
+    if (hasMockRegistry()) {
+      return MockSchemaRegistry.getClientForScope(getString(MOCK_SCHEMA_REGISTRY_SCOPE_CONFIG));
+    } else {
+      return null;
+    }
+  }
+
+  public boolean hasMockRegistry() {
+    if (contains(MOCK_SCHEMA_REGISTRY_SCOPE_CONFIG) && getSchemaRegistryUrls() == null) {
+      return true;
+    } else if (!contains(MOCK_SCHEMA_REGISTRY_SCOPE_CONFIG) && getSchemaRegistryUrls() != null) {
+      return false;
+    } else if (!contains(MOCK_SCHEMA_REGISTRY_SCOPE_CONFIG) && getSchemaRegistryUrls() == null) {
+      throw new ConfigException(
+        "Either " + MOCK_SCHEMA_REGISTRY_SCOPE_CONFIG + " or "
+        + SCHEMA_REGISTRY_URL_CONFIG + " is required."
+      );
+    } else {
+      throw new ConfigException(
+        MOCK_SCHEMA_REGISTRY_SCOPE_CONFIG + " cannot be used with "
+        + SCHEMA_REGISTRY_URL_CONFIG + "."
+      );
+    }
   }
 
   public boolean autoRegisterSchema() {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/testutil/MockSchemaRegistry.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/testutil/MockSchemaRegistry.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2014 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.testutil;
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A repository for mocked Schema Registry clients, to aid in testing.
+ *
+ * <p>Logically independent "instances" of mocked Schema Registry are created or retrieved
+ * via named scopes {@link MockSchemaRegistry#getClientForScope(String)}.
+ * Each named scope is an independent registry.
+ * Each named-scope registry is statically defined and visible to the entire JVM.
+ * Scopes can be cleaned up when no longer needed via {@link MockSchemaRegistry#dropScope(String)}.
+ * Reusing a scope name after cleanup results in a completely new mocked Schema Registry instance.
+ *
+ * <p>This registry can be used to manage scoped clients directly, but scopes can also be registered
+ * and used as {@code mock.schema.registry.scope} instead of {@code schema.registry.url}
+ * in serde configurations, so that testing code doesn't have to run an actual instance of
+ * Schema Registry listening on a local port.
+ */
+public final class MockSchemaRegistry {
+  private static final Map<String, SchemaRegistryClient> SCOPED_CLIENTS = new HashMap<>();
+
+  // Not instantiable. All access is via static methods.
+  private MockSchemaRegistry() { }
+
+  /**
+   * Get a client for a mocked Schema Registry. The {@code scope} represents a particular registry,
+   * so operations on one scope will never affect another.
+   *
+   * @param scope Identifies a logically independent Schema Registry instance. It's similar to a
+   *              schema registry URL, in that two different Schema Registry deployments have two
+   *              different URLs, except that these registries are only mocked, so they have no
+   *              actual URL.
+   * @return A client for the specified scope.
+   */
+  public static SchemaRegistryClient getClientForScope(final String scope) {
+    synchronized (SCOPED_CLIENTS) {
+      if (!SCOPED_CLIENTS.containsKey(scope)) {
+        SCOPED_CLIENTS.put(scope, new MockSchemaRegistryClient());
+      }
+    }
+    return SCOPED_CLIENTS.get(scope);
+  }
+
+  /**
+   * Destroy the mocked registry corresponding to the scope. Subsequent clients for the same scope
+   * will have a completely blank slate.
+   * @param scope Identifies a logically independent Schema Registry instance. It's similar to a
+   *             schema registry URL, in that two different Schema Registry deployments have two
+   *             different URLs, except that these registries are only mocked, so they have no
+   *             actual URL.
+   */
+  public static void dropScope(final String scope) {
+    synchronized (SCOPED_CLIENTS) {
+      SCOPED_CLIENTS.remove(scope);
+    }
+  }
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/testutil/MockSchemaRegistry.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/testutil/MockSchemaRegistry.java
@@ -33,9 +33,11 @@ import java.util.Map;
  * Reusing a scope name after cleanup results in a completely new mocked Schema Registry instance.
  *
  * <p>This registry can be used to manage scoped clients directly, but scopes can also be registered
- * and used as {@code mock.schema.registry.scope} instead of {@code schema.registry.url}
+ * and used as {@code schema.registry.url} with the special pseudo-protocol 'mock://'
  * in serde configurations, so that testing code doesn't have to run an actual instance of
- * Schema Registry listening on a local port.
+ * Schema Registry listening on a local port. For example,
+ * {@code schema.registry.url: 'mock://my-scope-name'} corresponds to
+ * {@code MockSchemaRegistry.getClientForScope("my-scope-name")}.
  */
 public final class MockSchemaRegistry {
   private static final Map<String, SchemaRegistryClient> SCOPED_CLIENTS = new HashMap<>();

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClientTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClientTest.java
@@ -59,7 +59,7 @@ public class MockSchemaRegistryClientTest extends ClusterTestHarness {
     props.put("auto.offset.reset", "earliest");
     props.put("key.deserializer", org.apache.kafka.common.serialization.StringDeserializer.class);
     props.put("value.deserializer", io.confluent.kafka.serializers.KafkaAvroDeserializer.class);
-    props.put("mock.schema.registry", "scope1");
+    props.put("schema.registry.url", "mock://scope1");
     return props;
   }
 
@@ -88,7 +88,7 @@ public class MockSchemaRegistryClientTest extends ClusterTestHarness {
   private Properties createNewProducerProps() {
     Properties props = new Properties();
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
-    props.put("mock.schema.registry", "scope1");
+    props.put("schema.registry.url", "mock://scope1");
     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
               org.apache.kafka.common.serialization.StringSerializer.class);
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
@@ -113,7 +113,7 @@ public class MockSchemaRegistryClientTest extends ClusterTestHarness {
     props.put("key.serializer", org.apache.kafka.common.serialization.StringSerializer.class);
     props.put("value.serializer", io.confluent.kafka.serializers.KafkaAvroSerializer.class);
     props.put("bootstrap.servers", brokerList);
-    props.put("mock.schema.registry", "scope1");
+    props.put("schema.registry.url", "mock://scope1");
     return props;
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClientTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClientTest.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright 2014 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.kafka.schemaregistry.client;
+
+import io.confluent.kafka.schemaregistry.ClusterTestHarness;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Properties;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class MockSchemaRegistryClientTest extends ClusterTestHarness {
+
+  private IndexedRecord createAvroRecord() {
+    String userSchema = "{\"namespace\": \"example.avro\", \"type\": \"record\", " +
+                        "\"name\": \"User\"," +
+                        "\"fields\": [{\"name\": \"name\", \"type\": \"string\"}]}";
+    Schema.Parser parser = new Schema.Parser();
+    Schema schema = parser.parse(userSchema);
+    GenericRecord avroRecord = new GenericData.Record(schema);
+    avroRecord.put("name", "testUser");
+    return avroRecord;
+  }
+
+  private Properties createConsumerProps() {
+    Properties props = new Properties();
+    props.put("bootstrap.servers", brokerList);
+    props.put("group.id", "avroGroup");
+    props.put("session.timeout.ms", "6000"); // default value of group.min.session.timeout.ms.
+    props.put("heartbeat.interval.ms", "2000");
+    props.put("auto.commit.interval.ms", "1000");
+    props.put("auto.offset.reset", "earliest");
+    props.put("key.deserializer", org.apache.kafka.common.serialization.StringDeserializer.class);
+    props.put("value.deserializer", io.confluent.kafka.serializers.KafkaAvroDeserializer.class);
+    props.put("mock.schema.registry", "scope1");
+    return props;
+  }
+
+  private Consumer<String, Object> createConsumer(Properties props) {
+    return new KafkaConsumer<>(props);
+  }
+
+  private ArrayList<Object> consume(Consumer<String, Object> consumer, String topic, int numMessages) {
+    ArrayList<Object> recordList = new ArrayList<Object>();
+
+    consumer.subscribe(Arrays.asList(topic));
+
+    int i = 0;
+    while (i < numMessages) {
+      ConsumerRecords<String, Object> records = consumer.poll(1000);
+      for (ConsumerRecord<String, Object> record : records) {
+        recordList.add(record.value());
+        i++;
+      }
+    }
+
+    consumer.close();
+    return recordList;
+  }
+
+  private Properties createNewProducerProps() {
+    Properties props = new Properties();
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
+    props.put("mock.schema.registry", "scope1");
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+              org.apache.kafka.common.serialization.StringSerializer.class);
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+              io.confluent.kafka.serializers.KafkaAvroSerializer.class);
+    return props;
+  }
+
+  private KafkaProducer createNewProducer(Properties props) {
+    return new KafkaProducer(props);
+  }
+
+  private void newProduce(KafkaProducer producer, String topic, Object[] objects) {
+    ProducerRecord<String, Object> record;
+    for (Object object : objects) {
+      record = new ProducerRecord<String, Object>(topic, object);
+      producer.send(record);
+    }
+  }
+
+  private Properties createProducerProps() {
+    Properties props = new Properties();
+    props.put("key.serializer", org.apache.kafka.common.serialization.StringSerializer.class);
+    props.put("value.serializer", io.confluent.kafka.serializers.KafkaAvroSerializer.class);
+    props.put("bootstrap.servers", brokerList);
+    props.put("mock.schema.registry", "scope1");
+    return props;
+  }
+
+  private Producer<String, Object> createProducer(Properties props) {
+    return new KafkaProducer<>(props);
+  }
+
+  private void produce(Producer<String, Object> producer, String topic, Object[] objects) {
+    ProducerRecord<String, Object> message;
+    for (Object object : objects) {
+      message = new ProducerRecord<>(topic, object);
+      producer.send(message);
+    }
+  }
+
+  @Test
+  public void testAvroProducer() {
+    String topic = "testAvro";
+    IndexedRecord avroRecord = createAvroRecord();
+    Object[] objects = new Object[]{avroRecord};
+    Properties producerProps = createProducerProps();
+    Producer<String, Object> producer = createProducer(producerProps);
+    produce(producer, topic, objects);
+
+    Properties consumerProps = createConsumerProps();
+    Consumer<String, Object> consumer = createConsumer(consumerProps);
+    ArrayList<Object> recordList = consume(consumer, topic, objects.length);
+    assertArrayEquals(objects, recordList.toArray());
+  }
+
+  @Test
+  public void testAvroNewProducer() {
+    String topic = "testAvro";
+    IndexedRecord avroRecord = createAvroRecord();
+    Object[] objects = new Object[]
+        {avroRecord, true, 130, 345L, 1.23f, 2.34d, "abc", "def".getBytes()};
+    Properties producerProps = createNewProducerProps();
+    KafkaProducer producer = createNewProducer(producerProps);
+    newProduce(producer, topic, objects);
+
+    Properties consumerProps = createConsumerProps();
+    Consumer<String, Object> consumer = createConsumer(consumerProps);
+    ArrayList<Object> recordList = consume(consumer, topic, objects.length);
+    assertArrayEquals(objects, recordList.toArray());
+  }
+}
+

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/testutil/MockSchemaRegistryTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/testutil/MockSchemaRegistryTest.java
@@ -1,0 +1,30 @@
+package io.confluent.kafka.schemaregistry.testutil;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MockSchemaRegistryTest {
+    @Test
+    public void testGetClient() {
+        final SchemaRegistryClient client = MockSchemaRegistry.getClientForScope("testGetClient");
+        Assert.assertNotNull(client);
+    }
+
+    @Test
+    public void testGetSameClient() {
+        final String scope = "testGetSameClient";
+        final SchemaRegistryClient client = MockSchemaRegistry.getClientForScope(scope);
+        Assert.assertNotNull(client);
+        Assert.assertSame(client, MockSchemaRegistry.getClientForScope(scope));
+    }
+
+    @Test
+    public void testDropScope() {
+        final String scope = "testDropScope";
+        final SchemaRegistryClient client = MockSchemaRegistry.getClientForScope(scope);
+        Assert.assertNotNull(client);
+        MockSchemaRegistry.dropScope(scope);
+        Assert.assertNotSame(client, MockSchemaRegistry.getClientForScope(scope));
+    }
+}


### PR DESCRIPTION
Removes the obligation to run an actual instance of Schema Registry for tests that use the avro serdes.
Adds an _alternate_ config option `mock.schema.registry.scope` that can be used _instead of_ `schema.registry.url` for testing.