### PR TITLE
Add /v1/metadata/id endpoint to display SR cluster information

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -39,7 +39,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -648,7 +647,8 @@ public class RestService implements Configurable {
     return getClusterId(DEFAULT_REQUEST_PROPERTIES);
   }
 
-  public ServerClusterId getClusterId(Map<String, String> requestProperties) throws IOException, RestClientException {
+  public ServerClusterId getClusterId(Map<String, String> requestProperties)
+      throws IOException, RestClientException {
     return httpRequest("/v1/metadata/id", "GET", null,
                         requestProperties, GET_CLUSTER_ID_RESPONSE_TYPE);
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -22,6 +22,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Config;
+import io.confluent.kafka.schemaregistry.client.rest.entities.ErrorMessage;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
+import io.confluent.kafka.schemaregistry.client.rest.entities.ServerClusterId;
 import io.confluent.kafka.schemaregistry.client.security.SslFactory;
 import io.confluent.kafka.schemaregistry.client.security.basicauth.BasicAuthCredentialProviderFactory;
 import io.confluent.kafka.schemaregistry.client.security.bearerauth.BearerAuthCredentialProvider;
@@ -34,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -45,10 +51,6 @@ import java.util.Map;
 
 import javax.net.ssl.HttpsURLConnection;
 
-import io.confluent.kafka.schemaregistry.client.rest.entities.Config;
-import io.confluent.kafka.schemaregistry.client.rest.entities.ErrorMessage;
-import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
-import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.CompatibilityCheckResponse;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.ConfigUpdateRequest;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.ModeGetResponse;
@@ -117,6 +119,9 @@ public class RestService implements Configurable {
       };
   private static final TypeReference<String> DELETE_MODE_RESPONSE_TYPE =
       new TypeReference<String>() {
+      };
+  private static final TypeReference<ServerClusterId> GET_CLUSTER_ID_RESPONSE_TYPE =
+      new TypeReference<ServerClusterId>() {
       };
 
   private static final int HTTP_CONNECT_TIMEOUT_MS = 60000;
@@ -637,6 +642,15 @@ public class RestService implements Configurable {
     List<Integer> response = httpRequest(path, "DELETE", null, requestProperties,
                                          DELETE_SUBJECT_RESPONSE_TYPE);
     return response;
+  }
+
+  public ServerClusterId getClusterId() throws IOException, RestClientException {
+    return getClusterId(DEFAULT_REQUEST_PROPERTIES);
+  }
+
+  public ServerClusterId getClusterId(Map<String, String> requestProperties) throws IOException, RestClientException {
+    return httpRequest("/v1/metadata/id", "GET", null,
+                        requestProperties, GET_CLUSTER_ID_RESPONSE_TYPE);
   }
 
   private static List<String> parseBaseUrl(String baseUrl) {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/ServerClusterId.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/ServerClusterId.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
@@ -28,25 +29,27 @@ public class ServerClusterId {
   private static final String SCHEMA_REGISTRY_CLUSTER = "schema-registry-cluster";
 
   private final String id = "";
-  private final Map<String, String> scope;
+  private final Map<String, Object> scope;
 
   @JsonCreator
-  public ServerClusterId(@JsonProperty("scope") final Map<String, String> scope) {
-    this.scope = ImmutableMap.copyOf(Objects.requireNonNull(scope));
+  public ServerClusterId(@JsonProperty("scope") final Map<String, Object> scope) {
+    this.scope = ImmutableMap.copyOf(Objects.requireNonNull(scope, "scope"));
   }
 
   public String getId() {
     return id;
   }
 
-  public Map<String, String> getScope() {
+  public Map<String, Object> getScope() {
     return scope;
   }
 
   public static ServerClusterId of(String kafkaClusterId, String schemaRegistryClusterId) {
     return new ServerClusterId(ImmutableMap.of(
-        KAFKA_CLUSTER, kafkaClusterId,
-        SCHEMA_REGISTRY_CLUSTER, schemaRegistryClusterId
+        "path", Collections.emptyList(),
+        "clusters", ImmutableMap.of(
+            KAFKA_CLUSTER, kafkaClusterId,
+            SCHEMA_REGISTRY_CLUSTER, schemaRegistryClusterId)
     ));
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/ServerClusterId.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/ServerClusterId.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.client.rest.entities;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class ServerClusterId {
+
+  private static final String KAFKA_CLUSTER = "kafka-cluster";
+  private static final String SCHEMA_REGISTRY_CLUSTER = "schema-registry-cluster";
+
+  private final String id = "";
+  private final Map<String, String> scope;
+
+  @JsonCreator
+  public ServerClusterId(@JsonProperty("scope") final Map<String, String> scope) {
+    this.scope = ImmutableMap.copyOf(Objects.requireNonNull(scope));
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public Map<String, String> getScope() {
+    return scope;
+  }
+
+  public static ServerClusterId of(String kafkaClusterId, String schemaRegistryClusterId) {
+    return new ServerClusterId(ImmutableMap.of(
+        KAFKA_CLUSTER, kafkaClusterId,
+        SCHEMA_REGISTRY_CLUSTER, schemaRegistryClusterId
+    ));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof ServerClusterId)) {
+      return false;
+    }
+
+    ServerClusterId that = (ServerClusterId) o;
+
+    return getId().equals(that.getId())
+           && getScope().equals(that.getScope());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getId(), getScope());
+  }
+}

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/ServerClusterIdTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/ServerClusterIdTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.client.rest.entities.ServerClusterId;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -15,14 +16,15 @@ public class ServerClusterIdTest {
     ServerClusterId serverClusterId = ServerClusterId.of("kafka1", "sr1");
 
     final String id = serverClusterId.getId();
-    final Map<String, String> scope = serverClusterId.getScope();
+    final Map<String, Object> scope = serverClusterId.getScope();
 
     assertEquals("", id);
     assertEquals(
         ImmutableMap.of(
-           "kafka-cluster", "kafka1",
-           "schema-registry-cluster", "sr1"
-        ), scope
-    );
+          "path", Collections.emptyList(),
+          "clusters", ImmutableMap.of(
+                  "kafka-cluster", "kafka1",
+                  "schema-registry-cluster", "sr1")
+    ), scope);
   }
 }

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/ServerClusterIdTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/ServerClusterIdTest.java
@@ -1,0 +1,28 @@
+package io.confluent.kafka.schemaregistry.client.rest;
+
+import com.google.common.collect.ImmutableMap;
+import io.confluent.kafka.schemaregistry.client.rest.entities.ServerClusterId;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class ServerClusterIdTest {
+
+  @Test
+  public void buildServerClusterId() {
+    ServerClusterId serverClusterId = ServerClusterId.of("kafka1", "sr1");
+
+    final String id = serverClusterId.getId();
+    final Map<String, String> scope = serverClusterId.getScope();
+
+    assertEquals("", id);
+    assertEquals(
+        ImmutableMap.of(
+           "kafka-cluster", "kafka1",
+           "schema-registry-cluster", "sr1"
+        ), scope
+    );
+  }
+}

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -809,6 +809,6 @@ definitions:
         type: "object"
         readOnly: true
         additionalProperties:
-          type: "string"
+          type: "object"
       id:
         type: "string"

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -664,6 +664,28 @@ paths:
           description: "Error code 42202 -- Invalid version"
         500:
           description: "Error code 50001 -- Error in the backend data store"
+  /v1/metadata/id:
+    get:
+      summary: "Get the server metadata"
+      description: ""
+      operationId: "getClusterId"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ServerClusterId"
+        500:
+          description: "Error code 50001 -- Error in the backend data store\n"
 definitions:
   CompatibilityCheckResponse:
     type: "object"
@@ -744,3 +766,13 @@ definitions:
       schema:
         type: "string"
         description: "Schema string identified by the ID"
+  ServerClusterId:
+    type: "object"
+    properties:
+      scope:
+        type: "object"
+        readOnly: true
+        additionalProperties:
+          type: "string"
+      id:
+        type: "string"

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
@@ -17,6 +17,14 @@ package io.confluent.kafka.schemaregistry.rest;
 
 import java.util.Map;
 
+import io.confluent.kafka.schemaregistry.rest.resources.CompatibilityResource;
+import io.confluent.kafka.schemaregistry.rest.resources.ConfigResource;
+import io.confluent.kafka.schemaregistry.rest.resources.ModeResource;
+import io.confluent.kafka.schemaregistry.rest.resources.RootResource;
+import io.confluent.kafka.schemaregistry.rest.resources.SchemasResource;
+import io.confluent.kafka.schemaregistry.rest.resources.ServerMetadataResource;
+import io.confluent.kafka.schemaregistry.rest.resources.SubjectVersionsResource;
+import io.confluent.kafka.schemaregistry.rest.resources.SubjectsResource;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceCollection;
@@ -31,13 +39,6 @@ import javax.ws.rs.core.Configurable;
 
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.rest.extensions.SchemaRegistryResourceExtension;
-import io.confluent.kafka.schemaregistry.rest.resources.CompatibilityResource;
-import io.confluent.kafka.schemaregistry.rest.resources.ConfigResource;
-import io.confluent.kafka.schemaregistry.rest.resources.ModeResource;
-import io.confluent.kafka.schemaregistry.rest.resources.RootResource;
-import io.confluent.kafka.schemaregistry.rest.resources.SchemasResource;
-import io.confluent.kafka.schemaregistry.rest.resources.SubjectVersionsResource;
-import io.confluent.kafka.schemaregistry.rest.resources.SubjectsResource;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
 import io.confluent.kafka.schemaregistry.storage.serialization.SchemaRegistrySerializer;
 import io.confluent.rest.Application;
@@ -103,6 +104,7 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
     config.register(new SubjectVersionsResource(schemaRegistry));
     config.register(new CompatibilityResource(schemaRegistry));
     config.register(new ModeResource(schemaRegistry));
+    config.register(new ServerMetadataResource(schemaRegistry, schemaRegistryConfig));
 
     if (schemaRegistryResourceExtensions != null) {
       try {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ServerMetadataResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ServerMetadataResource.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rest.resources;
+
+import io.confluent.kafka.schemaregistry.client.rest.Versions;
+import io.confluent.kafka.schemaregistry.client.rest.entities.ServerClusterId;
+import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
+import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
+import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
+import io.confluent.rest.annotations.PerformanceMetric;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+
+@Path("/v1/metadata")
+@Produces({Versions.SCHEMA_REGISTRY_V1_JSON_WEIGHTED,
+           Versions.SCHEMA_REGISTRY_DEFAULT_JSON_WEIGHTED,
+           Versions.JSON_WEIGHTED})
+@Consumes({Versions.SCHEMA_REGISTRY_V1_JSON,
+           Versions.SCHEMA_REGISTRY_DEFAULT_JSON,
+           Versions.JSON, Versions.GENERIC_REQUEST})
+public class ServerMetadataResource {
+
+  private static final Logger log = LoggerFactory.getLogger(ServerMetadataResource.class);
+  private final KafkaSchemaRegistry schemaRegistry;
+  private final SchemaRegistryConfig schemaRegistryConfig;
+
+  public ServerMetadataResource(KafkaSchemaRegistry schemaRegistry,
+                                SchemaRegistryConfig schemaRegistryConfig) {
+    this.schemaRegistry = schemaRegistry;
+    this.schemaRegistryConfig = schemaRegistryConfig;
+  }
+
+  @GET
+  @Path("/id")
+  @ApiOperation("Get the server metadata")
+  @ApiResponses(value = {
+      @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store\n")})
+  @PerformanceMetric("metadata.id")
+  public ServerClusterId getClusterId() {
+    final String errorMessage = "Error while retrieving cluster information";
+
+    try {
+      String kafkaClusterId = schemaRegistry.getKafkaClusterId();
+      String schemaRegistryClusterId =
+              schemaRegistryConfig.getString(SchemaRegistryConfig.SCHEMAREGISTRY_GROUP_ID_CONFIG);
+      return ServerClusterId.of(kafkaClusterId, schemaRegistryClusterId);
+    } catch (SchemaRegistryException e) {
+      log.debug(errorMessage, e);
+      throw Errors.schemaRegistryException(errorMessage, e);
+    }
+  }
+}

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -924,9 +924,8 @@ public class RestApiTest extends ClusterTestHarness {
     try {
       ServerClusterId serverClusterId = restApp.restClient.getClusterId();
       assertEquals("", serverClusterId.getId());
-      assertNotNull(serverClusterId.getScope().get("kafka-cluster"));
-      // by default, the cluster id for schema registry is schema-registry
-      assertEquals("schema-registry", serverClusterId.getScope().get("schema-registry-cluster"));
+      assertEquals(Collections.emptyList(), serverClusterId.getScope().get("path"));
+      assertNotNull(serverClusterId.getScope().get("clusters"));
     } catch (RestClientException rce) {
       fail("The operation shouldn't have failed");
     }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -19,6 +19,7 @@ import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
 import io.confluent.kafka.schemaregistry.avro.AvroUtils;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.ServerClusterId;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
@@ -35,10 +36,7 @@ import java.util.List;
 
 import static io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel.FORWARD;
 import static io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel.NONE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class RestApiTest extends ClusterTestHarness {
 
@@ -900,6 +898,19 @@ public class RestApiTest extends ClusterTestHarness {
     assertEquals("Top Compatibility Level Exists", AvroCompatibilityLevel.FULL.name, restApp
         .restClient.getConfig(null).getCompatibilityLevel());
 
+  }
+
+  @Test
+  public void testGetClusterId() throws Exception {
+    try {
+      ServerClusterId serverClusterId = restApp.restClient.getClusterId();
+      assertEquals("", serverClusterId.getId());
+      assertNotNull(serverClusterId.getScope().get("kafka-cluster"));
+      // by default, the cluster id for schema registry is schema-registry
+      assertEquals("schema-registry", serverClusterId.getScope().get("schema-registry-cluster"));
+    } catch (RestClientException rce) {
+      fail("The operation shouldn't have failed");
+    }
   }
 }
 


### PR DESCRIPTION
This new path `/v1/metadata/id` is added to have a consistent API between other CP components and returns the following information:

```json
{
  "id": "",
  "scope": {
    "kafka-cluster": "_nOhOtWLSkGVXcA6Pc4x3w",
    "schema-registry-cluster": "schema-registry"
  }
}
```