### PR TITLE
MINOR: Use thread-safe data structures

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
@@ -15,7 +15,6 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -23,6 +22,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
@@ -108,7 +108,7 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
   public void schemaDeleted(SchemaKey schemaKey, SchemaValue schemaValue) {
     guidToSchemaKey.put(schemaValue.getId(), schemaKey);
     guidToDeletedSchemaKeys
-        .computeIfAbsent(schemaValue.getId(), k -> new ArrayList<>()).add(schemaKey);
+        .computeIfAbsent(schemaValue.getId(), k -> new CopyOnWriteArrayList<>()).add(schemaKey);
   }
 
   @Override

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
@@ -108,7 +108,8 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
   public void schemaDeleted(SchemaKey schemaKey, SchemaValue schemaValue) {
     guidToSchemaKey.put(schemaValue.getId(), schemaKey);
     guidToDeletedSchemaKeys
-        .computeIfAbsent(schemaValue.getId(), k -> new CopyOnWriteArrayList<>()).add(schemaKey);
+        .computeIfAbsent(schemaValue.getId(), k -> new CopyOnWriteArrayList<>())
+        .add(schemaKey);
   }
 
   @Override

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaIdAndSubjects.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaIdAndSubjects.java
@@ -15,8 +15,8 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Kafka schema registry maintains a few in memory indices to facilitate schema lookups. One such
@@ -32,7 +32,7 @@ public class SchemaIdAndSubjects {
   private Map<String, Integer> subjectsAndVersions;
 
   public SchemaIdAndSubjects(int id) {
-    this.subjectsAndVersions = new HashMap<String, Integer>();
+    this.subjectsAndVersions = new ConcurrentHashMap<>();
     this.id = id;
   }
 


### PR DESCRIPTION
A minor change to use thread-safe data structures to prevent race conditions.