### PR TITLE
Fixed wrong Timeout unit. Shoukld be MS.

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -955,7 +955,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
       kafkaClusterId = adminClient
               .describeCluster()
               .clusterId()
-              .get(DESCRIBE_CLUSTER_TIMEOUT_MS, TimeUnit.MICROSECONDS);
+              .get(DESCRIBE_CLUSTER_TIMEOUT_MS, TimeUnit.MILLISECONDS);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       throw new SchemaRegistryException("Failed to get Kafka cluster ID", e);
     }


### PR DESCRIPTION
Thee wrong timeout unit caused the function getKafkaClusterId quick timeout without waiting for response from broker. It works fine after update timeout unit from microseconds to milliseconds. 
curl  http://localhost:8082/v1/metadata/id
{"scope":{"path":[],"clusters":{"kafka-cluster":"TejPGgMuQy-vIIzAYBA7PA","schema-registry-cluster":"schema-registry"}},"id":""}