### PR TITLE
DG-134: Fix NPE when schema.registry.ssl.protocol not specified

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/SslFactory.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/SslFactory.java
@@ -42,6 +42,9 @@ public class SslFactory {
 
   public SslFactory(Map<String, ?> configs) {
     this.protocol = (String) configs.get(SslConfigs.SSL_PROTOCOL_CONFIG);
+    if (this.protocol == null) {
+      this.protocol = SslConfigs.DEFAULT_SSL_PROTOCOL;
+    }
     this.provider = (String) configs.get(SslConfigs.SSL_PROVIDER_CONFIG);
 
     this.kmfAlgorithm = (String) configs.get(

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiSslTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiSslTest.java
@@ -98,6 +98,44 @@ public class RestApiSslTest extends ClusterTestHarness {
   }
 
 
+  @Test
+  public void testRegisterWithClientSecurityWithMinimalProperties() throws Exception {
+
+    setupHostNameVerifier();
+
+    String subject = "testSubject";
+    Schema schema = AvroUtils.parseSchema(
+        "{\"type\":\"record\","
+            + "\"name\":\"myrecord\","
+            + "\"fields\":"
+            + "[{\"type\":\"string\",\"name\":\"f2\"}]}").schemaObj;
+
+    int expectedIdSchema1 = 1;
+
+    Map clientsslConfigs = new HashMap();
+    clientsslConfigs.put(
+        SchemaRegistryClientConfig.CLIENT_NAMESPACE + SchemaRegistryConfig.SSL_KEYSTORE_LOCATION_CONFIG,
+        props.get(SchemaRegistryConfig.SSL_KEYSTORE_LOCATION_CONFIG));
+    clientsslConfigs.put(
+        SchemaRegistryClientConfig.CLIENT_NAMESPACE + SchemaRegistryConfig.SSL_KEYSTORE_PASSWORD_CONFIG,
+        props.get(SchemaRegistryConfig.SSL_KEYSTORE_PASSWORD_CONFIG));
+    clientsslConfigs.put(
+        SchemaRegistryClientConfig.CLIENT_NAMESPACE + SchemaRegistryConfig.SSL_TRUSTSTORE_LOCATION_CONFIG,
+        props.get(SchemaRegistryConfig.SSL_TRUSTSTORE_LOCATION_CONFIG));
+    clientsslConfigs.put(
+        SchemaRegistryClientConfig.CLIENT_NAMESPACE + SchemaRegistryConfig.SSL_TRUSTSTORE_PASSWORD_CONFIG,
+        props.get(SchemaRegistryConfig.SSL_TRUSTSTORE_PASSWORD_CONFIG));
+    CachedSchemaRegistryClient schemaRegistryClient = new CachedSchemaRegistryClient(restApp.restClient, 10, clientsslConfigs);
+
+    assertEquals(
+        "Registering should succeed",
+        expectedIdSchema1,
+        schemaRegistryClient.register(subject, schema)
+    );
+
+  }
+
+
   @Override
   protected Properties getSchemaRegistryProperties() {
     Configuration.setConfiguration(null);


### PR DESCRIPTION
This uses the same default of "TLS" as the rest of the platform.

I verified that without specifying `schema.registry.ssl.protocol`, an NPE results.  I also added a unit test that shows that with the fix, the code works with just the four properties:

schema.registry.ssl.truststore.location
schema.registry.ssl.truststore.password
schema.registry.ssl.keystore.location
schema.registry.ssl.keystore.password