### PR TITLE
MINOR: Change KafkaGroupMasterElector to accommodate recent AK Metadata change

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/KafkaGroupMasterElector.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/KafkaGroupMasterElector.java
@@ -120,7 +120,7 @@ public class KafkaGroupMasterElector implements MasterElector, SchemaRegistryReb
           = config.getList(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG);
       List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(bootstrapServers,
           clientConfig.getString(CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG));
-      this.metadata.bootstrap(addresses, time.milliseconds());
+      this.metadata.bootstrap(addresses);
       String metricGrpPrefix = "kafka.schema.registry";
 
       ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(clientConfig, time);


### PR DESCRIPTION
The signature of the `Metadata.bootstrap(...)` method was recently changed in AK (see [this AK PR](https://github.com/apache/kafka/pull/7682/files#diff-62bba39339405475f71241a182ef9819R212)) on the AK `trunk` branch to remove the 2nd parameter, so the `KafkaGroupMasterElector` needs to change accordingly.