### PR TITLE
DG-149 : Move master lock to KafkaStore

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -476,6 +476,10 @@ public class KafkaStore<K, V> implements Store<K, V> {
     this.lastWrittenOffset = lastOffset;
   }
 
+  public Lock masterLock() {
+    return lock;
+  }
+
   public Lock lockFor(String subject) {
     return lock;
   }


### PR DESCRIPTION
As part of refactoring SR, critical regions are not using the same lock.  