### PR TITLE
Use constant time lookup to check subject exists

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -152,7 +152,7 @@ public class CompatibilityResource {
 
   private void registerWithError(final String subject, final String errorMessage) {
     try {
-      if (!schemaRegistry.listSubjects().contains(subject)) {
+      if (!schemaRegistry.hasSubjects(subject)) {
         throw Errors.subjectNotFoundException();
       }
     } catch (SchemaRegistryStoreException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -153,7 +153,7 @@ public class SubjectVersionsResource {
                           + subject
                           + " exists in the registry";
     try {
-      if (!schemaRegistry.listSubjects().contains(subject)) {
+      if (!schemaRegistry.hasSubjects(subject)) {
         throw Errors.subjectNotFoundException();
       }
     } catch (SchemaRegistryStoreException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -139,7 +139,7 @@ public class SubjectsResource {
         @PathParam("subject") String subject) {
     List<Integer> deletedVersions;
     try {
-      if (!schemaRegistry.listSubjects().contains(subject)) {
+      if (!schemaRegistry.hasSubjects(subject)) {
         throw Errors.subjectNotFoundException();
       }
       Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -89,7 +89,7 @@ public class SubjectsResource {
     Schema schema = new Schema(subject, 0, -1, request.getSchema());
     io.confluent.kafka.schemaregistry.client.rest.entities.Schema matchingSchema = null;
     try {
-      if (!schemaRegistry.listSubjects().contains(subject)) {
+      if (!schemaRegistry.hasSubjects(subject)) {
         throw Errors.subjectNotFoundException();
       }
       matchingSchema =

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -714,7 +714,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
       returnDeletedSchema) throws SchemaRegistryException {
     Schema schema = this.get(subject, versionId.getVersionId(), returnDeletedSchema);
     if (schema == null) {
-      if (!this.listSubjects().contains(subject)) {
+      if (!this.hasSubjects(subject)) {
         throw Errors.subjectNotFoundException();
       } else {
         throw Errors.versionNotFoundException();


### PR DESCRIPTION
Previous method was iterating over each key in linear time to build a set. This one asks the cache directly.

I'm not confident this is acceptable, since I'm not too familiar with our cache invalidation strategy, and I'm not sure this method is allowed to rely on the cache. If it is disallowed, then I'll comment the code to make it clear to the next reader why current strategy is used.