### PR TITLE
DG-160:  Omit schemaType if specified as AVRO

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.util.StdConverter;
 
 import javax.ws.rs.DefaultValue;
 
@@ -158,12 +157,5 @@ public class Schema implements Comparable<Schema> {
     }
     result = this.version - that.version;
     return result;
-  }
-
-  static class SchemaTypeConverter extends StdConverter<String, String> {
-    @Override
-    public String convert(final String value) {
-      return AvroSchema.TYPE.equals(value) ? null : value;
-    }
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaString.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaString.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.annotations.VisibleForTesting;
-import io.confluent.kafka.schemaregistry.client.rest.entities.Schema.SchemaTypeConverter;
 import io.swagger.annotations.ApiModelProperty;
 
 import java.io.IOException;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaTypeConverter.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaTypeConverter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.client.rest.entities;
+
+import com.fasterxml.jackson.databind.util.StdConverter;
+
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+
+public class SchemaTypeConverter extends StdConverter<String, String> {
+  @Override
+  public String convert(final String value) {
+    return AvroSchema.TYPE.equals(value) ? null : value;
+  }
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaRequest.java
@@ -19,12 +19,14 @@ package io.confluent.kafka.schemaregistry.client.rest.entities.requests;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaTypeConverter;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class RegisterSchemaRequest {
@@ -60,6 +62,7 @@ public class RegisterSchemaRequest {
   }
 
   @JsonProperty("schemaType")
+  @JsonSerialize(converter = SchemaTypeConverter.class)
   public String getSchemaType() {
     return this.schemaType;
   }

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaRequestTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaRequestTest.java
@@ -60,4 +60,15 @@ public class RegisterSchemaRequestTest {
 
     assertEquals("{\"schema\":\"string\"}", request.toJson());
   }
+
+  @Test
+  public void buildRegisterSchemaRequestWithSchemaTypeAvro() throws Exception {
+
+    RegisterSchemaRequest request = new RegisterSchemaRequest();
+    request.setSchema("string");
+    request.setSchemaType("AVRO");
+
+    // Note that schemaType is omitted
+    assertEquals("{\"schema\":\"string\"}", request.toJson());
+  }
 }


### PR DESCRIPTION
This is for backward compatibility of CachedSchemaRegistryClient with older versions of Schema Registry.