### PR TITLE
CC-5036: Use swagger-maven-plugin to generate API spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ with Maven.
 This project uses the [Google Java code style](https://google.github.io/styleguide/javaguide.html)
 to keep code clean and consistent.
 
+OpenAPI Spec
+------------
+
+OpenAPI (formerly known as Swagger) specifications are built automatically using `swagger-maven-plugin`
+on `compile` phase.
+
+
 Contribute
 ----------
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -61,5 +61,15 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>1.5.22</version>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-core</artifactId>
+            <version>1.5.3</version>
+        </dependency>
     </dependencies>
 </project>

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Config.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Config.java
@@ -17,6 +17,7 @@
 package io.confluent.kafka.schemaregistry.client.rest.entities;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
 
 public class Config {
 
@@ -30,6 +31,9 @@ public class Config {
     compatibilityLevel = null;
   }
 
+  @ApiModelProperty(value = "Compatability Level",
+      allowableValues = "BACKWARD, BACKWARD_TRANSITIVE, FORWARD, FORWARD_TRANSITIVE, FULL, "
+          + "FULL_TRANSITIVE, NONE")
   @JsonProperty("compatibilityLevel")
   public String getCompatibilityLevel() {
     return compatibilityLevel;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaString.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaString.java
@@ -18,6 +18,7 @@ package io.confluent.kafka.schemaregistry.client.rest.entities;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.annotations.ApiModelProperty;
 
 import java.io.IOException;
 
@@ -37,6 +38,7 @@ public class SchemaString {
     return new ObjectMapper().readValue(json, SchemaString.class);
   }
 
+  @ApiModelProperty(value = "Schema string identified by the ID")
   @JsonProperty("schema")
   public String getSchemaString() {
     return schemaString;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/ConfigUpdateRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/ConfigUpdateRequest.java
@@ -19,6 +19,8 @@ package io.confluent.kafka.schemaregistry.client.rest.entities.requests;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.swagger.annotations.ApiModelProperty;
+
 import java.io.IOException;
 
 public class ConfigUpdateRequest {
@@ -29,6 +31,9 @@ public class ConfigUpdateRequest {
     return new ObjectMapper().readValue(json, ConfigUpdateRequest.class);
   }
 
+  @ApiModelProperty(value = "Compatability Level",
+      allowableValues = "BACKWARD, BACKWARD_TRANSITIVE, FORWARD, FORWARD_TRANSITIVE, FULL, "
+          + "FULL_TRANSITIVE, NONE")
   @JsonProperty("compatibility")
   public String getCompatibilityLevel() {
     return this.compatibilityLevel;

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -471,6 +471,12 @@ paths:
         description: "Name of the Subject"
         required: true
         type: "string"
+      - in: "body"
+        name: "body"
+        description: "Schema"
+        required: true
+        schema:
+          $ref: "#/definitions/RegisterSchemaRequest"
       responses:
         200:
           description: "successful operation"
@@ -656,6 +662,17 @@ definitions:
     type: "object"
     properties:
       mode:
+        type: "string"
+  RegisterSchemaRequest:
+    type: "object"
+    properties:
+      version:
+        type: "integer"
+        format: "int32"
+      id:
+        type: "integer"
+        format: "int32"
+      schema:
         type: "string"
   RegisterSchemaResponse:
     type: "object"

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -56,7 +56,7 @@ paths:
         \ compatibility level for the subject (http:get:: /config/(string: subject)).\
         \ If this subject's compatibility level was never changed, then the global\
         \ compatibility level applies (http:get:: /config)."
-      operationId: "lookUpSchemaUnderSubject"
+      operationId: "testCompatabilityBySubjectName"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
       - "application/vnd.schemaregistry+json"
@@ -410,7 +410,7 @@ paths:
     get:
       summary: "Get a list of versions registered under the specified subject."
       description: ""
-      operationId: "list"
+      operationId: "listVersions"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
       - "application/vnd.schemaregistry+json"
@@ -488,7 +488,7 @@ paths:
     get:
       summary: "Get a specific version of the schema registered under this subject."
       description: ""
-      operationId: "getSchema"
+      operationId: "getSchemaByVersion"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
       - "application/vnd.schemaregistry+json"

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -1,0 +1,510 @@
+---
+swagger: "2.0"
+info:
+  version: "v1"
+  title: "Confluent Schema Registry"
+schemes:
+- "http"
+- "https"
+paths:
+  /:
+    get:
+      summary: "Schema Registry Root Resource"
+      description: "The Root resource is a no-op."
+      operationId: "get"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+            additionalProperties:
+              type: "object"
+    post:
+      operationId: "post"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+            additionalProperties:
+              type: "string"
+  /compatibility/subjects/{subject}/versions/{version}:
+    post:
+      summary: "Test input schema against a particular version of a subject's schema\
+        \ for compatibility."
+      description: "the compatibility level applied for the check is the configured\
+        \ compatibility level for the subject (http:get:: /config/(string: subject)).\
+        \ If this subject's compatibility level was never changed, then the global\
+        \ compatibility level applies (http:get:: /config)."
+      operationId: "lookUpSchemaUnderSubject"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters:
+      - name: "Content-Type"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "Accept"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "subject"
+        in: "path"
+        description: "Subject of the schema version against which compatibility is\
+          \ to be tested"
+        required: true
+        type: "string"
+      - name: "version"
+        in: "path"
+        description: "Version of the subject's schema against which compatibility\
+          \ is to be tested. Valid values for versionId are between [1,2^31-1] or\
+          \ the string \"latest\".\"latest\" checks compatibility of the input schema\
+          \ with the last registered schema under the specified subject"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/CompatibilityCheckResponse"
+        404:
+          description: "Error code 40401 -- Subject not found\nError code 40402 --\
+            \ Version not found"
+        422:
+          description: "Error code 42201 -- Invalid Avro schema\nError code 42202\
+            \ -- Invalid version"
+        500:
+          description: "Error code 50001 -- Error in the backend data store"
+  /config:
+    get:
+      operationId: "getTopLevelConfig"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Config"
+    put:
+      operationId: "updateTopLevelConfig"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ConfigUpdateRequest"
+  /config/{subject}:
+    get:
+      operationId: "getSubjectLevelConfig"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters:
+      - name: "subject"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Config"
+    put:
+      operationId: "updateSubjectLevelConfig"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters:
+      - name: "subject"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ConfigUpdateRequest"
+  /mode:
+    get:
+      operationId: "getTopLevelMode"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ModeGetResponse"
+    put:
+      operationId: "updateTopLevelMode"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ModeUpdateRequest"
+  /mode/{subject}:
+    get:
+      operationId: "getMode"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters:
+      - name: "subject"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ModeGetResponse"
+    put:
+      operationId: "updateMode"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters:
+      - name: "subject"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ModeUpdateRequest"
+  /schemas/ids/{id}:
+    get:
+      operationId: "getSchema"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/SchemaString"
+  /subjects:
+    get:
+      operationId: "list"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              type: "string"
+            uniqueItems: true
+  /subjects/{subject}:
+    post:
+      operationId: "lookUpSchemaUnderSubject"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters:
+      - name: "subject"
+        in: "path"
+        required: true
+        type: "string"
+      - name: "deleted"
+        in: "query"
+        required: false
+        type: "boolean"
+      responses:
+        default:
+          description: "successful operation"
+    delete:
+      operationId: "deleteSubject"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters:
+      - name: "subject"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        default:
+          description: "successful operation"
+  /subjects/{subject}/versions:
+    get:
+      operationId: "list"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters:
+      - name: "subject"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              type: "integer"
+              format: "int32"
+    post:
+      operationId: "register"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters:
+      - name: "subject"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        default:
+          description: "successful operation"
+  /subjects/{subject}/versions/{version}:
+    get:
+      operationId: "getSchema"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters:
+      - name: "subject"
+        in: "path"
+        required: true
+        type: "string"
+      - name: "version"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Schema"
+    delete:
+      operationId: "deleteSchemaVersion"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters:
+      - name: "subject"
+        in: "path"
+        required: true
+        type: "string"
+      - name: "version"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        default:
+          description: "successful operation"
+  /subjects/{subject}/versions/{version}/schema:
+    get:
+      operationId: "getSchemaOnly"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters:
+      - name: "subject"
+        in: "path"
+        required: true
+        type: "string"
+      - name: "version"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "string"
+definitions:
+  CompatibilityCheckResponse:
+    type: "object"
+    properties:
+      is_compatible:
+        type: "boolean"
+  Config:
+    type: "object"
+    properties:
+      compatibilityLevel:
+        type: "string"
+  ConfigUpdateRequest:
+    type: "object"
+    properties:
+      compatibility:
+        type: "string"
+  ModeGetResponse:
+    type: "object"
+    properties:
+      mode:
+        type: "string"
+  ModeUpdateRequest:
+    type: "object"
+    properties:
+      mode:
+        type: "string"
+  Schema:
+    type: "object"
+    properties:
+      subject:
+        type: "string"
+      version:
+        type: "integer"
+        format: "int32"
+      id:
+        type: "integer"
+        format: "int32"
+      schema:
+        type: "string"
+  SchemaString:
+    type: "object"
+    properties:
+      schema:
+        type: "string"

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -104,6 +104,8 @@ paths:
           description: "Error code 50001 -- Error in the backend data store"
   /config:
     get:
+      summary: "Get global compatibility level."
+      description: ""
       operationId: "getTopLevelConfig"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
@@ -120,7 +122,11 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/Config"
+        500:
+          description: "Error code 50001 -- Error in the backend data store"
     put:
+      summary: "Update global compatibility level."
+      description: ""
       operationId: "updateTopLevelConfig"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
@@ -137,8 +143,15 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/ConfigUpdateRequest"
+        422:
+          description: "Error code 42203 -- Invalid compatibility level"
+        500:
+          description: "Error code 50001 -- Error in the backend data store\nError\
+            \ code 50003 -- Error while forwarding the request to the primary\n"
   /config/{subject}:
     get:
+      summary: "Get compatibility level for a subject."
+      description: ""
       operationId: "getSubjectLevelConfig"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
@@ -159,7 +172,13 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/Config"
+        404:
+          description: "Subject not found"
+        500:
+          description: "Error code 50001 -- Error in the backend data store"
     put:
+      summary: "Update compatibility level for the specified subject."
+      description: ""
       operationId: "updateSubjectLevelConfig"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
@@ -173,6 +192,7 @@ paths:
       parameters:
       - name: "subject"
         in: "path"
+        description: "Name of the Subject"
         required: true
         type: "string"
       responses:
@@ -180,6 +200,12 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/ConfigUpdateRequest"
+        422:
+          description: "Error code 42203 -- Invalid compatibility level\nError code\
+            \ 40402 -- Version not found"
+        500:
+          description: "Error code 50001 -- Error in the backend data store\nError\
+            \ code 50003 -- Error while forwarding the request to the primary"
   /mode:
     get:
       operationId: "getTopLevelMode"
@@ -260,6 +286,8 @@ paths:
             $ref: "#/definitions/ModeUpdateRequest"
   /schemas/ids/{id}:
     get:
+      summary: "Get the schema string identified by the input ID."
+      description: ""
       operationId: "getSchema"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
@@ -273,6 +301,7 @@ paths:
       parameters:
       - name: "id"
         in: "path"
+        description: "Globally unique identifier of the schema"
         required: true
         type: "integer"
         format: "int32"
@@ -281,8 +310,14 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/SchemaString"
+        404:
+          description: "Error code 40403 -- Schema not found\n"
+        500:
+          description: "Error code 50001 -- Error in the backend data store\n"
   /subjects:
     get:
+      summary: "Get a list of registered subjects."
+      description: ""
       operationId: "list"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
@@ -302,8 +337,14 @@ paths:
             items:
               type: "string"
             uniqueItems: true
+        500:
+          description: "Error code 50001 -- Error in the backend datastore"
   /subjects/{subject}:
     post:
+      summary: "Check if a schema has already been registered under the specified\
+        \ subject. If so, this returns the schema string along with its globally unique\
+        \ identifier, its version under this subject and the subject name."
+      description: ""
       operationId: "lookUpSchemaUnderSubject"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
@@ -317,6 +358,7 @@ paths:
       parameters:
       - name: "subject"
         in: "path"
+        description: "Subject under which the schema will be registered"
         required: true
         type: "string"
       - name: "deleted"
@@ -324,9 +366,18 @@ paths:
         required: false
         type: "boolean"
       responses:
-        default:
-          description: "successful operation"
+        404:
+          description: "Error code 40401 -- Subject not found\nError code 40403 --\
+            \ Schema not found"
+        500:
+          description: "Internal server error"
+          schema:
+            $ref: "#/definitions/Schema"
     delete:
+      summary: "Deletes the specified subject and its associated compatibility level\
+        \ if registered. It is recommended to use this API only when a topic needs\
+        \ to be recycled or in development environment."
+      description: ""
       operationId: "deleteSubject"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
@@ -340,13 +391,25 @@ paths:
       parameters:
       - name: "subject"
         in: "path"
+        description: "the name of the subject"
         required: true
         type: "string"
       responses:
-        default:
+        200:
           description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              type: "integer"
+              format: "int32"
+        404:
+          description: "Error code 40401 -- Subject not found"
+        500:
+          description: "Error code 50001 -- Error in the backend datastore"
   /subjects/{subject}/versions:
     get:
+      summary: "Get a list of versions registered under the specified subject."
+      description: ""
       operationId: "list"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
@@ -360,6 +423,7 @@ paths:
       parameters:
       - name: "subject"
         in: "path"
+        description: "Name of the Subject"
         required: true
         type: "string"
       responses:
@@ -370,7 +434,27 @@ paths:
             items:
               type: "integer"
               format: "int32"
+        404:
+          description: "Error code 40401 -- Subject not found"
+        500:
+          description: "Error code 50001 -- Error in the backend data store"
     post:
+      summary: "Register a new schema under the specified subject. If successfully\
+        \ registered, this returns the unique identifier of this schema in the registry.\
+        \ The returned identifier should be used to retrieve this schema from the\
+        \ schemas resource and is different from the schema's version which is associated\
+        \ with the subject. If the same schema is registered under a different subject,\
+        \ the same identifier will be returned. However, the version of the schema\
+        \ may be different under different subjects.\nA schema should be compatible\
+        \ with the previously registered schema or schemas (if there are any) as per\
+        \ the configured compatibility level. The configured compatibility level can\
+        \ be obtained by issuing a GET http:get:: /config/(string: subject). If that\
+        \ returns null, then GET http:get:: /config\nWhen there are multiple instances\
+        \ of Schema Registry running in the same cluster, the schema registration\
+        \ request will be forwarded to one of the instances designated as the primary.\
+        \ If the primary is not available, the client will get an error code indicating\
+        \ that the forwarding has failed."
+      description: ""
       operationId: "register"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
@@ -384,13 +468,26 @@ paths:
       parameters:
       - name: "subject"
         in: "path"
+        description: "Name of the Subject"
         required: true
         type: "string"
       responses:
-        default:
+        200:
           description: "successful operation"
+          schema:
+            $ref: "#/definitions/RegisterSchemaResponse"
+        409:
+          description: "Incompatible Avro schema"
+        422:
+          description: "Error code 42201 -- Invalid Avro schema"
+        500:
+          description: "Error code 50001 -- Error in the backend data store\nError\
+            \ code 50002 -- Operation timed out\nError code 50003 -- Error while forwarding\
+            \ the request to the primary"
   /subjects/{subject}/versions/{version}:
     get:
+      summary: "Get a specific version of the schema registered under this subject."
+      description: ""
       operationId: "getSchema"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
@@ -404,10 +501,16 @@ paths:
       parameters:
       - name: "subject"
         in: "path"
+        description: "Name of the Subject"
         required: true
         type: "string"
       - name: "version"
         in: "path"
+        description: "Version of the schema to be returned. Valid values for versionId\
+          \ are between [1,2^31-1] or the string \"latest\". \"latest\" returns the\
+          \ last registered schema under the specified subject. Note that there may\
+          \ be a new latest schema that gets registered right after this request is\
+          \ served."
         required: true
         type: "string"
       responses:
@@ -415,7 +518,21 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/Schema"
+        404:
+          description: "Error code 40401 -- Subject not found\nError code 40402 --\
+            \ Version not found"
+        422:
+          description: "Error code 42202 -- Invalid version"
+        500:
+          description: "Error code 50001 -- Error in the backend data store"
     delete:
+      summary: "Deletes a specific version of the schema registered under this subject.\
+        \ This only deletes the version and the schema ID remains intact making it\
+        \ still possible to decode data using the schema ID. This API is recommended\
+        \ to be used only in development environments or under extreme circumstances\
+        \ where-in, its required to delete a previously registered schema for compatibility\
+        \ purposes or re-register previously registered schema."
+      description: ""
       operationId: "deleteSchemaVersion"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
@@ -429,17 +546,36 @@ paths:
       parameters:
       - name: "subject"
         in: "path"
+        description: "Name of the Subject"
         required: true
         type: "string"
       - name: "version"
         in: "path"
+        description: "Version of the schema to be returned. Valid values for versionId\
+          \ are between [1,2^31-1] or the string \"latest\". \"latest\" returns the\
+          \ last registered schema under the specified subject. Note that there may\
+          \ be a new latest schema that gets registered right after this request is\
+          \ served."
         required: true
         type: "string"
       responses:
-        default:
+        200:
           description: "successful operation"
+          schema:
+            type: "integer"
+            format: "int32"
+        404:
+          description: "Error code 40401 -- Subject not found\nError code 40402 --\
+            \ Version not found"
+        422:
+          description: "Error code 42202 -- Invalid version"
+        500:
+          description: "Error code 50001 -- Error in the backend data store"
   /subjects/{subject}/versions/{version}/schema:
     get:
+      summary: "Get the avro schema for the specified version of this subject. The\
+        \ unescaped schema only is returned."
+      description: ""
       operationId: "getSchemaOnly"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
@@ -453,10 +589,16 @@ paths:
       parameters:
       - name: "subject"
         in: "path"
+        description: "Name of the Subject"
         required: true
         type: "string"
       - name: "version"
         in: "path"
+        description: "Version of the schema to be returned. Valid values for versionId\
+          \ are between [1,2^31-1] or the string \"latest\". \"latest\" returns the\
+          \ last registered schema under the specified subject. Note that there may\
+          \ be a new latest schema that gets registered right after this request is\
+          \ served."
         required: true
         type: "string"
       responses:
@@ -464,6 +606,13 @@ paths:
           description: "successful operation"
           schema:
             type: "string"
+        404:
+          description: "Error code 40401 -- Subject not found\nError code 40402 --\
+            \ Version not found"
+        422:
+          description: "Error code 42202 -- Invalid version"
+        500:
+          description: "Error code 50001 -- Error in the backend data store"
 definitions:
   CompatibilityCheckResponse:
     type: "object"
@@ -475,11 +624,29 @@ definitions:
     properties:
       compatibilityLevel:
         type: "string"
+        description: "Compatability Level"
+        enum:
+        - "BACKWARD"
+        - "BACKWARD_TRANSITIVE"
+        - "FORWARD"
+        - "FORWARD_TRANSITIVE"
+        - "FULL"
+        - "FULL_TRANSITIVE"
+        - "NONE"
   ConfigUpdateRequest:
     type: "object"
     properties:
       compatibility:
         type: "string"
+        description: "Compatability Level"
+        enum:
+        - "BACKWARD"
+        - "BACKWARD_TRANSITIVE"
+        - "FORWARD"
+        - "FORWARD_TRANSITIVE"
+        - "FULL"
+        - "FULL_TRANSITIVE"
+        - "NONE"
   ModeGetResponse:
     type: "object"
     properties:
@@ -490,6 +657,12 @@ definitions:
     properties:
       mode:
         type: "string"
+  RegisterSchemaResponse:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int32"
   Schema:
     type: "object"
     properties:
@@ -508,3 +681,4 @@ definitions:
     properties:
       schema:
         type: "string"
+        description: "Schema string identified by the ID"

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -89,6 +89,12 @@ paths:
           \ with the last registered schema under the specified subject"
         required: true
         type: "string"
+      - in: "body"
+        name: "body"
+        description: "Schema"
+        required: true
+        schema:
+          $ref: "#/definitions/RegisterSchemaRequest"
       responses:
         200:
           description: "successful operation"
@@ -365,6 +371,12 @@ paths:
         in: "query"
         required: false
         type: "boolean"
+      - in: "body"
+        name: "body"
+        description: "Schema"
+        required: true
+        schema:
+          $ref: "#/definitions/RegisterSchemaRequest"
       responses:
         404:
           description: "Error code 40401 -- Subject not found\nError code 40403 --\

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -199,6 +199,16 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>1.5.22</version>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-core</artifactId>
+            <version>1.5.3</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -216,6 +226,40 @@
                 <configuration>
                     <mainClass>io.confluent.kafka.schemaregistry.rest.SchemaRegistryMain</mainClass>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>com.github.kongchen</groupId>
+                <artifactId>swagger-maven-plugin</artifactId>
+                <version>3.1.8</version>
+                <configuration>
+                    <apiSources>
+                        <apiSource>
+                            <springmvc>false</springmvc>
+
+                            <locations>io.confluent.kafka.schemaregistry.rest.resources</locations>
+                            <schemes>http,https
+                            </schemes>
+                            <info>
+                                <title>Confluent Schema Registry</title>
+                                <version>v1</version>
+                            </info>
+                            <outputFormats>yaml</outputFormats>
+                            <swaggerFileName>schema-registry-api-spec</swaggerFileName>
+                            <outputPath>${basedir}/generated/document.html</outputPath>
+                            <swaggerDirectory>${basedir}/generated/swagger-ui</swaggerDirectory>
+                        </apiSource>
+
+                    </apiSources>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -237,7 +237,7 @@
                         <apiSource>
                             <springmvc>false</springmvc>
 
-                            <locations>io.confluent.kafka.schemaregistry.rest.resources</locations>
+                            <locations><location>io.confluent.kafka.schemaregistry.rest.resources</location></locations>
                             <schemes>http,https
                             </schemes>
                             <info>

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -81,7 +81,7 @@ public class CompatibilityResource {
           + "Error code 42202 -- Invalid version"),
       @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store") })
   @PerformanceMetric("compatibility.subjects.versions.verify")
-  public void lookUpSchemaUnderSubject(
+  public void testCompatabilityBySubjectName(
       final @Suspended AsyncResponse asyncResponse,
       final @HeaderParam("Content-Type") String contentType,
       final @HeaderParam("Accept") String accept,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -91,6 +91,7 @@ public class CompatibilityResource {
           + "tested. Valid values for versionId are between [1,2^31-1] or the string \"latest\"."
           + "\"latest\" checks compatibility of the input schema with the last registered schema "
           + "under the specified subject", required = true)@PathParam("version") String version,
+      @ApiParam(value = "Schema", required = true)
       @NotNull RegisterSchemaRequest request) {
     // returns true if posted schema is compatible with the specified version. "latest" is 
     // a special version

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -15,6 +15,10 @@
 
 package io.confluent.kafka.schemaregistry.rest.resources;
 
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,8 +68,15 @@ public class ConfigResource {
 
   @Path("/{subject}")
   @PUT
+  @ApiOperation(value = "Update compatibility level for the specified subject.")
+  @ApiResponses(value = {
+      @ApiResponse(code = 422, message = "Error code 42203 -- Invalid compatibility level\n"
+          + "Error code 40402 -- Version not found"),
+      @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store\n"
+          + "Error code 50003 -- Error while forwarding the request to the primary")
+  })
   public ConfigUpdateRequest updateSubjectLevelConfig(
-      @PathParam("subject") String subject,
+      @ApiParam(value = "Name of the Subject", required = true)@PathParam("subject") String subject,
       @Context HttpHeaders headers,
       @NotNull ConfigUpdateRequest request) {
     Set<String> subjects = null;
@@ -110,6 +121,10 @@ public class ConfigResource {
 
   @Path("/{subject}")
   @GET
+  @ApiOperation(value = "Get compatibility level for a subject.")
+  @ApiResponses(value = {
+      @ApiResponse(code = 404, message = "Subject not found"),
+      @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store")})
   public Config getSubjectLevelConfig(@PathParam("subject") String subject) {
     Config config = null;
     try {
@@ -127,6 +142,12 @@ public class ConfigResource {
   }
 
   @PUT
+  @ApiOperation(value = "Update global compatibility level.")
+  @ApiResponses(value = {
+      @ApiResponse(code = 422, message = "Error code 42203 -- Invalid compatibility level"),
+      @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store\n"
+          + "Error code 50003 -- Error while forwarding the request to the primary\n")
+  })
   public ConfigUpdateRequest updateTopLevelConfig(
       @Context HttpHeaders headers,
       @NotNull ConfigUpdateRequest request) {
@@ -154,6 +175,10 @@ public class ConfigResource {
   }
 
   @GET
+  @ApiOperation(value = "Get global compatibility level.")
+  @ApiResponses(value = {@ApiResponse(code = 500,
+      message = "Error code 50001 -- Error in the backend data store")}
+  )
   public Config getTopLevelConfig() {
     Config config = null;
     try {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/RootResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/RootResource.java
@@ -27,7 +27,12 @@ import javax.ws.rs.Produces;
 
 import io.confluent.kafka.schemaregistry.client.rest.Versions;
 
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+
 @Path("/")
+@Api(value = "/")
 @Produces(
     {Versions.SCHEMA_REGISTRY_V1_JSON_WEIGHTED, Versions.SCHEMA_REGISTRY_DEFAULT_JSON_WEIGHTED,
      Versions.JSON_WEIGHTED})
@@ -36,6 +41,9 @@ import io.confluent.kafka.schemaregistry.client.rest.Versions;
 public class RootResource {
 
   @GET
+  @ApiOperation(value = "Schema Registry Root Resource",
+      notes = "The Root resource is a no-op.",
+      response = Map.class)
   public Map<String, String> get() {
     // Currently this just provides an endpoint that's a nop and can be used to check for
     // liveness and can be used for tests that need to test the server setup rather than the

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
@@ -15,6 +15,10 @@
 
 package io.confluent.kafka.schemaregistry.rest.resources;
 
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,8 +54,14 @@ public class SchemasResource {
 
   @GET
   @Path("/ids/{id}")
+  @ApiOperation("Get the schema string identified by the input ID.")
+  @ApiResponses(value = {
+      @ApiResponse(code = 404, message = "Error code 40403 -- Schema not found\n"),
+      @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store\n")})
   @PerformanceMetric("schemas.ids.get-schema")
-  public SchemaString getSchema(@PathParam("id") Integer id) {
+  public SchemaString getSchema(
+      @ApiParam(value = "Globally unique identifier of the schema", required = true)
+      @PathParam("id") Integer id) {
     SchemaString schema = null;
     String errorMessage = "Error while retrieving schema with id " + id + " from the schema "
                           + "registry";

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -91,7 +91,7 @@ public class SubjectVersionsResource {
           + "Error code 40402 -- Version not found"),
       @ApiResponse(code = 422, message = "Error code 42202 -- Invalid version"),
       @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store")})
-  public Schema getSchema(
+  public Schema getSchemaByVersion(
       @ApiParam(value = "Name of the Subject", required = true)@PathParam("subject") String subject,
       @ApiParam(value = VERSION_PARAM_DESC, required = true)@PathParam("version") String version) {
     VersionId versionId = null;
@@ -134,7 +134,7 @@ public class SubjectVersionsResource {
   public String getSchemaOnly(
       @ApiParam(value = "Name of the Subject", required = true)@PathParam("subject") String subject,
       @ApiParam(value = VERSION_PARAM_DESC, required = true)@PathParam("version") String version) {
-    return getSchema(subject, version).getSchema();
+    return getSchemaByVersion(subject, version).getSchema();
   }
 
   @GET
@@ -143,7 +143,7 @@ public class SubjectVersionsResource {
   @ApiResponses(value = {
       @ApiResponse(code = 404, message = "Error code 40401 -- Subject not found"),
       @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store")})
-  public List<Integer> list(
+  public List<Integer> listVersions(
       @ApiParam(value = "Name of the Subject", required = true)
         @PathParam("subject") String subject) {
     // check if subject exists. If not, throw 404

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -205,6 +205,7 @@ public class SubjectVersionsResource {
       @Context HttpHeaders headers,
       @ApiParam(value = "Name of the Subject", required = true)
         @PathParam("subject") String subjectName,
+      @ApiParam(value = "Schema", required = true)
       @NotNull RegisterSchemaRequest request) {
 
     Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -15,6 +15,10 @@
 
 package io.confluent.kafka.schemaregistry.rest.resources;
 
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,12 +69,21 @@ public class SubjectsResource {
 
   @POST
   @Path("/{subject}")
+  @ApiOperation(value = "Check if a schema has already been registered under the specified subject."
+      + " If so, this returns the schema string along with its globally unique identifier, its "
+      + "version under this subject and the subject name.")
+  @ApiResponses(value = {
+      @ApiResponse(code = 404, message = "Error code 40401 -- Subject not found\n"
+          + "Error code 40403 -- Schema not found"),
+      @ApiResponse(code = 500, message = "Internal server error", response = Schema.class),
+  })
   @PerformanceMetric("subjects.get-schema")
-  public void lookUpSchemaUnderSubject(final @Suspended AsyncResponse asyncResponse,
-                                       @PathParam("subject") String subject,
-                                       @QueryParam("deleted") boolean
-                                           lookupDeletedSchema,
-                                       @NotNull RegisterSchemaRequest request) {
+  public void lookUpSchemaUnderSubject(
+      final @Suspended AsyncResponse asyncResponse,
+      @ApiParam(value = "Subject under which the schema will be registered", required = true)
+        @PathParam("subject") String subject,
+      @QueryParam("deleted") boolean lookupDeletedSchema,
+      @NotNull RegisterSchemaRequest request) {
     // returns version if the schema exists. Otherwise returns 404
     Schema schema = new Schema(subject, 0, -1, request.getSchema());
     io.confluent.kafka.schemaregistry.client.rest.entities.Schema matchingSchema = null;
@@ -94,6 +107,9 @@ public class SubjectsResource {
 
   @GET
   @Valid
+  @ApiOperation(value = "Get a list of registered subjects.")
+  @ApiResponses(value = {
+      @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend datastore")})
   @PerformanceMetric("subjects.list")
   public Set<String> list() {
     try {
@@ -107,10 +123,19 @@ public class SubjectsResource {
 
   @DELETE
   @Path("/{subject}")
+  @ApiOperation(value = "Deletes the specified subject and its associated compatibility level if "
+      + "registered. It is recommended to use this API only when a topic needs to be recycled or "
+      + "in development environment.", response = Integer.class, responseContainer = "List")
+  @ApiResponses(value = {
+      @ApiResponse(code = 404, message = "Error code 40401 -- Subject not found"),
+      @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend datastore")
+  })
   @PerformanceMetric("subjects.delete-subject")
-  public void deleteSubject(final @Suspended AsyncResponse asyncResponse,
-                            @Context HttpHeaders headers,
-                            @PathParam("subject") String subject) {
+  public void deleteSubject(
+      final @Suspended AsyncResponse asyncResponse,
+      @Context HttpHeaders headers,
+      @ApiParam(value = "the name of the subject", required = true)
+        @PathParam("subject") String subject) {
     List<Integer> deletedVersions;
     try {
       if (!schemaRegistry.listSubjects().contains(subject)) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -83,6 +83,7 @@ public class SubjectsResource {
       @ApiParam(value = "Subject under which the schema will be registered", required = true)
         @PathParam("subject") String subject,
       @QueryParam("deleted") boolean lookupDeletedSchema,
+      @ApiParam(value = "Schema", required = true)
       @NotNull RegisterSchemaRequest request) {
     // returns version if the schema exists. Otherwise returns 404
     Schema schema = new Schema(subject, 0, -1, request.getSchema());


### PR DESCRIPTION
The strategy is to autogenerate on `mvn compile` which will force our spec to be tied to the actual code. This has been manually tested with a generated go sdk locally and it works.

One open question is how we will keep public documentation up to date. This may involve manually copying the spec to the docs repo, and generating docs from there. This will have similar problem as connector configs: Updates will need to go into the product repo then copied into docs repo