### PR TITLE
MMA-5160 - Add defaultToGlobal flag for config API

### DIFF
--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -179,6 +179,10 @@ paths:
         in: "path"
         required: true
         type: "string"
+      - name: "defaultToGlobal"
+        in: "query"
+        required: false
+        type: "boolean"
       responses:
         200:
           description: "successful operation"

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -132,9 +132,10 @@ public class ConfigResource {
       @QueryParam("defaultToGlobal") boolean defaultToGlobal) {
     Config config = null;
     try {
-      AvroCompatibilityLevel compatibilityLevel = defaultToGlobal
-                                                  ? schemaRegistry.getCompatibilityLevelInScope(subject)
-                                                  : schemaRegistry.getCompatibilityLevel(subject);
+      AvroCompatibilityLevel compatibilityLevel =
+          defaultToGlobal
+          ? schemaRegistry.getCompatibilityLevelInScope(subject)
+          : schemaRegistry.getCompatibilityLevel(subject);
       if (compatibilityLevel == null) {
         throw Errors.subjectNotFoundException();
       }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -32,6 +32,7 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 
@@ -126,10 +127,14 @@ public class ConfigResource {
   @ApiResponses(value = {
       @ApiResponse(code = 404, message = "Subject not found"),
       @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store")})
-  public Config getSubjectLevelConfig(@PathParam("subject") String subject) {
+  public Config getSubjectLevelConfig(
+      @PathParam("subject") String subject,
+      @QueryParam("defaultToGlobal") boolean defaultToGlobal) {
     Config config = null;
     try {
-      AvroCompatibilityLevel compatibilityLevel = schemaRegistry.getCompatibilityLevel(subject);
+      AvroCompatibilityLevel compatibilityLevel = defaultToGlobal
+                                                  ? schemaRegistry.getCompatibilityLevelInScope(subject)
+                                                  : schemaRegistry.getCompatibilityLevel(subject);
       if (compatibilityLevel == null) {
         throw Errors.subjectNotFoundException();
       }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -913,7 +913,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     return lookupCache.compatibilityLevel(subject, false, defaultCompatibilityLevel);
   }
 
-  private AvroCompatibilityLevel getCompatibilityLevelInScope(String subject)
+  public AvroCompatibilityLevel getCompatibilityLevelInScope(String subject)
       throws SchemaRegistryStoreException {
     return lookupCache.compatibilityLevel(subject, true, defaultCompatibilityLevel);
   }


### PR DESCRIPTION
This adds a `defaultToGlobal` flag for the config API, to default to the global compatibility if the compatibility at the subject level is not set.