### PR TITLE
Fix for Issue #1197 Basic Authentication is a Singleton

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/basicauth/BasicAuthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/basicauth/BasicAuthCredentialProvider.java
@@ -25,4 +25,6 @@ public interface BasicAuthCredentialProvider extends Configurable {
   String alias();
 
   String getUserInfo(URL url);
+  
+  BasicAuthCredentialProvider clone();
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/basicauth/BasicAuthCredentialProviderFactory.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/basicauth/BasicAuthCredentialProviderFactory.java
@@ -44,6 +44,7 @@ public class BasicAuthCredentialProviderFactory {
     BasicAuthCredentialProvider basicAuthCredentialProvider =
         basicAuthCredentialProviderMap.get(basicAuthCredentialSource);
     if (basicAuthCredentialProvider != null) {
+      basicAuthCredentialProvider = basicAuthCredentialProvider.clone();
       basicAuthCredentialProvider.configure(configs);
     }
     return basicAuthCredentialProvider;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/basicauth/SaslBasicAuthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/basicauth/SaslBasicAuthCredentialProvider.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import javax.security.auth.login.AppConfigurationEntry;
 
 
-public class SaslBasicAuthCredentialProvider implements BasicAuthCredentialProvider {
+public class SaslBasicAuthCredentialProvider implements BasicAuthCredentialProvider, Cloneable {
 
   private String userInfo;
 
@@ -74,5 +74,15 @@ public class SaslBasicAuthCredentialProvider implements BasicAuthCredentialProvi
   @Override
   public String getUserInfo(URL url) {
     return userInfo;
+  }
+  
+  @Override
+  public SaslBasicAuthCredentialProvider clone() {
+    try {
+      return (SaslBasicAuthCredentialProvider) super.clone();
+    } catch (CloneNotSupportedException e) {
+      // Impossible
+      throw new IllegalStateException("Impossibly unable to clone Cloneable", e);
+    }  
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/basicauth/UrlBasicAuthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/basicauth/UrlBasicAuthCredentialProvider.java
@@ -19,7 +19,7 @@ package io.confluent.kafka.schemaregistry.client.security.basicauth;
 import java.net.URL;
 import java.util.Map;
 
-public class UrlBasicAuthCredentialProvider implements BasicAuthCredentialProvider {
+public class UrlBasicAuthCredentialProvider implements BasicAuthCredentialProvider, Cloneable {
 
   @Override
   public void configure(Map<String, ?> configs) {
@@ -33,5 +33,15 @@ public class UrlBasicAuthCredentialProvider implements BasicAuthCredentialProvid
   @Override
   public String getUserInfo(URL url) {
     return url.getUserInfo();
+  }
+  
+  @Override
+  public UrlBasicAuthCredentialProvider clone() {
+    try {
+      return (UrlBasicAuthCredentialProvider) super.clone();
+    } catch (CloneNotSupportedException e) {
+      // Impossible
+      throw new IllegalStateException("Impossibly unable to clone Cloneable", e);
+    }  
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/basicauth/UserInfoCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/basicauth/UserInfoCredentialProvider.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
 
-public class UserInfoCredentialProvider implements BasicAuthCredentialProvider {
+public class UserInfoCredentialProvider implements BasicAuthCredentialProvider, Cloneable {
 
   private String userInfo;
 
@@ -52,5 +52,14 @@ public class UserInfoCredentialProvider implements BasicAuthCredentialProvider {
   @Override
   public String getUserInfo(URL url) {
     return userInfo;
+  }
+  
+  @Override
+  public UserInfoCredentialProvider clone() {
+    try {
+      return (UserInfoCredentialProvider) super.clone();
+    } catch (CloneNotSupportedException e) {
+      throw new IllegalStateException("Impossibly unable to clone Cloneable", e);
+    }  
   }
 }


### PR DESCRIPTION
Fix for Issue #1197 

Before this commit, any attempt to use two Schema Regsitry clients to
access services that each required different Basic HTTP Authentication
credentials would fail because they shared a common singleton instance
of the provider class and one would overwrite the others' credentials.

This adds a Cloneable implementation to the provider and uses it from
the Factory before returning an instance to the RestService that
requests them.  Since the objects can now be distinct, they can now
carry distinct sets of credentials in their respective clones.

Test case included, which fails before this commit, and passes after.