### PR TITLE
API to retrieve all subjects associated with a schema id

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -218,6 +218,11 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
+  public Collection<String> getAllSubjectsById(int id) throws IOException, RestClientException {
+    return restService.getAllSubjectsById(id);
+  }
+
+  @Override
   public SchemaMetadata getSchemaMetadata(String subject, int version)
       throws IOException, RestClientException {
     io.confluent.kafka.schemaregistry.client.rest.entities.Schema response

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 /**
  * Mock implementation of SchemaRegistryClient that can be used for tests. This version is NOT
@@ -203,6 +204,13 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
       idSchemaMap.put(id, schema);
       return schema;
     }
+  }
+
+  @Override
+  public Collection<String> getAllSubjectsById(int id) throws IOException, RestClientException {
+    return idCache.entrySet().stream()
+            .filter(entry -> entry.getValue().containsKey(id))
+            .map(Map.Entry::getKey).collect(Collectors.toSet());
   }
 
   private int getLatestVersion(String subject)

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -42,6 +42,8 @@ public interface SchemaRegistryClient {
 
   public Schema getBySubjectAndId(String subject, int id) throws IOException, RestClientException;
 
+  public Collection<String> getAllSubjectsById(int id) throws IOException, RestClientException;
+
   public SchemaMetadata getLatestSchemaMetadata(String subject)
       throws IOException, RestClientException;
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -606,7 +606,8 @@ public class RestService implements Configurable {
       throws IOException, RestClientException {
     String path = String.format("/schemas/ids/%d/subjects", id);
 
-    List<String> response = httpRequest(path, "GET", null, requestProperties, ALL_TOPICS_RESPONSE_TYPE);
+    List<String> response = httpRequest(path, "GET", null, requestProperties,
+                                        ALL_TOPICS_RESPONSE_TYPE);
 
     return response;
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -596,6 +596,21 @@ public class RestService implements Configurable {
     return response;
   }
 
+  public List<String> getAllSubjectsById(int id)
+      throws IOException, RestClientException {
+    return getAllSubjectsById(DEFAULT_REQUEST_PROPERTIES, id);
+  }
+
+  public List<String> getAllSubjectsById(Map<String, String> requestProperties,
+                                         int id)
+      throws IOException, RestClientException {
+    String path = String.format("/schemas/ids/%d/subjects", id);
+
+    List<String> response = httpRequest(path, "GET", null, requestProperties, ALL_TOPICS_RESPONSE_TYPE);
+
+    return response;
+  }
+
   public Integer deleteSchemaVersion(
       Map<String, String> requestProperties,
       String subject,

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -320,6 +320,39 @@ paths:
           description: "Error code 40403 -- Schema not found\n"
         500:
           description: "Error code 50001 -- Error in the backend data store\n"
+  /schemas/ids/{id}/subjects:
+    get:
+      summary: "Get all the subjects associated with the input ID."
+      description: ""
+      operationId: "getSubjects"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "Globally unique identifier of the schema"
+        required: true
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              type: "string"
+            uniqueItems: true
+        404:
+          description: "Error code 40403 -- Schema not found\n"
+        500:
+          description: "Error code 50001 -- Error in the backend data store\n"
   /subjects:
     get:
       summary: "Get a list of registered subjects."

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
@@ -91,15 +91,16 @@ public class SchemasResource {
       @ApiParam(value = "Globally unique identifier of the schema", required = true)
       @PathParam("id") Integer id) {
     Set<String> subjects;
-    String errorMessage = "Error while retrieving all subjects associated with schema id " + id + " from the schema registry";
+    String errorMessage = "Error while retrieving all subjects associated with schema id "
+                          + id + " from the schema registry";
 
     try {
-     subjects = schemaRegistry.listSubjectsForId(id);
+      subjects = schemaRegistry.listSubjectsForId(id);
     } catch (SchemaRegistryStoreException e) {
-     log.debug(errorMessage, e);
-     throw Errors.storeException(errorMessage, e);
+      log.debug(errorMessage, e);
+      throw Errors.storeException(errorMessage, e);
     } catch (SchemaRegistryException e) {
-     throw Errors.schemaRegistryException(errorMessage, e);
+      throw Errors.schemaRegistryException(errorMessage, e);
     }
 
     if (subjects == null) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
@@ -36,6 +36,8 @@ import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
 import io.confluent.rest.annotations.PerformanceMetric;
 
+import java.util.Set;
+
 @Path("/schemas")
 @Produces({Versions.SCHEMA_REGISTRY_V1_JSON_WEIGHTED,
            Versions.SCHEMA_REGISTRY_DEFAULT_JSON_WEIGHTED,
@@ -77,5 +79,33 @@ public class SchemasResource {
       throw Errors.schemaNotFoundException();
     }
     return schema;
+  }
+
+  @GET
+  @Path("/ids/{id}/subjects")
+  @ApiOperation("Get all the subjects associated with the input ID.")
+  @ApiResponses(value = {
+      @ApiResponse(code = 404, message = "Error code 40403 -- Schema not found\n"),
+      @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store\n")})
+  public Set<String> getSubjects(
+      @ApiParam(value = "Globally unique identifier of the schema", required = true)
+      @PathParam("id") Integer id) {
+    Set<String> subjects;
+    String errorMessage = "Error while retrieving all subjects associated with schema id " + id + " from the schema registry";
+
+    try {
+     subjects = schemaRegistry.listSubjectsForId(id);
+    } catch (SchemaRegistryStoreException e) {
+     log.debug(errorMessage, e);
+     throw Errors.storeException(errorMessage, e);
+    } catch (SchemaRegistryException e) {
+     throw Errors.schemaRegistryException(errorMessage, e);
+    }
+
+    if (subjects == null) {
+      throw Errors.schemaNotFoundException();
+    }
+
+    return subjects;
   }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -793,7 +793,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
         return null;
       }
     } catch (StoreException e) {
-      throw new SchemaRegistryStoreException("Error while retrieving schema with id " + id + " from the backend Kafka store", e);
+      throw new SchemaRegistryStoreException("Error while retrieving schema with id "
+                                              + id + " from the backend Kafka store", e);
     }
 
     return lookupCache.schemaIdAndSubjects(new Schema(

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -781,6 +781,26 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     }
   }
 
+  public Set<String> listSubjectsForId(int id) throws SchemaRegistryException {
+    SchemaValue schema = null;
+    try {
+      SchemaKey subjectVersionKey = lookupCache.schemaKeyById(id);
+      if (subjectVersionKey == null) {
+        return null;
+      }
+      schema = (SchemaValue) kafkaStore.get(subjectVersionKey);
+      if (schema == null) {
+        return null;
+      }
+    } catch (StoreException e) {
+      throw new SchemaRegistryStoreException("Error while retrieving schema with id " + id + " from the backend Kafka store", e);
+    }
+
+    return lookupCache.schemaIdAndSubjects(new Schema(
+        schema.getSubject(), schema.getVersion(), schema.getId(), schema.getSchema()
+    )).allSubjects();
+  }
+
   private Set<String> extractUniqueSubjects(Iterator<SchemaRegistryKey> allKeys)
       throws StoreException {
     Set<String> subjects = new HashSet<String>();

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaIdAndSubjects.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaIdAndSubjects.java
@@ -16,6 +16,7 @@
 package io.confluent.kafka.schemaregistry.storage;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 
@@ -63,6 +64,10 @@ public class SchemaIdAndSubjects {
         .filter(key -> filter.test(key))
         .findAny()
         .orElse(null);
+  }
+
+  public Set<String> allSubjects() {
+    return subjectsAndVersions.keySet();
   }
 
   public void removeIf(Predicate<SchemaKey> filter) {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -450,6 +450,20 @@ public class RestApiTest extends ClusterTestHarness {
   }
 
   @Test
+  public void testGetSubjectsAssociatedWithSchemaId() throws Exception {
+    String subject1 = "testTopic1";
+    String subject2 = "testTopic2";
+
+    String schema = TestUtils.getRandomCanonicalAvroString(1).get(0);
+    TestUtils.registerAndVerifySchema(restApp.restClient, schema, 1, subject1);
+    TestUtils.registerAndVerifySchema(restApp.restClient, schema, 1, subject2);
+
+    List<String> associatedSubjects = restApp.restClient.getAllSubjectsById(1);
+    assertEquals(associatedSubjects.size(), 2);
+    assertEquals(Arrays.asList(subject1, subject2), associatedSubjects);
+  }
+
+  @Test
   public void testCompatibilityNonExistentSubject() throws Exception {
     String schema = TestUtils.getRandomCanonicalAvroString(1).get(0);
     try {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -464,6 +464,19 @@ public class RestApiTest extends ClusterTestHarness {
   }
 
   @Test
+  public void testGetSubjectsAssociatedWithNotFoundSchemaId() throws Exception {
+    try {
+      restApp.restClient.getAllSubjectsById(1);
+      fail("Getting all subjects associated with id 1 should fail with "
+            + Errors.SCHEMA_NOT_FOUND_ERROR_CODE + " (schema not found)");
+    } catch (RestClientException rce) {
+      assertEquals("Should get a 404 status for non-existing schema",
+              Errors.SCHEMA_NOT_FOUND_ERROR_CODE,
+              rce.getErrorCode());
+    }
+  }
+
+  @Test
   public void testCompatibilityNonExistentSubject() throws Exception {
     String schema = TestUtils.getRandomCanonicalAvroString(1).get(0);
     try {


### PR DESCRIPTION
Issue: currently there is no direct API available that tells us all the subjects a given schema id is associated with