### PR TITLE
DG-148 - Ensure end of topic is read during register

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -404,7 +404,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
             // Verify id is not already in use
             if (lookupCache.schemaKeyById(newId) == null) {
               schema.setId(newId);
-              if (retries > 0) {
+              if (retries > 1) {
                 log.warn(String.format("Retrying to register the schema with ID %s", newId));
               }
               kafkaStore.put(schemaKey, new SchemaValue(schema));

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -290,7 +290,11 @@ public class KafkaStore<K, V> implements Store<K, V> {
    */
   public void waitUntilKafkaReaderReachesLastOffset(String subject, int timeoutMs)
       throws StoreException {
-    waitUntilKafkaReaderReachesOffset(lastOffset(subject), timeoutMs);
+    long lastOffset = lastOffset(subject);
+    if (lastOffset == -1) {
+      lastOffset = getLatestOffset(timeoutMs);
+    }
+    waitUntilKafkaReaderReachesOffset(lastOffset, timeoutMs);
   }
 
   /**


### PR DESCRIPTION
If registering a schema times out, the next registration needs to read to the end of the topic in case the previous registration succeeded.   This is a regression caused by refactoring some code to support per-subject locks.