### PR TITLE
change toConnectSchema in AvroData to protected

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -1494,7 +1494,7 @@ public class AvroData {
   }
 
 
-  private Schema toConnectSchema(org.apache.avro.Schema schema,
+  protected Schema toConnectSchema(org.apache.avro.Schema schema,
                                  Integer version,
                                  ToConnectContext toConnectContext) {
 
@@ -1526,7 +1526,7 @@ public class AvroData {
    *                         used when converting Avro record fields since they define doc values
    * @param toConnectContext context object that holds state while doing the conversion
    */
-  private Schema toConnectSchema(org.apache.avro.Schema schema,
+  protected Schema toConnectSchema(org.apache.avro.Schema schema,
                                  boolean forceOptional,
                                  Object fieldDefaultVal,
                                  String docDefaultVal,


### PR DESCRIPTION
<!--
Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
The forceOptional parameter is default to false in the public method and there's no way to change it. If the methods can be inherited and use different parameters in the extended class, there will be much more flexibility.

References
----------
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

<!--
Open questions / Follow ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->
I'm sure there are good reasons for making the methods non-inheritable that I'm not aware of. This is just a proposal that will be beneficial for the project I'm working on. Let me know if that can't be done.

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
