### PR TITLE
MINOR: Change int to Integer for schemaRegistryPort

### DIFF
--- a/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
@@ -101,7 +101,7 @@ public abstract class ClusterTestHarness {
   protected String brokerList = null;
   protected String bootstrapServers = null;
 
-  protected int schemaRegistryPort;
+  protected Integer schemaRegistryPort;
   protected RestApp restApp = null;
 
   public ClusterTestHarness() {
@@ -170,7 +170,8 @@ public abstract class ClusterTestHarness {
     bootstrapServers = Utils.join(serverUrls, ",");
 
     if (setupRestApp) {
-      schemaRegistryPort = choosePort();
+      if (schemaRegistryPort == null)
+        schemaRegistryPort = choosePort();
       Properties schemaRegistryProps = getSchemaRegistryProperties();
       schemaRegistryProps.put(SchemaRegistryConfig.LISTENERS_CONFIG, getSchemaRegistryProtocol() +
                                                                      "://0.0.0.0:"

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
@@ -35,22 +35,22 @@ public class RestApp {
   public Server restServer;
   public String restConnect;
 
-  public RestApp(int port, String zkConnect, String kafkaTopic) {
+  public RestApp(Integer port, String zkConnect, String kafkaTopic) {
     this(port, zkConnect, kafkaTopic, AvroCompatibilityLevel.NONE.name, null);
   }
 
-  public RestApp(int port, String zkConnect, String kafkaTopic, String compatibilityType, Properties schemaRegistryProps) {
+  public RestApp(Integer port, String zkConnect, String kafkaTopic, String compatibilityType, Properties schemaRegistryProps) {
     this(port, zkConnect, null, kafkaTopic, compatibilityType, true, schemaRegistryProps);
   }
 
-  public RestApp(int port,
+  public RestApp(Integer port,
                  String zkConnect, String kafkaTopic,
                  String compatibilityType, boolean masterEligibility, Properties schemaRegistryProps) {
     this(port, zkConnect, null, kafkaTopic, compatibilityType,
          masterEligibility, schemaRegistryProps);
   }
 
-  public RestApp(int port,
+  public RestApp(Integer port,
                  String zkConnect, String bootstrapBrokers,
                  String kafkaTopic, String compatibilityType, boolean masterEligibility,
                  Properties schemaRegistryProps) {
@@ -58,7 +58,7 @@ public class RestApp {
     if (schemaRegistryProps != null) {
       prop.putAll(schemaRegistryProps);
     }
-    prop.setProperty(SchemaRegistryConfig.PORT_CONFIG, ((Integer) port).toString());
+    prop.setProperty(SchemaRegistryConfig.PORT_CONFIG, port.toString());
     if (zkConnect != null) {
       prop.setProperty(SchemaRegistryConfig.KAFKASTORE_CONNECTION_URL_CONFIG, zkConnect);
     }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
@@ -35,22 +35,22 @@ public class RestApp {
   public Server restServer;
   public String restConnect;
 
-  public RestApp(Integer port, String zkConnect, String kafkaTopic) {
+  public RestApp(int port, String zkConnect, String kafkaTopic) {
     this(port, zkConnect, kafkaTopic, AvroCompatibilityLevel.NONE.name, null);
   }
 
-  public RestApp(Integer port, String zkConnect, String kafkaTopic, String compatibilityType, Properties schemaRegistryProps) {
+  public RestApp(int port, String zkConnect, String kafkaTopic, String compatibilityType, Properties schemaRegistryProps) {
     this(port, zkConnect, null, kafkaTopic, compatibilityType, true, schemaRegistryProps);
   }
 
-  public RestApp(Integer port,
+  public RestApp(int port,
                  String zkConnect, String kafkaTopic,
                  String compatibilityType, boolean masterEligibility, Properties schemaRegistryProps) {
     this(port, zkConnect, null, kafkaTopic, compatibilityType,
          masterEligibility, schemaRegistryProps);
   }
 
-  public RestApp(Integer port,
+  public RestApp(int port,
                  String zkConnect, String bootstrapBrokers,
                  String kafkaTopic, String compatibilityType, boolean masterEligibility,
                  Properties schemaRegistryProps) {
@@ -58,7 +58,7 @@ public class RestApp {
     if (schemaRegistryProps != null) {
       prop.putAll(schemaRegistryProps);
     }
-    prop.setProperty(SchemaRegistryConfig.PORT_CONFIG, port.toString());
+    prop.setProperty(SchemaRegistryConfig.PORT_CONFIG, ((Integer) port).toString());
     if (zkConnect != null) {
       prop.setProperty(SchemaRegistryConfig.KAFKASTORE_CONNECTION_URL_CONFIG, zkConnect);
     }


### PR DESCRIPTION
This change gives us more flexibility to set `schemaRegistryPort` outside of `setUp`