### PR TITLE
Allowing HTTP Headers on requests to schema registry

### DIFF
--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
@@ -39,6 +39,8 @@ public abstract class SchemaRegistryMojo extends AbstractMojo {
   List<String> schemaRegistryUrls;
   @Parameter
   String userInfoConfig;
+  @Parameter
+  Map<String, String> httpHeaders;
   private SchemaRegistryClient client;
 
   void client(SchemaRegistryClient client) {
@@ -54,7 +56,7 @@ public abstract class SchemaRegistryMojo extends AbstractMojo {
         config.put(SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO");
         config.put(SchemaRegistryClientConfig.USER_INFO_CONFIG, userInfoConfig);
       }
-      this.client = new CachedSchemaRegistryClient(this.schemaRegistryUrls, 1000, config);
+      this.client = new CachedSchemaRegistryClient(this.schemaRegistryUrls, 1000, config, httpHeaders);
     }
     return this.client;
   }


### PR DESCRIPTION
Thee schema registry may be kept secure with some auth mechanism and there ability to add HEADER comes very useful. This PR will enable use to add headers as shown below.

```
                                       <plugin>
						<groupId>io.confluent</groupId>
						<artifactId>kafka-schema-registry-maven-plugin</artifactId>
						<version>5.3.0</version>
						<executions>
							<execution>
								<id>.....
								<configuration>
									.......

									<!-- Custom headers -->
									<httpHeaders>
										<auth-token>jjjjss-dcdc-sdcsdc-ssss-llls-lok9</auth-token>
									</httpHeaders>
								</configuration>
							</execution>
						</executions>
					</plugin>
```