### PR TITLE
DG-157: Replace default of quoted null with plain null

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -52,6 +52,10 @@
             <artifactId>avro</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.thisptr</groupId>
+            <artifactId>jackson-jq</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
         </dependency>

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroUtils.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroUtils.java
@@ -15,10 +15,23 @@
 
 package io.confluent.kafka.schemaregistry.avro;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import net.thisptr.jackson.jq.BuiltinFunctionLoader;
+import net.thisptr.jackson.jq.JsonQuery;
+import net.thisptr.jackson.jq.Scope;
+import net.thisptr.jackson.jq.Versions;
+import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
 public class AvroUtils {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   /**
    * Convert a schema string into a schema object and a canonical schema string.
@@ -27,13 +40,45 @@ public class AvroUtils {
    *     there is any parsing error.
    */
   public static AvroSchema parseSchema(String schemaString) {
+    Schema schema;
     try {
-      Schema.Parser parser1 = new Schema.Parser();
-      Schema schema = parser1.parse(schemaString);
-      //TODO: schema.toString() is not canonical (issue-28)
-      return new AvroSchema(schema, schema.toString());
+      try {
+        Schema.Parser parser1 = new Schema.Parser();
+        schema = parser1.parse(schemaString);
+      } catch (AvroTypeException e) {
+        // Must clear the parser
+        Schema.Parser parser1 = new Schema.Parser();
+        // In case of AvroTypeException,, attempt to replace quoted null with null for defaults
+        schema = parser1.parse(replaceQuotedNullWithNullForDefaults(schemaString));
+      }
     } catch (SchemaParseException e) {
       return null;
+    }
+    return new AvroSchema(schema, schema.toString());
+  }
+
+  private static String replaceQuotedNullWithNullForDefaults(String schemaString) {
+    try {
+      Scope rootScope = Scope.newEmptyScope();
+      // Load built-in jq functions such as "select"
+      BuiltinFunctionLoader.getInstance().loadFunctions(Versions.JQ_1_5, rootScope);
+      Scope childScope = Scope.newChildScope(rootScope);
+
+      // This jq expression recursively replaces all default properties that have
+      // a quoted null with a plain null
+      JsonQuery jq = JsonQuery.compile(
+          "(.. | .default? | select(. == \"null\")) = null", Versions.JQ_1_5);
+
+      JsonNode in = MAPPER.readTree(schemaString);
+      final List<JsonNode> out = new ArrayList<>();
+      // Perform the transformation using jq
+      jq.apply(childScope, in, out::add);
+      if (out.isEmpty()) {
+        throw new SchemaParseException("Invalid schema after jq processing");
+      }
+      return MAPPER.writeValueAsString(out.get(0));
+    } catch (IOException ex) {
+      throw new SchemaParseException(ex);
     }
   }
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityTest.java
@@ -17,6 +17,7 @@ package io.confluent.kafka.schemaregistry.avro;
 import org.apache.avro.Schema;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -73,6 +74,28 @@ public class AvroCompatibilityTest {
       + " {\"type\":\"string\",\"name\":\"f3\", \"default\": \"bar\"}]}";
   private final Schema schema8 = AvroUtils.parseSchema(schemaString8).schemaObj;
   
+  private final String goodDefaultNullString = "{\"type\":\"record\","
+      + "\"name\":\"myrecord\","
+      + "\"fields\":"
+      + "[{\"type\":[\"null\", \"string\"],\"name\":\"f1\", \"default\": null},"
+      + " {\"type\":\"string\",\"name\":\"f2\", \"default\": \"foo\"},"
+      + " {\"type\":\"string\",\"name\":\"f3\", \"default\": \"bar\"}]}";
+  private final Schema goodDefaultNull = AvroUtils.parseSchema(goodDefaultNullString).schemaObj;
+
+  private final String badDefaultNullString = "{\"type\":\"record\","
+      + "\"name\":\"myrecord\","
+      + "\"fields\":"
+      + "[{\"type\":[\"null\", \"string\"],\"name\":\"f1\", \"default\": \"null\"},"
+      + " {\"type\":\"string\",\"name\":\"f2\", \"default\": \"foo\"},"
+      + " {\"type\":\"string\",\"name\":\"f3\", \"default\": \"bar\"}]}";
+
+
+  @Test
+  public void testBadDefaultNull() {
+    Schema badDefaultNull = AvroUtils.parseSchema(badDefaultNullString).schemaObj;
+    assertEquals(badDefaultNull.toString(), goodDefaultNull.toString());
+  }
+
   /*
    * Backward compatibility: A new schema is backward compatible if it can be used to read the data
    * written in the previous schema.

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,11 @@
                 <artifactId>podam</artifactId>
                 <version>${podam.version}</version>
             </dependency>
+            <dependency>
+                <groupId>net.thisptr</groupId>
+                <artifactId>jackson-jq</artifactId>
+                <version>1.0.0-preview.20191208</version>
+            </dependency>
 
             <!--children-->
             <dependency>


### PR DESCRIPTION
If a schema fails default validation (with an AvroTypeException),
an attempt is made to repair the schema by replacing any default
of a quoted null with a plain null.  The repair is performed
recursively using a jq expression.