### PR TITLE
Make AbstractKafkaAvroDeserializer.getDatumReader() protected

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -170,7 +170,7 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaAvroSer
     }
   }
 
-  private DatumReader<?> getDatumReader(Schema writerSchema, Schema readerSchema) {
+  protected DatumReader<?> getDatumReader(Schema writerSchema, Schema readerSchema) {
     boolean writerSchemaIsPrimitive =
         AvroSchemaUtils.getPrimitiveSchemas().values().contains(writerSchema);
     // do not use SpecificDatumReader if writerSchema is a primitive


### PR DESCRIPTION
Hi,

please consider this PR to be merged upstream. My use case is for Kotlin classes generated from AVRO schemas. Because SpecificDatumReader is very Java specific, it was easier to implement a KotlinDatumReader on top of GenericDatumReader. However to be able to use it with Kafka I need to be able to override getDatumReader(), which is currently a private method. Hence this pull request.