### PR TITLE
Add javax.validation::validation-api-2.0.1.Final.jar as explicit dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,11 @@
                 <artifactId>jaxws-api</artifactId>
                 <version>2.3.0</version>
             </dependency>
+            <dependency>
+                <groupId>javax.validation</groupId>
+                <artifactId>validation-api</artifactId>
+                <version>2.0.1.Final</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,8 @@
                 <artifactId>jaxws-api</artifactId>
                 <version>2.3.0</version>
             </dependency>
+            <!-- This is a transitive dependency coming from swagger-core jar.
+            Here we are explicitly setting to 2.0.1.Final to avoid verison clash with jetty libs -->
             <dependency>
                 <groupId>javax.validation</groupId>
                 <artifactId>validation-api</artifactId>


### PR DESCRIPTION
we have recently updated [rest-utils jetty/jersey versions](https://github.com/confluentinc/rest-utils/pull/151) to match with Kafka version.  After this, `kafka-schema-registry-client => swagger => javax.validation::validation-api 1.0.1 ` dependency is clashing with latest `validation-api-2.0.1.Final.jar` from jetty.  This PR explicitly adds latest validation-api jar dependency.