### PR TITLE
MINOR: Add missing reset method to mock client

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -369,5 +369,9 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
 
   @Override
   public void reset() {
+    schemaCache.clear();
+    idCache.clear();
+    versionCache.clear();
+    idCache.put(null, new HashMap<Integer, Schema>());
   }
 }


### PR DESCRIPTION
The implementation of reset is copied from CachedSchemaRegistryClient.