### PR TITLE
MINOR: fix NPE by ignoring tombstones

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -42,6 +42,10 @@ public class KafkaStoreMessageHandler
    */
   @Override
   public void handleUpdate(SchemaRegistryKey key, SchemaRegistryValue value) {
+    if (value == null) {
+      // Ignore tombstones
+      return;
+    }
     if (key.getKeyType() == SchemaRegistryKeyType.SCHEMA) {
       handleSchemaUpdate((SchemaKey) key,
                          (SchemaValue) value);


### PR DESCRIPTION
Currently tombstones are causing an NPE in KafkaStoreMessageHandler