### PR TITLE
MINOR: remove type param on avro deserializer

### DIFF
--- a/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/ReflectionAvroDeserializer.java
+++ b/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/ReflectionAvroDeserializer.java
@@ -37,12 +37,12 @@ import org.apache.kafka.common.serialization.Deserializer;
 @InterfaceStability.Unstable
 public class ReflectionAvroDeserializer<T> implements Deserializer<T> {
 
-  private final KafkaAvroDeserializer<T> inner;
+  private final KafkaAvroDeserializer inner;
   private final Schema schema;
 
   public ReflectionAvroDeserializer(Class<T> type) {
     this.schema = ReflectData.get().getSchema(type);
-    this.inner = new KafkaAvroDeserializer<>();
+    this.inner = new KafkaAvroDeserializer();
   }
 
   /**
@@ -50,7 +50,7 @@ public class ReflectionAvroDeserializer<T> implements Deserializer<T> {
    */
   ReflectionAvroDeserializer(final SchemaRegistryClient client, Class<T> type) {
     this.schema = ReflectData.get().getSchema(type);
-    this.inner = new KafkaAvroDeserializer<>(client);
+    this.inner = new KafkaAvroDeserializer(client);
   }
 
   @Override
@@ -63,7 +63,7 @@ public class ReflectionAvroDeserializer<T> implements Deserializer<T> {
 
   @Override
   public T deserialize(final String topic, final byte[] bytes) {
-    return inner.deserialize(topic, bytes, schema);
+    return (T) inner.deserialize(topic, bytes, schema);
   }
 
   @Override

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
@@ -23,8 +23,8 @@ import java.util.Map;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 
-public class KafkaAvroDeserializer<T> extends AbstractKafkaAvroDeserializer<T>
-    implements Deserializer<T> {
+public class KafkaAvroDeserializer extends AbstractKafkaAvroDeserializer
+    implements Deserializer<Object> {
 
   private boolean isKey;
 
@@ -51,14 +51,14 @@ public class KafkaAvroDeserializer<T> extends AbstractKafkaAvroDeserializer<T>
   }
 
   @Override
-  public T deserialize(String s, byte[] bytes) {
+  public Object deserialize(String s, byte[] bytes) {
     return deserialize(bytes);
   }
 
   /**
    * Pass a reader schema to get an Avro projection
    */
-  public T deserialize(String s, byte[] bytes, Schema readerSchema) {
+  public Object deserialize(String s, byte[] bytes, Schema readerSchema) {
     return deserialize(bytes, readerSchema);
   }
 


### PR DESCRIPTION
This is to ensure backward compatibility with existing code.