### PR TITLE
CPKAFKA-3239: Create new BasicAuthCredentialProvider for every getBasicicAuthCredentialProvider call

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProviderFactory.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProviderFactory.java
@@ -16,36 +16,27 @@
 
 package io.confluent.kafka.schemaregistry.client.security.bearerauth;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
 
 public class BearerAuthCredentialProviderFactory {
 
-  public static final Map<String, BearerAuthCredentialProvider>
-      bearerAuthCredentialProviderMap = new HashMap<>();
+  public static BearerAuthCredentialProvider getBearerAuthCredentialProvider(
+      String bearerAuthCredentialSource,
+      Map<String, ?> configs) {
 
-  static {
     ServiceLoader<BearerAuthCredentialProvider> serviceLoader = ServiceLoader.load(
         BearerAuthCredentialProvider.class,
         BearerAuthCredentialProviderFactory.class.getClassLoader()
     );
 
     for (BearerAuthCredentialProvider bearerAuthCredentialProvider : serviceLoader) {
-      bearerAuthCredentialProviderMap.put(
-          bearerAuthCredentialProvider.alias(),
-          bearerAuthCredentialProvider);
+      if (bearerAuthCredentialProvider.alias().equals(bearerAuthCredentialSource)) {
+        bearerAuthCredentialProvider.configure(configs);
+        return bearerAuthCredentialProvider;
+      }
     }
-  }
 
-  public static BearerAuthCredentialProvider getBearerAuthCredentialProvider(
-      String bearerAuthCredentialSource,
-      Map<String, ?> configs) {
-    BearerAuthCredentialProvider bearerAuthCredentialProvider =
-        bearerAuthCredentialProviderMap.get(bearerAuthCredentialSource);
-    if (bearerAuthCredentialProvider != null) {
-      bearerAuthCredentialProvider.configure(configs);
-    }
-    return bearerAuthCredentialProvider;
+    return null;
   }
 }


### PR DESCRIPTION
Currently we are maintaining single instance of BasicAuthCredentialProvider per type. This is error-prone, if we have multiple SR clients with multiple users in same jvm.