### PR TITLE
Fix createParentPath issue where it was actually creating the child path

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -51,6 +51,14 @@
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.101tec</groupId>
+            <artifactId>zkclient</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/id/ZookeeperIdGenerator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/id/ZookeeperIdGenerator.java
@@ -15,13 +15,13 @@
 
 package io.confluent.kafka.schemaregistry.id;
 
-import io.confluent.common.utils.zookeeper.ZkData;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.exceptions.IdGenerationException;
 import io.confluent.kafka.schemaregistry.masterelector.zookeeper.ZookeeperMasterElector;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.storage.SchemaKey;
 import io.confluent.kafka.schemaregistry.storage.SchemaValue;
+import io.confluent.kafka.schemaregistry.utils.ZkData;
 import io.confluent.kafka.schemaregistry.utils.ZkUtils;
 
 import org.I0Itec.zkclient.exception.ZkNodeExistsException;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/utils/ZkData.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/utils/ZkData.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafka.schemaregistry.utils;
+
+import org.apache.zookeeper.data.Stat;
+
+public class ZkData {
+
+  private final String data;
+  private final Stat stat;
+
+  public ZkData(String data, Stat stat) {
+    this.data = data;
+    this.stat = stat;
+  }
+
+  public String getData() {
+    return this.data;
+  }
+
+  public Stat getStat() {
+    return this.stat;
+  }
+}

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/utils/ZkUtils.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/utils/ZkUtils.java
@@ -36,8 +36,6 @@ import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.data.ACL;
 import org.apache.zookeeper.data.Stat;
 
-import io.confluent.common.utils.zookeeper.ZkData;
-
 /**
  * This is a temporary replacement for kafka.utils.ZkUtils and will be removed in CP 6.0
  * when ZooKeeper references are removed from Schema Registry.
@@ -161,6 +159,10 @@ public class ZkUtils implements AutoCloseable {
     }
   }
 
+  public void updatePersistentPath(String path, String data) {
+    zkClient.writeData(path, data);
+  }
+
   public ZkData readData(String path) {
     Stat stat = new Stat();
     String data = zkClient.readData(path, stat);
@@ -176,6 +178,10 @@ public class ZkUtils implements AutoCloseable {
       data = null;
     }
     return new ZkData(data, stat);
+  }
+
+  public boolean delete(String path) {
+    return zkClient.delete(path);
   }
 
   private void createPersistent(String path, Object data) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/utils/ZkUtils.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/utils/ZkUtils.java
@@ -141,7 +141,7 @@ public class ZkUtils implements AutoCloseable {
     String parentDir = path.substring(0, path.lastIndexOf('/'));
     if (!parentDir.isEmpty()) {
       checkNamespace();
-      zkClient.createPersistent(path, true, acls);
+      zkClient.createPersistent(parentDir, true, acls);
     }
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
@@ -90,7 +90,6 @@ public abstract class ClusterTestHarness {
   // ZK Config
   protected EmbeddedZookeeper zookeeper;
   protected String zkConnect;
-  protected ZkClient zkClient;
   protected ZkUtils zkUtils;
   protected int zkConnectionTimeout = 30000; // a larger connection timeout is required for SASL tests
                                              // because SASL connections tend to take longer.
@@ -139,9 +138,7 @@ public abstract class ClusterTestHarness {
     ); // true or false doesn't matter because the schema registry Kafka principal is the same as the
     // Kafka broker principal, so ACLs won't make any difference. The principals are the same because
     // ZooKeeper, Kafka, and the Schema Registry are run in the same process during testing and hence share
-    // the same JAAS configuration file. Read comments in ASLClusterTestHarness.java for more details.
-    zkClient = zkUtils.zkClient();
-
+    // the same JAAS configuration file. Read comments in SASLClusterTestHarness.java for more details.
     configs = new Vector<>();
     servers = new Vector<>();
     for (int i = 0; i < numBrokers; i++) {


### PR DESCRIPTION
Also:
* Removed the dependency on `common.utils.zookeeper` classes as
it was confusing to use both that and the `ZkUtils` class in this project.
* Added explicit compile Maven dependency on `zookeeper` and `zkclient`
since we refer to them directly in this project.