### PR TITLE
Print actual error when trying to access registry

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -256,7 +256,9 @@ public class RestService implements Configurable {
       } else {
         ErrorMessage errorMessage;
         try (InputStream es = connection.getErrorStream()) {
-          errorMessage = jsonDeserializer.readValue(es, ErrorMessage.class);
+          java.util.Scanner s = new java.util.Scanner(es).useDelimiter("\\A");
+	    	  String errStr = s.hasNext() ? s.next() : "";
+          errorMessage = jsonDeserializer.readValue(errStr, ErrorMessage.class);
         } catch (JsonProcessingException e) {
           errorMessage = new ErrorMessage(JSON_PARSE_ERROR_CODE, e.getMessage());
         }


### PR DESCRIPTION
I spent three whole days trying to figure out what was wrong with my configs in a controlled environment. The problem was a simple \n character in my schema registry credentials. It would have helped a lot if I could see the HTML response from schema registry server, instead of a JSON deserializing exception.

This patch does not solve the issue described in #733, but at least prints the actual error in the stack trace. JsonDeserializer will print the source string when it's not an InputStream.

