### PR TITLE
Add support for schema imports/references

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
@@ -21,7 +21,7 @@ import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.serializers.AbstractKafkaAvroDeserializer;
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerializer;
-import io.confluent.kafka.serializers.AvroSchemaUtils;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
 import io.confluent.kafka.serializers.GenericContainerWithVersion;
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
 import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;

--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.avro;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.serializers.AbstractKafkaAvroDeserializer;
@@ -128,8 +129,12 @@ public class AvroConverter implements Converter {
     }
 
     public byte[] serialize(String topic, boolean isKey, Object value) {
+      if (value == null) {
+        return null;
+      }
       return serializeImpl(
-          getSubjectName(topic, isKey, value, AvroSchemaUtils.getSchema(value)), value);
+          getSubjectName(topic, isKey, value, new AvroSchema(AvroSchemaUtils.getSchema(value))),
+          value);
     }
   }
 

--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverterConfig.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverterConfig.java
@@ -19,9 +19,9 @@ package io.confluent.connect.avro;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 
-public class AvroConverterConfig extends AbstractKafkaAvroSerDeConfig {
+public class AvroConverterConfig extends AbstractKafkaSchemaSerDeConfig {
 
   public AvroConverterConfig(Map<?, ?> props) {
     super(baseConfigDef(), props);

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroConverterTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroConverterTest.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.avro;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.serializers.subject.RecordNameStrategy;
 
@@ -36,8 +37,8 @@ import java.util.Map;
 
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDe;
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDe;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -56,7 +57,7 @@ public class AvroConverterTest {
   private static final String TOPIC = "topic";
 
   private static final Map<String, ?> SR_CONFIG = Collections.singletonMap(
-      AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "localhost");
+      AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "localhost");
 
   private final SchemaRegistryClient schemaRegistry;
   private final AvroConverter converter;
@@ -76,7 +77,7 @@ public class AvroConverterTest {
     converter.configure(SR_CONFIG, true);
     assertTrue(Whitebox.<Boolean>getInternalState(converter, "isKey"));
     assertNotNull(Whitebox.getInternalState(
-        Whitebox.<AbstractKafkaAvroSerDe>getInternalState(converter, "serializer"),
+        Whitebox.<AbstractKafkaSchemaSerDe>getInternalState(converter, "serializer"),
         "schemaRegistry"));
   }
 
@@ -85,7 +86,7 @@ public class AvroConverterTest {
     converter.configure(SR_CONFIG, false);
     assertFalse(Whitebox.<Boolean>getInternalState(converter, "isKey"));
     assertNotNull(Whitebox.getInternalState(
-        Whitebox.<AbstractKafkaAvroSerDe>getInternalState(converter, "serializer"),
+        Whitebox.<AbstractKafkaSchemaSerDe>getInternalState(converter, "serializer"),
         "schemaRegistry"));
   }
 
@@ -197,14 +198,14 @@ public class AvroConverterTest {
         .record("Foo").fields()
         .requiredInt("key")
         .endRecord();
-    schemaRegistry.register(subject, avroSchema1);
+    schemaRegistry.register(subject, new AvroSchema(avroSchema1));
 
     org.apache.avro.Schema avroSchema2 = org.apache.avro.SchemaBuilder
         .record("Foo").fields()
         .requiredInt("key")
         .requiredString("value")
         .endRecord();
-    schemaRegistry.register(subject, avroSchema2);
+    schemaRegistry.register(subject, new AvroSchema(avroSchema2));
 
 
     // Get serialized data
@@ -271,8 +272,8 @@ public class AvroConverterTest {
     SchemaRegistryClient schemaRegistry = new MockSchemaRegistryClient();
     AvroConverter avroConverter = new AvroConverter(schemaRegistry);
     Map<String, ?> converterConfig = ImmutableMap.of(
-        AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "localhost",
-        AbstractKafkaAvroSerDeConfig.VALUE_SUBJECT_NAME_STRATEGY, DeprecatedTestTopicNameStrategy.class.getName());
+        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "localhost",
+        AbstractKafkaSchemaSerDeConfig.VALUE_SUBJECT_NAME_STRATEGY, DeprecatedTestTopicNameStrategy.class.getName());
     avroConverter.configure(converterConfig, false);
     assertSameSchemaMultipleTopic(avroConverter, schemaRegistry, false);
   }
@@ -282,8 +283,8 @@ public class AvroConverterTest {
     SchemaRegistryClient schemaRegistry = new MockSchemaRegistryClient();
     AvroConverter avroConverter = new AvroConverter(schemaRegistry);
     Map<String, ?> converterConfig = ImmutableMap.of(
-        AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "localhost",
-        AbstractKafkaAvroSerDeConfig.KEY_SUBJECT_NAME_STRATEGY, DeprecatedTestTopicNameStrategy.class.getName());
+        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "localhost",
+        AbstractKafkaSchemaSerDeConfig.KEY_SUBJECT_NAME_STRATEGY, DeprecatedTestTopicNameStrategy.class.getName());
     avroConverter.configure(converterConfig, true);
     assertSameSchemaMultipleTopic(avroConverter, schemaRegistry, true);
   }
@@ -300,7 +301,7 @@ public class AvroConverterTest {
     final AvroConverter avroConverter = new AvroConverter(new MockSchemaRegistryClient());
     avroConverter.configure(
         Collections.singletonMap(
-            AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "localhost"
+            AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "localhost"
         ),
         false
     );
@@ -330,9 +331,9 @@ public class AvroConverterTest {
         .requiredString("value")
         .endRecord();
     String subjectSuffix = isKey ? "key" : "value";
-    schemaRegistry.register("topic1-" + subjectSuffix, avroSchema2_1);
-    schemaRegistry.register("topic2-" + subjectSuffix, avroSchema1);
-    schemaRegistry.register("topic2-" + subjectSuffix, avroSchema2_2);
+    schemaRegistry.register("topic1-" + subjectSuffix, new AvroSchema(avroSchema2_1));
+    schemaRegistry.register("topic2-" + subjectSuffix, new AvroSchema(avroSchema1));
+    schemaRegistry.register("topic2-" + subjectSuffix, new AvroSchema(avroSchema2_2));
 
     org.apache.avro.generic.GenericRecord avroRecord1
         = new org.apache.avro.generic.GenericRecordBuilder(avroSchema2_1).set("key", 15).set

--- a/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -1974,8 +1974,8 @@ public class AvroData {
 
   private static boolean isEnumSchema(Schema schema) {
     return schema.type() == Schema.Type.STRING
-           && schema.name() != null
-           && schema.name().equals(AVRO_TYPE_ENUM);
+           && schema.parameters() != null
+           && schema.parameters().containsKey(AVRO_TYPE_ENUM);
   }
 
   private static boolean isInstanceOfAvroSchemaTypeForSimpleSchema(Schema fieldSchema,

--- a/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -59,6 +59,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.serializers.NonRecordContainer;
 
 
@@ -300,45 +301,9 @@ public class AvroData {
   }
 
   private Cache<Schema, org.apache.avro.Schema> fromConnectSchemaCache;
-  private Cache<AvroSchemaAndVersion, Schema> toConnectSchemaCache;
+  private Cache<AvroSchema, Schema> toConnectSchemaCache;
   private boolean connectMetaData;
   private boolean enhancedSchemaSupport;
-
-  private static class AvroSchemaAndVersion {
-    private org.apache.avro.Schema schema;
-    private Integer version;
-
-    public AvroSchemaAndVersion(org.apache.avro.Schema schema, Integer version) {
-      this.schema = schema;
-      this.version = version;
-    }
-
-    public org.apache.avro.Schema schema() {
-      return schema;
-    }
-
-    public Integer version() {
-      return version;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      AvroSchemaAndVersion that = (AvroSchemaAndVersion) o;
-      return Objects.equals(schema, that.schema) && Objects.equals(version, that.version);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(schema, version);
-    }
-  }
-
 
   public AvroData(int cacheSize) {
     this(new AvroDataConfig.Builder()
@@ -1510,7 +1475,7 @@ public class AvroData {
     // the internal conversions, this is the safest place to add caching since some of the internal
     // conversions take extra flags (like forceOptional) which means the resulting schema might not
     // exactly match the Avro schema.
-    AvroSchemaAndVersion schemaAndVersion = new AvroSchemaAndVersion(schema, version);
+    AvroSchema schemaAndVersion = new AvroSchema(schema, version);
     Schema cachedSchema = toConnectSchemaCache.get(schemaAndVersion);
     if (cachedSchema != null) {
       return cachedSchema;

--- a/avro-serde/src/test/java/io/confluent/kafka/streams/serdes/avro/GenericAvroSerdeTest.java
+++ b/avro-serde/src/test/java/io/confluent/kafka/streams/serdes/avro/GenericAvroSerdeTest.java
@@ -24,7 +24,7 @@ import java.util.Map;
 
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -38,7 +38,7 @@ public class GenericAvroSerdeTest {
     SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
     GenericAvroSerde serde = new GenericAvroSerde(schemaRegistryClient);
     Map<String, Object> serdeConfig = new HashMap<>();
-    serdeConfig.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "fake");
+    serdeConfig.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "fake");
     serde.configure(serdeConfig, false);
     return serde;
   }

--- a/avro-serde/src/test/java/io/confluent/kafka/streams/serdes/avro/SpecificAvroSerdeTest.java
+++ b/avro-serde/src/test/java/io/confluent/kafka/streams/serdes/avro/SpecificAvroSerdeTest.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import io.confluent.kafka.example.User;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -40,7 +40,7 @@ public class SpecificAvroSerdeTest {
     SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
     SpecificAvroSerde<T> serde = new SpecificAvroSerde<>(schemaRegistryClient);
     Map<String, Object> serdeConfig = new HashMap<>();
-    serdeConfig.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "fake");
+    serdeConfig.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "fake");
     serde.configure(serdeConfig, false);
     return serde;
   }
@@ -96,7 +96,8 @@ public class SpecificAvroSerdeTest {
     SpecificAvroSerde<User> serde = createConfiguredSerdeForRecordValues();
     User record = User.newBuilder().setName("alice").build();
     Map<String, Object> serdeConfig = new HashMap<>();
-    serdeConfig.put(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+    serdeConfig.put(
+        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
         "fake-to-satisfy-checks");
     serdeConfig.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, false);
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageFormatter.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageFormatter.java
@@ -40,7 +40,7 @@ import java.util.Properties;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.serializers.AbstractKafkaAvroDeserializer;
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import kafka.common.MessageFormatter;
 
 /**
@@ -105,7 +105,7 @@ public class AvroMessageFormatter extends AbstractKafkaAvroDeserializer
     if (props == null) {
       throw new ConfigException("Missing schema registry url!");
     }
-    String url = props.getProperty(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG);
+    String url = props.getProperty(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG);
     if (url == null) {
       throw new ConfigException("Missing schema registry url!");
     }
@@ -244,7 +244,7 @@ public class AvroMessageFormatter extends AbstractKafkaAvroDeserializer
   ) {
     return schemaRegistry != null ? schemaRegistry : new CachedSchemaRegistryClient(
         schemaRegistryUrl,
-        AbstractKafkaAvroSerDeConfig.MAX_SCHEMAS_PER_SUBJECT_DEFAULT,
+        AbstractKafkaSchemaSerDeConfig.MAX_SCHEMAS_PER_SUBJECT_DEFAULT,
         originals
     );
   }

--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageFormatter.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageFormatter.java
@@ -16,7 +16,7 @@
 
 package io.confluent.kafka.formatter;
 
-import io.confluent.kafka.serializers.AvroSchemaUtils;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumWriter;

--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
@@ -37,7 +37,7 @@ import java.util.Properties;
 
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import kafka.common.KafkaException;
 import kafka.common.MessageReader;
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerializer;
@@ -131,7 +131,7 @@ public class AvroMessageReader extends AbstractKafkaAvroSerializer implements Me
       ignoreError = props.getProperty("ignore.error").trim().toLowerCase().equals("true");
     }
     reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
-    String url = props.getProperty(AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG);
+    String url = props.getProperty(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG);
     if (url == null) {
       throw new ConfigException("Missing schema registry url!");
     }
@@ -139,7 +139,7 @@ public class AvroMessageReader extends AbstractKafkaAvroSerializer implements Me
     Map<String, Object> originals = getPropertiesMap(props);
 
     schemaRegistry = new CachedSchemaRegistryClient(
-        url, AbstractKafkaAvroSerDeConfig.MAX_SCHEMAS_PER_SUBJECT_DEFAULT, originals);
+        url, AbstractKafkaSchemaSerDeConfig.MAX_SCHEMAS_PER_SUBJECT_DEFAULT, originals);
     if (!props.containsKey("value.schema")) {
       throw new ConfigException("Must provide the Avro schema string in value.schema");
     }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import kafka.utils.VerifiableProperties;
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -31,11 +31,9 @@ import org.apache.avro.reflect.ReflectDatumReader;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
@@ -52,11 +50,7 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
    * Useful for testing, where a mock client is injected.
    */
   protected void configure(KafkaAvroDeserializerConfig config) {
-    Map<String, Object> schemaProviderConfigs = new HashMap<>();
-    schemaProviderConfigs.put(SchemaProvider.SCHEMA_VERSION_FETCHER_CONFIG, schemaRegistry);
-    SchemaProvider schemaProvider = new AvroSchemaProvider();
-    schemaProvider.configure(schemaProviderConfigs);
-    configureClientProperties(config, schemaProvider);
+    configureClientProperties(config, new AvroSchemaProvider());
     useSpecificAvroReader = config
         .getBoolean(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG);
   }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -34,10 +34,12 @@ import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import kafka.utils.VerifiableProperties;
 
-public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaAvroSerDe {
+public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaSerDe {
   private final DecoderFactory decoderFactory = DecoderFactory.get();
   protected boolean useSpecificAvroReader = false;
   private final Map<String, Schema> readerSchemaCache = new ConcurrentHashMap<>();
@@ -47,7 +49,7 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaAvroSer
    * Useful for testing, where a mock client is injected.
    */
   protected void configure(KafkaAvroDeserializerConfig config) {
-    configureClientProperties(config);
+    configureClientProperties(config, new AvroSchemaProvider());
     useSpecificAvroReader = config
         .getBoolean(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG);
   }
@@ -99,19 +101,19 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaAvroSer
     }
 
     DeserializationContext context = new DeserializationContext(topic, isKey, payload);
-    return context.read(context.schemaFromRegistry(), readerSchema);
+    return context.read(context.schemaFromRegistry().schemaObj, readerSchema);
   }
 
   private Integer schemaVersion(String topic,
                                 Boolean isKey,
                                 int id,
                                 String subject,
-                                Schema schema,
+                                AvroSchema schema,
                                 Object result) throws IOException, RestClientException {
     Integer version;
     if (isDeprecatedSubjectNameStrategy(isKey)) {
       subject = getSubjectName(topic, isKey, result, schema);
-      Schema subjectSchema = schemaRegistry.getBySubjectAndId(subject, id);
+      AvroSchema subjectSchema = (AvroSchema) schemaRegistry.getSchemaBySubjectAndId(subject, id);
       version = schemaRegistry.getVersion(subject, subjectSchema);
     } else {
       //we already got the subject name
@@ -120,7 +122,7 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaAvroSer
     return version;
   }
 
-  private String subjectName(String topic, Boolean isKey, Schema schemaFromRegistry) {
+  private String subjectName(String topic, Boolean isKey, AvroSchema schemaFromRegistry) {
     return isDeprecatedSubjectNameStrategy(isKey)
         ? null
         : getSubjectName(topic, isKey, null, schemaFromRegistry);
@@ -153,16 +155,17 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaAvroSer
     // schema registry's ordering (which is implicit by auto-registration time rather than
     // explicit from the Connector).
     DeserializationContext context = new DeserializationContext(topic, isKey, payload);
-    Schema schema = context.schemaForDeserialize();
-    Object result = context.read(schema, null);
+    AvroSchema schema = context.schemaForDeserialize();
+    Object result = context.read(schema.schemaObj, null);
 
     try {
       Integer version = schemaVersion(topic, isKey, context.getSchemaId(),
           context.getSubject(), schema, result);
-      if (schema.getType().equals(Schema.Type.RECORD)) {
+      if (schema.schemaObj.getType().equals(Schema.Type.RECORD)) {
         return new GenericContainerWithVersion((GenericContainer) result, version);
       } else {
-        return new GenericContainerWithVersion(new NonRecordContainer(schema, result), version);
+        return new GenericContainerWithVersion(new NonRecordContainer(schema.schemaObj, result),
+            version);
       }
     } catch (RestClientException | IOException e) {
       throw new SerializationException("Error retrieving Avro "
@@ -238,9 +241,9 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaAvroSer
       this.schemaId = buffer.getInt();
     }
 
-    Schema schemaFromRegistry() {
+    AvroSchema schemaFromRegistry() {
       try {
-        return schemaRegistry.getById(schemaId);
+        return (AvroSchema) schemaRegistry.getSchemaById(schemaId);
       } catch (RestClientException | IOException e) {
         throw new SerializationException("Error retrieving Avro "
                                          + getSchemaType(isKey)
@@ -249,11 +252,11 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaAvroSer
       }
     }
 
-    Schema schemaForDeserialize() {
+    AvroSchema schemaForDeserialize() {
       try {
         return isDeprecatedSubjectNameStrategy(isKey)
-            ? AvroSchemaUtils.copyOf(schemaFromRegistry())
-            : schemaRegistry.getBySubjectAndId(getSubject(), schemaId);
+            ? new AvroSchema(AvroSchemaUtils.copyOf(schemaFromRegistry().schemaObj))
+            : (AvroSchema) schemaRegistry.getSchemaBySubjectAndId(getSubject(), schemaId);
       } catch (RestClientException | IOException e) {
         throw new SerializationException("Error retrieving Avro "
                                          + getSchemaType(isKey)

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerDeConfig.java
@@ -23,7 +23,8 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
 import io.confluent.kafka.serializers.subject.TopicNameStrategy;
 
 /**
- * @deprecated  Use {@link io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig} instead
+ * TODO: deprecate this class
+ * Use {@link io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig} instead
  */
 public class AbstractKafkaAvroSerDeConfig extends AbstractKafkaSchemaSerDeConfig {
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -29,10 +29,8 @@ import org.apache.kafka.common.errors.SerializationException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.HashMap;
 import java.util.Map;
 
-import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
@@ -45,11 +43,7 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
   protected boolean autoRegisterSchema;
 
   protected void configure(KafkaAvroSerializerConfig config) {
-    Map<String, Object> schemaProviderConfigs = new HashMap<>();
-    schemaProviderConfigs.put(SchemaProvider.SCHEMA_VERSION_FETCHER_CONFIG, schemaRegistry);
-    SchemaProvider schemaProvider = new AvroSchemaProvider();
-    schemaProvider.configure(schemaProviderConfigs);
-    configureClientProperties(config, schemaProvider);
+    configureClientProperties(config, new AvroSchemaProvider());
     autoRegisterSchema = config.autoRegisterSchema();
   }
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -31,16 +31,18 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Map;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import kafka.utils.VerifiableProperties;
 
-public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaAvroSerDe {
+public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSerDe {
 
   private final EncoderFactory encoderFactory = EncoderFactory.get();
   protected boolean autoRegisterSchema;
 
   protected void configure(KafkaAvroSerializerConfig config) {
-    configureClientProperties(config);
+    configureClientProperties(config, new AvroSchemaProvider());
     autoRegisterSchema = config.autoRegisterSchema();
   }
 
@@ -68,10 +70,10 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaAvroSerDe
       schema = AvroSchemaUtils.getSchema(object, useSchemaReflection);
       if (autoRegisterSchema) {
         restClientErrorMsg = "Error registering Avro schema: ";
-        id = schemaRegistry.register(subject, schema);
+        id = schemaRegistry.register(subject, new AvroSchema(schema));
       } else {
         restClientErrorMsg = "Error retrieving Avro schema: ";
-        id = schemaRegistry.getId(subject, schema);
+        id = schemaRegistry.getId(subject, new AvroSchema(schema));
       }
       ByteArrayOutputStream out = new ByteArrayOutputStream();
       out.write(MAGIC_BYTE);

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -29,8 +29,10 @@ import org.apache.kafka.common.errors.SerializationException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.HashMap;
 import java.util.Map;
 
+import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
@@ -42,7 +44,11 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
   protected boolean autoRegisterSchema;
 
   protected void configure(KafkaAvroSerializerConfig config) {
-    configureClientProperties(config, new AvroSchemaProvider());
+    Map<String, Object> schemaProviderConfigs = new HashMap<>();
+    schemaProviderConfigs.put(SchemaProvider.SCHEMA_VERSION_FETCHER_CONFIG, schemaRegistry);
+    SchemaProvider schemaProvider = new AvroSchemaProvider();
+    schemaProvider.configure(schemaProviderConfigs);
+    configureClientProperties(config, schemaProvider);
     autoRegisterSchema = config.autoRegisterSchema();
   }
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import kafka.utils.VerifiableProperties;
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.SerializationException;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -63,7 +64,7 @@ public abstract class AbstractKafkaSchemaSerDe {
         schemaRegistry = new CachedSchemaRegistryClient(
             urls,
             maxSchemaObject,
-            provider,
+            Collections.singletonList(provider),
             originals,
             config.requestHeaders()
         );

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -16,6 +16,7 @@
 
 package io.confluent.kafka.serializers;
 
+import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.SerializationException;
@@ -134,15 +135,31 @@ public abstract class AbstractKafkaSchemaSerDe {
     }
   }
 
+  @Deprecated
+  public int register(String subject, Schema schema) throws IOException, RestClientException {
+    return schemaRegistry.register(subject, schema);
+  }
+
   public int register(String subject, ParsedSchema schema) throws IOException, RestClientException {
     return schemaRegistry.register(subject, schema);
   }
 
-  public ParsedSchema getById(int id) throws IOException, RestClientException {
+  @Deprecated
+  public Schema getById(int id) throws IOException, RestClientException {
+    return schemaRegistry.getById(id);
+  }
+
+  public ParsedSchema getSchemaById(int id) throws IOException, RestClientException {
     return schemaRegistry.getSchemaById(id);
   }
 
-  public ParsedSchema getBySubjectAndId(String subject, int id)
+  @Deprecated
+  public Schema getBySubjectAndId(String subject, int id)
+      throws IOException, RestClientException {
+    return schemaRegistry.getBySubjectAndId(subject, id);
+  }
+
+  public ParsedSchema getSchemaBySubjectAndId(String subject, int id)
       throws IOException, RestClientException {
     return schemaRegistry.getSchemaBySubjectAndId(subject, id);
   }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AvroSchemaUtils.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AvroSchemaUtils.java
@@ -25,6 +25,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+
 public class AvroSchemaUtils {
 
   private static final Map<String, Schema> primitiveSchemas;
@@ -48,10 +50,9 @@ public class AvroSchemaUtils {
     return parser.parse(schemaString);
   }
 
-  protected static Schema copyOf(Schema schema) {
-    Schema.Parser parser = new Schema.Parser();
-    parser.setValidateDefaults(false);
-    return parser.parse(schema.toString());
+  protected static AvroSchema copyOf(AvroSchema schema) {
+    return new AvroSchema(schema.canonicalString(), schema.references(),
+        schema.resolvedReferences(), schema.version());
   }
 
   protected static Map<String, Schema> getPrimitiveSchemas() {

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializerConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializerConfig.java
@@ -23,7 +23,7 @@ import io.confluent.common.config.ConfigDef.Type;
 
 import java.util.Map;
 
-public class KafkaAvroDeserializerConfig extends AbstractKafkaAvroSerDeConfig {
+public class KafkaAvroDeserializerConfig extends AbstractKafkaSchemaSerDeConfig {
 
   public static final String SPECIFIC_AVRO_READER_CONFIG = "specific.avro.reader";
   public static final boolean SPECIFIC_AVRO_READER_DEFAULT = false;

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.serialization.Serializer;
 import java.util.Map;
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 
 public class KafkaAvroSerializer extends AbstractKafkaAvroSerializer implements Serializer<Object> {

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.serialization.Serializer;
 
 import java.util.Map;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 
 public class KafkaAvroSerializer extends AbstractKafkaAvroSerializer implements Serializer<Object> {
@@ -50,9 +51,13 @@ public class KafkaAvroSerializer extends AbstractKafkaAvroSerializer implements 
 
   @Override
   public byte[] serialize(String topic, Object record) {
+    if (record == null) {
+      return null;
+    }
     return serializeImpl(
         getSubjectName(topic, isKey, record,
-            AvroSchemaUtils.getSchema(record, useSchemaReflection)), record);
+            new AvroSchema(AvroSchemaUtils.getSchema(record, useSchemaReflection))),
+            record);
   }
 
   @Override

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializerConfig.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializerConfig.java
@@ -20,7 +20,7 @@ import io.confluent.common.config.ConfigDef;
 
 import java.util.Map;
 
-public class KafkaAvroSerializerConfig extends AbstractKafkaAvroSerDeConfig {
+public class KafkaAvroSerializerConfig extends AbstractKafkaSchemaSerDeConfig {
 
   private static ConfigDef config;
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/RecordNameStrategy.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/RecordNameStrategy.java
@@ -34,7 +34,7 @@ import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
  * Instead, checks compatibility of any occurrences of the same record name
  * across <em>all</em> topics.
  */
-public class RecordNameStrategy implements SubjectNameStrategy<ParsedSchema>,
+public class RecordNameStrategy implements SubjectNameStrategy,
     io.confluent.kafka.serializers.subject.SubjectNameStrategy {
 
   @Override

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/RecordNameStrategy.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/RecordNameStrategy.java
@@ -16,22 +16,25 @@
 
 package io.confluent.kafka.serializers.subject;
 
-import java.util.Map;
-import org.apache.avro.Schema;
 import org.apache.kafka.common.errors.SerializationException;
-import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
+
+import java.util.Map;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
 import io.confluent.kafka.serializers.AvroSchemaUtils;
 
 /**
- * For any Avro record type that is published to Kafka, registers the schema
+ * For any record type that is published to Kafka, registers the schema
  * in the registry under the fully-qualified record name (regardless of the
  * topic). This strategy allows a topic to contain a mixture of different
  * record types, since no intra-topic compatibility checking is performed.
  * Instead, checks compatibility of any occurrences of the same record name
  * across <em>all</em> topics.
  */
-public class RecordNameStrategy implements SubjectNameStrategy<Schema>,
+public class RecordNameStrategy implements SubjectNameStrategy<ParsedSchema>,
     io.confluent.kafka.serializers.subject.SubjectNameStrategy {
 
   @Override
@@ -39,37 +42,38 @@ public class RecordNameStrategy implements SubjectNameStrategy<Schema>,
   }
 
   @Override
-  public String subjectName(String topic, boolean isKey, Schema schema) {
-    if (schema == null || schema.getType() == Schema.Type.NULL) {
+  public String subjectName(String topic, boolean isKey, ParsedSchema schema) {
+    if (schema == null) {
       return null;
     }
     return getRecordName(schema, isKey);
   }
 
   /**
-   * If the schema is an Avro record type, returns its fully-qualified name.
+   * If the schema is a record type, returns its fully-qualified name.
    * Otherwise throws an error.
    */
-  protected String getRecordName(Schema schema, boolean isKey) {
-    if (schema != null && schema.getType() == Schema.Type.RECORD) {
-      return schema.getFullName();
+  protected String getRecordName(ParsedSchema schema, boolean isKey) {
+    String name = schema.name();
+    if (name != null) {
+      return name;
     }
 
     // isKey is only used to produce more helpful error messages
     if (isKey) {
       throw new SerializationException("In configuration "
-          + AbstractKafkaAvroSerDeConfig.KEY_SUBJECT_NAME_STRATEGY + " = "
-          + getClass().getName() + ", the message key must only be an Avro record schema");
+          + AbstractKafkaSchemaSerDeConfig.KEY_SUBJECT_NAME_STRATEGY + " = "
+          + getClass().getName() + ", the message key must only be a record schema");
     } else {
       throw new SerializationException("In configuration "
-          + AbstractKafkaAvroSerDeConfig.VALUE_SUBJECT_NAME_STRATEGY + " = "
-          + getClass().getName() + ", the message value must only be an Avro record schema");
+          + AbstractKafkaSchemaSerDeConfig.VALUE_SUBJECT_NAME_STRATEGY + " = "
+          + getClass().getName() + ", the message value must only be a record schema");
     }
   }
 
   @Override
   @Deprecated
   public String getSubjectName(String topic, boolean isKey, Object value) {
-    return subjectName(topic, isKey, AvroSchemaUtils.getSchema(value));
+    return subjectName(topic, isKey, new AvroSchema(AvroSchemaUtils.getSchema(value)));
   }
 }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/RecordNameStrategy.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/RecordNameStrategy.java
@@ -24,7 +24,7 @@ import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
-import io.confluent.kafka.serializers.AvroSchemaUtils;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
 
 /**
  * For any record type that is published to Kafka, registers the schema

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/SubjectNameStrategy.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/SubjectNameStrategy.java
@@ -20,7 +20,7 @@ package io.confluent.kafka.serializers.subject;
 import org.apache.kafka.common.Configurable;
 
 /**
- * A {@link SubjectNameStrategy} is used by the Avro serializer to determine
+ * A {@link SubjectNameStrategy} is used by the serializer to determine
  * the subject name under which the event record schemas should be registered
  * in the schema registry. The default is {@link TopicNameStrategy}.
  * @deprecated use {@link io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy}

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/TopicNameStrategy.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/TopicNameStrategy.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * the subject name &lt;topic&gt;-key, and the message value is registered
  * under the subject name &lt;topic&gt;-value.
  */
-public class TopicNameStrategy implements SubjectNameStrategy<ParsedSchema>,
+public class TopicNameStrategy implements SubjectNameStrategy,
     io.confluent.kafka.serializers.subject.SubjectNameStrategy {
 
   @Override

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/TopicNameStrategy.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/TopicNameStrategy.java
@@ -16,9 +16,8 @@
 
 package io.confluent.kafka.serializers.subject;
 
-import io.confluent.kafka.serializers.AvroSchemaUtils;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
-import org.apache.avro.Schema;
 
 import java.util.Map;
 
@@ -28,7 +27,7 @@ import java.util.Map;
  * the subject name &lt;topic&gt;-key, and the message value is registered
  * under the subject name &lt;topic&gt;-value.
  */
-public class TopicNameStrategy implements SubjectNameStrategy<Schema>,
+public class TopicNameStrategy implements SubjectNameStrategy<ParsedSchema>,
     io.confluent.kafka.serializers.subject.SubjectNameStrategy {
 
   @Override
@@ -36,13 +35,13 @@ public class TopicNameStrategy implements SubjectNameStrategy<Schema>,
   }
 
   @Override
-  public String subjectName(String topic, boolean isKey, Schema schema) {
+  public String subjectName(String topic, boolean isKey, ParsedSchema schema) {
     return isKey ? topic + "-key" : topic + "-value";
   }
 
   @Override
   @Deprecated
   public String getSubjectName(String topic, boolean isKey, Object value) {
-    return subjectName(topic, isKey, AvroSchemaUtils.getSchema(value));
+    return subjectName(topic, isKey, null);
   }
 }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/TopicRecordNameStrategy.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/TopicRecordNameStrategy.java
@@ -16,13 +16,13 @@
 
 package io.confluent.kafka.serializers.subject;
 
-import org.apache.avro.Schema;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 
 /**
- * For any Avro record type that is published to Kafka topic &lt;topic&gt;,
+ * For any record type that is published to Kafka topic &lt;topic&gt;,
  * registers the schema in the registry under the subject name
  * &lt;topic&gt;-&lt;recordName&gt;, where &lt;recordName&gt; is the
- * fully-qualified Avro record name. This strategy allows a topic to contain
+ * fully-qualified record name. This strategy allows a topic to contain
  * a mixture of different record types, since no intra-topic compatibility
  * checking is performed. Moreover, different topics may contain mutually
  * incompatible versions of the same record name, since the compatibility
@@ -31,8 +31,8 @@ import org.apache.avro.Schema;
 public class TopicRecordNameStrategy extends RecordNameStrategy {
 
   @Override
-  public String subjectName(String topic, boolean isKey, Schema schema) {
-    if (schema == null || schema.getType() == Schema.Type.NULL) {
+  public String subjectName(String topic, boolean isKey, ParsedSchema schema) {
+    if (schema == null) {
       return null;
     }
     return topic + "-" + getRecordName(schema, isKey);

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/strategy/SubjectNameStrategy.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/strategy/SubjectNameStrategy.java
@@ -21,7 +21,7 @@ import org.apache.kafka.common.Configurable;
 import io.confluent.kafka.serializers.subject.TopicNameStrategy;
 
 /**
- * A {@link SubjectNameStrategy} is used by the Avro serializer to determine
+ * A {@link SubjectNameStrategy} is used by the serializer to determine
  * the subject name under which the event record schemas should be registered
  * in the schema registry. The default is {@link TopicNameStrategy}.
  */

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/strategy/SubjectNameStrategy.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/subject/strategy/SubjectNameStrategy.java
@@ -18,6 +18,7 @@ package io.confluent.kafka.serializers.subject.strategy;
 
 import org.apache.kafka.common.Configurable;
 
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.serializers.subject.TopicNameStrategy;
 
 /**
@@ -25,7 +26,7 @@ import io.confluent.kafka.serializers.subject.TopicNameStrategy;
  * the subject name under which the event record schemas should be registered
  * in the schema registry. The default is {@link TopicNameStrategy}.
  */
-public interface SubjectNameStrategy<T> extends Configurable {
+public interface SubjectNameStrategy extends Configurable {
 
   /**
    * For a given topic and message, returns the subject name under which the
@@ -36,6 +37,6 @@ public interface SubjectNameStrategy<T> extends Configurable {
    * @param schema the schema of the record being serialized/deserialized
    * @return The subject name under which the schema should be registered.
    */
-  String subjectName(String topic, boolean isKey, T schema);
+  String subjectName(String topic, boolean isKey, ParsedSchema schema);
 
 }

--- a/avro-serializer/src/test/java/io/confluent/kafka/formatter/AvroMessageFormatterTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/formatter/AvroMessageFormatterTest.java
@@ -16,6 +16,8 @@
 package io.confluent.kafka.formatter;
 
 import static org.junit.Assert.assertEquals;
+
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
@@ -66,8 +68,8 @@ public class AvroMessageFormatterTest {
     Schema schema1 = Schema.create(Type.BYTES);
     Schema schema2 = Schema.create(Type.BYTES);
     schema2.addProp("foo", "bar"); // must be different than schema1
-    schemaRegistry.register("topicname", schema1);
-    schemaRegistry.register("othertopic", schema2);
+    schemaRegistry.register("topicname", new AvroSchema(schema1));
+    schemaRegistry.register("othertopic", new AvroSchema(schema2));
 
     formatter = new AvroMessageFormatter(schemaRegistry, null);
   }

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializerTest.java
@@ -64,7 +64,7 @@ public class AbstractKafkaAvroDeserializerTest {
 
   public void assertSchemaNotCopiedWhenDeserializedWithVersion(
       String topic,
-      SubjectNameStrategy<ParsedSchema> subjectNameStrategy) throws IOException,
+      SubjectNameStrategy subjectNameStrategy) throws IOException,
       RestClientException {
     Map configs = ImmutableMap.builder()
         .putAll(defaultConfigs)

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/AvroSchemaTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/AvroSchemaTest.java
@@ -1,0 +1,414 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.serializers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericArray;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericEnumSymbol;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.avro.util.Utf8;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class AvroSchemaTest {
+
+  private static ObjectMapper objectMapper = new ObjectMapper();
+
+  private static final Schema.Parser parser = new Schema.Parser();
+
+  private static final Schema recordSchema = new Schema.Parser().parse(
+      "{\"namespace\": \"namespace\",\n"
+          + " \"type\": \"record\",\n"
+          + " \"name\": \"test\",\n"
+          + " \"fields\": [\n"
+          + "     {\"name\": \"null\", \"type\": \"null\"},\n"
+          + "     {\"name\": \"boolean\", \"type\": \"boolean\"},\n"
+          + "     {\"name\": \"int\", \"type\": \"int\"},\n"
+          + "     {\"name\": \"long\", \"type\": \"long\"},\n"
+          + "     {\"name\": \"float\", \"type\": \"float\"},\n"
+          + "     {\"name\": \"double\", \"type\": \"double\"},\n"
+          + "     {\"name\": \"bytes\", \"type\": \"bytes\"},\n"
+          + "     {\"name\": \"string\", \"type\": \"string\", \"aliases\": [\"string_alias\"]},\n"
+          + "     {\"name\": \"null_default\", \"type\": \"null\", \"default\": null},\n"
+          + "     {\"name\": \"boolean_default\", \"type\": \"boolean\", \"default\": false},\n"
+          + "     {\"name\": \"int_default\", \"type\": \"int\", \"default\": 24},\n"
+          + "     {\"name\": \"long_default\", \"type\": \"long\", \"default\": 4000000000},\n"
+          + "     {\"name\": \"float_default\", \"type\": \"float\", \"default\": 12.3},\n"
+          + "     {\"name\": \"double_default\", \"type\": \"double\", \"default\": 23.2},\n"
+          + "     {\"name\": \"bytes_default\", \"type\": \"bytes\", \"default\": \"bytes\"},\n"
+          + "     {\"name\": \"string_default\", \"type\": \"string\", \"default\": "
+          + "\"default string\"}\n"
+          + "]\n"
+          + "}");
+
+  private static final Schema arraySchema = new Schema.Parser().parse(
+      "{\"namespace\": \"namespace\",\n"
+          + " \"type\": \"array\",\n"
+          + " \"name\": \"test\",\n"
+          + " \"items\": \"string\"\n"
+          + "}");
+
+  private static final Schema mapSchema = new Schema.Parser().parse(
+      "{\"namespace\": \"namespace\",\n"
+          + " \"type\": \"map\",\n"
+          + " \"name\": \"test\",\n"
+          + " \"values\": \"string\"\n"
+          + "}");
+
+  private static final Schema unionSchema = new Schema.Parser().parse("{\"type\": \"record\",\n"
+      + " \"name\": \"test\",\n"
+      + " \"fields\": [\n"
+      + "     {\"name\": \"union\", \"type\": [\"string\", \"int\"]}\n"
+      + "]}");
+
+
+  private static final Schema enumSchema = new Schema.Parser().parse("{ \"type\": \"enum\",\n"
+      + "  \"name\": \"Suit\",\n"
+      + "  \"symbols\" : [\"SPADES\", \"HEARTS\", \"DIAMONDS\", \"CLUBS\"]\n"
+      + "}");
+
+  @Test
+  public void testPrimitiveTypesToAvro() throws Exception {
+    Object result = AvroSchemaUtils.toObject(null, createPrimitiveSchema("null"));
+    assertTrue(result == null);
+
+    result = AvroSchemaUtils.toObject(jsonTree("true"), createPrimitiveSchema("boolean"));
+    assertEquals(true, result);
+    result = AvroSchemaUtils.toObject(jsonTree("false"), createPrimitiveSchema("boolean"));
+    assertEquals(false, result);
+
+    result = AvroSchemaUtils.toObject(jsonTree("12"), createPrimitiveSchema("int"));
+    assertTrue(result instanceof Integer);
+    assertEquals(12, result);
+
+    result = AvroSchemaUtils.toObject(jsonTree("12"), createPrimitiveSchema("long"));
+    assertTrue(result instanceof Long);
+    assertEquals(12L, result);
+    result = AvroSchemaUtils.toObject(jsonTree("5000000000"), createPrimitiveSchema("long"));
+    assertTrue(result instanceof Long);
+    assertEquals(5000000000L, result);
+
+    result = AvroSchemaUtils.toObject(jsonTree("23.2"), createPrimitiveSchema("float"));
+    assertTrue(result instanceof Float);
+    assertEquals(23.2f, result);
+    result = AvroSchemaUtils.toObject(jsonTree("23"), createPrimitiveSchema("float"));
+    assertTrue(result instanceof Float);
+    assertEquals(23.0f, result);
+
+    result = AvroSchemaUtils.toObject(jsonTree("23.2"), createPrimitiveSchema("double"));
+    assertTrue(result instanceof Double);
+    assertEquals(23.2, result);
+    result = AvroSchemaUtils.toObject(jsonTree("23"), createPrimitiveSchema("double"));
+    assertTrue(result instanceof Double);
+    assertEquals(23.0, result);
+
+    // We can test bytes simply using simple ASCII string since the translation is direct in that
+    // case
+    result = AvroSchemaUtils.toObject(new TextNode("hello"), createPrimitiveSchema("bytes"));
+    assertTrue(result instanceof ByteBuffer);
+    assertArrayEquals(Base64.getEncoder().encode("hello".getBytes()),
+        Base64.getEncoder().encode(((ByteBuffer) result).array())
+    );
+
+    result = AvroSchemaUtils.toObject(jsonTree("\"a string\""), createPrimitiveSchema("string"));
+    assertTrue(result instanceof Utf8);
+    assertEquals(new Utf8("a string"), result);
+  }
+
+  @Test
+  public void testPrimitiveTypeToAvroSchemaMismatches() throws Exception {
+    expectConversionException(jsonTree("12"), createPrimitiveSchema("null"));
+
+    expectConversionException(jsonTree("12"), createPrimitiveSchema("boolean"));
+
+    expectConversionException(jsonTree("false"), createPrimitiveSchema("int"));
+    // Note that we don't test real numbers => int because JsonDecoder permits this and removes
+    // the decimal part
+    expectConversionException(jsonTree("5000000000"), createPrimitiveSchema("int"));
+
+    expectConversionException(jsonTree("false"), createPrimitiveSchema("long"));
+    // Note that we don't test real numbers => long because JsonDecoder permits this and removes
+    // the decimal part
+
+    expectConversionException(jsonTree("false"), createPrimitiveSchema("float"));
+
+    expectConversionException(jsonTree("false"), createPrimitiveSchema("double"));
+
+    expectConversionException(jsonTree("false"), createPrimitiveSchema("bytes"));
+
+    expectConversionException(jsonTree("false"), createPrimitiveSchema("string"));
+  }
+
+  @Test
+  public void testRecordToAvro() throws Exception {
+    String json = "{\n"
+        + "    \"null\": null,\n"
+        + "    \"boolean\": true,\n"
+        + "    \"int\": 12,\n"
+        + "    \"long\": 5000000000,\n"
+        + "    \"float\": 23.4,\n"
+        + "    \"double\": 800.25,\n"
+        + "    \"bytes\": \"hello\",\n"
+        + "    \"string\": \"string\",\n"
+        + "    \"null_default\": null,\n"
+        + "    \"boolean_default\": false,\n"
+        + "    \"int_default\": 24,\n"
+        + "    \"long_default\": 4000000000,\n"
+        + "    \"float_default\": 12.3,\n"
+        + "    \"double_default\": 23.2,\n"
+        + "    \"bytes_default\": \"bytes\",\n"
+        + "    \"string_default\": \"default\"\n"
+        + "}";
+
+    Object result = AvroSchemaUtils.toObject(jsonTree(json), new AvroSchema(recordSchema));
+    assertTrue(result instanceof GenericRecord);
+    GenericRecord resultRecord = (GenericRecord) result;
+    assertEquals(null, resultRecord.get("null"));
+    assertEquals(true, resultRecord.get("boolean"));
+    assertEquals(12, resultRecord.get("int"));
+    assertEquals(5000000000L, resultRecord.get("long"));
+    assertEquals(23.4f, resultRecord.get("float"));
+    assertEquals(800.25, resultRecord.get("double"));
+    assertArrayEquals(Base64.getEncoder().encode("hello".getBytes()),
+        Base64.getEncoder().encode(((ByteBuffer) resultRecord.get("bytes")).array())
+    );
+    assertEquals("string", resultRecord.get("string").toString());
+    // Nothing to check with default values, just want to make sure an exception wasn't thrown
+    // when they values weren't specified for their fields.
+  }
+
+  @Test
+  public void testArrayToAvro() throws Exception {
+    String json = "[\"one\", \"two\", \"three\"]";
+
+    Object result = AvroSchemaUtils.toObject(jsonTree(json), new AvroSchema(arraySchema));
+    assertTrue(result instanceof GenericArray);
+    assertArrayEquals(new Utf8[]{new Utf8("one"), new Utf8("two"), new Utf8("three")},
+        ((GenericArray) result).toArray()
+    );
+  }
+
+  @Test
+  public void testMapToAvro() throws Exception {
+    String json = "{\"first\": \"one\", \"second\": \"two\"}";
+
+    Object result = AvroSchemaUtils.toObject(jsonTree(json), new AvroSchema(mapSchema));
+    assertTrue(result instanceof Map);
+    assertEquals(2, ((Map<String, Object>) result).size());
+  }
+
+  @Test
+  public void testUnionToAvro() throws Exception {
+    Object result = AvroSchemaUtils.toObject(jsonTree("{\"union\":{\"string\":\"test string\"}}"),
+        new AvroSchema(unionSchema)
+    );
+    Object foo = ((GenericRecord) result).get("union");
+    assertTrue(((GenericRecord) result).get("union") instanceof Utf8);
+
+    result = AvroSchemaUtils.toObject(jsonTree("{\"union\":{\"int\":12}}"),
+        new AvroSchema(unionSchema)
+    );
+    assertTrue(((GenericRecord) result).get("union") instanceof Integer);
+
+    try {
+      AvroSchemaUtils.toObject(jsonTree("12.4"), new AvroSchema(unionSchema));
+      fail("Trying to convert floating point number to union(string,int) schema should fail");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testEnumToAvro() throws Exception {
+    Object result = AvroSchemaUtils.toObject(jsonTree("\"SPADES\""), new AvroSchema(enumSchema));
+    assertTrue(result instanceof GenericEnumSymbol);
+
+    // There's no failure case here because the only failure mode is passing in non-string data.
+    // Even if they put in an invalid symbol name, the exception won't be thrown until
+    // serialization.
+  }
+
+
+  @Test
+  public void testPrimitiveTypesToJson() throws Exception {
+    JsonNode result = objectMapper.readTree(AvroSchemaUtils.toJson((int) 0));
+    assertTrue(result.isNumber());
+
+    result = objectMapper.readTree(AvroSchemaUtils.toJson((long) 0));
+    assertTrue(result.isNumber());
+
+    result = objectMapper.readTree(AvroSchemaUtils.toJson(0.1f));
+    assertTrue(result.isNumber());
+
+    result = objectMapper.readTree(AvroSchemaUtils.toJson(0.1));
+    assertTrue(result.isNumber());
+
+    result = objectMapper.readTree(AvroSchemaUtils.toJson(true));
+    assertTrue(result.isBoolean());
+
+    // "Primitive" here refers to Avro primitive types, which are returned as standalone objects,
+    // which can't have attached schemas. This includes, for example, Strings and byte[] even
+    // though they are not Java primitives
+
+    result = objectMapper.readTree(AvroSchemaUtils.toJson("abcdefg"));
+    assertTrue(result.isTextual());
+    assertEquals("abcdefg", result.textValue());
+
+    result = objectMapper.readTree(AvroSchemaUtils.toJson(ByteBuffer.wrap("hello".getBytes())));
+    assertTrue(result.isTextual());
+    // Was generated from a string, so the Avro encoding should be equivalent to the string
+    assertEquals("hello", result.textValue());
+  }
+
+  @Test
+  public void testUnsupportedJavaPrimitivesToJson() throws Exception {
+    expectConversionException((byte) 0);
+    expectConversionException((char) 0);
+    expectConversionException((short) 0);
+  }
+
+  @Test
+  public void testRecordToJson() throws Exception {
+    GenericRecord data = new GenericRecordBuilder(recordSchema).set("null", null)
+        .set("boolean", true)
+        .set("int", 12)
+        .set("long", 5000000000L)
+        .set("float", 23.4f)
+        .set("double", 800.25)
+        .set("bytes", ByteBuffer.wrap("bytes".getBytes()))
+        .set("string", "string")
+        .build();
+
+    JsonNode result = objectMapper.readTree(AvroSchemaUtils.toJson(data));
+    assertTrue(result.isObject());
+    assertTrue(result.get("null").isNull());
+    assertTrue(result.get("boolean").isBoolean());
+    assertEquals(true, result.get("boolean").booleanValue());
+    assertTrue(result.get("int").isIntegralNumber());
+    assertEquals(12, result.get("int").intValue());
+    assertTrue(result.get("long").isIntegralNumber());
+    assertEquals(5000000000L, result.get("long").longValue());
+    assertTrue(result.get("float").isFloatingPointNumber());
+    assertEquals(23.4f, result.get("float").floatValue(), 0.1);
+    assertTrue(result.get("double").isFloatingPointNumber());
+    assertEquals(800.25, result.get("double").doubleValue(), 0.01);
+    assertTrue(result.get("bytes").isTextual());
+    // The bytes value was created from an ASCII string, so Avro's encoding should just give that
+    // string back to us in the JSON-serialized version
+    assertEquals("bytes", result.get("bytes").textValue());
+    assertTrue(result.get("string").isTextual());
+    assertEquals("string", result.get("string").textValue());
+  }
+
+  @Test
+  public void testArrayToJson() throws Exception {
+    GenericData.Array<String> data = new GenericData.Array(arraySchema,
+        Arrays.asList("one", "two", "three")
+    );
+    JsonNode result = objectMapper.readTree(AvroSchemaUtils.toJson(data));
+
+    assertTrue(result.isArray());
+    assertEquals(3, result.size());
+    assertEquals(JsonNodeFactory.instance.textNode("one"), result.get(0));
+    assertEquals(JsonNodeFactory.instance.textNode("two"), result.get(1));
+    assertEquals(JsonNodeFactory.instance.textNode("three"), result.get(2));
+  }
+
+  @Test
+  public void testMapToJson() throws Exception {
+    Map<String, Object> data = new HashMap<String, Object>();
+    data.put("first", "one");
+    data.put("second", "two");
+    JsonNode result = objectMapper.readTree(AvroSchemaUtils.toJson(data));
+
+    assertTrue(result.isObject());
+    assertEquals(2, result.size());
+    assertNotNull(result.get("first"));
+    assertEquals("one", result.get("first").asText());
+    assertNotNull(result.get("second"));
+    assertEquals("two", result.get("second").asText());
+  }
+
+  @Test
+  public void testEnumToJson() throws Exception {
+    JsonNode result =
+        objectMapper.readTree(AvroSchemaUtils.toJson(new GenericData.EnumSymbol(enumSchema,
+        "SPADES"
+    )));
+    assertTrue(result.isTextual());
+    assertEquals("SPADES", result.textValue());
+  }
+
+
+  private static void expectConversionException(JsonNode obj, ParsedSchema schema) {
+    try {
+      AvroSchemaUtils.toObject(obj, schema);
+      fail("Expected conversion of "
+          + (obj == null ? "null" : obj.toString())
+          + " to schema "
+          + schema.toString()
+          + " to fail");
+    } catch (Exception e) {
+      // Expected
+    }
+  }
+
+  private static void expectConversionException(Object obj) {
+    try {
+      AvroSchemaUtils.toJson(obj);
+      fail("Expected conversion of "
+          + (
+          obj == null ? "null" : (obj.toString() + " (" + obj.getClass().getName() + ")"))
+          + " to fail");
+    } catch (Exception e) {
+      // Expected
+    }
+  }
+
+  private static ParsedSchema createPrimitiveSchema(String type) {
+    String schemaString = String.format("{\"type\" : \"%s\"}", type);
+    return new AvroSchema(parser.parse(schemaString));
+  }
+
+  private static JsonNode jsonTree(String jsonData) {
+    try {
+      return objectMapper.readTree(jsonData);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to parse JSON", e);
+    }
+  }
+}

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
@@ -36,10 +36,10 @@ import java.util.Properties;
 import io.confluent.kafka.example.ExtendedUser;
 import io.confluent.kafka.example.User;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-import io.confluent.kafka.serializers.subject.RecordNameStrategy;
 import io.confluent.kafka.serializers.subject.TopicRecordNameStrategy;
 import kafka.utils.VerifiableProperties;
 

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
@@ -35,9 +35,11 @@ import java.util.Properties;
 
 import io.confluent.kafka.example.ExtendedUser;
 import io.confluent.kafka.example.User;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.serializers.subject.RecordNameStrategy;
 import io.confluent.kafka.serializers.subject.TopicRecordNameStrategy;
 import kafka.utils.VerifiableProperties;
 
@@ -217,7 +219,7 @@ public class KafkaAvroSerializerTest {
     );
     avroSerializer.configure(configs, false);
     IndexedRecord avroRecord = createAvroRecord();
-    schemaRegistry.register(topic + "-value", avroRecord.getSchema());
+    schemaRegistry.register(topic + "-value", new AvroSchema(avroRecord.getSchema()));
     byte[] bytes = avroSerializer.serialize(topic, avroRecord);
     assertEquals(avroRecord, avroDeserializer.deserialize(topic, bytes));
     assertEquals(avroRecord, avroDecoder.fromBytes(bytes));
@@ -475,7 +477,7 @@ public class KafkaAvroSerializerTest {
     HashMap<String, String> props = new HashMap<>();
     props.put(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "bogus");
     props.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, "true");
-    props.put(AbstractKafkaAvroSerDeConfig.MAX_SCHEMAS_PER_SUBJECT_CONFIG, "5");
+    props.put(AbstractKafkaSchemaSerDeConfig.MAX_SCHEMAS_PER_SUBJECT_CONFIG, "5");
     avroSerializer.configure(props, false);
   }
 

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -22,10 +22,10 @@
               files="(Errors|AvroMessageReader).java"/>
 
     <suppress checks="CyclomaticComplexity"
-              files="(AbstractKafkaAvroDeserializer|AvroSchemaUtils|CompatibilityResource|KafkaSchemaRegistry|KafkaStoreReaderThread|AvroData|DownloadSchemaRegistryMojo|AvroMessageFormatter|MockSchemaRegistryClient|SchemaRegistrySerializer|SubjectVersionsResource).java"/>
+              files="(AbstractKafkaAvroDeserializer|AvroSchemaUtils|CompatibilityResource|KafkaSchemaRegistry|KafkaStoreReaderThread|AvroData|DownloadSchemaRegistryMojo|AvroMessageFormatter|MockSchemaRegistryClient|SchemaRegistrySerializer|SchemaValue|SubjectVersionsResource).java"/>
 
     <suppress checks="NPathComplexity"
-              files="(AvroData|DownloadSchemaRegistryMojo|AvroMessageFormatter|KafkaSchemaRegistry|SchemaValue).java"/>
+              files="(AvroData|DownloadSchemaRegistryMojo|AvroMessageFormatter|KafkaSchemaRegistry|Schema|SchemaValue).java"/>
 
     <suppress checks="JavaNCSS"
               files="AvroData.java"/>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -25,7 +25,7 @@
               files="(AbstractKafkaAvroDeserializer|AvroSchemaUtils|CompatibilityResource|KafkaSchemaRegistry|KafkaStoreReaderThread|AvroData|DownloadSchemaRegistryMojo|AvroMessageFormatter|MockSchemaRegistryClient|SchemaRegistrySerializer|SubjectVersionsResource).java"/>
 
     <suppress checks="NPathComplexity"
-              files="(AvroData|DownloadSchemaRegistryMojo|AvroMessageFormatter|KafkaSchemaRegistry).java"/>
+              files="(AvroData|DownloadSchemaRegistryMojo|AvroMessageFormatter|KafkaSchemaRegistry|SchemaValue).java"/>
 
     <suppress checks="JavaNCSS"
               files="AvroData.java"/>

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -13,7 +13,7 @@
               files="SchemaRegistryCoordinator.java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(AbstractKafkaAvroDeserializer|AvroMessageReader|RestService|Errors|SchemaRegistryRestApplication|KafkaSchemaRegistry|KafkaStore|AvroData|KafkaGroupMasterElector).java"/>
+              files="(AbstractKafkaAvroDeserializer|AbstractKafkaAvroSerializer|AvroMessageReader|RestService|Errors|SchemaRegistryRestApplication|KafkaSchemaRegistry|KafkaStore|AvroData|KafkaGroupMasterElector).java"/>
 
     <suppress checks="ClassFanOutComplexity"
               files="(RestService|KafkaSchemaRegistry|KafkaStore|KafkaStoreReaderThread|AvroData|KafkaGroupMasterElector).java"/>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -40,6 +40,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.ext</groupId>
+            <artifactId>jersey-bean-validation</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.easymock</groupId>

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/AbstractSchemaProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/AbstractSchemaProvider.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.confluent.kafka.schemaregistry.client.SchemaVersionFetcher;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+
+public abstract class AbstractSchemaProvider implements SchemaProvider {
+
+  private SchemaVersionFetcher schemaVersionFetcher;
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    schemaVersionFetcher =
+        (SchemaVersionFetcher) configs.get(SchemaProvider.SCHEMA_VERSION_FETCHER_CONFIG);
+  }
+
+  public SchemaVersionFetcher schemaVersionFetcher() {
+    return schemaVersionFetcher;
+  }
+
+  protected Map<String, String> resolveReferences(List<SchemaReference> references) {
+    if (references == null) {
+      return Collections.emptyMap();
+    }
+    Map<String, String> result = new LinkedHashMap<>();
+    resolveReferences(references, result);
+    return result;
+  }
+
+  private void resolveReferences(List<SchemaReference> references, Map<String, String> schemas) {
+    if (references == null) {
+      return;
+    }
+    for (SchemaReference reference : references) {
+      String subject = reference.getSubject();
+      Schema schema = schemaVersionFetcher().getByVersion(subject, reference.getVersion(), true);
+      resolveReferences(schema.getReferences(), schemas);
+      schemas.put(reference.getName(), schema.getSchema());
+    }
+  }
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/CompatibilityChecker.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/CompatibilityChecker.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class CompatibilityChecker {
+
+  // Check if the new schema can be used to read data produced by the previous schema
+  private static final SchemaValidator BACKWARD_VALIDATOR =
+      new SchemaValidatorBuilder().canReadStrategy()
+      .validateLatest();
+  public static final CompatibilityChecker BACKWARD_CHECKER = new CompatibilityChecker(
+      BACKWARD_VALIDATOR);
+
+  // Check if data produced by the new schema can be read by the previous schema
+  private static final SchemaValidator FORWARD_VALIDATOR =
+      new SchemaValidatorBuilder().canBeReadStrategy()
+      .validateLatest();
+  public static final CompatibilityChecker FORWARD_CHECKER = new CompatibilityChecker(
+      FORWARD_VALIDATOR);
+
+  // Check if the new schema is both forward and backward compatible with the previous schema
+  private static final SchemaValidator FULL_VALIDATOR =
+      new SchemaValidatorBuilder().mutualReadStrategy()
+      .validateLatest();
+  public static final CompatibilityChecker FULL_CHECKER = new CompatibilityChecker(FULL_VALIDATOR);
+
+  // Check if the new schema can be used to read data produced by all earlier schemas
+  private static final SchemaValidator BACKWARD_TRANSITIVE_VALIDATOR =
+      new SchemaValidatorBuilder().canReadStrategy()
+      .validateAll();
+  public static final CompatibilityChecker BACKWARD_TRANSITIVE_CHECKER = new CompatibilityChecker(
+      BACKWARD_TRANSITIVE_VALIDATOR);
+
+  // Check if data produced by the new schema can be read by all earlier schemas
+  private static final SchemaValidator FORWARD_TRANSITIVE_VALIDATOR =
+      new SchemaValidatorBuilder().canBeReadStrategy()
+      .validateAll();
+  public static final CompatibilityChecker FORWARD_TRANSITIVE_CHECKER = new CompatibilityChecker(
+      FORWARD_TRANSITIVE_VALIDATOR);
+
+  // Check if the new schema is both forward and backward compatible with all earlier schemas
+  private static final SchemaValidator FULL_TRANSITIVE_VALIDATOR =
+      new SchemaValidatorBuilder().mutualReadStrategy()
+      .validateAll();
+  public static final CompatibilityChecker FULL_TRANSITIVE_CHECKER = new CompatibilityChecker(
+      FULL_TRANSITIVE_VALIDATOR);
+
+  private static final SchemaValidator NO_OP_VALIDATOR = (schema, schemas) -> true;
+  public static final CompatibilityChecker NO_OP_CHECKER =
+      new CompatibilityChecker(NO_OP_VALIDATOR);
+
+  private final SchemaValidator validator;
+
+  private CompatibilityChecker(SchemaValidator validator) {
+    this.validator = validator;
+  }
+
+  // visible for testing
+  public boolean isCompatible(
+      ParsedSchema newSchema, List<? extends ParsedSchema> previousSchemas
+  ) {
+    List<? extends ParsedSchema> previousSchemasCopy = new ArrayList<>(previousSchemas);
+    // Validator checks in list order, but checks should occur in reverse chronological order
+    Collections.reverse(previousSchemasCopy);
+    return validator.validate(newSchema, previousSchemasCopy);
+  }
+
+  public static CompatibilityChecker checker(CompatibilityLevel level) {
+    switch (level) {
+      case NONE:
+        return CompatibilityChecker.NO_OP_CHECKER;
+      case BACKWARD:
+        return CompatibilityChecker.BACKWARD_CHECKER;
+      case BACKWARD_TRANSITIVE:
+        return CompatibilityChecker.BACKWARD_TRANSITIVE_CHECKER;
+      case FORWARD:
+        return CompatibilityChecker.FORWARD_CHECKER;
+      case FORWARD_TRANSITIVE:
+        return CompatibilityChecker.FORWARD_TRANSITIVE_CHECKER;
+      case FULL:
+        return CompatibilityChecker.FULL_CHECKER;
+      case FULL_TRANSITIVE:
+        return CompatibilityChecker.FULL_TRANSITIVE_CHECKER;
+      default:
+        throw new IllegalArgumentException("Invalid level " + level);
+    }
+  }
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/CompatibilityLevel.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/CompatibilityLevel.java
@@ -14,30 +14,24 @@
  * limitations under the License.
  */
 
-package io.confluent.kafka.schemaregistry.avro;
+package io.confluent.kafka.schemaregistry;
 
-/**
- * @deprecated  Use {@link io.confluent.kafka.schemaregistry.CompatibilityLevel} instead
- */
-@Deprecated
-public enum AvroCompatibilityLevel {
-  NONE("NONE", AvroCompatibilityChecker.NO_OP_CHECKER),
-  BACKWARD("BACKWARD", AvroCompatibilityChecker.BACKWARD_CHECKER),
-  BACKWARD_TRANSITIVE("BACKWARD_TRANSITIVE", AvroCompatibilityChecker.BACKWARD_TRANSITIVE_CHECKER),
-  FORWARD("FORWARD", AvroCompatibilityChecker.FORWARD_CHECKER),
-  FORWARD_TRANSITIVE("FORWARD_TRANSITIVE", AvroCompatibilityChecker.FORWARD_TRANSITIVE_CHECKER),
-  FULL("FULL", AvroCompatibilityChecker.FULL_CHECKER),
-  FULL_TRANSITIVE("FULL_TRANSITIVE", AvroCompatibilityChecker.FULL_TRANSITIVE_CHECKER);
+public enum CompatibilityLevel {
+  NONE,
+  BACKWARD,
+  BACKWARD_TRANSITIVE,
+  FORWARD,
+  FORWARD_TRANSITIVE,
+  FULL,
+  FULL_TRANSITIVE;
 
   public final String name;
-  public final AvroCompatibilityChecker compatibilityChecker;
 
-  private AvroCompatibilityLevel(String name, AvroCompatibilityChecker compatibilityChecker) {
-    this.name = name;
-    this.compatibilityChecker = compatibilityChecker;
+  private CompatibilityLevel() {
+    this.name = name();
   }
 
-  public static AvroCompatibilityLevel forName(String name) {
+  public static CompatibilityLevel forName(String name) {
     if (name == null) {
       return null;
     }
@@ -61,5 +55,4 @@ public enum AvroCompatibilityLevel {
       return null;
     }
   }
-
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
@@ -18,6 +18,8 @@ package io.confluent.kafka.schemaregistry;
 
 import java.util.List;
 
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+
 public interface ParsedSchema {
 
   /**
@@ -42,11 +44,11 @@ public interface ParsedSchema {
   String canonicalString();
 
   /**
-   * Returns the version associated with this schema, if any.
+   * Returns a list of schema references.
    *
-   * @return the version, or null
+   * @return the schema references
    */
-  Integer version();
+  List<SchemaReference> references();
 
   /**
    * Checks the backward compatibility between this schema and the specified schema.

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
@@ -28,6 +28,13 @@ public interface ParsedSchema {
   String schemaType();
 
   /**
+   * Returns a name for the schema.
+   *
+   * @return the name, or null
+   */
+  String name();
+
+  /**
    * Returns a canonical string representation of the schema.
    *
    * @return the canonical representation

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry;
+
+import java.util.List;
+
+public interface ParsedSchema {
+
+  /**
+   * Returns the schema type.
+   *
+   * @return the schema type
+   */
+  String schemaType();
+
+  /**
+   * Returns a canonical string representation of the schema.
+   *
+   * @return the canonical representation
+   */
+  String canonicalString();
+
+  /**
+   * Returns the version associated with this schema, if any.
+   *
+   * @return the version, or null
+   */
+  Integer version();
+
+  /**
+   * Checks the backward compatibility between this schema and the specified schema.
+   *
+   * @param previousSchema previous schema
+   * @return whether this schema is backward compatible with the previous schema
+   */
+  boolean isBackwardCompatible(ParsedSchema previousSchema);
+
+  /**
+   * Checks the compatibility between this schema and the specified schemas.
+   *
+   * @param level the compatibility level
+   * @param previousSchemas full schema history in chronological order
+   * @return whether this schema is compatible with the previous schemas
+   */
+  default boolean isCompatible(CompatibilityLevel level,
+                               List<? extends ParsedSchema> previousSchemas) {
+    for (ParsedSchema previousSchema : previousSchemas) {
+      if (!schemaType().equals(previousSchema.schemaType())) {
+        return false;
+      }
+    }
+    return CompatibilityChecker.checker(level).isCompatible(this, previousSchemas);
+  }
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaProvider.java
@@ -18,7 +18,6 @@ package io.confluent.kafka.schemaregistry;
 
 import org.apache.kafka.common.Configurable;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -47,8 +46,4 @@ public interface SchemaProvider extends Configurable {
    * @return an optional parsed schema
    */
   Optional<ParsedSchema> parseSchema(String schemaString, List<SchemaReference> references);
-
-  default Optional<ParsedSchema> parseSchema(String schemaString) {
-    return parseSchema(schemaString, Collections.emptyList());
-  }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaProvider.java
@@ -18,11 +18,18 @@ package io.confluent.kafka.schemaregistry;
 
 import org.apache.kafka.common.Configurable;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 
 public interface SchemaProvider extends Configurable {
 
-  default void configure(Map<String, ?> var1) {
+  String SCHEMA_VERSION_FETCHER_CONFIG = "schemaVersionFetcher";
+
+  default void configure(Map<String, ?> configs) {
   }
 
   /**
@@ -36,7 +43,12 @@ public interface SchemaProvider extends Configurable {
    * Parses a string representing a schema.
    *
    * @param schemaString the schema
-   * @return a parsed schema, or null if the schema could not be parsed
+   * @param references a list of schema references
+   * @return an optional parsed schema
    */
-  ParsedSchema parseSchema(String schemaString);
+  Optional<ParsedSchema> parseSchema(String schemaString, List<SchemaReference> references);
+
+  default Optional<ParsedSchema> parseSchema(String schemaString) {
+    return parseSchema(schemaString, Collections.emptyList());
+  }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaProvider.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry;
+
+import org.apache.kafka.common.Configurable;
+
+import java.util.Map;
+
+public interface SchemaProvider extends Configurable {
+
+  default void configure(Map<String, ?> var1) {
+  }
+
+  /**
+   * Returns the schema type.
+   *
+   * @return the schema type
+   */
+  String schemaType();
+
+  /**
+   * Parses a string representing a schema.
+   *
+   * @param schemaString the schema
+   * @return a parsed schema, or null if the schema could not be parsed
+   */
+  ParsedSchema parseSchema(String schemaString);
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidationStrategy.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidationStrategy.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry;
+
+/**
+ * An interface for validating the compatibility of a single schema against
+ * another.
+ *
+ * <p>What makes one schema compatible with another is not defined by the contract.
+ * </p>
+ */
+public interface SchemaValidationStrategy {
+
+  /**
+   * Validates that one schema is compatible with another.
+   *
+   * @param toValidate The schema to validate
+   * @param existing The schema to validate against
+   */
+  boolean validate(ParsedSchema toValidate, ParsedSchema existing);
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidator.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry;
+
+/**
+ * <p>
+ * A SchemaValidator has one method, which validates that a {@link ParsedSchema} is
+ * <b>compatible</b> with the other schemas provided.
+ * </p>
+ * <p>
+ * What makes one Schema compatible with another is not part of the interface
+ * contract.
+ * </p>
+ */
+public interface SchemaValidator {
+
+  /**
+   * Validate one schema against others. The order of the schemas to validate
+   * against is chronological from most recent to oldest, if there is a natural
+   * chronological order. This allows some validators to identify which schemas
+   * are the most "recent" in order to validate only against the most recent
+   * schema(s).
+   *
+   * @param toValidate The schema to validate
+   * @param existing The schemas to validate against, in order from most recent to latest if
+   *     applicable
+   */
+  boolean validate(ParsedSchema toValidate, Iterable<? extends ParsedSchema> existing);
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidatorBuilder.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidatorBuilder.java
@@ -74,8 +74,7 @@ public final class SchemaValidatorBuilder {
     valid();
     return (toValidate, schemasInOrder) -> {
       for (ParsedSchema existing : schemasInOrder) {
-        boolean valid = strategy.validate(toValidate, existing);
-        if (!valid) {
+        if (!strategy.validate(toValidate, existing)) {
           return false;
         }
       }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidatorBuilder.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidatorBuilder.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry;
+
+import java.util.Iterator;
+
+/**
+ * <p>
+ * A Builder for creating SchemaValidators.
+ * </p>
+ */
+public final class SchemaValidatorBuilder {
+  private SchemaValidationStrategy strategy;
+
+  /**
+   * Use a strategy that validates that a schema can be used to read existing
+   * schema(s) according to the JSON default schema resolution.
+   */
+  public SchemaValidatorBuilder canReadStrategy() {
+    this.strategy = (toValidate, existing) -> toValidate.isBackwardCompatible(existing);
+    return this;
+  }
+
+  /**
+   * Use a strategy that validates that a schema can be read by existing
+   * schema(s) according to the JSON default schema resolution.
+   */
+  public SchemaValidatorBuilder canBeReadStrategy() {
+    this.strategy = (toValidate, existing) -> existing.isBackwardCompatible(toValidate);
+    return this;
+  }
+
+  /**
+   * Use a strategy that validates that a schema can read existing schema(s),
+   * and vice-versa, according to the JSON default schema resolution.
+   */
+  public SchemaValidatorBuilder mutualReadStrategy() {
+    this.strategy = (toValidate, existing) -> existing.isBackwardCompatible(toValidate)
+        && toValidate.isBackwardCompatible(existing);
+    return this;
+  }
+
+  public SchemaValidator validateLatest() {
+    valid();
+    return (toValidate, schemasInOrder) -> {
+      Iterator<? extends ParsedSchema> schemas = schemasInOrder.iterator();
+      if (schemas.hasNext()) {
+        ParsedSchema existing = schemas.next();
+        return strategy.validate(toValidate, existing);
+      }
+      return true;
+    };
+  }
+
+  public SchemaValidator validateAll() {
+    valid();
+    return (toValidate, schemasInOrder) -> {
+      for (ParsedSchema existing : schemasInOrder) {
+        boolean valid = strategy.validate(toValidate, existing);
+        if (!valid) {
+          return false;
+        }
+      }
+      return true;
+    };
+  }
+
+  private void valid() {
+    if (null == strategy) {
+      throw new RuntimeException("SchemaValidationStrategy not specified in builder");
+    }
+  }
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityChecker.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityChecker.java
@@ -25,6 +25,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * @deprecated  Use {@link io.confluent.kafka.schemaregistry.CompatibilityChecker} instead
+ */
+@Deprecated
 public class AvroCompatibilityChecker {
 
   // Check if the new schema can be used to read data produced by the previous schema

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
@@ -35,10 +35,16 @@ public class AvroSchema implements ParsedSchema {
 
   public final Schema schemaObj;
   private final String canonicalString;
+  private final Integer version;
 
   public AvroSchema(Schema schemaObj) {
+    this(schemaObj, null);
+  }
+
+  public AvroSchema(Schema schemaObj, Integer version) {
     this.schemaObj = schemaObj;
     this.canonicalString = schemaObj.toString();
+    this.version = version;
   }
 
   public AvroSchema(String schemaString) {
@@ -48,11 +54,20 @@ public class AvroSchema implements ParsedSchema {
     
     this.schemaObj = schemaObj;
     this.canonicalString = schemaObj.toString();
+    this.version = null;
   }
 
   @Override
   public String schemaType() {
     return AVRO;
+  }
+
+  @Override
+  public String name() {
+    if (schemaObj != null && schemaObj.getType() == Schema.Type.RECORD) {
+      return schemaObj.getFullName();
+    }
+    return null;
   }
 
   @Override
@@ -62,8 +77,7 @@ public class AvroSchema implements ParsedSchema {
 
   @Override
   public Integer version() {
-    // The version is set directly on the Schema instead.
-    return null;
+    return version;
   }
 
   @Override
@@ -89,12 +103,13 @@ public class AvroSchema implements ParsedSchema {
       return false;
     }
     AvroSchema that = (AvroSchema) o;
-    return Objects.equals(schemaObj, that.schemaObj);
+    return Objects.equals(schemaObj, that.schemaObj)
+        && Objects.equals(version, that.version);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(schemaObj);
+    return Objects.hash(schemaObj, version);
   }
 
   @Override

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2014 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.avro;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaValidationException;
+import org.apache.avro.SchemaValidator;
+import org.apache.avro.SchemaValidatorBuilder;
+
+import java.util.Collections;
+import java.util.Objects;
+
+public class AvroSchema implements ParsedSchema {
+
+  public static final String AVRO = "AVRO";
+
+  private static final SchemaValidator BACKWARD_VALIDATOR =
+      new SchemaValidatorBuilder().canReadStrategy().validateLatest();
+
+  public final Schema schemaObj;
+  private final String canonicalString;
+
+  public AvroSchema(Schema schemaObj) {
+    this.schemaObj = schemaObj;
+    this.canonicalString = schemaObj.toString();
+  }
+
+  public AvroSchema(String schemaString) {
+    Schema.Parser parser = new Schema.Parser();
+    parser.setValidateDefaults(false);
+    Schema schemaObj = parser.parse(schemaString);
+    
+    this.schemaObj = schemaObj;
+    this.canonicalString = schemaObj.toString();
+  }
+
+  @Override
+  public String schemaType() {
+    return AVRO;
+  }
+
+  @Override
+  public String canonicalString() {
+    return canonicalString;
+  }
+
+  @Override
+  public Integer version() {
+    // The version is set directly on the Schema instead.
+    return null;
+  }
+
+  @Override
+  public boolean isBackwardCompatible(ParsedSchema previousSchema) {
+    if (!schemaType().equals(previousSchema.schemaType())) {
+      return false;
+    }
+    try {
+      BACKWARD_VALIDATOR.validate(this.schemaObj,
+          Collections.singleton(((AvroSchema) previousSchema).schemaObj));
+      return true;
+    } catch (SchemaValidationException e) {
+      return false;
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AvroSchema that = (AvroSchema) o;
+    return Objects.equals(schemaObj, that.schemaObj);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(schemaObj);
+  }
+
+  @Override
+  public String toString() {
+    return schemaObj.toString();
+  }
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaProvider.java
@@ -17,22 +17,28 @@ package io.confluent.kafka.schemaregistry.avro;
 
 import org.apache.avro.SchemaParseException;
 
-import io.confluent.kafka.schemaregistry.ParsedSchema;
-import io.confluent.kafka.schemaregistry.SchemaProvider;
+import java.util.List;
+import java.util.Optional;
 
-public class AvroSchemaProvider implements SchemaProvider {
+import io.confluent.kafka.schemaregistry.AbstractSchemaProvider;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+
+public class AvroSchemaProvider extends AbstractSchemaProvider {
 
   @Override
   public String schemaType() {
-    return AvroSchema.AVRO;
+    return AvroSchema.TYPE;
   }
 
   @Override
-  public ParsedSchema parseSchema(String schemaString) {
+  public Optional<ParsedSchema> parseSchema(String schemaString,
+                                            List<SchemaReference> references) {
     try {
-      return new AvroSchema(schemaString);
+      return Optional.of(
+          new AvroSchema(schemaString, references, resolveReferences(references), null));
     } catch (SchemaParseException e) {
-      return null;
+      return Optional.empty();
     }
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaProvider.java
@@ -15,15 +15,24 @@
 
 package io.confluent.kafka.schemaregistry.avro;
 
-import org.apache.avro.Schema;
+import org.apache.avro.SchemaParseException;
 
-public class AvroSchema {
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.SchemaProvider;
 
-  public final Schema schemaObj;
-  public final String canonicalString;
+public class AvroSchemaProvider implements SchemaProvider {
 
-  public AvroSchema(Schema schemaObj, String canonicalString) {
-    this.schemaObj = schemaObj;
-    this.canonicalString = canonicalString;
+  @Override
+  public String schemaType() {
+    return AvroSchema.AVRO;
+  }
+
+  @Override
+  public ParsedSchema parseSchema(String schemaString) {
+    try {
+      return new AvroSchema(schemaString);
+    } catch (SchemaParseException e) {
+      return null;
+    }
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaUtils.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaUtils.java
@@ -14,20 +14,37 @@
  * limitations under the License.
  */
 
-package io.confluent.kafka.serializers;
+package io.confluent.kafka.schemaregistry.avro;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.io.JsonEncoder;
 import org.apache.avro.reflect.ReflectData;
 import org.apache.kafka.common.errors.SerializationException;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 
 public class AvroSchemaUtils {
+
+  private static final EncoderFactory encoderFactory = EncoderFactory.get();
+  private static final DecoderFactory decoderFactory = DecoderFactory.get();
+  private static final ObjectMapper jsonMapper = new ObjectMapper();
 
   private static final Map<String, Schema> primitiveSchemas;
 
@@ -50,12 +67,15 @@ public class AvroSchemaUtils {
     return parser.parse(schemaString);
   }
 
-  protected static AvroSchema copyOf(AvroSchema schema) {
-    return new AvroSchema(schema.canonicalString(), schema.references(),
-        schema.resolvedReferences(), schema.version());
+  public static AvroSchema copyOf(AvroSchema schema) {
+    return new AvroSchema(schema.canonicalString(),
+        schema.references(),
+        schema.resolvedReferences(),
+        schema.version()
+    );
   }
 
-  protected static Map<String, Schema> getPrimitiveSchemas() {
+  public static Map<String, Schema> getPrimitiveSchemas() {
     return Collections.unmodifiableMap(primitiveSchemas);
   }
 
@@ -78,22 +98,64 @@ public class AvroSchemaUtils {
       return primitiveSchemas.get("Double");
     } else if (object instanceof CharSequence) {
       return primitiveSchemas.get("String");
-    } else if (object instanceof byte[]) {
+    } else if (object instanceof byte[] || object instanceof ByteBuffer) {
       return primitiveSchemas.get("Bytes");
     } else if (useReflection) {
       Schema schema = ReflectData.get().getSchema(object.getClass());
       if (schema == null) {
-        throw new SerializationException("Schema is null for object of class "
-            + object.getClass().getCanonicalName());
+        throw new SerializationException("Schema is null for object of class " + object.getClass()
+            .getCanonicalName());
       } else {
         return schema;
       }
     } else if (object instanceof GenericContainer) {
       return ((GenericContainer) object).getSchema();
+    } else if (object instanceof Map) {
+      // This case is unusual -- the schema isn't available directly anywhere, instead we have to
+      // take get the value schema out of one of the entries and then construct the full schema.
+      Map mapValue = ((Map) object);
+      if (mapValue.isEmpty()) {
+        // In this case the value schema doesn't matter since there is no content anyway. This
+        // only works because we know in this case that we are only using this for conversion and
+        // no data will be added to the map.
+        return Schema.createMap(primitiveSchemas.get("Null"));
+      }
+      Schema valueSchema = getSchema(mapValue.values().iterator().next());
+      return Schema.createMap(valueSchema);
     } else {
       throw new IllegalArgumentException(
           "Unsupported Avro type. Supported types are null, Boolean, Integer, Long, "
               + "Float, Double, String, byte[] and IndexedRecord");
     }
+  }
+
+  public static Object toObject(JsonNode value, ParsedSchema parsedSchema) throws IOException {
+    Schema schema = ((AvroSchema) parsedSchema).rawSchema();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    jsonMapper.writeValue(out, value);
+    DatumReader<Object> reader = new GenericDatumReader<Object>(schema);
+    Object object = reader.read(
+        null,
+        decoderFactory.jsonDecoder(schema, new ByteArrayInputStream(out.toByteArray()))
+    );
+    out.close();
+    return object;
+  }
+
+  public static byte[] toJson(Object value) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    Schema schema = getSchema(value);
+    JsonEncoder encoder = encoderFactory.jsonEncoder(schema, out);
+    DatumWriter<Object> writer = new GenericDatumWriter<Object>(schema);
+    // Some types require wrapping/conversion
+    Object wrappedValue = value;
+    if (value instanceof byte[]) {
+      wrappedValue = ByteBuffer.wrap((byte[]) value);
+    }
+    writer.write(wrappedValue, encoder);
+    encoder.flush();
+    byte[] bytes = out.toByteArray();
+    out.close();
+    return bytes;
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -180,6 +180,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
       String schemaType,
       String schemaString,
       List<SchemaReference> references) {
+    if (schemaType == null) schemaType = AvroSchema.TYPE;
     SchemaProvider schemaProvider = providers.get(schemaType);
     if (schemaProvider == null) {
       return Optional.empty();

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -180,7 +180,9 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
       String schemaType,
       String schemaString,
       List<SchemaReference> references) {
-    if (schemaType == null) schemaType = AvroSchema.TYPE;
+    if (schemaType == null) {
+      schemaType = AvroSchema.TYPE;
+    }
     SchemaProvider schemaProvider = providers.get(schemaType);
     if (schemaProvider == null) {
       return Optional.empty();

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -176,6 +176,17 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
+  public Optional<ParsedSchema> parseSchema(
+      String schemaType,
+      String schemaString,
+      List<SchemaReference> references) {
+    SchemaProvider schemaProvider = providers.get(schemaType);
+    if (schemaProvider == null) {
+      return Optional.empty();
+    }
+    return schemaProvider.parseSchema(schemaString, references);
+  }
+
   public Map<String, SchemaProvider> getSchemaProviders() {
     return providers;
   }
@@ -194,12 +205,8 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
 
   protected ParsedSchema getSchemaByIdFromRegistry(int id) throws IOException, RestClientException {
     SchemaString restSchema = restService.getId(id);
-    SchemaProvider provider = providers.get(restSchema.getSchemaType());
-    if (provider == null) {
-      throw new IOException("Invalid schema type " + restSchema.getSchemaType());
-    }
-    Optional<ParsedSchema> schema =
-        provider.parseSchema(restSchema.getSchemaString(), restSchema.getReferences());
+    Optional<ParsedSchema> schema = parseSchema(
+        restSchema.getSchemaType(), restSchema.getSchemaString(), restSchema.getReferences());
     return schema.orElseThrow(() ->
         new IOException("Invalid schema " + restSchema.getSchemaString()));
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -243,8 +243,9 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
     io.confluent.kafka.schemaregistry.client.rest.entities.Schema response
         = restService.getVersion(subject, version);
     int id = response.getId();
+    String schemaType = response.getSchemaType();
     String schema = response.getSchema();
-    return new SchemaMetadata(id, version, schema);
+    return new SchemaMetadata(id, version, schemaType, schema);
   }
 
   @Override
@@ -254,8 +255,9 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
         = restService.getLatestVersion(subject);
     int id = response.getId();
     int version = response.getVersion();
+    String schemaType = response.getSchemaType();
     String schema = response.getSchema();
-    return new SchemaMetadata(id, version, schema);
+    return new SchemaMetadata(id, version, schemaType, schema);
   }
 
   @Override

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -84,6 +84,7 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
       String schemaType,
       String schemaString,
       List<SchemaReference> references) {
+    if (schemaType == null) schemaType = AvroSchema.TYPE;
     SchemaProvider schemaProvider = providers.get(schemaType);
     if (schemaProvider == null) {
       return Optional.empty();

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -16,7 +16,9 @@
 
 package io.confluent.kafka.schemaregistry.client;
 
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
+import io.confluent.kafka.schemaregistry.CompatibilityChecker;
+import io.confluent.kafka.schemaregistry.CompatibilityLevel;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import org.apache.avro.Schema;
 
@@ -240,7 +242,7 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
         id = entry.getKey();
       }
     }
-    return new SchemaMetadata(id, version, schemaString);
+    return new SchemaMetadata(id, version, AvroSchema.AVRO, schemaString);
   }
 
   @Override
@@ -268,18 +270,20 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
       compatibility = defaultCompatibility;
     }
 
-    AvroCompatibilityLevel compatibilityLevel = AvroCompatibilityLevel.forName(compatibility);
+    CompatibilityLevel compatibilityLevel = CompatibilityLevel.forName(compatibility);
     if (compatibilityLevel == null) {
       return false;
     }
 
-    List<Schema> schemaHistory = new ArrayList<>();
+    List<AvroSchema> schemaHistory = new ArrayList<>();
     for (int version : getAllVersions(subject)) {
       SchemaMetadata schemaMetadata = getSchemaMetadata(subject, version);
-      schemaHistory.add(getSchemaBySubjectAndIdFromRegistry(subject, schemaMetadata.getId()));
+      schemaHistory.add(new AvroSchema(getSchemaBySubjectAndIdFromRegistry(subject,
+          schemaMetadata.getId())));
     }
 
-    return compatibilityLevel.compatibilityChecker.isCompatible(newSchema, schemaHistory);
+    return CompatibilityChecker.checker(compatibilityLevel).isCompatible(new AvroSchema(newSchema),
+        schemaHistory);
   }
 
   @Override

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -22,6 +22,7 @@ import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 
 import java.io.IOException;
@@ -32,6 +33,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -78,8 +80,15 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
-  public Map<String, SchemaProvider> getSchemaProviders() {
-    return providers;
+  public Optional<ParsedSchema> parseSchema(
+      String schemaType,
+      String schemaString,
+      List<SchemaReference> references) {
+    SchemaProvider schemaProvider = providers.get(schemaType);
+    if (schemaProvider == null) {
+      return Optional.empty();
+    }
+    return schemaProvider.parseSchema(schemaString, references);
   }
 
   private int getIdFromRegistry(

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -84,7 +84,9 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
       String schemaType,
       String schemaString,
       List<SchemaReference> references) {
-    if (schemaType == null) schemaType = AvroSchema.TYPE;
+    if (schemaType == null) {
+      schemaType = AvroSchema.TYPE;
+    }
     SchemaProvider schemaProvider = providers.get(schemaType);
     if (schemaProvider == null) {
       return Optional.empty();

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -16,11 +16,9 @@
 
 package io.confluent.kafka.schemaregistry.client;
 
-import io.confluent.kafka.schemaregistry.CompatibilityChecker;
 import io.confluent.kafka.schemaregistry.CompatibilityLevel;
-import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-import org.apache.avro.Schema;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -42,32 +40,33 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
   private static final String WILDCARD = "*";
 
   private String defaultCompatibility = "BACKWARD";
-  private final Map<String, Map<Schema, Integer>> schemaCache;
-  private final Map<Schema, Integer> schemaIdCache;
-  private final Map<String, Map<Integer, Schema>> idCache;
-  private final Map<String, Map<Schema, Integer>> versionCache;
+  private final Map<String, Map<ParsedSchema, Integer>> schemaCache;
+  private final Map<ParsedSchema, Integer> schemaIdCache;
+  private final Map<String, Map<Integer, ParsedSchema>> idCache;
+  private final Map<String, Map<ParsedSchema, Integer>> versionCache;
   private final Map<String, String> compatibilityCache;
   private final Map<String, String> modes;
   private final AtomicInteger ids;
 
   public MockSchemaRegistryClient() {
-    schemaCache = new HashMap<String, Map<Schema, Integer>>();
+    schemaCache = new HashMap<String, Map<ParsedSchema, Integer>>();
     schemaIdCache = new HashMap<>();
-    idCache = new HashMap<String, Map<Integer, Schema>>();
-    versionCache = new HashMap<String, Map<Schema, Integer>>();
+    idCache = new HashMap<String, Map<Integer, ParsedSchema>>();
+    versionCache = new HashMap<String, Map<ParsedSchema, Integer>>();
     compatibilityCache = new HashMap<String, String>();
     modes = new HashMap<String, String>();
     ids = new AtomicInteger(0);
-    idCache.put(null, new HashMap<Integer, Schema>());
+    idCache.put(null, new HashMap<Integer, ParsedSchema>());
   }
 
-  private int getIdFromRegistry(String subject, Schema schema, boolean registerRequest, int id)
+  private int getIdFromRegistry(
+      String subject, ParsedSchema schema, boolean registerRequest, int id)
       throws IOException, RestClientException {
-    Map<Integer, Schema> idSchemaMap;
+    Map<Integer, ParsedSchema> idSchemaMap;
     if (idCache.containsKey(subject)) {
       idSchemaMap = idCache.get(subject);
-      for (Map.Entry<Integer, Schema> entry : idSchemaMap.entrySet()) {
-        if (entry.getValue().toString().equals(schema.toString())) {
+      for (Map.Entry<Integer, ParsedSchema> entry : idSchemaMap.entrySet()) {
+        if (entry.getValue().canonicalString().equals(schema.canonicalString())) {
           if (registerRequest) {
             if (id >= 0 && id != entry.getKey()) {
               throw new IllegalStateException("Schema already registered with id "
@@ -79,7 +78,7 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
         }
       }
     } else {
-      idSchemaMap = new HashMap<Integer, Schema>();
+      idSchemaMap = new HashMap<Integer, ParsedSchema>();
     }
     if (registerRequest) {
       Integer schemaId = schemaIdCache.get(schema);
@@ -99,12 +98,12 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
     }
   }
 
-  private void generateVersion(String subject, Schema schema) {
+  private void generateVersion(String subject, ParsedSchema schema) {
     List<Integer> versions = getAllVersions(subject);
-    Map<Schema, Integer> schemaVersionMap;
+    Map<ParsedSchema, Integer> schemaVersionMap;
     int currentVersion;
     if (versions.isEmpty()) {
-      schemaVersionMap = new HashMap<Schema, Integer>();
+      schemaVersionMap = new HashMap<ParsedSchema, Integer>();
       currentVersion = 1;
     } else {
       schemaVersionMap = versionCache.get(subject);
@@ -124,9 +123,10 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
     return versions;
   }
 
-  private Schema getSchemaBySubjectAndIdFromRegistry(String subject, int id) throws IOException {
+  private ParsedSchema getSchemaBySubjectAndIdFromRegistry(String subject, int id)
+      throws IOException {
     if (idCache.containsKey(subject)) {
-      Map<Integer, Schema> idSchemaMap = idCache.get(subject);
+      Map<Integer, ParsedSchema> idSchemaMap = idCache.get(subject);
       if (idSchemaMap.containsKey(id)) {
         return idSchemaMap.get(id);
       }
@@ -135,19 +135,19 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
-  public synchronized int register(String subject, Schema schema)
+  public synchronized int register(String subject, ParsedSchema schema)
       throws IOException, RestClientException {
     return register(subject, schema, 0, -1);
   }
 
   @Override
-  public synchronized int register(String subject, Schema schema, int version, int id)
+  public synchronized int register(String subject, ParsedSchema schema, int version, int id)
       throws IOException, RestClientException {
-    Map<Schema, Integer> schemaIdMap;
+    Map<ParsedSchema, Integer> schemaIdMap;
     if (schemaCache.containsKey(subject)) {
       schemaIdMap = schemaCache.get(subject);
     } else {
-      schemaIdMap = new HashMap<Schema, Integer>();
+      schemaIdMap = new HashMap<ParsedSchema, Integer>();
       schemaCache.put(subject, schemaIdMap);
     }
 
@@ -162,48 +162,32 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
       id = getIdFromRegistry(subject, schema, true, id);
       schemaIdMap.put(schema, id);
       if (!idCache.get(null).containsKey(id)) {
-        // CachedSchema Registry client would have a cached version of schema instance for
-        // each schema. You could also get the schema without using a subject and to cover that we
-        // need to add an entry with null subject
-        Schema.Parser parser = new Schema.Parser();
-        parser.setValidateDefaults(false);
-        idCache.get(null).put(id, parser.parse(schema.toString()));
+        idCache.get(null).put(id, schema);
       }
       return id;
     }
   }
 
   @Override
-  public Schema getByID(final int id) throws IOException, RestClientException {
-    return getById(id);
+  public synchronized ParsedSchema getSchemaById(int id) throws IOException, RestClientException {
+    return getSchemaBySubjectAndId(null, id);
   }
 
   @Override
-  public synchronized Schema getById(int id) throws IOException, RestClientException {
-    return getBySubjectAndId(null, id);
-  }
-
-  @Override
-  public Schema getBySubjectAndID(final String subject, final int id)
+  public synchronized ParsedSchema getSchemaBySubjectAndId(String subject, int id)
       throws IOException, RestClientException {
-    return getBySubjectAndId(subject, id);
-  }
-
-  @Override
-  public synchronized Schema getBySubjectAndId(String subject, int id)
-      throws IOException, RestClientException {
-    Map<Integer, Schema> idSchemaMap;
+    Map<Integer, ParsedSchema> idSchemaMap;
     if (idCache.containsKey(subject)) {
       idSchemaMap = idCache.get(subject);
     } else {
-      idSchemaMap = new HashMap<Integer, Schema>();
+      idSchemaMap = new HashMap<Integer, ParsedSchema>();
       idCache.put(subject, idSchemaMap);
     }
 
     if (idSchemaMap.containsKey(id)) {
       return idSchemaMap.get(id);
     } else {
-      Schema schema = getSchemaBySubjectAndIdFromRegistry(subject, id);
+      ParsedSchema schema = getSchemaBySubjectAndIdFromRegistry(subject, id);
       idSchemaMap.put(id, schema);
       return schema;
     }
@@ -228,21 +212,21 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
 
   @Override
   public synchronized SchemaMetadata getSchemaMetadata(String subject, int version) {
-    String schemaString = null;
-    Map<Schema, Integer> schemaVersionMap = versionCache.get(subject);
-    for (Map.Entry<Schema, Integer> entry : schemaVersionMap.entrySet()) {
+    ParsedSchema schema = null;
+    Map<ParsedSchema, Integer> schemaVersionMap = versionCache.get(subject);
+    for (Map.Entry<ParsedSchema, Integer> entry : schemaVersionMap.entrySet()) {
       if (entry.getValue() == version) {
-        schemaString = entry.getKey().toString();
+        schema = entry.getKey();
       }
     }
     int id = -1;
-    Map<Integer, Schema> idSchemaMap = idCache.get(subject);
-    for (Map.Entry<Integer, Schema> entry : idSchemaMap.entrySet()) {
-      if (entry.getValue().toString().equals(schemaString)) {
+    Map<Integer, ParsedSchema> idSchemaMap = idCache.get(subject);
+    for (Map.Entry<Integer, ParsedSchema> entry : idSchemaMap.entrySet()) {
+      if (entry.getValue().canonicalString().equals(schema.canonicalString())) {
         id = entry.getKey();
       }
     }
-    return new SchemaMetadata(id, version, AvroSchema.AVRO, schemaString);
+    return new SchemaMetadata(id, version, schema.schemaType(), schema.canonicalString());
   }
 
   @Override
@@ -253,17 +237,18 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
-  public synchronized int getVersion(String subject, Schema schema)
+  public synchronized int getVersion(String subject, ParsedSchema schema)
       throws IOException, RestClientException {
     if (versionCache.containsKey(subject)) {
-      return versionCache.get(subject).get(schema);
+      Map<ParsedSchema, Integer> versions = versionCache.get(subject);
+      return versions.get(schema);
     } else {
       throw new IOException("Cannot get version from schema registry!");
     }
   }
 
   @Override
-  public boolean testCompatibility(String subject, Schema newSchema) throws IOException,
+  public boolean testCompatibility(String subject, ParsedSchema newSchema) throws IOException,
                                                                             RestClientException {
     String compatibility = compatibilityCache.get(subject);
     if (compatibility == null) {
@@ -275,15 +260,14 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
       return false;
     }
 
-    List<AvroSchema> schemaHistory = new ArrayList<>();
+    List<ParsedSchema> schemaHistory = new ArrayList<>();
     for (int version : getAllVersions(subject)) {
       SchemaMetadata schemaMetadata = getSchemaMetadata(subject, version);
-      schemaHistory.add(new AvroSchema(getSchemaBySubjectAndIdFromRegistry(subject,
-          schemaMetadata.getId())));
+      schemaHistory.add(getSchemaBySubjectAndIdFromRegistry(subject,
+          schemaMetadata.getId()));
     }
 
-    return CompatibilityChecker.checker(compatibilityLevel).isCompatible(new AvroSchema(newSchema),
-        schemaHistory);
+    return newSchema.isCompatible(compatibilityLevel, schemaHistory);
   }
 
   @Override
@@ -340,7 +324,7 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
-  public int getId(String subject, Schema schema) throws IOException, RestClientException {
+  public int getId(String subject, ParsedSchema schema) throws IOException, RestClientException {
     return getIdFromRegistry(subject, schema, false, -1);
   }
 
@@ -385,6 +369,6 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
     schemaCache.clear();
     idCache.clear();
     versionCache.clear();
-    idCache.put(null, new HashMap<Integer, Schema>());
+    idCache.put(null, new HashMap<Integer, ParsedSchema>());
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaMetadata.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaMetadata.java
@@ -16,7 +16,11 @@
 
 package io.confluent.kafka.schemaregistry.client;
 
+import java.util.Collections;
+import java.util.List;
+
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 
 public class SchemaMetadata {
 
@@ -24,16 +28,23 @@ public class SchemaMetadata {
   private int version;
   private String schemaType;
   private String schema;
+  private List<SchemaReference> references;
 
   public SchemaMetadata(int id, int version, String schema) {
-    this(id, version, AvroSchema.AVRO, schema);
+    this(id, version, AvroSchema.TYPE, Collections.emptyList(), schema);
   }
 
-  public SchemaMetadata(int id, int version, String schemaType, String schema) {
+  public SchemaMetadata(int id,
+                        int version,
+                        String schemaType,
+                        List<SchemaReference> references,
+                        String schema
+  ) {
     this.id = id;
     this.version = version;
     this.schemaType = schemaType;
     this.schema = schema;
+    this.references = references;
   }
 
   public int getId() {
@@ -50,5 +61,9 @@ public class SchemaMetadata {
 
   public String getSchema() {
     return schema;
+  }
+
+  public List<SchemaReference> getReferences() {
+    return references;
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaMetadata.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaMetadata.java
@@ -16,17 +16,24 @@
 
 package io.confluent.kafka.schemaregistry.client;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+
 public class SchemaMetadata {
 
   private int id;
   private int version;
+  private String schemaType = AvroSchema.AVRO;
   private String schema;
 
   public SchemaMetadata(int id, int version, String schema) {
+    this(id, version, AvroSchema.AVRO, schema);
+  }
+
+  public SchemaMetadata(int id, int version, String schemaType, String schema) {
     this.id = id;
     this.version = version;
+    this.schemaType = schemaType;
     this.schema = schema;
-
   }
 
   public int getId() {
@@ -35,6 +42,10 @@ public class SchemaMetadata {
 
   public int getVersion() {
     return version;
+  }
+
+  public String getSchemaType() {
+    return schemaType;
   }
 
   public String getSchema() {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaMetadata.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaMetadata.java
@@ -16,8 +16,10 @@
 
 package io.confluent.kafka.schemaregistry.client;
 
+import java.util.Collections;
 import java.util.List;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 
 public class SchemaMetadata {
@@ -27,6 +29,13 @@ public class SchemaMetadata {
   private String schemaType;
   private String schema;
   private List<SchemaReference> references;
+
+  public SchemaMetadata(int id,
+                        int version,
+                        String schema
+  ) {
+    this(id, version, AvroSchema.TYPE, Collections.emptyList(), schema);
+  }
 
   public SchemaMetadata(int id,
                         int version,

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaMetadata.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaMetadata.java
@@ -22,7 +22,7 @@ public class SchemaMetadata {
 
   private int id;
   private int version;
-  private String schemaType = AvroSchema.AVRO;
+  private String schemaType;
   private String schema;
 
   public SchemaMetadata(int id, int version, String schema) {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaMetadata.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaMetadata.java
@@ -16,10 +16,8 @@
 
 package io.confluent.kafka.schemaregistry.client;
 
-import java.util.Collections;
 import java.util.List;
 
-import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 
 public class SchemaMetadata {
@@ -29,10 +27,6 @@ public class SchemaMetadata {
   private String schemaType;
   private String schema;
   private List<SchemaReference> references;
-
-  public SchemaMetadata(int id, int version, String schema) {
-    this(id, version, AvroSchema.TYPE, Collections.emptyList(), schema);
-  }
 
   public SchemaMetadata(int id,
                         int version,

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -20,16 +20,20 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
-import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 
 public interface SchemaRegistryClient extends SchemaVersionFetcher {
 
-  Map<String, SchemaProvider> getSchemaProviders();
+  public Optional<ParsedSchema> parseSchema(
+      String schemaType,
+      String schemaString,
+      List<SchemaReference> references);
 
   //TODO deprecate
   //@Deprecated

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -16,8 +16,6 @@
 
 package io.confluent.kafka.schemaregistry.client;
 
-import org.apache.avro.Schema;
-
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
@@ -25,12 +23,13 @@ import java.util.Map;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 
-public interface SchemaRegistryClient {
+public interface SchemaRegistryClient extends SchemaVersionFetcher {
 
   @Deprecated
-  default int register(String subject, Schema schema) throws IOException,
+  default int register(String subject, org.apache.avro.Schema schema) throws IOException,
       RestClientException {
     return register(subject, new AvroSchema(schema));
   }
@@ -38,7 +37,8 @@ public interface SchemaRegistryClient {
   public int register(String subject, ParsedSchema schema) throws IOException, RestClientException;
 
   @Deprecated
-  default int register(String subject, Schema schema, int version, int id) throws IOException,
+  default int register(String subject, org.apache.avro.Schema schema, int version, int id)
+      throws IOException,
       RestClientException {
     return register(subject, new AvroSchema(schema), version, id);
   }
@@ -47,35 +47,40 @@ public interface SchemaRegistryClient {
       RestClientException;
 
   @Deprecated
-  default Schema getByID(int id) throws IOException, RestClientException {
+  default org.apache.avro.Schema getByID(int id) throws IOException, RestClientException {
     return getById(id);
   }
 
   @Deprecated
-  default Schema getById(int id) throws IOException, RestClientException {
+  default org.apache.avro.Schema getById(int id) throws IOException, RestClientException {
     ParsedSchema schema = getSchemaById(id);
-    return schema instanceof AvroSchema ? ((AvroSchema)schema).schemaObj : null;
+    return schema instanceof AvroSchema ? ((AvroSchema) schema).rawSchema() : null;
   }
 
   public ParsedSchema getSchemaById(int id) throws IOException, RestClientException;
 
   @Deprecated
-  default Schema getBySubjectAndID(String subject, int id)
+  default org.apache.avro.Schema getBySubjectAndID(String subject, int id)
       throws IOException, RestClientException {
     return getBySubjectAndId(subject, id);
   }
 
   @Deprecated
-  default Schema getBySubjectAndId(String subject, int id)
+  default org.apache.avro.Schema getBySubjectAndId(String subject, int id)
       throws IOException, RestClientException {
     ParsedSchema schema = getSchemaBySubjectAndId(subject, id);
-    return schema instanceof AvroSchema ? ((AvroSchema)schema).schemaObj : null;
+    return schema instanceof AvroSchema ? ((AvroSchema) schema).rawSchema() : null;
   }
 
   public ParsedSchema getSchemaBySubjectAndId(String subject, int id)
       throws IOException, RestClientException;
 
   public Collection<String> getAllSubjectsById(int id) throws IOException, RestClientException;
+
+  @Override
+  default Schema getByVersion(String subject, int version, boolean lookupDeletedSchema) {
+    throw new UnsupportedOperationException();
+  }
 
   public SchemaMetadata getLatestSchemaMetadata(String subject)
       throws IOException, RestClientException;
@@ -84,7 +89,7 @@ public interface SchemaRegistryClient {
       throws IOException, RestClientException;
 
   @Deprecated
-  default int getVersion(String subject, Schema schema)
+  default int getVersion(String subject, org.apache.avro.Schema schema)
       throws IOException, RestClientException {
     return getVersion(subject, new AvroSchema(schema));
   }
@@ -95,7 +100,7 @@ public interface SchemaRegistryClient {
   public List<Integer> getAllVersions(String subject) throws IOException, RestClientException;
 
   @Deprecated
-  default boolean testCompatibility(String subject, Schema schema)
+  default boolean testCompatibility(String subject, org.apache.avro.Schema schema)
       throws IOException, RestClientException {
     return testCompatibility(subject, new AvroSchema(schema));
   }
@@ -121,7 +126,8 @@ public interface SchemaRegistryClient {
   public Collection<String> getAllSubjects() throws IOException, RestClientException;
 
   @Deprecated
-  default int getId(String subject, Schema schema) throws IOException, RestClientException {
+  default int getId(String subject, org.apache.avro.Schema schema)
+      throws IOException, RestClientException {
     return getId(subject, new AvroSchema(schema));
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -31,7 +31,8 @@ public interface SchemaRegistryClient extends SchemaVersionFetcher {
 
   Map<String, SchemaProvider> getSchemaProviders();
 
-  @Deprecated
+  //TODO deprecate
+  //@Deprecated
   default int register(String subject, org.apache.avro.Schema schema) throws IOException,
       RestClientException {
     return register(subject, new AvroSchema(schema));
@@ -54,7 +55,8 @@ public interface SchemaRegistryClient extends SchemaVersionFetcher {
     return getById(id);
   }
 
-  @Deprecated
+  //TODO deprecate
+  //@Deprecated
   default org.apache.avro.Schema getById(int id) throws IOException, RestClientException {
     ParsedSchema schema = getSchemaById(id);
     return schema instanceof AvroSchema ? ((AvroSchema) schema).rawSchema() : null;
@@ -102,7 +104,8 @@ public interface SchemaRegistryClient extends SchemaVersionFetcher {
 
   public List<Integer> getAllVersions(String subject) throws IOException, RestClientException;
 
-  @Deprecated
+  //TODO deprecate
+  //@Deprecated
   default boolean testCompatibility(String subject, org.apache.avro.Schema schema)
       throws IOException, RestClientException {
     return testCompatibility(subject, new AvroSchema(schema));

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -22,11 +22,14 @@ import java.util.List;
 import java.util.Map;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 
 public interface SchemaRegistryClient extends SchemaVersionFetcher {
+
+  Map<String, SchemaProvider> getSchemaProviders();
 
   @Deprecated
   default int register(String subject, org.apache.avro.Schema schema) throws IOException,

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -23,24 +23,57 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 
 public interface SchemaRegistryClient {
 
-  public int register(String subject, Schema schema) throws IOException, RestClientException;
+  @Deprecated
+  default int register(String subject, Schema schema) throws IOException,
+      RestClientException {
+    return register(subject, new AvroSchema(schema));
+  }
 
-  public int register(String subject, Schema schema, int version, int id) throws IOException,
+  public int register(String subject, ParsedSchema schema) throws IOException, RestClientException;
+
+  @Deprecated
+  default int register(String subject, Schema schema, int version, int id) throws IOException,
+      RestClientException {
+    return register(subject, new AvroSchema(schema), version, id);
+  }
+
+  public int register(String subject, ParsedSchema schema, int version, int id) throws IOException,
       RestClientException;
 
   @Deprecated
-  public Schema getByID(int id) throws IOException, RestClientException;
-
-  public Schema getById(int id) throws IOException, RestClientException;
+  default Schema getByID(int id) throws IOException, RestClientException {
+    return getById(id);
+  }
 
   @Deprecated
-  public Schema getBySubjectAndID(String subject, int id) throws IOException, RestClientException;
+  default Schema getById(int id) throws IOException, RestClientException {
+    ParsedSchema schema = getSchemaById(id);
+    return schema instanceof AvroSchema ? ((AvroSchema)schema).schemaObj : null;
+  }
 
-  public Schema getBySubjectAndId(String subject, int id) throws IOException, RestClientException;
+  public ParsedSchema getSchemaById(int id) throws IOException, RestClientException;
+
+  @Deprecated
+  default Schema getBySubjectAndID(String subject, int id)
+      throws IOException, RestClientException {
+    return getBySubjectAndId(subject, id);
+  }
+
+  @Deprecated
+  default Schema getBySubjectAndId(String subject, int id)
+      throws IOException, RestClientException {
+    ParsedSchema schema = getSchemaBySubjectAndId(subject, id);
+    return schema instanceof AvroSchema ? ((AvroSchema)schema).schemaObj : null;
+  }
+
+  public ParsedSchema getSchemaBySubjectAndId(String subject, int id)
+      throws IOException, RestClientException;
 
   public Collection<String> getAllSubjectsById(int id) throws IOException, RestClientException;
 
@@ -50,11 +83,24 @@ public interface SchemaRegistryClient {
   public SchemaMetadata getSchemaMetadata(String subject, int version)
       throws IOException, RestClientException;
 
-  public int getVersion(String subject, Schema schema) throws IOException, RestClientException;
+  @Deprecated
+  default int getVersion(String subject, Schema schema)
+      throws IOException, RestClientException {
+    return getVersion(subject, new AvroSchema(schema));
+  }
+
+  public int getVersion(String subject, ParsedSchema schema)
+      throws IOException, RestClientException;
 
   public List<Integer> getAllVersions(String subject) throws IOException, RestClientException;
 
-  public boolean testCompatibility(String subject, Schema schema)
+  @Deprecated
+  default boolean testCompatibility(String subject, Schema schema)
+      throws IOException, RestClientException {
+    return testCompatibility(subject, new AvroSchema(schema));
+  }
+
+  public boolean testCompatibility(String subject, ParsedSchema schema)
       throws IOException, RestClientException;
 
   public String updateCompatibility(String subject, String compatibility)
@@ -74,7 +120,12 @@ public interface SchemaRegistryClient {
 
   public Collection<String> getAllSubjects() throws IOException, RestClientException;
 
-  int getId(String subject, Schema schema) throws IOException, RestClientException;
+  @Deprecated
+  default int getId(String subject, Schema schema) throws IOException, RestClientException {
+    return getId(subject, new AvroSchema(schema));
+  }
+
+  int getId(String subject, ParsedSchema schema) throws IOException, RestClientException;
 
   public List<Integer> deleteSubject(String subject) throws IOException, RestClientException;
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaVersionFetcher.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaVersionFetcher.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.client;
+
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+
+public interface SchemaVersionFetcher {
+
+  Schema getByVersion(String subject, int version, boolean lookupDeletedSchema);
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -30,6 +30,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.ServerClusterId;
 import io.confluent.kafka.schemaregistry.client.security.basicauth.BasicAuthCredentialProviderFactory;
 import io.confluent.kafka.schemaregistry.client.security.bearerauth.BearerAuthCredentialProvider;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.config.ConfigException;
 import org.slf4j.Logger;
@@ -340,6 +341,7 @@ public class RestService implements Configurable {
     return baseUrl.replaceFirst("/$", "") + "/" + path.replaceFirst("^/", "");
   }
 
+  @VisibleForTesting
   public Schema lookUpSubjectVersion(String schemaString, String subject)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
@@ -368,12 +370,25 @@ public class RestService implements Configurable {
     return schema;
   }
 
-
-  public Schema lookUpSubjectVersion(String schemaString, String subject,
+  @VisibleForTesting
+  public Schema lookUpSubjectVersion(String schemaString,
+                                     String subject,
                                      boolean lookupDeletedSchema)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
+    return lookUpSubjectVersion(DEFAULT_REQUEST_PROPERTIES, request, subject, lookupDeletedSchema);
+  }
+
+
+  public Schema lookUpSubjectVersion(String schemaString,
+                                     String schemaType,
+                                     String subject,
+                                     boolean lookupDeletedSchema)
+      throws IOException, RestClientException {
+    RegisterSchemaRequest request = new RegisterSchemaRequest();
+    request.setSchema(schemaString);
+    request.setSchemaType(schemaType);
     return lookUpSubjectVersion(DEFAULT_REQUEST_PROPERTIES, request, subject, lookupDeletedSchema);
   }
 
@@ -393,6 +408,7 @@ public class RestService implements Configurable {
     return schema;
   }
 
+  @VisibleForTesting
   public int registerSchema(String schemaString, String subject)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
@@ -400,10 +416,30 @@ public class RestService implements Configurable {
     return registerSchema(request, subject);
   }
 
+  public int registerSchema(String schemaString, String schemaType, String subject)
+      throws IOException, RestClientException {
+    RegisterSchemaRequest request = new RegisterSchemaRequest();
+    request.setSchema(schemaString);
+    request.setSchemaType(schemaType);
+    return registerSchema(request, subject);
+  }
+
+  @VisibleForTesting
   public int registerSchema(String schemaString, String subject, int version, int id)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
+    request.setVersion(version);
+    request.setId(id);
+    return registerSchema(request, subject);
+  }
+
+  public int registerSchema(String schemaString, String schemaType,
+                            String subject, int version, int id)
+      throws IOException, RestClientException {
+    RegisterSchemaRequest request = new RegisterSchemaRequest();
+    request.setSchema(schemaString);
+    request.setSchemaType(schemaType);
     request.setVersion(version);
     request.setId(id);
     return registerSchema(request, subject);
@@ -428,10 +464,22 @@ public class RestService implements Configurable {
     return response.getId();
   }
 
+  @VisibleForTesting
   public boolean testCompatibility(String schemaString, String subject, String version)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
+    return testCompatibility(request, subject, version);
+  }
+
+  public boolean testCompatibility(String schemaString,
+                                   String schemaType,
+                                   String subject,
+                                   String version)
+      throws IOException, RestClientException {
+    RegisterSchemaRequest request = new RegisterSchemaRequest();
+    request.setSchema(schemaString);
+    request.setSchemaType(schemaType);
     return testCompatibility(request, subject, version);
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
@@ -50,7 +50,7 @@ public class Schema implements Comparable<Schema> {
     this.version = version;
     this.id = id;
     this.schemaType = schemaType;
-    this.references = references;
+    this.references = references != null ? references : Collections.emptyList();
     this.schema = schema;
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
@@ -24,6 +24,9 @@ import com.fasterxml.jackson.databind.util.StdConverter;
 
 import javax.ws.rs.DefaultValue;
 
+import java.util.Collections;
+import java.util.List;
+
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -32,7 +35,8 @@ public class Schema implements Comparable<Schema> {
   private String subject;
   private Integer version;
   private Integer id;
-  private String schemaType = AvroSchema.AVRO;
+  private String schemaType = AvroSchema.TYPE;
+  private List<SchemaReference> references = Collections.emptyList();
   private String schema;
 
   public Schema(@JsonProperty("subject") String subject,
@@ -50,11 +54,13 @@ public class Schema implements Comparable<Schema> {
                 @JsonProperty("version") Integer version,
                 @JsonProperty("id") Integer id,
                 @JsonProperty("schemaType") @DefaultValue("AVRO") String schemaType,
+                @JsonProperty("references") List<SchemaReference> references,
                 @JsonProperty("schema") String schema) {
     this.subject = subject;
     this.version = version;
     this.id = id;
     this.schemaType = schemaType;
+    this.references = references;
     this.schema = schema;
   }
 
@@ -99,6 +105,16 @@ public class Schema implements Comparable<Schema> {
     this.schemaType = schemaType;
   }
 
+  @JsonProperty("references")
+  public List<SchemaReference> getReferences() {
+    return this.references;
+  }
+
+  @JsonProperty("references")
+  public void setReferences(List<SchemaReference> references) {
+    this.references = references;
+  }
+
   @JsonProperty("schema")
   public String getSchema() {
     return this.schema;
@@ -132,6 +148,9 @@ public class Schema implements Comparable<Schema> {
     if (!this.schemaType.equals(that.getSchemaType())) {
       return false;
     }
+    if (!this.references.equals(that.getReferences())) {
+      return false;
+    }
     if (!this.schema.equals(that.schema)) {
       return false;
     }
@@ -145,6 +164,7 @@ public class Schema implements Comparable<Schema> {
     result = 31 * result + version;
     result = 31 * result + id.intValue();
     result = 31 * result + schemaType.hashCode();
+    result = 31 * result + references.hashCode();
     result = 31 * result + schema.hashCode();
     return result;
   }
@@ -156,6 +176,7 @@ public class Schema implements Comparable<Schema> {
     sb.append("version=" + this.version + ",");
     sb.append("id=" + this.id + ",");
     sb.append("schemaType=" + this.schemaType + ",");
+    sb.append("references=" + this.references + ",");
     sb.append("schema=" + this.schema + "}");
     return sb.toString();
   }
@@ -173,7 +194,7 @@ public class Schema implements Comparable<Schema> {
   static class SchemaTypeConverter extends StdConverter<String, String> {
     @Override
     public String convert(final String value) {
-      return AvroSchema.AVRO.equals(value) ? null : value;
+      return AvroSchema.TYPE.equals(value) ? null : value;
     }
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
@@ -39,16 +39,6 @@ public class Schema implements Comparable<Schema> {
   private List<SchemaReference> references = Collections.emptyList();
   private String schema;
 
-  public Schema(@JsonProperty("subject") String subject,
-                @JsonProperty("version") Integer version,
-                @JsonProperty("id") Integer id,
-                @JsonProperty("schema") String schema) {
-    this.subject = subject;
-    this.version = version;
-    this.id = id;
-    this.schema = schema;
-  }
-
   @JsonCreator
   public Schema(@JsonProperty("subject") String subject,
                 @JsonProperty("version") Integer version,

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
@@ -16,13 +16,23 @@
 
 package io.confluent.kafka.schemaregistry.client.rest.entities;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.util.StdConverter;
 
+import javax.ws.rs.DefaultValue;
+
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Schema implements Comparable<Schema> {
 
   private String subject;
   private Integer version;
   private Integer id;
+  private String schemaType = AvroSchema.AVRO;
   private String schema;
 
   public Schema(@JsonProperty("subject") String subject,
@@ -32,6 +42,19 @@ public class Schema implements Comparable<Schema> {
     this.subject = subject;
     this.version = version;
     this.id = id;
+    this.schema = schema;
+  }
+
+  @JsonCreator
+  public Schema(@JsonProperty("subject") String subject,
+                @JsonProperty("version") Integer version,
+                @JsonProperty("id") Integer id,
+                @JsonProperty("schemaType") @DefaultValue("AVRO") String schemaType,
+                @JsonProperty("schema") String schema) {
+    this.subject = subject;
+    this.version = version;
+    this.id = id;
+    this.schemaType = schemaType;
     this.schema = schema;
   }
 
@@ -65,6 +88,17 @@ public class Schema implements Comparable<Schema> {
     this.id = id;
   }
 
+  @JsonProperty("schemaType")
+  @JsonSerialize(converter = SchemaTypeConverter.class)
+  public String getSchemaType() {
+    return this.schemaType;
+  }
+
+  @JsonProperty("schemaType")
+  public void setSchemaType(String schemaType) {
+    this.schemaType = schemaType;
+  }
+
   @JsonProperty("schema")
   public String getSchema() {
     return this.schema;
@@ -95,6 +129,9 @@ public class Schema implements Comparable<Schema> {
     if (!this.id.equals(that.getId())) {
       return false;
     }
+    if (!this.schemaType.equals(that.getSchemaType())) {
+      return false;
+    }
     if (!this.schema.equals(that.schema)) {
       return false;
     }
@@ -107,6 +144,7 @@ public class Schema implements Comparable<Schema> {
     int result = subject.hashCode();
     result = 31 * result + version;
     result = 31 * result + id.intValue();
+    result = 31 * result + schemaType.hashCode();
     result = 31 * result + schema.hashCode();
     return result;
   }
@@ -117,6 +155,7 @@ public class Schema implements Comparable<Schema> {
     sb.append("{subject=" + this.subject + ",");
     sb.append("version=" + this.version + ",");
     sb.append("id=" + this.id + ",");
+    sb.append("schemaType=" + this.schemaType + ",");
     sb.append("schema=" + this.schema + "}");
     return sb.toString();
   }
@@ -129,5 +168,12 @@ public class Schema implements Comparable<Schema> {
     }
     result = this.version - that.version;
     return result;
+  }
+
+  static class SchemaTypeConverter extends StdConverter<String, String> {
+    @Override
+    public String convert(final String value) {
+      return AvroSchema.AVRO.equals(value) ? null : value;
+    }
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaReference.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaReference.java
@@ -95,4 +95,18 @@ public class SchemaReference implements Comparable<SchemaReference> {
     result = this.version - that.version;
     return result;
   }
+
+  @Override
+  public String toString() {
+    return "{"
+        + "name='"
+        + name
+        + '\''
+        + ", subject='"
+        + subject
+        + '\''
+        + ", version="
+        + version
+        + '}';
+  }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaReference.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaReference.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.client.rest.entities;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.validation.constraints.Min;
+import java.util.Objects;
+
+public class SchemaReference implements Comparable<SchemaReference> {
+
+  private String name;
+  private String subject;
+  @Min(1)
+  private Integer version;
+
+  @JsonCreator
+  public SchemaReference(@JsonProperty("name") String name,
+                         @JsonProperty("subject") String subject,
+                         @JsonProperty("version") Integer version) {
+    this.name = name;
+    this.subject = subject;
+    this.version = version;
+  }
+
+  @JsonProperty("name")
+  public String getName() {
+    return name;
+  }
+
+  @JsonProperty("name")
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @JsonProperty("subject")
+  public String getSubject() {
+    return subject;
+  }
+
+  @JsonProperty("subject")
+  public void setSubject(String subject) {
+    this.subject = subject;
+  }
+
+  @JsonProperty("version")
+  public Integer getVersion() {
+    return this.version;
+  }
+
+  @JsonProperty("version")
+  public void setVersion(Integer version) {
+    this.version = version;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SchemaReference that = (SchemaReference) o;
+    return Objects.equals(name, that.name)
+        && Objects.equals(subject, that.subject)
+        && Objects.equals(version, that.version);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, subject, version);
+  }
+
+  @Override
+  public int compareTo(SchemaReference that) {
+    int result = this.subject.compareTo(that.subject);
+    if (result != 0) {
+      return result;
+    }
+    result = this.version - that.version;
+    return result;
+  }
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaString.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaString.java
@@ -25,9 +25,12 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class SchemaString {
 
+  private String schemaType = AvroSchema.TYPE;
   private String schemaString;
   private List<SchemaReference> references = Collections.emptyList();
   private Integer maxId;
@@ -41,6 +44,17 @@ public class SchemaString {
 
   public static SchemaString fromJson(String json) throws IOException {
     return new ObjectMapper().readValue(json, SchemaString.class);
+  }
+
+  @ApiModelProperty(value = "Schema type")
+  @JsonProperty("schemaType")
+  public String getSchemaType() {
+    return schemaType;
+  }
+
+  @JsonProperty("schemaType")
+  public void setSchemaType(String schemaType) {
+    this.schemaType = schemaType;
   }
 
   @ApiModelProperty(value = "Schema string identified by the ID")

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaString.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaString.java
@@ -19,7 +19,9 @@ package io.confluent.kafka.schemaregistry.client.rest.entities;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.annotations.VisibleForTesting;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema.SchemaTypeConverter;
 import io.swagger.annotations.ApiModelProperty;
 
 import java.io.IOException;
@@ -50,6 +52,7 @@ public class SchemaString {
 
   @ApiModelProperty(value = "Schema type")
   @JsonProperty("schemaType")
+  @JsonSerialize(converter = SchemaTypeConverter.class)
   public String getSchemaType() {
     return schemaType;
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaString.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaString.java
@@ -19,6 +19,7 @@ package io.confluent.kafka.schemaregistry.client.rest.entities;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import io.swagger.annotations.ApiModelProperty;
 
 import java.io.IOException;
@@ -38,6 +39,7 @@ public class SchemaString {
   public SchemaString() {
   }
 
+  @VisibleForTesting
   public SchemaString(String schemaString) {
     this.schemaString = schemaString;
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaString.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaString.java
@@ -22,15 +22,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.ApiModelProperty;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class SchemaString {
 
   private String schemaString;
+  private List<SchemaReference> references = Collections.emptyList();
   private Integer maxId;
 
   public SchemaString() {
-
   }
 
   public SchemaString(String schemaString) {
@@ -52,6 +54,18 @@ public class SchemaString {
     this.schemaString = schemaString;
   }
 
+  @ApiModelProperty(value = "Schema references")
+  @JsonProperty("references")
+  public List<SchemaReference> getReferences() {
+    return this.references;
+  }
+
+  @JsonProperty("references")
+  public void setReferences(List<SchemaReference> references) {
+    this.references = references;
+  }
+
+  @ApiModelProperty(value = "Maximum ID")
   @JsonProperty("maxId")
   public Integer getMaxId() {
     return maxId;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaRequest.java
@@ -105,7 +105,7 @@ public class RegisterSchemaRequest {
     if (id != null) {
       buf.append("id=").append(id).append(", ");
     }
-    buf.append("schemaType=" + this.schemaType + ",");
+    buf.append("schemaType=").append(this.schemaType).append(",");
     buf.append("schema=").append(schema).append("}");
     return buf.toString();
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaRequest.java
@@ -28,6 +28,7 @@ public class RegisterSchemaRequest {
 
   private Integer version;
   private Integer id;
+  private String schemaType;
   private String schema;
 
   public static RegisterSchemaRequest fromJson(String json) throws IOException {
@@ -54,6 +55,16 @@ public class RegisterSchemaRequest {
     this.id = id;
   }
 
+  @JsonProperty("schemaType")
+  public String getSchemaType() {
+    return this.schemaType;
+  }
+
+  @JsonProperty("schemaType")
+  public void setSchemaType(String schemaType) {
+    this.schemaType = schemaType;
+  }
+
   @JsonProperty("schema")
   public String getSchema() {
     return this.schema;
@@ -75,12 +86,13 @@ public class RegisterSchemaRequest {
     RegisterSchemaRequest that = (RegisterSchemaRequest) o;
     return Objects.equals(version, that.version)
         && Objects.equals(id, that.id)
+        && Objects.equals(schemaType, that.schemaType)
         && Objects.equals(schema, that.schema);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(version, id, schema);
+    return Objects.hash(schemaType, version, id, schema);
   }
 
   @Override
@@ -93,6 +105,7 @@ public class RegisterSchemaRequest {
     if (id != null) {
       buf.append("id=").append(id).append(", ");
     }
+    buf.append("schemaType=" + this.schemaType + ",");
     buf.append("schema=").append(schema).append("}");
     return buf.toString();
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaRequest.java
@@ -21,14 +21,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Objects;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class RegisterSchemaRequest {
 
   private Integer version;
   private Integer id;
   private String schemaType;
+  private List<SchemaReference> references = null;
   private String schema;
 
   public static RegisterSchemaRequest fromJson(String json) throws IOException {
@@ -65,6 +69,16 @@ public class RegisterSchemaRequest {
     this.schemaType = schemaType;
   }
 
+  @JsonProperty("references")
+  public List<SchemaReference> getReferences() {
+    return this.references;
+  }
+
+  @JsonProperty("references")
+  public void setReferences(List<SchemaReference> references) {
+    this.references = references;
+  }
+
   @JsonProperty("schema")
   public String getSchema() {
     return this.schema;
@@ -87,12 +101,13 @@ public class RegisterSchemaRequest {
     return Objects.equals(version, that.version)
         && Objects.equals(id, that.id)
         && Objects.equals(schemaType, that.schemaType)
+        && Objects.equals(references, that.references)
         && Objects.equals(schema, that.schema);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(schemaType, version, id, schema);
+    return Objects.hash(schemaType, references, version, id, schema);
   }
 
   @Override
@@ -106,6 +121,7 @@ public class RegisterSchemaRequest {
       buf.append("id=").append(id).append(", ");
     }
     buf.append("schemaType=").append(this.schemaType).append(",");
+    buf.append("references=").append(this.references).append(",");
     buf.append("schema=").append(schema).append("}");
     return buf.toString();
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/tools/SchemaRegistryClientPerformance.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/tools/SchemaRegistryClientPerformance.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import io.confluent.common.utils.AbstractPerformanceTest;
 import io.confluent.common.utils.PerformanceStats;
 import io.confluent.kafka.schemaregistry.CompatibilityLevel;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
@@ -73,7 +74,7 @@ public class SchemaRegistryClientPerformance extends AbstractPerformanceTest {
   }
 
   // sequential schema maker
-  private static Schema makeSchema(long num) {
+  private static AvroSchema makeAvroSchema(long num) {
     String schemaString = "{\"type\":\"record\","
                           + "\"name\":\"myrecord\","
                           + "\"fields\":"
@@ -81,12 +82,12 @@ public class SchemaRegistryClientPerformance extends AbstractPerformanceTest {
                           + "\"f" + num + "\"}]}";
     Schema.Parser parser1 = new Schema.Parser();
     Schema schema = parser1.parse(schemaString);
-    return schema;
+    return new AvroSchema(schema);
   }
 
   @Override
   protected void doIteration(PerformanceStats.Callback cb) {
-    Schema schema = makeSchema(this.registeredSchemas);
+    AvroSchema schema = makeAvroSchema(this.registeredSchemas);
 
     try {
       client.register(this.subject, schema);

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/tools/SchemaRegistryClientPerformance.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/tools/SchemaRegistryClientPerformance.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 
 import io.confluent.common.utils.AbstractPerformanceTest;
 import io.confluent.common.utils.PerformanceStats;
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
+import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
@@ -69,7 +69,7 @@ public class SchemaRegistryClientPerformance extends AbstractPerformanceTest {
 
     client = new CachedSchemaRegistryClient(restService, Integer.MAX_VALUE);
     // No compatibility verification
-    client.updateCompatibility(null, AvroCompatibilityLevel.NONE.name);
+    client.updateCompatibility(null, CompatibilityLevel.NONE.name);
   }
 
   // sequential schema maker

--- a/client/src/main/java/org/apache/avro/Schemas.java
+++ b/client/src/main/java/org/apache/avro/Schemas.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.avro;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Collection;
+
+import static org.apache.avro.Schema.FACTORY;
+
+public class Schemas {
+
+  public static String toString(Schema schema, Collection<Schema> schemas) {
+    try {
+      StringWriter writer = new StringWriter();
+      JsonGenerator gen = FACTORY.createGenerator(writer);
+      Schema.Names names = new Schema.Names();
+      if (schemas != null) {
+        for (Schema s : schemas) {
+          names.add(s);
+        }
+      }
+      schema.toJson(names, gen);
+      gen.flush();
+      return writer.toString();
+    } catch (IOException e) {
+      throw new AvroRuntimeException(e);
+    }
+  }
+}

--- a/client/src/main/java/org/apache/avro/Schemas.java
+++ b/client/src/main/java/org/apache/avro/Schemas.java
@@ -27,9 +27,16 @@ import static org.apache.avro.Schema.FACTORY;
 public class Schemas {
 
   public static String toString(Schema schema, Collection<Schema> schemas) {
+    return toString(schema, schemas, false);
+  }
+
+  public static String toString(Schema schema, Collection<Schema> schemas, boolean pretty) {
     try {
       StringWriter writer = new StringWriter();
       JsonGenerator gen = FACTORY.createGenerator(writer);
+      if (pretty) {
+        gen.useDefaultPrettyPrinter();
+      }
       Schema.Names names = new Schema.Names();
       if (schemas != null) {
         for (Schema s : schemas) {

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
@@ -32,6 +32,17 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.requests.ModeUpdat
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
 
 import static org.easymock.EasyMock.anyBoolean;
+import org.apache.avro.Schema;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Arrays;
+
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.rest.RestService;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
+
 import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.createNiceMock;
 import static org.easymock.EasyMock.eq;
@@ -57,7 +68,7 @@ public class CachedSchemaRegistryClientTest {
   private static final int ID_25 = 25;
   private static final io.confluent.kafka.schemaregistry.client.rest.entities.Schema SCHEMA_DETAILS
       = new io.confluent.kafka.schemaregistry.client.rest.entities.Schema(
-          SUBJECT_0, 7, ID_25, SCHEMA_STR_0);
+          SUBJECT_0, 7, ID_25, AvroSchema.AVRO, SCHEMA_STR_0);
 
   private RestService restService;
   private CachedSchemaRegistryClient client;
@@ -172,7 +183,7 @@ public class CachedSchemaRegistryClientTest {
     expect(restService.lookUpSubjectVersion(anyString(), eq(SUBJECT_0), eq(true)))
         .andReturn(
             new io.confluent.kafka.schemaregistry.client.rest.entities.Schema(SUBJECT_0, version,
-                ID_25, SCHEMA_STR_0));
+                ID_25, AvroSchema.AVRO, SCHEMA_STR_0));
 
     replay(restService);
 
@@ -247,6 +258,7 @@ public class CachedSchemaRegistryClientTest {
         .andReturn(new io.confluent.kafka.schemaregistry.client.rest.entities.Schema(SUBJECT_0,
                                                                                      version,
             ID_25,
+            AvroSchema.AVRO,
             SCHEMA_STR_0));
 
     expect(restService.deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES,

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
@@ -58,7 +58,7 @@ public class CachedSchemaRegistryClientTest {
   private static final int ID_25 = 25;
   private static final io.confluent.kafka.schemaregistry.client.rest.entities.Schema SCHEMA_DETAILS
       = new io.confluent.kafka.schemaregistry.client.rest.entities.Schema(
-          SUBJECT_0, 7, ID_25, SCHEMA_STR_0);
+          SUBJECT_0, 7, ID_25, AvroSchema.TYPE, Collections.emptyList(), SCHEMA_STR_0);
 
   private RestService restService;
   private CachedSchemaRegistryClient client;
@@ -185,7 +185,7 @@ public class CachedSchemaRegistryClientTest {
         eq(true)))
         .andReturn(
             new io.confluent.kafka.schemaregistry.client.rest.entities.Schema(SUBJECT_0, version,
-                ID_25, SCHEMA_STR_0));
+                ID_25, AvroSchema.TYPE, Collections.emptyList(), SCHEMA_STR_0));
 
     replay(restService);
 
@@ -276,8 +276,7 @@ public class CachedSchemaRegistryClientTest {
         anyObject(List.class), eq(SUBJECT_0), eq(true)))
         .andReturn(new io.confluent.kafka.schemaregistry.client.rest.entities.Schema(SUBJECT_0,
                                                                                      version,
-            ID_25,
-            SCHEMA_STR_0));
+            ID_25, AvroSchema.TYPE, Collections.emptyList(), SCHEMA_STR_0));
 
     expect(restService.deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES,
         SUBJECT_0,

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -772,6 +772,8 @@ definitions:
       id:
         type: "integer"
         format: "int32"
+      schemaType:
+        type: "string"
       schema:
         type: "string"
   RegisterSchemaResponse:
@@ -792,6 +794,8 @@ definitions:
         type: "integer"
         format: "int32"
       schema:
+        type: "string"
+      schemaType:
         type: "string"
   SchemaString:
     type: "object"

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -597,6 +597,10 @@ paths:
           \ served."
         required: true
         type: "string"
+      - name: "deleted"
+        in: "query"
+        required: false
+        type: "boolean"
       responses:
         200:
           description: "successful operation"
@@ -685,6 +689,10 @@ paths:
           \ served."
         required: true
         type: "string"
+      - name: "deleted"
+        in: "query"
+        required: false
+        type: "boolean"
       responses:
         200:
           description: "successful operation"
@@ -774,6 +782,10 @@ definitions:
         format: "int32"
       schemaType:
         type: "string"
+      references:
+        type: "array"
+        items:
+          $ref: "#/definitions/SchemaReference"
       schema:
         type: "string"
   RegisterSchemaResponse:
@@ -797,15 +809,36 @@ definitions:
         type: "string"
       schemaType:
         type: "string"
+      references:
+        type: "array"
+        items:
+          $ref: "#/definitions/SchemaReference"
+  SchemaReference:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      subject:
+        type: "string"
+      version:
+        type: "integer"
+        format: "int32"
+        minimum: 1
   SchemaString:
     type: "object"
     properties:
       schema:
         type: "string"
         description: "Schema string identified by the ID"
+      references:
+        type: "array"
+        description: "Schema references"
+        items:
+          $ref: "#/definitions/SchemaReference"
       maxId:
         type: "integer"
         format: "int32"
+        description: "Maximum ID"
   ServerClusterId:
     type: "object"
     properties:

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -805,14 +805,14 @@ definitions:
       id:
         type: "integer"
         format: "int32"
-      schema:
-        type: "string"
       schemaType:
         type: "string"
       references:
         type: "array"
         items:
           $ref: "#/definitions/SchemaReference"
+      schema:
+        type: "string"
   SchemaReference:
     type: "object"
     properties:

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -827,6 +827,9 @@ definitions:
   SchemaString:
     type: "object"
     properties:
+      schemaType:
+        type: "string"
+        description: "Schema type"
       schema:
         type: "string"
         description: "Schema string identified by the ID"

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -222,6 +222,18 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <executions>

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroUtils.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroUtils.java
@@ -15,7 +15,6 @@
 
 package io.confluent.kafka.schemaregistry.avro;
 
-import org.apache.avro.Schema;
 import org.apache.avro.SchemaParseException;
 
 public class AvroUtils {
@@ -28,11 +27,7 @@ public class AvroUtils {
    */
   public static AvroSchema parseSchema(String schemaString) {
     try {
-      Schema.Parser parser1 = new Schema.Parser();
-      parser1.setValidateDefaults(false);
-      Schema schema = parser1.parse(schemaString);
-      //TODO: schema.toString() is not canonical (issue-28)
-      return new AvroSchema(schema, schema.toString());
+      return new AvroSchema(schemaString);
     } catch (SchemaParseException e) {
       return null;
     }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroUtils.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroUtils.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafka.schemaregistry.avro;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.avro.SchemaParseException;
 
 public class AvroUtils {
@@ -25,6 +26,7 @@ public class AvroUtils {
    * @return A schema object and a canonical representation of the schema string. Return null if
    *     there is any parsing error.
    */
+  @VisibleForTesting
   public static AvroSchema parseSchema(String schemaString) {
     try {
       return new AvroSchema(schemaString);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -117,9 +117,11 @@ public class SchemaRegistryConfig extends RestConfig {
   public static final String SCHEMA_PROVIDERS_CONFIG = "schema.providers";
 
   /**
-   * <code>avro.compatibility.level</code>
+   * <code>schema.compatibility.level</code>
    */
+  @Deprecated
   public static final String COMPATIBILITY_CONFIG = "avro.compatibility.level";
+  public static final String SCHEMA_COMPATIBILITY_CONFIG = "schema.compatibility.level";
 
   public static final String ZOOKEEPER_SET_ACL_CONFIG = "zookeeper.set.acl";
   public static final String KAFKASTORE_SECURITY_PROTOCOL_CONFIG =
@@ -247,8 +249,8 @@ public class SchemaRegistryConfig extends RestConfig {
       "  A list of classes to use as SchemaProvider. Implementing the interface "
           + "<code>SchemaProvider</code> allows you to add custom schema types to Schema Registry.";
   protected static final String COMPATIBILITY_DOC =
-      "The Avro compatibility type. Valid values are: "
-      + "none (new schema can be any valid Avro schema), "
+      "The compatibility type. Valid values are: "
+      + "none (new schema can be any valid schema), "
       + "backward (new schema can read data produced by latest registered schema), "
       + "forward (latest registered schema can read data produced by the new schema), "
       + "full (new schema is backward and forward compatible with latest registered schema), "
@@ -403,7 +405,10 @@ public class SchemaRegistryConfig extends RestConfig {
     .define(SCHEMA_PROVIDERS_CONFIG, ConfigDef.Type.LIST, "",
         ConfigDef.Importance.LOW, SCHEMA_PROVIDERS_DOC
     )
-    .define(COMPATIBILITY_CONFIG, ConfigDef.Type.STRING, COMPATIBILITY_DEFAULT,
+    .define(COMPATIBILITY_CONFIG, ConfigDef.Type.STRING, "",
+        ConfigDef.Importance.HIGH, COMPATIBILITY_DOC
+    )
+    .define(SCHEMA_COMPATIBILITY_CONFIG, ConfigDef.Type.STRING, COMPATIBILITY_DEFAULT,
         ConfigDef.Importance.HIGH, COMPATIBILITY_DOC
     )
     .define(ZOOKEEPER_SET_ACL_CONFIG, ConfigDef.Type.BOOLEAN, ZOOKEEPER_SET_ACL_DEFAULT,
@@ -530,10 +535,13 @@ public class SchemaRegistryConfig extends RestConfig {
   public SchemaRegistryConfig(ConfigDef configDef, Properties props) throws RestConfigException {
     super(configDef, props);
     this.originalProperties = props;
-    String compatibilityTypeString = getString(SchemaRegistryConfig.COMPATIBILITY_CONFIG);
+    String compatibilityTypeString = getString(COMPATIBILITY_CONFIG);
+    if (compatibilityTypeString == null || compatibilityTypeString.isEmpty()) {
+      compatibilityTypeString = getString(SCHEMA_COMPATIBILITY_CONFIG);
+    }
     compatibilityType = CompatibilityLevel.forName(compatibilityTypeString);
     if (compatibilityType == null) {
-      throw new RestConfigException("Unknown Avro compatibility level: " + compatibilityTypeString);
+      throw new RestConfigException("Unknown compatibility level: " + compatibilityTypeString);
     }
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -33,7 +33,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import io.confluent.common.config.AbstractConfig;
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
+import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.utils.ZkUtils;
 import io.confluent.rest.RestConfig;
 import io.confluent.rest.RestConfigException;
@@ -113,6 +113,9 @@ public class SchemaRegistryConfig extends RestConfig {
    * <code>host.name</code>
    */
   public static final String HOST_NAME_CONFIG = "host.name";
+
+  public static final String SCHEMA_PROVIDERS_CONFIG = "schema.providers";
+
   /**
    * <code>avro.compatibility.level</code>
    */
@@ -240,6 +243,9 @@ public class SchemaRegistryConfig extends RestConfig {
       + "authentication is "
       + "configured. IMPORTANT: if set to `true`, the SASL principal must be the same as the Kafka"
       + " brokers.";
+  protected static final String SCHEMA_PROVIDERS_DOC =
+      "  A list of classes to use as SchemaProvider. Implementing the interface "
+          + "<code>SchemaProvider</code> allows you to add custom schema types to Schema Registry.";
   protected static final String COMPATIBILITY_DOC =
       "The Avro compatibility type. Valid values are: "
       + "none (new schema can be any valid Avro schema), "
@@ -394,6 +400,9 @@ public class SchemaRegistryConfig extends RestConfig {
     .define(HOST_NAME_CONFIG, ConfigDef.Type.STRING, getDefaultHost(),
         ConfigDef.Importance.HIGH, HOST_DOC
     )
+    .define(SCHEMA_PROVIDERS_CONFIG, ConfigDef.Type.LIST, "",
+        ConfigDef.Importance.LOW, SCHEMA_PROVIDERS_DOC
+    )
     .define(COMPATIBILITY_CONFIG, ConfigDef.Type.STRING, COMPATIBILITY_DEFAULT,
         ConfigDef.Importance.HIGH, COMPATIBILITY_DOC
     )
@@ -508,7 +517,7 @@ public class SchemaRegistryConfig extends RestConfig {
             ConfigDef.Importance.LOW, SCHEMAREGISTRY_INTER_INSTANCE_PROTOCOL_DOC);
   }
 
-  private final AvroCompatibilityLevel compatibilityType;
+  private final CompatibilityLevel compatibilityType;
 
   public SchemaRegistryConfig(String propsFile) throws RestConfigException {
     this(AbstractConfig.getPropsFromFile(propsFile));
@@ -522,7 +531,7 @@ public class SchemaRegistryConfig extends RestConfig {
     super(configDef, props);
     this.originalProperties = props;
     String compatibilityTypeString = getString(SchemaRegistryConfig.COMPATIBILITY_CONFIG);
-    compatibilityType = AvroCompatibilityLevel.forName(compatibilityTypeString);
+    compatibilityType = CompatibilityLevel.forName(compatibilityTypeString);
     if (compatibilityType == null) {
       throw new RestConfigException("Unknown Avro compatibility level: " + compatibilityTypeString);
     }
@@ -540,7 +549,7 @@ public class SchemaRegistryConfig extends RestConfig {
     return originalProperties;
   }
 
-  public AvroCompatibilityLevel compatibilityType() {
+  public CompatibilityLevel compatibilityType() {
     return compatibilityType;
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -35,6 +35,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.rest.Versions;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.CompatibilityCheckResponse;
@@ -124,8 +125,12 @@ public class CompatibilityResource {
       }
     } else {
       try {
-        isCompatible = schemaRegistry
-            .isCompatible(subject, request.getSchema(), schemaForSpecifiedVersion.getSchema());
+        isCompatible = schemaRegistry.isCompatible(
+            subject,
+            request.getSchemaType() != null ? request.getSchemaType() : AvroSchema.AVRO,
+            request.getSchema(),
+            schemaForSpecifiedVersion
+        );
       } catch (InvalidSchemaException e) {
         throw Errors.invalidAvroException("Invalid input schema " + request.getSchema(), e);
       } catch (SchemaRegistryStoreException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -35,7 +35,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 
-import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.rest.Versions;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.CompatibilityCheckResponse;
@@ -126,9 +125,8 @@ public class CompatibilityResource {
     } else {
       try {
         isCompatible = schemaRegistry.isCompatible(
-            subject,
-            request.getSchemaType() != null ? request.getSchemaType() : AvroSchema.TYPE,
-            request.getSchema(),
+            subject, new Schema(subject, request.getVersion(), request.getId(),
+                request.getSchemaType(), request.getReferences(), request.getSchema()),
             schemaForSpecifiedVersion
         );
       } catch (InvalidSchemaException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -127,7 +127,7 @@ public class CompatibilityResource {
       try {
         isCompatible = schemaRegistry.isCompatible(
             subject,
-            request.getSchemaType() != null ? request.getSchemaType() : AvroSchema.AVRO,
+            request.getSchemaType() != null ? request.getSchemaType() : AvroSchema.TYPE,
             request.getSchema(),
             schemaForSpecifiedVersion
         );

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -36,7 +36,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
+import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.client.rest.Versions;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Config;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.ConfigUpdateRequest;
@@ -91,8 +91,8 @@ public class ConfigResource {
       throw Errors.schemaRegistryException("Failed to retrieve a list of all subjects"
                                            + " from the registry", e);
     }
-    AvroCompatibilityLevel compatibilityLevel =
-        AvroCompatibilityLevel.forName(request.getCompatibilityLevel());
+    CompatibilityLevel compatibilityLevel =
+        CompatibilityLevel.forName(request.getCompatibilityLevel());
     if (compatibilityLevel == null) {
       throw new RestInvalidCompatibilityException();
     }
@@ -132,7 +132,7 @@ public class ConfigResource {
       @QueryParam("defaultToGlobal") boolean defaultToGlobal) {
     Config config = null;
     try {
-      AvroCompatibilityLevel compatibilityLevel =
+      CompatibilityLevel compatibilityLevel =
           defaultToGlobal
           ? schemaRegistry.getCompatibilityLevelInScope(subject)
           : schemaRegistry.getCompatibilityLevel(subject);
@@ -159,8 +159,8 @@ public class ConfigResource {
       @Context HttpHeaders headers,
       @ApiParam(value = "Config Update Request", required = true)
       @NotNull ConfigUpdateRequest request) {
-    AvroCompatibilityLevel compatibilityLevel =
-        AvroCompatibilityLevel.forName(request.getCompatibilityLevel());
+    CompatibilityLevel compatibilityLevel =
+        CompatibilityLevel.forName(request.getCompatibilityLevel());
     if (compatibilityLevel == null) {
       throw new RestInvalidCompatibilityException();
     }
@@ -190,7 +190,7 @@ public class ConfigResource {
   public Config getTopLevelConfig() {
     Config config = null;
     try {
-      AvroCompatibilityLevel compatibilityLevel = schemaRegistry.getCompatibilityLevel(null);
+      CompatibilityLevel compatibilityLevel = schemaRegistry.getCompatibilityLevel(null);
       config = new Config(compatibilityLevel == null ? null : compatibilityLevel.name);
     } catch (SchemaRegistryStoreException e) {
       throw Errors.storeException("Failed to get compatibility level", e);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -35,6 +35,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Context;
@@ -94,7 +95,8 @@ public class SubjectVersionsResource {
       @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store")})
   public Schema getSchemaByVersion(
       @ApiParam(value = "Name of the Subject", required = true)@PathParam("subject") String subject,
-      @ApiParam(value = VERSION_PARAM_DESC, required = true)@PathParam("version") String version) {
+      @ApiParam(value = VERSION_PARAM_DESC, required = true)@PathParam("version") String version,
+      @QueryParam("deleted") boolean lookupDeletedSchema) {
     VersionId versionId = null;
     try {
       versionId = new VersionId(version);
@@ -108,7 +110,7 @@ public class SubjectVersionsResource {
           + version
           + " from the schema registry";
     try {
-      schema = schemaRegistry.validateAndGetSchema(subject, versionId, false);
+      schema = schemaRegistry.validateAndGetSchema(subject, versionId, lookupDeletedSchema);
     } catch (SchemaRegistryStoreException e) {
       log.debug(errorMessage, e);
       throw Errors.storeException(errorMessage, e);
@@ -132,8 +134,9 @@ public class SubjectVersionsResource {
       message = "Error code 50001 -- Error in the backend data store")})
   public String getSchemaOnly(
       @ApiParam(value = "Name of the Subject", required = true)@PathParam("subject") String subject,
-      @ApiParam(value = VERSION_PARAM_DESC, required = true)@PathParam("version") String version) {
-    return getSchemaByVersion(subject, version).getSchema();
+      @ApiParam(value = VERSION_PARAM_DESC, required = true)@PathParam("version") String version,
+      @QueryParam("deleted") boolean lookupDeletedSchema) {
+    return getSchemaByVersion(subject, version, lookupDeletedSchema).getSchema();
   }
 
   @GET
@@ -214,7 +217,8 @@ public class SubjectVersionsResource {
         subjectName,
         request.getVersion() != null ? request.getVersion() : 0,
         request.getId() != null ? request.getId() : -1,
-        request.getSchemaType() != null ? request.getSchemaType() : AvroSchema.AVRO,
+        request.getSchemaType() != null ? request.getSchemaType() : AvroSchema.TYPE,
+        request.getReferences(),
         request.getSchema()
     );
     int id;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -40,6 +40,7 @@ import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.rest.Versions;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
@@ -213,6 +214,7 @@ public class SubjectVersionsResource {
         subjectName,
         request.getVersion() != null ? request.getVersion() : 0,
         request.getId() != null ? request.getId() : -1,
+        request.getSchemaType() != null ? request.getSchemaType() : AvroSchema.AVRO,
         request.getSchema()
     );
     int id;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -91,7 +91,8 @@ public class SubjectsResource {
         subject,
         0,
         -1,
-        request.getSchemaType() != null ? request.getSchemaType() : AvroSchema.AVRO,
+        request.getSchemaType() != null ? request.getSchemaType() : AvroSchema.TYPE,
+        request.getReferences(),
         request.getSchema()
     );
     io.confluent.kafka.schemaregistry.client.rest.entities.Schema matchingSchema = null;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -41,6 +41,7 @@ import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.rest.Versions;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
@@ -86,7 +87,13 @@ public class SubjectsResource {
       @ApiParam(value = "Schema", required = true)
       @NotNull RegisterSchemaRequest request) {
     // returns version if the schema exists. Otherwise returns 404
-    Schema schema = new Schema(subject, 0, -1, request.getSchema());
+    Schema schema = new Schema(
+        subject,
+        0,
+        -1,
+        request.getSchemaType() != null ? request.getSchemaType() : AvroSchema.AVRO,
+        request.getSchema()
+    );
     io.confluent.kafka.schemaregistry.client.rest.entities.Schema matchingSchema = null;
     try {
       if (!schemaRegistry.hasSubjects(subject)) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
@@ -17,14 +17,14 @@ package io.confluent.kafka.schemaregistry.storage;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
+import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 
 public class ConfigValue implements SchemaRegistryValue {
 
-  private AvroCompatibilityLevel compatibilityLevel;
+  private CompatibilityLevel compatibilityLevel;
 
   public ConfigValue(@JsonProperty("compatibilityLevel")
-                     AvroCompatibilityLevel compatibilityLevel) {
+                     CompatibilityLevel compatibilityLevel) {
     this.compatibilityLevel = compatibilityLevel;
   }
 
@@ -33,12 +33,12 @@ public class ConfigValue implements SchemaRegistryValue {
   }
 
   @JsonProperty("compatibilityLevel")
-  public AvroCompatibilityLevel getCompatibilityLevel() {
+  public CompatibilityLevel getCompatibilityLevel() {
     return compatibilityLevel;
   }
 
   @JsonProperty("compatibilityLevel")
-  public void setCompatibilityLevel(AvroCompatibilityLevel compatibilityLevel) {
+  public void setCompatibilityLevel(CompatibilityLevel compatibilityLevel) {
     this.compatibilityLevel = compatibilityLevel;
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
@@ -25,7 +25,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Predicate;
 
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
+import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreInitializationException;
@@ -153,9 +153,9 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
 
   @Override
   @SuppressWarnings("unchecked")
-  public AvroCompatibilityLevel compatibilityLevel(String subject,
-                                                   boolean returnTopLevelIfNotFound,
-                                                   AvroCompatibilityLevel defaultForTopLevel
+  public CompatibilityLevel compatibilityLevel(String subject,
+                                               boolean returnTopLevelIfNotFound,
+                                               CompatibilityLevel defaultForTopLevel
   ) {
     ConfigKey subjectConfigKey = new ConfigKey(subject);
     ConfigValue config = (ConfigValue) get((K) subjectConfigKey);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -647,6 +647,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
 
     RegisterSchemaRequest registerSchemaRequest = new RegisterSchemaRequest();
     registerSchemaRequest.setSchema(schema.getSchema());
+    registerSchemaRequest.setSchemaType(schema.getSchemaType());
     registerSchemaRequest.setVersion(schema.getVersion());
     registerSchemaRequest.setId(schema.getId());
     log.debug(String.format("Forwarding registering schema request %s to %s",

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -52,6 +52,7 @@ import io.confluent.common.metrics.stats.Gauge;
 import io.confluent.common.utils.SystemTime;
 import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.SchemaProvider;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
@@ -764,9 +765,11 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
   }
 
   private ParsedSchema parseSchema(Schema schema) throws InvalidSchemaException {
-    SchemaProvider provider = providers.get(schema.getSchemaType());
+    String schemaType = schema.getSchemaType();
+    if (schemaType == null) schemaType = AvroSchema.TYPE;
+    SchemaProvider provider = providers.get(schemaType);
     if (provider == null) {
-      throw new IllegalArgumentException("Invalid schema type " + schema.getSchemaType());
+      throw new IllegalArgumentException("Invalid schema type " + schemaType);
     }
     ParsedSchema parsedSchema = provider.parseSchema(schema.getSchema(), schema.getReferences())
         .orElseThrow(() -> new InvalidSchemaException("Invalid schema " + schema));

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -415,9 +415,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
         undeletedSchemasList.add(latestSchema);
       }
 
-      Schema canonicalizeSchema = canonicalizeSchema(schema);
+      canonicalizeSchema(schema);
       // assign a guid and put the schema in the kafka store
-      if (latestSchema == null || isCompatible(subject, canonicalizeSchema, undeletedSchemasList)) {
+      if (latestSchema == null || isCompatible(subject, schema, undeletedSchemasList)) {
         if (schema.getVersion() <= 0) {
           schema.setVersion(newVersion);
         }
@@ -755,13 +755,12 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     }
   }
 
-  private Schema canonicalizeSchema(Schema schema) throws InvalidSchemaException {
+  private void canonicalizeSchema(Schema schema) throws InvalidSchemaException {
     if (schema == null || schema.getSchema().trim().isEmpty()) {
       throw new InvalidSchemaException("Invalid schema " + schema);
     }
     ParsedSchema parsedSchema = parseSchema(schema);
-    return new Schema(schema.getSubject(), schema.getVersion(), schema.getId(),
-        schema.getSchemaType(), schema.getReferences(), parsedSchema.canonicalString());
+    schema.setSchema(parsedSchema.canonicalString());
   }
 
   private ParsedSchema parseSchema(Schema schema) throws InvalidSchemaException {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -840,8 +840,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
           + " store", e);
     }
     SchemaString schemaString = new SchemaString();
+    schemaString.setSchemaType(schema.getSchemaType());
     schemaString.setSchemaString(schema.getSchema());
-    List<SchemaReference>  refs = schema.getReferences();
+    List<SchemaReference> refs = schema.getReferences();
     if (refs != null) {
       schemaString.setReferences(refs.stream()
           .map(ref -> new io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference(

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -766,7 +766,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
 
   private ParsedSchema parseSchema(Schema schema) throws InvalidSchemaException {
     String schemaType = schema.getSchemaType();
-    if (schemaType == null) schemaType = AvroSchema.TYPE;
+    if (schemaType == null) {
+      schemaType = AvroSchema.TYPE;
+    }
     SchemaProvider provider = providers.get(schemaType);
     if (provider == null) {
       throw new IllegalArgumentException("Invalid schema type " + schemaType);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupCache.java
@@ -101,8 +101,8 @@ public interface LookupCache<K,V> extends Store<K,V> {
    * @return the compatibility level if found, otherwise null
    */
   CompatibilityLevel compatibilityLevel(String subject,
-                                            boolean returnTopLevelIfNotFound,
-                                            CompatibilityLevel defaultForTopLevel);
+                                        boolean returnTopLevelIfNotFound,
+                                        CompatibilityLevel defaultForTopLevel);
 
   /**
    * Retrieves the mode for a subject.

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupCache.java
@@ -15,7 +15,7 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
+import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
 
@@ -100,9 +100,9 @@ public interface LookupCache<K,V> extends Store<K,V> {
    * @param defaultForTopLevel default value for the top level scope
    * @return the compatibility level if found, otherwise null
    */
-  AvroCompatibilityLevel compatibilityLevel(String subject,
+  CompatibilityLevel compatibilityLevel(String subject,
                                             boolean returnTopLevelIfNotFound,
-                                            AvroCompatibilityLevel defaultForTopLevel);
+                                            CompatibilityLevel defaultForTopLevel);
 
   /**
    * Retrieves the mode for a subject.

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaReference.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaReference.java
@@ -98,4 +98,18 @@ public class SchemaReference implements Comparable<SchemaReference> {
     result = this.version - that.version;
     return result;
   }
+
+  @Override
+  public String toString() {
+    return "{"
+        + "name='"
+        + name
+        + '\''
+        + ", subject='"
+        + subject
+        + '\''
+        + ", version="
+        + version
+        + '}';
+  }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaReference.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaReference.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hibernate.validator.constraints.NotEmpty;
+
+import javax.validation.constraints.Min;
+import java.util.Objects;
+
+public class SchemaReference implements Comparable<SchemaReference> {
+
+  @NotEmpty
+  private String name;
+  @NotEmpty
+  private String subject;
+  @Min(1)
+  private Integer version;
+
+  @JsonCreator
+  public SchemaReference(@JsonProperty("name") String name,
+                         @JsonProperty("subject") String subject,
+                         @JsonProperty("version") Integer version) {
+    this.name = name;
+    this.subject = subject;
+    this.version = version;
+  }
+
+  @JsonProperty("name")
+  public String getName() {
+    return name;
+  }
+
+  @JsonProperty("name")
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @JsonProperty("subject")
+  public String getSubject() {
+    return subject;
+  }
+
+  @JsonProperty("subject")
+  public void setSubject(String subject) {
+    this.subject = subject;
+  }
+
+  @JsonProperty("version")
+  public Integer getVersion() {
+    return this.version;
+  }
+
+  @JsonProperty("version")
+  public void setVersion(Integer version) {
+    this.version = version;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SchemaReference that = (SchemaReference) o;
+    return Objects.equals(name, that.name)
+        && Objects.equals(subject, that.subject)
+        && Objects.equals(version, that.version);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, subject, version);
+  }
+
+  @Override
+  public int compareTo(SchemaReference that) {
+    int result = this.subject.compareTo(that.subject);
+    if (result != 0) {
+      return result;
+    }
+    result = this.version - that.version;
+    return result;
+  }
+}

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
@@ -57,13 +57,11 @@ public interface SchemaRegistry extends SchemaVersionFetcher {
       throws SchemaRegistryException;
 
   boolean isCompatible(String subject,
-                       String schemaType,
-                       String inputSchema,
+                       Schema newSchema,
                        Schema targetSchema) throws SchemaRegistryException;
 
   boolean isCompatible(String subject,
-                       String schemaType,
-                       String newSchema,
+                       Schema newSchema,
                        List<Schema> previousSchemas) throws SchemaRegistryException;
 
   void close();

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
@@ -19,16 +19,25 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import io.confluent.kafka.schemaregistry.client.SchemaVersionFetcher;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 
-public interface SchemaRegistry {
+public interface SchemaRegistry extends SchemaVersionFetcher {
 
   void init() throws SchemaRegistryException;
 
   int register(String subject, Schema schema) throws SchemaRegistryException;
+
+  default Schema getByVersion(String subject, int version, boolean returnDeletedSchema) {
+    try {
+      return get(subject, version, returnDeletedSchema);
+    } catch (SchemaRegistryException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
   Schema get(String subject, int version, boolean returnDeletedSchema)
       throws SchemaRegistryException;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
@@ -48,12 +48,14 @@ public interface SchemaRegistry {
       throws SchemaRegistryException;
 
   boolean isCompatible(String subject,
+                       String schemaType,
                        String inputSchema,
-                       String targetSchema) throws SchemaRegistryException;
+                       Schema targetSchema) throws SchemaRegistryException;
 
   boolean isCompatible(String subject,
+                       String schemaType,
                        String newSchema,
-                       List<String> previousSchemas) throws SchemaRegistryException;
+                       List<Schema> previousSchemas) throws SchemaRegistryException;
 
   void close();
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaValue.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+
+import com.google.common.annotations.VisibleForTesting;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.constraints.Min;
@@ -45,6 +47,7 @@ public class SchemaValue implements Comparable<SchemaValue>, SchemaRegistryValue
   @NotEmpty
   private boolean deleted;
 
+  @VisibleForTesting
   public SchemaValue(@JsonProperty("subject") String subject,
                      @JsonProperty("version") Integer version,
                      @JsonProperty("id") Integer id,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaValue.java
@@ -72,7 +72,7 @@ public class SchemaValue implements Comparable<SchemaValue>, SchemaRegistryValue
     this.version = version;
     this.id = id;
     this.schemaType = schemaType;
-    this.references = references;
+    this.references = references != null ? references : Collections.emptyList();
     this.schema = schema;
     this.deleted = deleted;
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaValue.java
@@ -15,11 +15,14 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.constraints.Min;
+import javax.ws.rs.DefaultValue;
 
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 
@@ -33,6 +36,7 @@ public class SchemaValue implements Comparable<SchemaValue>, SchemaRegistryValue
   private Integer id;
   @NotEmpty
   private String schema;
+  private String schemaType = AvroSchema.AVRO;
   @NotEmpty
   private boolean deleted;
 
@@ -48,10 +52,26 @@ public class SchemaValue implements Comparable<SchemaValue>, SchemaRegistryValue
     this.deleted = deleted;
   }
 
+  @JsonCreator
+  public SchemaValue(@JsonProperty("subject") String subject,
+                     @JsonProperty("version") Integer version,
+                     @JsonProperty("id") Integer id,
+                     @JsonProperty("schemaType") @DefaultValue("avro") String schemaType,
+                     @JsonProperty("schema") String schema,
+                     @JsonProperty("deleted") boolean deleted) {
+    this.subject = subject;
+    this.version = version;
+    this.id = id;
+    this.schemaType = schemaType;
+    this.schema = schema;
+    this.deleted = deleted;
+  }
+
   public SchemaValue(Schema schemaEntity) {
     this.subject = schemaEntity.getSubject();
     this.version = schemaEntity.getVersion();
     this.id = schemaEntity.getId();
+    this.schemaType = schemaEntity.getSchemaType();
     this.schema = schemaEntity.getSchema();
     this.deleted = false;
   }
@@ -84,6 +104,16 @@ public class SchemaValue implements Comparable<SchemaValue>, SchemaRegistryValue
   @JsonProperty("id")
   public void setId(Integer id) {
     this.id = id;
+  }
+
+  @JsonProperty("schemaType")
+  public String getSchemaType() {
+    return this.schemaType;
+  }
+
+  @JsonProperty("schemaType")
+  public void setSchemaType(String schemaType) {
+    this.schemaType = schemaType;
   }
 
   @JsonProperty("schema")
@@ -126,6 +156,9 @@ public class SchemaValue implements Comparable<SchemaValue>, SchemaRegistryValue
     if (!this.id.equals(that.getId())) {
       return false;
     }
+    if (!this.schemaType.equals(that.getSchemaType())) {
+      return false;
+    }
     if (!this.schema.equals(that.schema)) {
       return false;
     }
@@ -141,6 +174,7 @@ public class SchemaValue implements Comparable<SchemaValue>, SchemaRegistryValue
     int result = subject.hashCode();
     result = 31 * result + version;
     result = 31 * result + id.intValue();
+    result = 31 * result + schemaType.hashCode();
     result = 31 * result + schema.hashCode();
     result = 31 * result + (deleted ? 1 : 0);
     return result;
@@ -152,6 +186,7 @@ public class SchemaValue implements Comparable<SchemaValue>, SchemaRegistryValue
     sb.append("{subject=" + this.subject + ",");
     sb.append("version=" + this.version + ",");
     sb.append("id=" + this.id + ",");
+    sb.append("schemaType=" + this.schemaType + ",");
     sb.append("schema=" + this.schema + ",");
     sb.append("deleted=" + this.deleted + "}");
     return sb.toString();

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaValue.java
@@ -56,7 +56,7 @@ public class SchemaValue implements Comparable<SchemaValue>, SchemaRegistryValue
   public SchemaValue(@JsonProperty("subject") String subject,
                      @JsonProperty("version") Integer version,
                      @JsonProperty("id") Integer id,
-                     @JsonProperty("schemaType") @DefaultValue("avro") String schemaType,
+                     @JsonProperty("schemaType") @DefaultValue("AVRO") String schemaType,
                      @JsonProperty("schema") String schema,
                      @JsonProperty("deleted") boolean deleted) {
     this.subject = subject;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/tools/SchemaRegistryPerformance.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/tools/SchemaRegistryPerformance.java
@@ -17,7 +17,7 @@ package io.confluent.kafka.schemaregistry.tools;
 
 import io.confluent.common.utils.AbstractPerformanceTest;
 import io.confluent.common.utils.PerformanceStats;
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
+import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.avro.AvroUtils;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.ConfigUpdateRequest;
@@ -67,7 +67,7 @@ public class SchemaRegistryPerformance extends AbstractPerformanceTest {
 
     // No compatibility verification
     ConfigUpdateRequest request = new ConfigUpdateRequest();
-    request.setCompatibilityLevel(AvroCompatibilityLevel.NONE.name);
+    request.setCompatibilityLevel(CompatibilityLevel.NONE.name);
     restService.updateConfig(request, null);
   }
 
@@ -78,7 +78,7 @@ public class SchemaRegistryPerformance extends AbstractPerformanceTest {
                           + "\"fields\":"
                           + "[{\"type\":\"string\",\"name\":"
                           + "\"f" + num + "\"}]}";
-    return AvroUtils.parseSchema(schemaString).canonicalString;
+    return AvroUtils.parseSchema(schemaString).canonicalString();
   }
 
   @Override

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Vector;
 
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.utils.ZkUtils;
 
@@ -113,7 +112,7 @@ public abstract class ClusterTestHarness {
   }
 
   public ClusterTestHarness(int numBrokers, boolean setupRestApp) {
-    this(numBrokers, setupRestApp, AvroCompatibilityLevel.NONE.name);
+    this(numBrokers, setupRestApp, CompatibilityLevel.NONE.name);
   }
 
   public ClusterTestHarness(int numBrokers, boolean setupRestApp, String compatibilityType

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/MasterElectorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/MasterElectorTest.java
@@ -30,7 +30,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
@@ -40,8 +39,8 @@ import io.confluent.kafka.schemaregistry.utils.TestUtils;
 import io.confluent.kafka.schemaregistry.id.ZookeeperIdGenerator;
 import io.confluent.kafka.schemaregistry.storage.SchemaRegistryIdentity;
 
-import static io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel.FORWARD;
-import static io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel.NONE;
+import static io.confluent.kafka.schemaregistry.CompatibilityLevel.FORWARD;
+import static io.confluent.kafka.schemaregistry.CompatibilityLevel.NONE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -112,13 +111,13 @@ public class MasterElectorTest extends ClusterTestHarness {
     // create schema registry instance 1
     final RestApp restApp1 = new RestApp(port1,
                                          zkConnect(), bootstrapServers(), KAFKASTORE_TOPIC,
-                                         AvroCompatibilityLevel.NONE.name, true, null);
+                                         CompatibilityLevel.NONE.name, true, null);
     restApp1.start();
 
     // create schema registry instance 2
     final RestApp restApp2 = new RestApp(port2,
                                          zkConnect(), bootstrapServers(), KAFKASTORE_TOPIC,
-                                         AvroCompatibilityLevel.NONE.name, true, null);
+                                         CompatibilityLevel.NONE.name, true, null);
     restApp2.start();
     assertTrue("Schema registry instance 1 should be the master", restApp1.isMaster());
     assertFalse("Schema registry instance 2 shouldn't be the master", restApp2.isMaster());
@@ -169,26 +168,26 @@ public class MasterElectorTest extends ClusterTestHarness {
 
     // update config to master
     restApp1.restClient
-        .updateCompatibility(AvroCompatibilityLevel.FORWARD.name, configSubject);
+        .updateCompatibility(CompatibilityLevel.FORWARD.name, configSubject);
     assertEquals("New compatibility level should be FORWARD on the master",
                  FORWARD.name,
                  restApp1.restClient.getConfig(configSubject).getCompatibilityLevel());
 
     // the new config should be eventually readable on the non-master
     waitUntilCompatibilityLevelSet(restApp2.restClient, configSubject,
-                                   AvroCompatibilityLevel.FORWARD.name,
+                                   CompatibilityLevel.FORWARD.name,
                                    "New compatibility level should be FORWARD on the non-master");
 
     // update config to non-master
     restApp2.restClient
-        .updateCompatibility(AvroCompatibilityLevel.NONE.name, configSubject);
+        .updateCompatibility(CompatibilityLevel.NONE.name, configSubject);
     assertEquals("New compatibility level should be NONE on the master",
                  NONE.name,
                  restApp1.restClient.getConfig(configSubject).getCompatibilityLevel());
 
     // the new config should be eventually readable on the non-master
     waitUntilCompatibilityLevelSet(restApp2.restClient, configSubject,
-                                   AvroCompatibilityLevel.NONE.name,
+                                   CompatibilityLevel.NONE.name,
                                    "New compatibility level should be NONE on the non-master");
 
     // fake an incorrect master and registration should fail
@@ -220,7 +219,7 @@ public class MasterElectorTest extends ClusterTestHarness {
     // update config should fail if master is not available
     int updateConfigStatusCodeFromRestApp1 = 0;
     try {
-      restApp1.restClient.updateCompatibility(AvroCompatibilityLevel.FORWARD.name,
+      restApp1.restClient.updateCompatibility(CompatibilityLevel.FORWARD.name,
               configSubject);
       fail("Update config should fail on the master");
     } catch (RestClientException e) {
@@ -230,7 +229,7 @@ public class MasterElectorTest extends ClusterTestHarness {
 
     int updateConfigStatusCodeFromRestApp2 = 0;
     try {
-      restApp2.restClient.updateCompatibility(AvroCompatibilityLevel.FORWARD.name,
+      restApp2.restClient.updateCompatibility(CompatibilityLevel.FORWARD.name,
               configSubject);
       fail("Update config should fail on the non-master");
     } catch (RestClientException e) {
@@ -316,7 +315,7 @@ public class MasterElectorTest extends ClusterTestHarness {
     for (int i = 0; i < numSlaves; i++) {
       RestApp slave = new RestApp(choosePort(),
                                   zkConnect(), bootstrapServers(), KAFKASTORE_TOPIC,
-                                  AvroCompatibilityLevel.NONE.name, false, null);
+                                  CompatibilityLevel.NONE.name, false, null);
       slaveApps.add(slave);
       slave.start();
       aSlave = slave;
@@ -344,7 +343,7 @@ public class MasterElectorTest extends ClusterTestHarness {
     for (int i = 0; i < numMasters; i++) {
       RestApp master = new RestApp(choosePort(),
                                    zkConnect(), bootstrapServers(), KAFKASTORE_TOPIC,
-                                   AvroCompatibilityLevel.NONE.name, true, null);
+                                   CompatibilityLevel.NONE.name, true, null);
       masterApps.add(master);
       master.start();
       waitUntilMasterElectionCompletes(masterApps);
@@ -395,7 +394,7 @@ public class MasterElectorTest extends ClusterTestHarness {
     for (int i = 0; i < numSlaves; i++) {
       RestApp slave = new RestApp(choosePort(),
                                   zkConnect(), bootstrapServers(), KAFKASTORE_TOPIC,
-                                  AvroCompatibilityLevel.NONE.name, false, null);
+                                  CompatibilityLevel.NONE.name, false, null);
       slaveApps.add(slave);
       slave.start();
       aSlave = slave;
@@ -420,7 +419,7 @@ public class MasterElectorTest extends ClusterTestHarness {
     for (int i = 0; i < numMasters; i++) {
       RestApp master = new RestApp(choosePort(),
                                    zkConnect(), bootstrapServers(), KAFKASTORE_TOPIC,
-                                   AvroCompatibilityLevel.NONE.name, true, null);
+                                   CompatibilityLevel.NONE.name, true, null);
       masterApps.add(master);
       master.start();
       aMaster = master;
@@ -526,7 +525,7 @@ public class MasterElectorTest extends ClusterTestHarness {
     for (int i = 0; i < numSlaves; i++) {
       RestApp slave = new RestApp(choosePort(),
           zkConnect(), bootstrapServers(), KAFKASTORE_TOPIC,
-          AvroCompatibilityLevel.NONE.name, false, props);
+          CompatibilityLevel.NONE.name, false, props);
       slaveApps.add(slave);
       slave.start();
       aSlave = slave;
@@ -551,7 +550,7 @@ public class MasterElectorTest extends ClusterTestHarness {
     for (int i = 0; i < numMasters; i++) {
       RestApp master = new RestApp(choosePort(),
           zkConnect(), bootstrapServers(), KAFKASTORE_TOPIC,
-          AvroCompatibilityLevel.NONE.name, true, props);
+          CompatibilityLevel.NONE.name, true, props);
       masterApps.add(master);
       master.start();
       aMaster = master;

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
@@ -19,7 +19,6 @@ import org.eclipse.jetty.server.Server;
 
 import java.util.Properties;
 
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
@@ -36,7 +35,7 @@ public class RestApp {
   public String restConnect;
 
   public RestApp(int port, String zkConnect, String kafkaTopic) {
-    this(port, zkConnect, kafkaTopic, AvroCompatibilityLevel.NONE.name, null);
+    this(port, zkConnect, kafkaTopic, CompatibilityLevel.NONE.name, null);
   }
 
   public RestApp(int port, String zkConnect, String kafkaTopic, String compatibilityType, Properties schemaRegistryProps) {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
@@ -65,7 +65,7 @@ public class RestApp {
       prop.setProperty(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, bootstrapBrokers);
     }
     prop.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG, kafkaTopic);
-    prop.put(SchemaRegistryConfig.COMPATIBILITY_CONFIG, compatibilityType);
+    prop.put(SchemaRegistryConfig.SCHEMA_COMPATIBILITY_CONFIG, compatibilityType);
     prop.put(SchemaRegistryConfig.MASTER_ELIGIBILITY, masterEligibility);
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityTest.java
@@ -24,47 +24,49 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.Collections;
 
+import io.confluent.kafka.schemaregistry.CompatibilityChecker;
+
 public class AvroCompatibilityTest {
 
   private final String schemaString1 = "{\"type\":\"record\","
       + "\"name\":\"myrecord\","
       + "\"fields\":"
       + "[{\"type\":\"string\",\"name\":\"f1\"}]}";
-  private final Schema schema1 = AvroUtils.parseSchema(schemaString1).schemaObj;
+  private final AvroSchema schema1 = AvroUtils.parseSchema(schemaString1);
   
   private final String schemaString2 = "{\"type\":\"record\","
       + "\"name\":\"myrecord\","
       + "\"fields\":"
       + "[{\"type\":\"string\",\"name\":\"f1\"},"
       + " {\"type\":\"string\",\"name\":\"f2\", \"default\": \"foo\"}]}";
-  private final Schema schema2 = AvroUtils.parseSchema(schemaString2).schemaObj;
+  private final AvroSchema schema2 = AvroUtils.parseSchema(schemaString2);
   
   private final String schemaString3 = "{\"type\":\"record\","
       + "\"name\":\"myrecord\","
       + "\"fields\":"
       + "[{\"type\":\"string\",\"name\":\"f1\"},"
       + " {\"type\":\"string\",\"name\":\"f2\"}]}";
-  private final Schema schema3 = AvroUtils.parseSchema(schemaString3).schemaObj;
-  
+  private final AvroSchema schema3 = AvroUtils.parseSchema(schemaString3);
+
   private final String schemaString4 = "{\"type\":\"record\","
       + "\"name\":\"myrecord\","
       + "\"fields\":"
       + "[{\"type\":\"string\",\"name\":\"f1_new\", \"aliases\": [\"f1\"]}]}";
-  private final Schema schema4 = AvroUtils.parseSchema(schemaString4).schemaObj;
+  private final AvroSchema schema4 = AvroUtils.parseSchema(schemaString4);
   
   private final String schemaString6 = "{\"type\":\"record\","
       + "\"name\":\"myrecord\","
       + "\"fields\":"
       + "[{\"type\":[\"null\", \"string\"],\"name\":\"f1\","
       + " \"doc\":\"doc of f1\"}]}";
-  private final Schema schema6 = AvroUtils.parseSchema(schemaString6).schemaObj;
+  private final AvroSchema schema6 = AvroUtils.parseSchema(schemaString6);
   
   private final String schemaString7 = "{\"type\":\"record\","
       + "\"name\":\"myrecord\","
       + "\"fields\":"
       + "[{\"type\":[\"null\", \"string\", \"int\"],\"name\":\"f1\","
       + " \"doc\":\"doc of f1\"}]}";
-  private final Schema schema7 = AvroUtils.parseSchema(schemaString7).schemaObj;
+  private final AvroSchema schema7 = AvroUtils.parseSchema(schemaString7);
 
   private final String schemaString8 = "{\"type\":\"record\","
       + "\"name\":\"myrecord\","
@@ -72,7 +74,7 @@ public class AvroCompatibilityTest {
       + "[{\"type\":\"string\",\"name\":\"f1\"},"
       + " {\"type\":\"string\",\"name\":\"f2\", \"default\": \"foo\"}]},"
       + " {\"type\":\"string\",\"name\":\"f3\", \"default\": \"bar\"}]}";
-  private final Schema schema8 = AvroUtils.parseSchema(schemaString8).schemaObj;
+  private final AvroSchema schema8 = AvroUtils.parseSchema(schemaString8);
 
   private final String badDefaultNullString = "{\"type\":\"record\","
       + "\"name\":\"myrecord\","
@@ -93,7 +95,7 @@ public class AvroCompatibilityTest {
    */
   @Test
   public void testBasicBackwardsCompatibility() {
-    AvroCompatibilityChecker checker = AvroCompatibilityChecker.BACKWARD_CHECKER;
+    CompatibilityChecker checker = CompatibilityChecker.BACKWARD_CHECKER;
     assertTrue("adding a field with default is a backward compatible change",
                checker.isCompatible(schema2, Collections.singletonList(schema1)));
     assertFalse("adding a field w/o default is not a backward compatible change",
@@ -120,7 +122,7 @@ public class AvroCompatibilityTest {
    */
   @Test
   public void testBasicBackwardsTransitiveCompatibility() {
-    AvroCompatibilityChecker checker = AvroCompatibilityChecker.BACKWARD_TRANSITIVE_CHECKER;
+    CompatibilityChecker checker = CompatibilityChecker.BACKWARD_TRANSITIVE_CHECKER;
     // All compatible
     assertTrue("iteratively adding fields with defaults is a compatible change",
         checker.isCompatible(schema8, Arrays.asList(schema1, schema2)));
@@ -140,7 +142,7 @@ public class AvroCompatibilityTest {
    */
   @Test
   public void testBasicForwardsCompatibility() {
-    AvroCompatibilityChecker checker = AvroCompatibilityChecker.FORWARD_CHECKER;
+    CompatibilityChecker checker = CompatibilityChecker.FORWARD_CHECKER;
     assertTrue("adding a field is a forward compatible change",
         checker.isCompatible(schema2, Collections.singletonList(schema1)));
     assertTrue("adding a field is a forward compatible change",
@@ -161,7 +163,7 @@ public class AvroCompatibilityTest {
    */
   @Test
   public void testBasicForwardsTransitiveCompatibility() {
-    AvroCompatibilityChecker checker = AvroCompatibilityChecker.FORWARD_TRANSITIVE_CHECKER;
+    CompatibilityChecker checker = CompatibilityChecker.FORWARD_TRANSITIVE_CHECKER;
     // All compatible
     assertTrue("iteratively removing fields with defaults is a compatible change",
         checker.isCompatible(schema1, Arrays.asList(schema8, schema2)));
@@ -180,7 +182,7 @@ public class AvroCompatibilityTest {
    */
   @Test
   public void testBasicFullCompatibility() {
-    AvroCompatibilityChecker checker = AvroCompatibilityChecker.FULL_CHECKER;
+    CompatibilityChecker checker = CompatibilityChecker.FULL_CHECKER;
     assertTrue("adding a field with default is a backward and a forward compatible change",
         checker.isCompatible(schema2, Collections.singletonList(schema1)));
     
@@ -198,7 +200,7 @@ public class AvroCompatibilityTest {
    */
   @Test
   public void testBasicFullTransitiveCompatibility() {
-    AvroCompatibilityChecker checker = AvroCompatibilityChecker.FULL_TRANSITIVE_CHECKER;
+    CompatibilityChecker checker = CompatibilityChecker.FULL_TRANSITIVE_CHECKER;
     
     // Simple check
     assertTrue("iteratively adding fields with defaults is a compatible change",

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiCompatibilityTest.java
@@ -15,7 +15,7 @@
 package io.confluent.kafka.schemaregistry.rest;
 
 import io.confluent.kafka.schemaregistry.ClusterTestHarness;
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
+import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.avro.AvroUtils;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestIncompatibleAvroSchemaException;
@@ -28,7 +28,7 @@ import static org.junit.Assert.fail;
 public class RestApiCompatibilityTest extends ClusterTestHarness {
 
   public RestApiCompatibilityTest() {
-    super(1, true, AvroCompatibilityLevel.BACKWARD.name);
+    super(1, true, CompatibilityLevel.BACKWARD.name);
   }
 
   @Test
@@ -36,25 +36,21 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     String subject = "testSubject";
 
     // register a valid avro
-    String schemaString1 = AvroUtils.parseSchema(
-        "{\"type\":\"record\","
+    String schemaString1 = AvroUtils.parseSchema("{\"type\":\"record\","
         + "\"name\":\"myrecord\","
         + "\"fields\":"
-        + "[{\"type\":\"string\",\"name\":\"f1\"}]}")
-        .canonicalString;
+        + "[{\"type\":\"string\",\"name\":\"f1\"}]}").canonicalString();
     int expectedIdSchema1 = 1;
     assertEquals("Registering should succeed",
             expectedIdSchema1,
             restApp.restClient.registerSchema(schemaString1, subject));
 
     // register an incompatible avro
-    String incompatibleSchemaString = AvroUtils.parseSchema(
-        "{\"type\":\"record\","
+    String incompatibleSchemaString = AvroUtils.parseSchema("{\"type\":\"record\","
         + "\"name\":\"myrecord\","
         + "\"fields\":"
         + "[{\"type\":\"string\",\"name\":\"f1\"},"
-        + " {\"type\":\"string\",\"name\":\"f2\"}]}"
-    ).canonicalString;
+        + " {\"type\":\"string\",\"name\":\"f2\"}]}").canonicalString();
     try {
       restApp.restClient.registerSchema(incompatibleSchemaString, subject);
       fail("Registering an incompatible schema should fail");
@@ -78,13 +74,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     }
 
     // register a backward compatible avro
-    String schemaString2 = AvroUtils.parseSchema(
-        "{\"type\":\"record\","
+    String schemaString2 = AvroUtils.parseSchema("{\"type\":\"record\","
         + "\"name\":\"myrecord\","
         + "\"fields\":"
         + "[{\"type\":\"string\",\"name\":\"f1\"},"
-        + " {\"type\":\"string\",\"name\":\"f2\", \"default\": \"foo\"}]}"
-    ).canonicalString;
+        + " {\"type\":\"string\",\"name\":\"f2\", \"default\": \"foo\"}]}").canonicalString();
     int expectedIdSchema2 = 2;
     assertEquals("Registering a compatible schema should succeed",
                  expectedIdSchema2,
@@ -96,25 +90,21 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     String subject = "testSubject";
 
     // register a valid avro
-    String schemaString1 = AvroUtils.parseSchema(
-        "{\"type\":\"record\","
+    String schemaString1 = AvroUtils.parseSchema("{\"type\":\"record\","
         + "\"name\":\"myrecord\","
         + "\"fields\":"
-        + "[{\"type\":\"string\",\"name\":\"f1\"}]}")
-        .canonicalString;
+        + "[{\"type\":\"string\",\"name\":\"f1\"}]}").canonicalString();
     int expectedIdSchema1 = 1;
     assertEquals("Registering should succeed",
             expectedIdSchema1,
             restApp.restClient.registerSchema(schemaString1, subject));
 
     // register an incompatible avro
-    String incompatibleSchemaString = AvroUtils.parseSchema(
-        "{\"type\":\"record\","
+    String incompatibleSchemaString = AvroUtils.parseSchema("{\"type\":\"record\","
         + "\"name\":\"myrecord\","
         + "\"fields\":"
         + "[{\"type\":\"string\",\"name\":\"f1\"},"
-        + " {\"type\":\"string\",\"name\":\"f2\"}]}"
-    ).canonicalString;
+        + " {\"type\":\"string\",\"name\":\"f2\"}]}").canonicalString();
     try {
       restApp.restClient.registerSchema(incompatibleSchemaString, subject);
       fail("Registering an incompatible schema should fail");
@@ -127,9 +117,9 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
 
     // change compatibility level to none and try again
     assertEquals("Changing compatibility level should succeed",
-            AvroCompatibilityLevel.NONE.name,
+            CompatibilityLevel.NONE.name,
             restApp.restClient
-                    .updateCompatibility(AvroCompatibilityLevel.NONE.name, null)
+                    .updateCompatibility(CompatibilityLevel.NONE.name, null)
                     .getCompatibilityLevel());
 
     try {
@@ -144,38 +134,36 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
   public void testCompatibilityLevelChangeToBackward() throws Exception {
     String subject = "testSubject";
 
-    String schemaString1 = AvroUtils.parseSchema(
-        "{\"type\":\"record\","
+    String schemaString1 = AvroUtils.parseSchema("{\"type\":\"record\","
         + "\"name\":\"myrecord\","
         + "\"fields\":"
-        + "[{\"type\":\"string\",\"name\":\"f1\"}]}").canonicalString;
+        + "[{\"type\":\"string\",\"name\":\"f1\"}]}").canonicalString();
     int expectedIdSchema1 = 1;
     assertEquals("Registering should succeed",
             expectedIdSchema1,
             restApp.restClient.registerSchema(schemaString1, subject));
     // verify that default compatibility level is backward
     assertEquals("Default compatibility level should be backward",
-            AvroCompatibilityLevel.BACKWARD.name,
+            CompatibilityLevel.BACKWARD.name,
             restApp.restClient.getConfig(null).getCompatibilityLevel());
     // change it to forward
     assertEquals("Changing compatibility level should succeed",
-            AvroCompatibilityLevel.FORWARD.name,
+            CompatibilityLevel.FORWARD.name,
             restApp.restClient
-                    .updateCompatibility(AvroCompatibilityLevel.FORWARD.name, null)
+                    .updateCompatibility(CompatibilityLevel.FORWARD.name, null)
                     .getCompatibilityLevel());
 
     // verify that new compatibility level is forward
     assertEquals("New compatibility level should be forward",
-            AvroCompatibilityLevel.FORWARD.name,
+            CompatibilityLevel.FORWARD.name,
             restApp.restClient.getConfig(null).getCompatibilityLevel());
 
     // register schema that is forward compatible with schemaString1
-    String schemaString2 = AvroUtils.parseSchema(
-        "{\"type\":\"record\","
+    String schemaString2 = AvroUtils.parseSchema("{\"type\":\"record\","
         + "\"name\":\"myrecord\","
         + "\"fields\":"
         + "[{\"type\":\"string\",\"name\":\"f1\"},"
-        + " {\"type\":\"string\",\"name\":\"f2\"}]}").canonicalString;
+        + " {\"type\":\"string\",\"name\":\"f2\"}]}").canonicalString();
     int expectedIdSchema2 = 2;
     assertEquals("Registering should succeed",
                  expectedIdSchema2,
@@ -183,23 +171,22 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
 
     // change compatibility to backward
     assertEquals("Changing compatibility level should succeed",
-            AvroCompatibilityLevel.BACKWARD.name,
-            restApp.restClient.updateCompatibility(AvroCompatibilityLevel.BACKWARD.name,
+            CompatibilityLevel.BACKWARD.name,
+            restApp.restClient.updateCompatibility(CompatibilityLevel.BACKWARD.name,
                     null).getCompatibilityLevel());
 
     // verify that new compatibility level is backward
     assertEquals("Updated compatibility level should be backward",
-            AvroCompatibilityLevel.BACKWARD.name,
+            CompatibilityLevel.BACKWARD.name,
             restApp.restClient.getConfig(null).getCompatibilityLevel());
 
             // register forward compatible schema, which should fail
-            String schemaString3 = AvroUtils.parseSchema(
-            "{\"type\":\"record\","
-                    + "\"name\":\"myrecord\","
-                    + "\"fields\":"
-                    + "[{\"type\":\"string\",\"name\":\"f1\"},"
-                    + " {\"type\":\"string\",\"name\":\"f2\"},"
-                    + " {\"type\":\"string\",\"name\":\"f3\"}]}").canonicalString;
+            String schemaString3 = AvroUtils.parseSchema("{\"type\":\"record\","
+                + "\"name\":\"myrecord\","
+                + "\"fields\":"
+                + "[{\"type\":\"string\",\"name\":\"f1\"},"
+                + " {\"type\":\"string\",\"name\":\"f2\"},"
+                + " {\"type\":\"string\",\"name\":\"f3\"}]}").canonicalString();
     try {
       restApp.restClient.registerSchema(schemaString3, subject);
       fail("Registering a forward compatible schema should fail");
@@ -211,13 +198,12 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     }
 
     // now try registering a backward compatible schema (add a field with a default)
-    String schemaString4 = AvroUtils.parseSchema(
-        "{\"type\":\"record\","
+    String schemaString4 = AvroUtils.parseSchema("{\"type\":\"record\","
         + "\"name\":\"myrecord\","
         + "\"fields\":"
         + "[{\"type\":\"string\",\"name\":\"f1\"},"
         + " {\"type\":\"string\",\"name\":\"f2\"},"
-        + " {\"type\":\"string\",\"name\":\"f3\", \"default\": \"foo\"}]}").canonicalString;
+        + " {\"type\":\"string\",\"name\":\"f3\", \"default\": \"foo\"}]}").canonicalString();
     int expectedIdSchema4 = 3;
     assertEquals("Registering should succeed with backwards compatible schema",
             expectedIdSchema4,

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiModeTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiModeTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 import java.util.Collections;
 
 import io.confluent.kafka.schemaregistry.ClusterTestHarness;
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
+import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.avro.AvroUtils;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestIncompatibleAvroSchemaException;
@@ -36,10 +36,10 @@ public class RestApiModeTest extends ClusterTestHarness {
           + "\"name\":\"myrecord\","
           + "\"fields\":"
           + "[{\"type\":\"string\",\"name\":\"f1\"}]}")
-      .canonicalString;
+      .canonicalString();
 
   public RestApiModeTest() {
-    super(1, true, AvroCompatibilityLevel.BACKWARD.name);
+    super(1, true, CompatibilityLevel.BACKWARD.name);
   }
 
   @Test

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiSslTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiSslTest.java
@@ -54,11 +54,10 @@ public class RestApiSslTest extends ClusterTestHarness {
     setupHostNameVerifier();
 
     String subject = "testSubject";
-    Schema schema = AvroUtils.parseSchema(
-        "{\"type\":\"record\","
+    Schema schema = AvroUtils.parseSchema("{\"type\":\"record\","
         + "\"name\":\"myrecord\","
         + "\"fields\":"
-        + "[{\"type\":\"string\",\"name\":\"f1\"}]}").schemaObj;
+        + "[{\"type\":\"string\",\"name\":\"f1\"}]}").rawSchema();
 
     int expectedIdSchema1 = 1;
 
@@ -108,7 +107,7 @@ public class RestApiSslTest extends ClusterTestHarness {
         "{\"type\":\"record\","
             + "\"name\":\"myrecord\","
             + "\"fields\":"
-            + "[{\"type\":\"string\",\"name\":\"f2\"}]}").schemaObj;
+            + "[{\"type\":\"string\",\"name\":\"f2\"}]}").rawSchema();
 
     int expectedIdSchema1 = 1;
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -15,7 +15,7 @@
 package io.confluent.kafka.schemaregistry.rest;
 
 import io.confluent.kafka.schemaregistry.ClusterTestHarness;
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
+import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.avro.AvroUtils;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
@@ -34,8 +34,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
-import static io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel.FORWARD;
-import static io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel.NONE;
+import static io.confluent.kafka.schemaregistry.CompatibilityLevel.FORWARD;
+import static io.confluent.kafka.schemaregistry.CompatibilityLevel.NONE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -169,18 +169,18 @@ public class RestApiTest extends ClusterTestHarness {
                            + "\"fields\":"
                            + "[{\"type\":\"string\",\"name\":"
                            + "\"f" + "\"}]}";
-    String schema1 = AvroUtils.parseSchema(schema1String).canonicalString;
+    String schema1 = AvroUtils.parseSchema(schema1String).canonicalString();
 
     String schema2String = "{\"type\":\"record\","
                            + "\"name\":\"myrecord\","
                            + "\"fields\":"
                            + "[{\"type\":\"int\",\"name\":"
                            + "\"f" + "\"}]}";
-    String schema2 = AvroUtils.parseSchema(schema2String).canonicalString;
+    String schema2 = AvroUtils.parseSchema(schema2String).canonicalString();
 
     // ensure registering incompatible schemas will raise an error
     restApp.restClient.updateCompatibility(
-        AvroCompatibilityLevel.FULL.name, subject);
+        CompatibilityLevel.FULL.name, subject);
 
     // test that compatibility check for incompatible schema returns false and the appropriate 
     // error response from Avro
@@ -204,18 +204,18 @@ public class RestApiTest extends ClusterTestHarness {
                            + "\"fields\":"
                            + "[{\"type\":\"string\",\"name\":"
                            + "\"f" + "\"}]}";
-    String schema1 = AvroUtils.parseSchema(schemaString1).canonicalString;
+    String schema1 = AvroUtils.parseSchema(schemaString1).canonicalString();
     String schemaString2 = "{\"type\":\"record\","
                            + "\"name\":\"myrecord\","
                            + "\"fields\":"
                            + "[{\"type\":\"int\",\"name\":"
                            + "\"foo" + "\"}]}";
-    String schema2 = AvroUtils.parseSchema(schemaString2).canonicalString;
+    String schema2 = AvroUtils.parseSchema(schemaString2).canonicalString();
 
     restApp.restClient.updateCompatibility(
-        AvroCompatibilityLevel.NONE.name, subject1);
+        CompatibilityLevel.NONE.name, subject1);
     restApp.restClient.updateCompatibility(
-        AvroCompatibilityLevel.NONE.name, subject2);
+        CompatibilityLevel.NONE.name, subject2);
 
     int idOfRegisteredSchema1Subject1 =
         restApp.restClient.registerSchema(schema1, subject1);
@@ -255,7 +255,7 @@ public class RestApiTest extends ClusterTestHarness {
                  restApp.restClient.getConfig(null).getCompatibilityLevel());
 
     // change it to forward
-    restApp.restClient.updateCompatibility(AvroCompatibilityLevel.FORWARD.name, null);
+    restApp.restClient.updateCompatibility(CompatibilityLevel.FORWARD.name, null);
 
     assertEquals("New compatibility level should be forward for this test instance",
                  FORWARD.name,
@@ -266,7 +266,7 @@ public class RestApiTest extends ClusterTestHarness {
   public void testNonExistentSubjectConfigChange() throws Exception {
     String subject = "testSubject";
     try {
-      restApp.restClient.updateCompatibility(AvroCompatibilityLevel.FORWARD.name, subject);
+      restApp.restClient.updateCompatibility(CompatibilityLevel.FORWARD.name, subject);
     } catch (RestClientException e) {
       fail("Changing config for an invalid subject should succeed");
     }
@@ -283,7 +283,7 @@ public class RestApiTest extends ClusterTestHarness {
                  restApp.restClient.getConfig(null).getCompatibilityLevel());
 
     // change subject compatibility to forward
-    restApp.restClient.updateCompatibility(AvroCompatibilityLevel.FORWARD.name, subject);
+    restApp.restClient.updateCompatibility(CompatibilityLevel.FORWARD.name, subject);
 
     assertEquals("Global compatibility level should remain none for this test instance",
                  NONE.name,
@@ -454,7 +454,7 @@ public class RestApiTest extends ClusterTestHarness {
     String subject = "test";
     List<String> schemas = TestUtils.getRandomCanonicalAvroString(2);
     TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(0), 1, subject);
-    restApp.restClient.updateCompatibility(AvroCompatibilityLevel.NONE.name, subject);
+    restApp.restClient.updateCompatibility(CompatibilityLevel.NONE.name, subject);
 
     try {
       restApp.restClient.lookUpSubjectVersion(schemas.get(1), subject);
@@ -733,7 +733,7 @@ public class RestApiTest extends ClusterTestHarness {
                            + "\"fields\":"
                            + "[{\"type\":\"string\",\"name\":"
                            + "\"f" + "\"}]}";
-    String schema1 = AvroUtils.parseSchema(schema1String).canonicalString;
+    String schema1 = AvroUtils.parseSchema(schema1String).canonicalString();
 
     String wrongSchema2String = "{\"type\":\"record\","
                                 + "\"name\":\"myrecord\","
@@ -743,7 +743,7 @@ public class RestApiTest extends ClusterTestHarness {
                                 + "{\"type\":\"string\",\"name\":"
                                 + "\"g\" , \"default\":\"d\"}"
                                 + "]}";
-    String wrongSchema2 = AvroUtils.parseSchema(wrongSchema2String).canonicalString;
+    String wrongSchema2 = AvroUtils.parseSchema(wrongSchema2String).canonicalString();
 
     String correctSchema2String = "{\"type\":\"record\","
                                   + "\"name\":\"myrecord\","
@@ -753,10 +753,10 @@ public class RestApiTest extends ClusterTestHarness {
                                   + "{\"type\":\"int\",\"name\":"
                                   + "\"g\" , \"default\":0}"
                                   + "]}";
-    String correctSchema2 = AvroUtils.parseSchema(correctSchema2String).canonicalString;
+    String correctSchema2 = AvroUtils.parseSchema(correctSchema2String).canonicalString();
     // ensure registering incompatible schemas will raise an error
     restApp.restClient.updateCompatibility(
-        AvroCompatibilityLevel.BACKWARD.name, subject);
+        CompatibilityLevel.BACKWARD.name, subject);
 
     // test that compatibility check for incompatible schema returns false and the appropriate
     // error response from Avro
@@ -801,7 +801,7 @@ public class RestApiTest extends ClusterTestHarness {
                            + "\"fields\":"
                            + "[{\"type\":\"string\",\"name\":"
                            + "\"f" + "\"}]}";
-    String schema1 = AvroUtils.parseSchema(schema1String).canonicalString;
+    String schema1 = AvroUtils.parseSchema(schema1String).canonicalString();
 
     String schema2String = "{\"type\":\"record\","
                            + "\"name\":\"myrecord\","
@@ -811,19 +811,19 @@ public class RestApiTest extends ClusterTestHarness {
                            + "{\"type\":\"string\",\"name\":"
                            + "\"g\" , \"default\":\"d\"}"
                            + "]}";
-    String schema2 = AvroUtils.parseSchema(schema2String).canonicalString;
+    String schema2 = AvroUtils.parseSchema(schema2String).canonicalString();
     restApp.restClient.updateCompatibility(
-        AvroCompatibilityLevel.FULL.name, null);
+        CompatibilityLevel.FULL.name, null);
     restApp.restClient.updateCompatibility(
-        AvroCompatibilityLevel.BACKWARD.name, subject);
+        CompatibilityLevel.BACKWARD.name, subject);
 
     restApp.restClient.registerSchema(schema1, subject);
     restApp.restClient.registerSchema(schema2, subject);
 
     restApp.restClient.deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject, "1");
-    assertEquals("Compatibility Level Exists", AvroCompatibilityLevel.BACKWARD.name, restApp
+    assertEquals("Compatibility Level Exists", CompatibilityLevel.BACKWARD.name, restApp
         .restClient.getConfig(subject).getCompatibilityLevel());
-    assertEquals("Top Compatibility Level Exists", AvroCompatibilityLevel.FULL.name, restApp
+    assertEquals("Top Compatibility Level Exists", CompatibilityLevel.FULL.name, restApp
         .restClient.getConfig(null).getCompatibilityLevel());
     restApp.restClient.deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject, "2");
     try {
@@ -832,7 +832,7 @@ public class RestApiTest extends ClusterTestHarness {
       assertEquals("Compatibility Level doesn't exist", Errors.SUBJECT_NOT_FOUND_ERROR_CODE, rce
           .getErrorCode());
     }
-    assertEquals("Top Compatibility Level Exists", AvroCompatibilityLevel.FULL.name, restApp
+    assertEquals("Top Compatibility Level Exists", CompatibilityLevel.FULL.name, restApp
         .restClient.getConfig(null).getCompatibilityLevel());
 
   }
@@ -888,7 +888,7 @@ public class RestApiTest extends ClusterTestHarness {
                            + "\"fields\":"
                            + "[{\"type\":\"string\",\"name\":"
                            + "\"f" + "\"}]}";
-    String schema1 = AvroUtils.parseSchema(schema1String).canonicalString;
+    String schema1 = AvroUtils.parseSchema(schema1String).canonicalString();
 
     String schema2String = "{\"type\":\"record\","
                            + "\"name\":\"myrecord\","
@@ -898,11 +898,11 @@ public class RestApiTest extends ClusterTestHarness {
                            + "{\"type\":\"string\",\"name\":"
                            + "\"g\" , \"default\":\"d\"}"
                            + "]}";
-    String schema2 = AvroUtils.parseSchema(schema2String).canonicalString;
+    String schema2 = AvroUtils.parseSchema(schema2String).canonicalString();
     restApp.restClient.updateCompatibility(
-        AvroCompatibilityLevel.FULL.name, null);
+        CompatibilityLevel.FULL.name, null);
     restApp.restClient.updateCompatibility(
-        AvroCompatibilityLevel.BACKWARD.name, subject);
+        CompatibilityLevel.BACKWARD.name, subject);
 
     restApp.restClient.registerSchema(schema1, subject);
     restApp.restClient.registerSchema(schema2, subject);
@@ -914,7 +914,7 @@ public class RestApiTest extends ClusterTestHarness {
       assertEquals("Compatibility Level doesn't exist", Errors.SUBJECT_NOT_FOUND_ERROR_CODE, rce
           .getErrorCode());
     }
-    assertEquals("Top Compatibility Level Exists", AvroCompatibilityLevel.FULL.name, restApp
+    assertEquals("Top Compatibility Level Exists", CompatibilityLevel.FULL.name, restApp
         .restClient.getConfig(null).getCompatibilityLevel());
 
   }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTransitiveCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTransitiveCompatibilityTest.java
@@ -15,7 +15,7 @@
 package io.confluent.kafka.schemaregistry.rest;
 
 import io.confluent.kafka.schemaregistry.ClusterTestHarness;
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
+import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.avro.AvroUtils;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestIncompatibleAvroSchemaException;
@@ -26,32 +26,26 @@ import static org.junit.Assert.fail;
 
 public class RestApiTransitiveCompatibilityTest extends ClusterTestHarness {
 
-  String baseSchema = AvroUtils.parseSchema(
-      "{\"type\":\"record\","
+  String baseSchema = AvroUtils.parseSchema("{\"type\":\"record\","
       + "\"name\":\"myrecord\","
       + "\"fields\":"
-      + "[{\"type\":\"string\",\"name\":\"f1\"}]}")
-      .canonicalString;
+      + "[{\"type\":\"string\",\"name\":\"f1\"}]}").canonicalString();
   
-  String baseSchemaWithColumnWithDefault = AvroUtils.parseSchema(
-      "{\"type\":\"record\","
+  String baseSchemaWithColumnWithDefault = AvroUtils.parseSchema("{\"type\":\"record\","
       + "\"name\":\"myrecord\","
       + "\"fields\":"
       + "[{\"type\":\"string\",\"name\":\"f1\"},"
-      + " {\"type\":\"string\",\"name\":\"f2\", \"default\": \"foo\"}]}"
-      ).canonicalString;
+      + " {\"type\":\"string\",\"name\":\"f2\", \"default\": \"foo\"}]}").canonicalString();
   
-  String baseSchemaWithColumnNoDefault = AvroUtils.parseSchema(
-      "{\"type\":\"record\","
+  String baseSchemaWithColumnNoDefault = AvroUtils.parseSchema("{\"type\":\"record\","
       + "\"name\":\"myrecord\","
       + "\"fields\":"
       + "[{\"type\":\"string\",\"name\":\"f1\"},"
-      + " {\"type\":\"string\",\"name\":\"f2\"}]}"
-  ).canonicalString;
+      + " {\"type\":\"string\",\"name\":\"f2\"}]}").canonicalString();
   
   
   public RestApiTransitiveCompatibilityTest() {
-    super(1, true, AvroCompatibilityLevel.BACKWARD_TRANSITIVE.name);
+    super(1, true, CompatibilityLevel.BACKWARD_TRANSITIVE.name);
   }
 
   /* Confirm that removing a default in from a column that was added earlier is not compatible. */

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryErrorHandlerTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryErrorHandlerTest.java
@@ -16,7 +16,7 @@
 package io.confluent.kafka.schemaregistry.rest;
 
 import io.confluent.kafka.schemaregistry.ClusterTestHarness;
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
+import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.avro.AvroUtils;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
@@ -48,12 +48,12 @@ public class SchemaRegistryErrorHandlerTest extends ClusterTestHarness {
       + "\"name\":\"myrecord\","
       + "\"fields\":"
       + "[{\"type\":\"string\",\"name\":\"f1\"}]}")
-      .canonicalString;
+      .canonicalString();
 
   private final String subject = "testSubject";
 
   public SchemaRegistryErrorHandlerTest() {
-    super(1, true, AvroCompatibilityLevel.BACKWARD.name);
+    super(1, true, CompatibilityLevel.BACKWARD.name);
   }
 
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryExtensionTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryExtensionTest.java
@@ -32,7 +32,7 @@ import javax.ws.rs.core.Configurable;
 import javax.ws.rs.core.Response;
 
 import io.confluent.kafka.schemaregistry.ClusterTestHarness;
-import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel;
+import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.avro.AvroUtils;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.rest.extensions.SchemaRegistryResourceExtension;
@@ -56,19 +56,17 @@ public class SchemaRegistryExtensionTest extends ClusterTestHarness {
   public String resourceExtensionConfigName;
 
   public SchemaRegistryExtensionTest() {
-    super(1, true, AvroCompatibilityLevel.BACKWARD.name);
+    super(1, true, CompatibilityLevel.BACKWARD.name);
   }
 
   @Test
   public void testAllowResource() throws Exception {
     String subject = "testSubject";
 
-    String schemaString1 = AvroUtils.parseSchema(
-        "{\"type\":\"record\","
+    String schemaString1 = AvroUtils.parseSchema("{\"type\":\"record\","
         + "\"name\":\"myrecord\","
         + "\"fields\":"
-        + "[{\"type\":\"string\",\"name\":\"f1\"}]}")
-        .canonicalString;
+        + "[{\"type\":\"string\",\"name\":\"f1\"}]}").canonicalString();
     int expectedIdSchema1 = 1;
     assertEquals(
         "Registering should succeed",

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
@@ -358,10 +358,10 @@ public class KafkaStoreTest extends ClusterTestHarness {
     kafkaStore.init();
     int id = 100;
     kafkaStore.put(new SchemaKey("subject", 1),
-        new SchemaValue("subject", 1, id, AvroSchema.AVRO, "schemaString", false)
+        new SchemaValue("subject", 1, id, "schemaString", false)
     );
     kafkaStore.put(new SchemaKey("subject2", 1),
-        new SchemaValue("subject2", 1, id, AvroSchema.AVRO, "schemaString2", false)
+        new SchemaValue("subject2", 1, id, "schemaString2", false)
     );
     int size = 0;
     for (Iterator<SchemaRegistryKey> iter = kafkaStore.getAllKeys(); iter.hasNext(); ) {
@@ -387,10 +387,10 @@ public class KafkaStoreTest extends ClusterTestHarness {
     kafkaStore.init();
     int id = 100;
     kafkaStore.put(new SchemaKey("subject", 1),
-        new SchemaValue("subject", 1, id, AvroSchema.AVRO, "schemaString", false)
+        new SchemaValue("subject", 1, id, "schemaString", false)
     );
     kafkaStore.put(new SchemaKey("subject2", 1),
-        new SchemaValue("subject2", 1, id, AvroSchema.AVRO, "schemaString", false)
+        new SchemaValue("subject2", 1, id, "schemaString", false)
     );
     int size = 0;
     for (Iterator<SchemaRegistryKey> iter = kafkaStore.getAllKeys(); iter.hasNext(); ) {
@@ -407,11 +407,11 @@ public class KafkaStoreTest extends ClusterTestHarness {
     int id = 100;
     SchemaKey schemaKey = new SchemaKey("subject", 1);
     SchemaValue schemaValue =
-        new SchemaValue("subject", 1, id, AvroSchema.AVRO, "schemaString", false);
+        new SchemaValue("subject", 1, id, "schemaString", false);
 
     SchemaKey schemaKey2 = new SchemaKey("subject2", 1);
     SchemaValue schemaValue2 =
-        new SchemaValue("subject2", 1, id, AvroSchema.AVRO, "schemaString", false);
+        new SchemaValue("subject2", 1, id, "schemaString", false);
 
     inMemoryStore.put(schemaKey, schemaValue);
     inMemoryStore.schemaRegistered(schemaKey, schemaValue);
@@ -438,7 +438,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
     int id = 100;
     SchemaKey schemaKey = new SchemaKey("subject", 1);
     SchemaValue schemaValue =
-        new SchemaValue("subject", 1, id, AvroSchema.AVRO, "schemaString", true);
+        new SchemaValue("subject", 1, id, "schemaString", true);
 
     // After a compaction, the schema will not be registered but only deleted
     inMemoryStore.put(schemaKey, schemaValue);

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
@@ -14,6 +14,7 @@
  */
 package io.confluent.kafka.schemaregistry.storage;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.id.IncrementalIdGenerator;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -357,10 +358,10 @@ public class KafkaStoreTest extends ClusterTestHarness {
     kafkaStore.init();
     int id = 100;
     kafkaStore.put(new SchemaKey("subject", 1),
-        new SchemaValue("subject", 1, id, "schemaString", false)
+        new SchemaValue("subject", 1, id, AvroSchema.AVRO, "schemaString", false)
     );
     kafkaStore.put(new SchemaKey("subject2", 1),
-        new SchemaValue("subject2", 1, id, "schemaString2", false)
+        new SchemaValue("subject2", 1, id, AvroSchema.AVRO, "schemaString2", false)
     );
     int size = 0;
     for (Iterator<SchemaRegistryKey> iter = kafkaStore.getAllKeys(); iter.hasNext(); ) {
@@ -386,10 +387,10 @@ public class KafkaStoreTest extends ClusterTestHarness {
     kafkaStore.init();
     int id = 100;
     kafkaStore.put(new SchemaKey("subject", 1),
-        new SchemaValue("subject", 1, id, "schemaString", false)
+        new SchemaValue("subject", 1, id, AvroSchema.AVRO, "schemaString", false)
     );
     kafkaStore.put(new SchemaKey("subject2", 1),
-        new SchemaValue("subject2", 1, id, "schemaString", false)
+        new SchemaValue("subject2", 1, id, AvroSchema.AVRO, "schemaString", false)
     );
     int size = 0;
     for (Iterator<SchemaRegistryKey> iter = kafkaStore.getAllKeys(); iter.hasNext(); ) {
@@ -405,10 +406,12 @@ public class KafkaStoreTest extends ClusterTestHarness {
 
     int id = 100;
     SchemaKey schemaKey = new SchemaKey("subject", 1);
-    SchemaValue schemaValue = new SchemaValue("subject", 1, id, "schemaString", false);
+    SchemaValue schemaValue =
+        new SchemaValue("subject", 1, id, AvroSchema.AVRO, "schemaString", false);
 
     SchemaKey schemaKey2 = new SchemaKey("subject2", 1);
-    SchemaValue schemaValue2 = new SchemaValue("subject2", 1, id, "schemaString", false);
+    SchemaValue schemaValue2 =
+        new SchemaValue("subject2", 1, id, AvroSchema.AVRO, "schemaString", false);
 
     inMemoryStore.put(schemaKey, schemaValue);
     inMemoryStore.schemaRegistered(schemaKey, schemaValue);
@@ -434,7 +437,8 @@ public class KafkaStoreTest extends ClusterTestHarness {
 
     int id = 100;
     SchemaKey schemaKey = new SchemaKey("subject", 1);
-    SchemaValue schemaValue = new SchemaValue("subject", 1, id, "schemaString", true);
+    SchemaValue schemaValue =
+        new SchemaValue("subject", 1, id, AvroSchema.AVRO, "schemaString", true);
 
     // After a compaction, the schema will not be registered but only deleted
     inMemoryStore.put(schemaKey, schemaValue);

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/utils/TestUtils.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/utils/TestUtils.java
@@ -128,7 +128,7 @@ public class TestUtils {
                             + "\"fields\":"
                             + "[{\"type\":\"string\",\"name\":"
                             + "\"f" + random.nextInt(Integer.MAX_VALUE) + "\"}]}";
-      avroStrings.add(AvroUtils.parseSchema(schemaString).canonicalString);
+      avroStrings.add(AvroUtils.parseSchema(schemaString).canonicalString());
     }
     return avroStrings;
   }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/utils/TestUtils.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/utils/TestUtils.java
@@ -14,6 +14,10 @@
  */
 package io.confluent.kafka.schemaregistry.utils;
 
+import org.apache.avro.Protocol;
+import org.apache.avro.Schema;
+import org.apache.avro.Schemas;
+
 import io.confluent.kafka.schemaregistry.avro.AvroUtils;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
@@ -131,5 +135,22 @@ public class TestUtils {
       avroStrings.add(AvroUtils.parseSchema(schemaString).canonicalString());
     }
     return avroStrings;
+  }
+
+  public static List<String> getAvroSchemaWithReferences() {
+    List<String> schemas = new ArrayList<>();
+    String reference = "{\"type\":\"record\","
+        + "\"name\":\"subrecord\","
+        + "\"namespace\":\"otherns\","
+        + "\"fields\":"
+        + "[{\"name\":\"field2\",\"type\":\"string\"}]}";
+    schemas.add(reference);
+    String schemaString = "{\"type\":\"record\","
+        + "\"name\":\"myrecord\","
+        + "\"namespace\":\"ns\","
+        + "\"fields\":"
+        + "[{\"name\":\"field1\",\"type\":\"otherns.subrecord\"}]}";
+    schemas.add(schemaString);
+    return schemas;
   }
 }

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -49,7 +49,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.6.0</version>
                 <configuration>
                     <goalPrefix>schema-registry</goalPrefix>
                 </configuration>

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/DownloadSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/DownloadSchemaRegistryMojo.java
@@ -16,11 +16,11 @@
 
 package io.confluent.kafka.schemaregistry.maven;
 
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 
-import org.apache.avro.Schema;
-import org.apache.avro.SchemaParseException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -37,6 +37,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -46,34 +47,40 @@ public class DownloadSchemaRegistryMojo extends SchemaRegistryMojo {
 
   @Parameter(required = false, defaultValue = ".avsc")
   String schemaExtension;
+
   @Parameter(required = true)
   List<String> subjectPatterns = new ArrayList<>();
+
   @Parameter(required = true)
   File outputDirectory;
 
-
-  @Parameter(required = false, defaultValue = "true")
-  boolean prettyPrintSchemas;
-
-  Map<String, Schema> downloadSchemas(Collection<String> subjects) throws MojoExecutionException {
-    Map<String, Schema> results = new LinkedHashMap<>();
+  Map<String, ParsedSchema> downloadSchemas(Collection<String> subjects)
+      throws MojoExecutionException {
+    Map<String, ParsedSchema> results = new LinkedHashMap<>();
 
     for (String subject : subjects) {
-      Schema.Parser parser = new Schema.Parser();
       SchemaMetadata schemaMetadata;
       try {
         getLog().info(String.format("Downloading latest metadata for %s.", subject));
         schemaMetadata = this.client().getLatestSchemaMetadata(subject);
-        Schema schema = parser.parse(schemaMetadata.getSchema());
-        results.put(subject, schema);
+        SchemaProvider schemaProvider =
+            client().getSchemaProviders().get(schemaMetadata.getSchemaType());
+        if (schemaProvider == null) {
+          throw new MojoExecutionException(
+              String.format("Invalid schema type %s", schemaMetadata.getSchemaType())
+          );
+        }
+        Optional<ParsedSchema> schema = schemaProvider.parseSchema(schemaMetadata.getSchema());
+        if (schema.isPresent()) {
+          results.put(subject, schema.get());
+        } else {
+          throw new MojoExecutionException(
+              String.format("Error while parsing schema for %s", subject)
+          );
+        }
       } catch (RestClientException | IOException ex) {
         throw new MojoExecutionException(
             String.format("Exception thrown while downloading metadata for %s.", subject),
-            ex
-        );
-      } catch (SchemaParseException ex) {
-        throw new MojoExecutionException(
-            String.format("Exception thrown while parsing avro schema for %s.", subject),
             ex
         );
       }
@@ -144,9 +151,9 @@ public class DownloadSchemaRegistryMojo extends SchemaRegistryMojo {
       }
     }
 
-    Map<String, Schema> subjectToSchema = downloadSchemas(subjectsToDownload);
+    Map<String, ParsedSchema> subjectToSchema = downloadSchemas(subjectsToDownload);
 
-    for (Map.Entry<String, Schema> kvp : subjectToSchema.entrySet()) {
+    for (Map.Entry<String, ParsedSchema> kvp : subjectToSchema.entrySet()) {
       String fileName = String.format("%s%s", kvp.getKey(), this.schemaExtension);
       File outputFile = new File(this.outputDirectory, fileName);
 
@@ -157,7 +164,7 @@ public class DownloadSchemaRegistryMojo extends SchemaRegistryMojo {
       try (OutputStreamWriter writer = new OutputStreamWriter(
           new FileOutputStream(outputFile), StandardCharsets.UTF_8)
       ) {
-        writer.write(kvp.getValue().toString(this.prettyPrintSchemas));
+        writer.write(kvp.getValue().toString());
       } catch (IOException ex) {
         throw new MojoExecutionException(
             String.format("Exception thrown while writing subject('%s') schema to %s", kvp.getKey(),

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/DownloadSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/DownloadSchemaRegistryMojo.java
@@ -17,7 +17,6 @@
 package io.confluent.kafka.schemaregistry.maven;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
-import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 
@@ -63,14 +62,11 @@ public class DownloadSchemaRegistryMojo extends SchemaRegistryMojo {
       try {
         getLog().info(String.format("Downloading latest metadata for %s.", subject));
         schemaMetadata = this.client().getLatestSchemaMetadata(subject);
-        SchemaProvider schemaProvider =
-            client().getSchemaProviders().get(schemaMetadata.getSchemaType());
-        if (schemaProvider == null) {
-          throw new MojoExecutionException(
-              String.format("Invalid schema type %s", schemaMetadata.getSchemaType())
-          );
-        }
-        Optional<ParsedSchema> schema = schemaProvider.parseSchema(schemaMetadata.getSchema());
+        Optional<ParsedSchema> schema =
+            this.client().parseSchema(
+                schemaMetadata.getSchemaType(),
+                schemaMetadata.getSchema(),
+                schemaMetadata.getReferences());
         if (schema.isPresent()) {
           results.put(subject, schema.get());
         } else {

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/RegisterSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/RegisterSchemaRegistryMojo.java
@@ -16,78 +16,39 @@
 
 package io.confluent.kafka.schemaregistry.maven;
 
-import com.google.inject.internal.util.Preconditions;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 
-import org.apache.avro.Schema;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 
-import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 @Mojo(name = "register")
-public class RegisterSchemaRegistryMojo extends SchemaRegistryMojo {
-
-  @Parameter(required = true)
-  Map<String, File> subjects = new HashMap<>();
-
-  Map<String, Integer> schemaVersions;
-
-  @Parameter(required = false)
-  List<String> imports;
+public class RegisterSchemaRegistryMojo extends UploadSchemaRegistryMojo {
 
   @Override
-  public void execute() throws MojoExecutionException, MojoFailureException {
-    Map<String, ParsedSchema> subjectToSchemaLookup = loadSchemas(this.subjects);
-    this.schemaVersions = new LinkedHashMap<>();
+  protected boolean processSchema(String subject,
+                                  ParsedSchema schema,
+                                  Map<String, Integer> schemaVersions)
+      throws IOException, RestClientException {
 
-    int errors = 0;
-    for (Map.Entry<String, ParsedSchema> kvp : subjectToSchemaLookup.entrySet()) {
-      try {
-        if (getLog().isDebugEnabled()) {
-          getLog().debug(
-              String.format("Calling register('%s', '%s')", kvp.getKey(),
-                            kvp.getValue().toString())
-          );
-        }
-
-        Integer id = this.client().register(kvp.getKey(), kvp.getValue());
-        Integer version = this.client().getVersion(kvp.getKey(), kvp.getValue());
-        getLog().info(
-            String.format(
-                "Registered subject(%s) with id %s version %s",
-                kvp.getKey(),
-                id,
-                version
-            ));
-        this.schemaVersions.put(kvp.getKey(), version);
-      } catch (IOException | RestClientException e) {
-        errors++;
-        getLog().error(
-            String.format("Exception thrown while registering subject(%s)", kvp.getKey()),
-            e
-        );
-      }
+    if (getLog().isDebugEnabled()) {
+      getLog().debug(
+          String.format("Calling register('%s', '%s')", subject, schema)
+      );
     }
 
-    Preconditions.checkState(errors == 0,
-                             "One or more exceptions were encountered while registering the "
-                             + "schemas.");
-  }
-
-  @Override
-  protected Schema.Parser newParser() {
-    if (imports == null || imports.isEmpty()) {
-      return super.newParser();
-    }
-    return parserWithDependencies(imports);
+    Integer id = this.client().register(subject, schema);
+    Integer version = this.client().getVersion(subject, schema);
+    getLog().info(
+        String.format(
+            "Registered subject(%s) with id %s version %s",
+            subject,
+            id,
+            version
+        ));
+    schemaVersions.put(subject, version);
+    return true;
   }
 }

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/RegisterSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/RegisterSchemaRegistryMojo.java
@@ -17,7 +17,9 @@
 package io.confluent.kafka.schemaregistry.maven;
 
 import com.google.inject.internal.util.Preconditions;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+
 import org.apache.avro.Schema;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -44,16 +46,16 @@ public class RegisterSchemaRegistryMojo extends SchemaRegistryMojo {
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
-    Map<String, Schema> subjectToSchemaLookup = loadSchemas(this.subjects);
+    Map<String, ParsedSchema> subjectToSchemaLookup = loadSchemas(this.subjects);
     this.schemaVersions = new LinkedHashMap<>();
 
     int errors = 0;
-    for (Map.Entry<String, Schema> kvp : subjectToSchemaLookup.entrySet()) {
+    for (Map.Entry<String, ParsedSchema> kvp : subjectToSchemaLookup.entrySet()) {
       try {
         if (getLog().isDebugEnabled()) {
           getLog().debug(
               String.format("Calling register('%s', '%s')", kvp.getKey(),
-                            kvp.getValue().toString(true))
+                            kvp.getValue().toString())
           );
         }
 

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
@@ -16,6 +16,8 @@
 
 package io.confluent.kafka.schemaregistry.maven;
 
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
@@ -59,9 +61,9 @@ public abstract class SchemaRegistryMojo extends AbstractMojo {
     return this.client;
   }
 
-  protected Map<String, Schema> loadSchemas(Map<String, File> subjects) {
+  protected Map<String, ParsedSchema> loadSchemas(Map<String, File> subjects) {
     int errorCount = 0;
-    Map<String, Schema> results = new LinkedHashMap<>();
+    Map<String, ParsedSchema> results = new LinkedHashMap<>();
 
     for (Map.Entry<String, File> kvp : subjects.entrySet()) {
       Schema.Parser parser = newParser();
@@ -75,7 +77,7 @@ public abstract class SchemaRegistryMojo extends AbstractMojo {
 
       try (FileInputStream inputStream = new FileInputStream(kvp.getValue())) {
         Schema schema = parser.parse(inputStream);
-        results.put(kvp.getKey(), schema);
+        results.put(kvp.getKey(), new AvroSchema(schema));
       } catch (IOException ex) {
         getLog().error("Exception thrown while loading " + kvp.getValue(), ex);
         errorCount++;

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
@@ -16,32 +16,35 @@
 
 package io.confluent.kafka.schemaregistry.maven;
 
-import io.confluent.kafka.schemaregistry.ParsedSchema;
-import io.confluent.kafka.schemaregistry.avro.AvroSchema;
-import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
-
-import org.apache.avro.Schema;
-import org.apache.avro.SchemaParseException;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.util.LinkedHashMap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
+import java.util.stream.Collectors;
+
+import io.confluent.kafka.schemaregistry.SchemaProvider;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
 
 public abstract class SchemaRegistryMojo extends AbstractMojo {
 
   @Parameter(required = true)
   List<String> schemaRegistryUrls;
+
   @Parameter
   String userInfoConfig;
-  private SchemaRegistryClient client;
+
+  @Parameter(required = false)
+  List<String> schemaProviders = new ArrayList<>();
+
+  protected SchemaRegistryClient client;
 
   void client(SchemaRegistryClient client) {
     this.client = client;
@@ -56,65 +59,25 @@ public abstract class SchemaRegistryMojo extends AbstractMojo {
         config.put(SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO");
         config.put(SchemaRegistryClientConfig.USER_INFO_CONFIG, userInfoConfig);
       }
-      this.client = new CachedSchemaRegistryClient(this.schemaRegistryUrls, 1000, config);
+      List<SchemaProvider> providers = schemaProviders != null && !schemaProviders.isEmpty()
+                                       ? schemaProviders()
+                                       : Collections.singletonList(new AvroSchemaProvider());
+      this.client = new CachedSchemaRegistryClient(this.schemaRegistryUrls,
+          1000,
+          providers,
+          config
+      );
     }
     return this.client;
   }
 
-  protected Map<String, ParsedSchema> loadSchemas(Map<String, File> subjects) {
-    int errorCount = 0;
-    Map<String, ParsedSchema> results = new LinkedHashMap<>();
-
-    for (Map.Entry<String, File> kvp : subjects.entrySet()) {
-      Schema.Parser parser = newParser();
-      getLog().debug(
-          String.format(
-              "Loading schema for subject(%s) from %s.",
-              kvp.getKey(),
-              kvp.getValue()
-          )
-      );
-
-      try (FileInputStream inputStream = new FileInputStream(kvp.getValue())) {
-        Schema schema = parser.parse(inputStream);
-        results.put(kvp.getKey(), new AvroSchema(schema));
-      } catch (IOException ex) {
-        getLog().error("Exception thrown while loading " + kvp.getValue(), ex);
-        errorCount++;
-      } catch (SchemaParseException ex) {
-        getLog().error("Exception thrown while parsing " + kvp.getValue(), ex);
-        errorCount++;
+  private List<SchemaProvider> schemaProviders() {
+    return schemaProviders.stream().map(s -> {
+      try {
+        return Utils.newInstance(s, SchemaProvider.class);
+      } catch (ClassNotFoundException e) {
+        throw new RuntimeException(e);
       }
-    }
-
-    if (errorCount > 0) {
-      throw new IllegalStateException("One or more schemas could not be loaded.");
-    }
-
-    return results;
+    }).collect(Collectors.toList());
   }
-
-  protected Schema.Parser newParser() {
-    return new Schema.Parser();
-  }
-
-  Schema.Parser parserWithDependencies(List<String> dependencies) {
-    Schema.Parser parserWithDepencies = new Schema.Parser();
-
-    for (String dependency : dependencies) {
-      try (FileInputStream inputStream = new FileInputStream(dependency)) {
-        parserWithDepencies.parse(inputStream);
-        getLog().debug(String.format("Parsing imports:%s", dependency));
-      } catch (IOException ex) {
-        getLog().error("Exception thrown while loading dependency " + dependency, ex);
-      } catch (SchemaParseException ex) {
-        getLog().error("Exception thrown while parsing dependency " + dependency, ex);
-      }
-    }
-
-    return parserWithDepencies;
-  }
-
-
-
 }

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/TestCompatibilitySchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/TestCompatibilitySchemaRegistryMojo.java
@@ -17,6 +17,7 @@
 package io.confluent.kafka.schemaregistry.maven;
 
 import com.google.inject.internal.util.Preconditions;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import org.apache.avro.Schema;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -44,19 +45,19 @@ public class TestCompatibilitySchemaRegistryMojo extends SchemaRegistryMojo {
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
-    Map<String, Schema> subjectToSchemaLookup = loadSchemas(this.subjects);
+    Map<String, ParsedSchema> subjectToSchemaLookup = loadSchemas(this.subjects);
     this.schemaCompatibility = new LinkedHashMap<>();
 
     int errorCount = 0;
 
-    for (Map.Entry<String, Schema> kvp : subjectToSchemaLookup.entrySet()) {
+    for (Map.Entry<String, ParsedSchema> kvp : subjectToSchemaLookup.entrySet()) {
       try {
         File schemaPath = this.subjects.get(kvp.getKey());
 
         if (getLog().isDebugEnabled()) {
           getLog().debug(
               String.format("Calling register('%s', '%s')", kvp.getKey(),
-                            kvp.getValue().toString(true))
+                            kvp.getValue().toString())
           );
         }
 

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/TestCompatibilitySchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/TestCompatibilitySchemaRegistryMojo.java
@@ -16,91 +16,60 @@
 
 package io.confluent.kafka.schemaregistry.maven;
 
-import com.google.inject.internal.util.Preconditions;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-import org.apache.avro.Schema;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 @Mojo(name = "test-compatibility")
-public class TestCompatibilitySchemaRegistryMojo extends SchemaRegistryMojo {
+public class TestCompatibilitySchemaRegistryMojo extends UploadSchemaRegistryMojo {
 
-  @Parameter(required = true)
-  Map<String, File> subjects = new HashMap<>();
-
-  Map<String, Boolean> schemaCompatibility;
-
-  @Parameter(required = false)
-  List<String> imports;
+  Map<String, Boolean> schemaCompatibility = new HashMap<>();
 
   @Override
-  public void execute() throws MojoExecutionException, MojoFailureException {
-    Map<String, ParsedSchema> subjectToSchemaLookup = loadSchemas(this.subjects);
-    this.schemaCompatibility = new LinkedHashMap<>();
+  protected boolean processSchema(String subject,
+                                  ParsedSchema schema,
+                                  Map<String, Integer> schemaVersions)
+      throws IOException, RestClientException {
 
-    int errorCount = 0;
+    File schemaPath = this.subjects.get(subject);
 
-    for (Map.Entry<String, ParsedSchema> kvp : subjectToSchemaLookup.entrySet()) {
-      try {
-        File schemaPath = this.subjects.get(kvp.getKey());
-
-        if (getLog().isDebugEnabled()) {
-          getLog().debug(
-              String.format("Calling register('%s', '%s')", kvp.getKey(),
-                            kvp.getValue().toString())
-          );
-        }
-
-        boolean compatible = this.client().testCompatibility(kvp.getKey(), kvp.getValue());
-
-        if (compatible) {
-          getLog().info(
-              String.format(
-                  "Schema %s is compatible with subject(%s)",
-                  schemaPath,
-                  kvp.getKey()
-              )
-          );
-        } else {
-          getLog().error(
-              String.format(
-                  "Schema %s is not compatible with subject(%s)",
-                  schemaPath,
-                  kvp.getKey()
-              )
-          );
-          errorCount++;
-        }
-
-        this.schemaCompatibility.put(kvp.getKey(), compatible);
-      } catch (IOException | RestClientException e) {
-        getLog().error(
-            String.format("Exception thrown while registering subject(%s)", kvp.getKey()),
-            e
-        );
-      }
+    if (getLog().isDebugEnabled()) {
+      getLog().debug(
+          String.format("Calling testCompatibility('%s', '%s')", subject, schema)
+      );
     }
 
-    Preconditions.checkState(errorCount == 0,
-                             "One or more schema was found to be incompatible with the current "
-                             + "version.");
+    boolean compatible = this.client().testCompatibility(subject, schema);
+
+    if (compatible) {
+      getLog().info(
+          String.format(
+              "Schema %s is compatible with subject(%s)",
+              schemaPath,
+              subject
+          )
+      );
+    } else {
+      getLog().error(
+          String.format(
+              "Schema %s is not compatible with subject(%s)",
+              schemaPath,
+              subject
+          )
+      );
+    }
+
+    this.schemaCompatibility.put(subject, compatible);
+    return compatible;
   }
 
   @Override
-  protected Schema.Parser newParser() {
-    if (imports == null || imports.isEmpty()) {
-      return super.newParser();
-    }
-    return parserWithDependencies(imports);
+  protected String failureMessage() {
+    return "One or more schemas found to be incompatible with the current version.";
   }
 }

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/UploadSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/UploadSchemaRegistryMojo.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.maven;
+
+import com.google.common.base.Preconditions;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.SchemaProvider;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+
+public abstract class UploadSchemaRegistryMojo extends SchemaRegistryMojo {
+
+  @Parameter(required = true)
+  Map<String, File> subjects = new HashMap<>();
+
+  @Parameter(required = false)
+  Map<String, String> schemaTypes = new HashMap<>();
+
+  @Parameter(required = false)
+  Map<String, List<Reference>> references = new HashMap<>();
+
+  Map<String, ParsedSchema> schemas = new HashMap<>();
+  Map<String, Integer> schemaVersions = new HashMap<>();
+
+  @Override
+  public void execute() throws MojoExecutionException, MojoFailureException {
+    int errors = 0;
+    int failures = 0;
+
+    for (Map.Entry<String, File> kvp : subjects.entrySet()) {
+      getLog().debug(
+          String.format(
+              "Loading schema for subject(%s) from %s.",
+              kvp.getKey(),
+              kvp.getValue()
+          )
+      );
+
+      String schemaType = schemaTypes.getOrDefault(kvp.getKey(), AvroSchema.TYPE);
+      SchemaProvider schemaProvider = client().getSchemaProviders().get(schemaType);
+      if (schemaProvider == null) {
+        getLog().error("Invalid schema type " + schemaType);
+        errors++;
+        continue;
+      }
+      try {
+        List<SchemaReference> schemaReferences = getReferences(kvp.getKey(), schemaVersions);
+        String schemaString = readFile(kvp.getValue(), StandardCharsets.UTF_8);
+        Optional<ParsedSchema> schema = schemaProvider.parseSchema(schemaString, schemaReferences);
+        if (!schema.isPresent()) {
+          throw new IllegalStateException("Schema for " + kvp.getKey() + " could not be loaded.");
+        } else {
+          schemas.put(kvp.getKey(), schema.get());
+        }
+
+        boolean success = processSchema(kvp.getKey(), schema.get(), schemaVersions);
+        if (!success) {
+          failures++;
+        }
+      } catch (IOException | RestClientException ex) {
+        getLog().error("Exception thrown while processing " + kvp.getKey(), ex);
+        errors++;
+      } catch (IllegalArgumentException ex) {
+        getLog().error("Exception thrown while retrieving reference " + kvp.getValue(), ex);
+        errors++;
+      }
+    }
+
+    Preconditions.checkState(errors == 0, "One or more exceptions were encountered.");
+    Preconditions.checkState(failures == 0, failureMessage());
+  }
+
+  protected abstract boolean processSchema(String subject,
+                                           ParsedSchema schema,
+                                           Map<String, Integer> schemaVersions)
+      throws IOException, RestClientException;
+
+
+  protected String failureMessage() {
+    return "Failed to process one or more schemas.";
+  }
+
+  private List<SchemaReference> getReferences(String subject, Map<String, Integer> schemaVersions) {
+    List<Reference> refs = references.getOrDefault(subject, Collections.emptyList());
+    List<SchemaReference> result = new ArrayList<>();
+    for (Reference ref : refs) {
+      Integer version = ref.version != null ? ref.version : schemaVersions.get(ref.subject);
+      if (version == null) {
+        throw new IllegalArgumentException("Could not retrieve version for subject " + ref.subject);
+      }
+      result.add(new SchemaReference(ref.name, ref.subject, version));
+    }
+    return result;
+  }
+
+  private static String readFile(File file, Charset encoding) throws IOException {
+    byte[] encoded = Files.readAllBytes(file.toPath());
+    return new String(encoded, encoding);
+  }
+
+  public static class Reference {
+
+    public Reference(String name, String subject, Integer version) {
+      this.name = name;
+      this.subject = subject;
+      this.version = version;
+    }
+
+    @Parameter(required = true)
+    private String name;
+
+    @Parameter(required = true)
+    private String subject;
+
+    @Parameter(required = false)
+    private Integer version;
+
+    @Override
+    public String toString() {
+      return "SchemaReference{"
+          + "name='"
+          + name
+          + '\''
+          + ", subject='"
+          + subject
+          + '\''
+          + ", version="
+          + version
+          + '}';
+    }
+  }
+}

--- a/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/DownloadSchemaRegistryMojoTest.java
+++ b/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/DownloadSchemaRegistryMojoTest.java
@@ -15,6 +15,7 @@
  */
 package io.confluent.kafka.schemaregistry.maven;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import org.apache.avro.Schema;
@@ -48,8 +49,8 @@ public class DownloadSchemaRegistryMojoTest extends SchemaRegistryTest {
       String valueSubject = String.format("TestSubject%03d-value", i);
       Schema keySchema = Schema.create(Schema.Type.STRING);
       Schema valueSchema = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.STRING), Schema.create(Schema.Type.NULL)));
-      this.mojo.client().register(keySubject, keySchema);
-      this.mojo.client().register(valueSubject, valueSchema);
+      this.mojo.client().register(keySubject, new AvroSchema(keySchema));
+      this.mojo.client().register(valueSubject, new AvroSchema(valueSchema));
       File keySchemaFile = new File(this.tempDirectory, keySubject + ".avsc");
       File valueSchemaFile = new File(this.tempDirectory, valueSubject + ".avsc");
 

--- a/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/SchemasWithDependenciesTest.java
+++ b/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/SchemasWithDependenciesTest.java
@@ -14,6 +14,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+
 public class SchemasWithDependenciesTest extends SchemaRegistryTest {
 
     private final String dependency = "{\n" +
@@ -75,8 +78,8 @@ public class SchemasWithDependenciesTest extends SchemaRegistryTest {
         Map<String,File> schemas = new HashMap<>();
         schemas.put("Pizza", pizzaFile);
 
-        Map<String, Schema> parsedSchemas = schemaRegistryMojo.loadSchemas(schemas);
-        Schema pizza = parsedSchemas.get("Pizza");
+        Map<String, ParsedSchema> parsedSchemas = schemaRegistryMojo.loadSchemas(schemas);
+        Schema pizza = ((AvroSchema) parsedSchemas.get("Pizza")).schemaObj;
 
         Assert.assertNotNull("The schema should've been generated", pizza);
         Assert.assertTrue("The schema should contain fields from the dependency", pizza.toString().contains("currency"));
@@ -110,8 +113,8 @@ public class SchemasWithDependenciesTest extends SchemaRegistryTest {
         Map<String,File> schemas = new HashMap<>();
         schemas.put("Pizza", pizzaFile);
 
-        Map<String, Schema> parsedSchemas = schemaRegistryMojo.loadSchemas(schemas);
-        Schema pizza = parsedSchemas.get("Pizza");
+        Map<String, ParsedSchema> parsedSchemas = schemaRegistryMojo.loadSchemas(schemas);
+        Schema pizza = ((AvroSchema) parsedSchemas.get("Pizza")).schemaObj;
 
         Assert.assertNotNull("The schema should've been generated", pizza);
         Assert.assertTrue("The schema should contain fields from the dependency", pizza.toString().contains("currency"));

--- a/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/SchemasWithDependenciesTest.java
+++ b/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/SchemasWithDependenciesTest.java
@@ -11,7 +11,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
@@ -79,7 +78,7 @@ public class SchemasWithDependenciesTest extends SchemaRegistryTest {
         schemas.put("Pizza", pizzaFile);
 
         Map<String, ParsedSchema> parsedSchemas = schemaRegistryMojo.loadSchemas(schemas);
-        Schema pizza = ((AvroSchema) parsedSchemas.get("Pizza")).schemaObj;
+        Schema pizza = ((AvroSchema) parsedSchemas.get("Pizza")).rawSchema();
 
         Assert.assertNotNull("The schema should've been generated", pizza);
         Assert.assertTrue("The schema should contain fields from the dependency", pizza.toString().contains("currency"));
@@ -114,7 +113,7 @@ public class SchemasWithDependenciesTest extends SchemaRegistryTest {
         schemas.put("Pizza", pizzaFile);
 
         Map<String, ParsedSchema> parsedSchemas = schemaRegistryMojo.loadSchemas(schemas);
-        Schema pizza = ((AvroSchema) parsedSchemas.get("Pizza")).schemaObj;
+        Schema pizza = ((AvroSchema) parsedSchemas.get("Pizza")).rawSchema();
 
         Assert.assertNotNull("The schema should've been generated", pizza);
         Assert.assertTrue("The schema should contain fields from the dependency", pizza.toString().contains("currency"));

--- a/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/SchemasWithDependenciesTest.java
+++ b/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/SchemasWithDependenciesTest.java
@@ -1,19 +1,18 @@
 package io.confluent.kafka.schemaregistry.maven;
 
 import org.apache.avro.Schema;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.FileWriter;
-import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
-import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.maven.UploadSchemaRegistryMojo.Reference;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 
 public class SchemasWithDependenciesTest extends SchemaRegistryTest {
@@ -52,13 +51,9 @@ public class SchemasWithDependenciesTest extends SchemaRegistryTest {
 
 
     @Test
-    public void testSchemaWithDependenciesRegister() throws IOException {
-        RegisterSchemaRegistryMojo schemaRegistryMojo = new RegisterSchemaRegistryMojo() {
-            @Override
-            public void execute() throws MojoExecutionException, MojoFailureException {
-
-            }
-        };
+    public void testSchemaWithDependencies() throws Exception {
+        RegisterSchemaRegistryMojo schemaRegistryMojo = new RegisterSchemaRegistryMojo();
+        schemaRegistryMojo.client = new MockSchemaRegistryClient();
 
         File pizzaFile = new File(tempDirectory, "pizza.avsc");
         File amountFile = new File(tempDirectory, "amount.avsc");
@@ -70,50 +65,19 @@ public class SchemasWithDependenciesTest extends SchemaRegistryTest {
             amountWriter.write(dependency);
         }
 
-        ArrayList<String> imports = new ArrayList<>();
-        imports.add(amountFile.getAbsolutePath());
-        schemaRegistryMojo.imports = imports;
+        Map<String, List<Reference>> refs = new LinkedHashMap<>();
+        List<Reference> subjectRefs = new ArrayList<>();
+        subjectRefs.add(new Reference("com.pizza.Amount", "Amount", null));
+        refs.put("Pizza", subjectRefs);
+        schemaRegistryMojo.references = refs;
 
-        Map<String,File> schemas = new HashMap<>();
+        Map<String, File> schemas = new LinkedHashMap<>();
+        schemas.put("Amount", amountFile);
         schemas.put("Pizza", pizzaFile);
+        schemaRegistryMojo.subjects = schemas;
 
-        Map<String, ParsedSchema> parsedSchemas = schemaRegistryMojo.loadSchemas(schemas);
-        Schema pizza = ((AvroSchema) parsedSchemas.get("Pizza")).rawSchema();
-
-        Assert.assertNotNull("The schema should've been generated", pizza);
-        Assert.assertTrue("The schema should contain fields from the dependency", pizza.toString().contains("currency"));
-    }
-
-    @Test
-    public void testSchemaWithDependencies() throws IOException {
-        TestCompatibilitySchemaRegistryMojo schemaRegistryMojo = new TestCompatibilitySchemaRegistryMojo() {
-            @Override
-            public void execute() throws MojoExecutionException, MojoFailureException {
-
-            }
-
-
-        };
-
-        File pizzaFile = new File(tempDirectory, "pizza.avsc");
-        File amountFile = new File(tempDirectory, "amount.avsc");
-        try (
-                FileWriter pizzaWriter = new FileWriter(pizzaFile);
-                FileWriter amountWriter = new FileWriter(amountFile)
-        ) {
-            pizzaWriter.write(schema);
-            amountWriter.write(dependency);
-        }
-
-        ArrayList<String> imports = new ArrayList<>();
-        imports.add(amountFile.getAbsolutePath());
-        schemaRegistryMojo.imports = imports;
-
-        Map<String,File> schemas = new HashMap<>();
-        schemas.put("Pizza", pizzaFile);
-
-        Map<String, ParsedSchema> parsedSchemas = schemaRegistryMojo.loadSchemas(schemas);
-        Schema pizza = ((AvroSchema) parsedSchemas.get("Pizza")).rawSchema();
+        schemaRegistryMojo.execute();
+        Schema pizza = ((AvroSchema) schemaRegistryMojo.schemas.get("Pizza")).rawSchema();
 
         Assert.assertNotNull("The schema should've been generated", pizza);
         Assert.assertTrue("The schema should contain fields from the dependency", pizza.toString().contains("currency"));

--- a/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/TestCompatibilitySchemaRegistryMojoTest.java
+++ b/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/TestCompatibilitySchemaRegistryMojoTest.java
@@ -15,6 +15,7 @@
  */
 package io.confluent.kafka.schemaregistry.maven;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import org.apache.avro.Schema;
@@ -50,8 +51,8 @@ public class TestCompatibilitySchemaRegistryMojoTest extends SchemaRegistryTest 
       String valueSubject = String.format("TestSubject%03d-Value", i);
       Schema keySchema = Schema.create(Schema.Type.STRING);
       Schema valueSchema = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.STRING), Schema.create(Schema.Type.NULL)));
-      this.mojo.client().register(keySubject, keySchema);
-      this.mojo.client().register(valueSubject, valueSchema);
+      this.mojo.client().register(keySubject, new AvroSchema(keySchema));
+      this.mojo.client().register(valueSubject, new AvroSchema(valueSchema));
       File keySchemaFile = new File(this.tempDirectory, keySubject + ".avsc");
       File valueSchemaFile = new File(this.tempDirectory, valueSubject + ".avsc");
       writeSchema(keySchemaFile, keySchema);
@@ -78,8 +79,8 @@ public class TestCompatibilitySchemaRegistryMojoTest extends SchemaRegistryTest 
       String valueSubject = String.format("TestSubject%03d-Value", i);
       Schema keySchema = Schema.create(Schema.Type.STRING);
       Schema valueSchema = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.STRING), Schema.create(Schema.Type.NULL)));
-      this.mojo.client().register(keySubject, keySchema);
-      this.mojo.client().register(valueSubject, valueSchema);
+      this.mojo.client().register(keySubject, new AvroSchema(keySchema));
+      this.mojo.client().register(valueSubject, new AvroSchema(valueSchema));
       File keySchemaFile = new File(this.tempDirectory, keySubject + ".avsc");
       File valueSchemaFile = new File(this.tempDirectory, valueSubject + ".avsc");
       if (i % 7 == 0) {
@@ -103,8 +104,8 @@ public class TestCompatibilitySchemaRegistryMojoTest extends SchemaRegistryTest 
       String valueSubject = String.format("TestSubject%03d-Value", i);
       Schema keySchema = Schema.create(Schema.Type.STRING);
       Schema valueSchema = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.STRING), Schema.create(Schema.Type.NULL)));
-      this.mojo.client().register(keySubject, keySchema);
-      this.mojo.client().register(valueSubject, valueSchema);
+      this.mojo.client().register(keySubject, new AvroSchema(keySchema));
+      this.mojo.client().register(valueSubject, new AvroSchema(valueSchema));
       File keySchemaFile = new File(this.tempDirectory, keySubject + ".avsc");
       File valueSchemaFile = new File(this.tempDirectory, valueSubject + ".avsc");
       if (i % 7 == 0) {
@@ -129,8 +130,8 @@ public class TestCompatibilitySchemaRegistryMojoTest extends SchemaRegistryTest 
       String valueSubject = String.format("TestSubject%03d-Value", i);
       Schema keySchema = Schema.create(Schema.Type.STRING);
       Schema valueSchema = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.STRING), Schema.create(Schema.Type.NULL)));
-      this.mojo.client().register(keySubject, keySchema);
-      this.mojo.client().register(valueSubject, valueSchema);
+      this.mojo.client().register(keySubject, new AvroSchema(keySchema));
+      this.mojo.client().register(valueSubject, new AvroSchema(valueSchema));
       File keySchemaFile = new File(this.tempDirectory, keySubject + ".avsc");
       File valueSchemaFile = new File(this.tempDirectory, valueSubject + ".avsc");
 


### PR DESCRIPTION
This PR add supports for pluggability and schema references.

The notion of a schema has been abstracted into a new interface in Schema Registry called ParsedSchema. Implementing a ParsedSchema and a SchemaProvider are all that is needed to add new a schema type to Schema Registry.

In order to add further schema types, the following property should be set in the Schema Registry properties file:

schema.providers=my.package.MySchemaProvider

Avro, JSON Schema, and Protobuf all have the notion of schema references (also sometimes referred to as schema imports or schema includes). This feature is less important for Avro since the feature is associated with their protocol functionality, which is not used by Schema Registry. However, for JSON Schema and especially Protobuf, the use of schema references is more prevalent. Therefore Schema Registry now supports the notion of schema references. A schema reference is comprised of

A name for the reference.

For Avro, it would be a fully qualified schema name.
For JSON Schema, it would be a URL.
For Protobuf, it would be the name of another Protobuf file.
A subject, representing the subject under which the referenced schema is registered.
A version, representing the exact version of the schema under the registered subject.
When registering a schema, the associated references, if any, need to be passed. Typically the referenced schemas would be first registered, then their subjects and versions can be used when registering the schema that references them.

When a schema that has references is retrieved from Schema Registry, the referenced schemas will also be retrieved if needed.