### PR TITLE
DG-42: Upgrade to Avro 1.9.1; fixes #1122

### DIFF
--- a/avro-converter/src/test/java/io/confluent/connect/avro/AdditionalAvroDataTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AdditionalAvroDataTest.java
@@ -132,7 +132,7 @@ public class AdditionalAvroDataTest
            "{"
            + "  \"type\" : \"record\","
            + "  \"name\" : \"MyObjectToPersist\","
-           + "  \"namespace\" : \"io.confluent.connect.avro.AdditionalAvroDataTest$\","
+           + "  \"namespace\" : \"io.confluent.connect.avro.AdditionalAvroDataTest\","
            + "  \"fields\" : [ {"
            + "    \"name\" : \"obj\","
            + "    \"type\" : [ \"null\", {"

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroConverterTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroConverterTest.java
@@ -16,9 +16,10 @@
 
 package io.confluent.connect.avro;
 
-import avro.shaded.com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.serializers.subject.RecordNameStrategy;
+
+import com.google.common.collect.ImmutableMap;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.SchemaBuilder;

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializerTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
-import avro.shaded.com.google.common.collect.ImmutableMap;
 import io.confluent.common.config.ConfigException;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -19,6 +18,8 @@ import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
@@ -17,6 +17,8 @@ package io.confluent.kafka.serializers;
 
 import io.confluent.kafka.example.ExtendedWidget;
 import io.confluent.kafka.example.Widget;
+
+import com.google.common.collect.ImmutableMap;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -31,7 +33,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import avro.shaded.com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.example.ExtendedUser;
 import io.confluent.kafka.example.User;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/RestServiceTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/RestServiceTest.java
@@ -35,8 +35,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
-import avro.shaded.com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.client.security.bearerauth.BearerAuthCredentialProvider;
+
+import com.google.common.collect.ImmutableMap;
 import org.easymock.EasyMock;
 import org.easymock.IArgumentMatcher;
 import org.junit.Test;

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/basicauth/SaslBasicAuthCredentialProviderTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/basicauth/SaslBasicAuthCredentialProviderTest.java
@@ -16,6 +16,7 @@
 
 package io.confluent.kafka.schemaregistry.client.security.basicauth;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.types.Password;
@@ -33,8 +34,6 @@ import java.util.List;
 import java.util.Map;
 
 import javax.security.auth.login.Configuration;
-
-import avro.shaded.com.google.common.collect.ImmutableMap;
 
 public class SaslBasicAuthCredentialProviderTest {
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityTest.java
@@ -84,7 +84,7 @@ public class AvroCompatibilityTest {
                checker.isCompatible(schema2, Collections.singletonList(schema1)));
     assertFalse("adding a field w/o default is not a backward compatible change",
                 checker.isCompatible(schema3, Collections.singletonList(schema1)));
-    assertFalse("changing field name is not a backward compatible change",
+    assertTrue("changing field name with alias is a backward compatible change",
                 checker.isCompatible(schema4, Collections.singletonList(schema1)));
     assertTrue("evolving a field type to a union is a backward compatible change",
                checker.isCompatible(schema6, Collections.singletonList(schema1)));

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RequestHeaderBuilderTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RequestHeaderBuilderTest.java
@@ -15,8 +15,8 @@
 
 package io.confluent.kafka.schemaregistry.rest;
 
-import avro.shaded.com.google.common.collect.ImmutableList;
-import avro.shaded.com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;


### PR DESCRIPTION
Upgrade to Avro 1.9.1

The main change is that Avro 1.9.x removes use of `codehaus.jackson` in favor of `fasterxml.jackson`.  In addition, the JSON properties of an Avro schema are no longer exposed as instances of `JsonNode` but are instead exposed as typed objects via `ObjectMapper` unmarshalling.

Also, the following Avro fixes caused a couple of unit tests to change:

https://issues.apache.org/jira/browse/AVRO-2143

