### PR TITLE
First cut at JSON Schema support

### DIFF
--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/AvroSchemaTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/AvroSchemaTest.java
@@ -374,7 +374,7 @@ public class AvroSchemaTest {
   }
 
 
-  private static void expectConversionException(JsonNode obj, ParsedSchema schema) {
+  private static void expectConversionException(JsonNode obj, AvroSchema schema) {
     try {
       AvroSchemaUtils.toObject(obj, schema);
       fail("Expected conversion of "
@@ -399,7 +399,7 @@ public class AvroSchemaTest {
     }
   }
 
-  private static ParsedSchema createPrimitiveSchema(String type) {
+  private static AvroSchema createPrimitiveSchema(String type) {
     String schemaString = String.format("{\"type\" : \"%s\"}", type);
     return new AvroSchema(parser.parse(schemaString));
   }

--- a/bin/kafka-json-schema-console-consumer
+++ b/bin/kafka-json-schema-console-consumer
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# Copyright 2020 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+base_dir=$(dirname $0)/..
+
+# Production jars
+export CLASSPATH=$CLASSPATH:$base_dir/share/java/kafka-serde-tools/*
+
+# Development jars. `mvn package` should collect all the required dependency jars here
+for dir in $base_dir/package-kafka-serde-tools/target/kafka-serde-tools-package-*-development; do
+  export CLASSPATH=$CLASSPATH:$dir/share/java/kafka-serde-tools/*
+done
+
+DEFAULT_PROTOBUF_FORMATTER="--formatter io.confluent.kafka.formatter.JsonSchemaMessageFormatter"
+
+DEFAULT_SCHEMA_REGISTRY_URL="--property schema.registry.url=http://localhost:8081"
+
+for OPTION in "$@"
+do 
+  case $OPTION in
+    --formatter)
+      DEFAULT_PROTOBUF_FORMATTER=""
+      ;;
+    --*)
+      ;;
+    *)
+      PROPERTY=$OPTION
+      case $PROPERTY in
+        schema.registry.url*)
+          DEFAULT_SCHEMA_REGISTRY_URL=""
+        ;;
+      esac
+      ;;
+    esac
+done
+exec $(dirname $0)/schema-registry-run-class kafka.tools.ConsoleConsumer $DEFAULT_PROTOBUF_FORMATTER $DEFAULT_SCHEMA_REGISTRY_URL "$@"

--- a/bin/kafka-json-schema-console-producer
+++ b/bin/kafka-json-schema-console-producer
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# Copyright 2020 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+base_dir=$(dirname $0)/..
+
+# Production jars
+export CLASSPATH=$CLASSPATH:$base_dir/share/java/kafka-serde-tools/*
+
+# Development jars. `mvn package` should collect all the required dependency jars here
+for dir in $base_dir/package-kafka-serde-tools/target/kafka-serde-tools-package-*-development; do
+  export CLASSPATH=$CLASSPATH:$dir/share/java/kafka-serde-tools/*
+done
+
+
+DEFAULT_LINE_READER="--line-reader io.confluent.kafka.formatter.JsonSchemaMessageReader"
+
+DEFAULT_SCHEMA_REGISTRY_URL="--property schema.registry.url=http://localhost:8081"
+
+for OPTION in "$@"
+do
+  case $OPTION in
+    --line-reader)
+      DEFAULT_LINE_READER=""
+      ;;
+    --*)
+      ;;
+    *)
+      PROPERTY=$OPTION
+      case $PROPERTY in
+        schema.registry.url*)
+          DEFAULT_SCHEMA_REGISTRY_URL=""
+        ;;
+      esac
+      ;;
+    esac
+done
+exec $(dirname $0)/schema-registry-run-class kafka.tools.ConsoleProducer $DEFAULT_LINE_READER $DEFAULT_SCHEMA_REGISTRY_URL "$@"

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -13,7 +13,7 @@
               files="SchemaRegistryCoordinator.java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(AbstractKafkaAvroDeserializer|AbstractKafkaAvroSerializer|AvroMessageReader|RestService|Errors|SchemaRegistryRestApplication|KafkaSchemaRegistry|KafkaStore|AvroData|KafkaGroupMasterElector|ProtobufSchema|ProtobufData).java"/>
+              files="(AbstractKafkaAvroDeserializer|AbstractKafkaAvroSerializer|AvroMessageReader|RestService|Errors|SchemaRegistryRestApplication|KafkaSchemaRegistry|KafkaStore|AvroData|KafkaGroupMasterElector|ProtobufSchema|ProtobufData|JsonSchemaConverter).java"/>
 
     <suppress checks="ClassFanOutComplexity"
               files="(RestService|KafkaSchemaRegistry|KafkaStore|KafkaStoreReaderThread|AvroData|KafkaGroupMasterElector).java"/>
@@ -22,22 +22,22 @@
               files="(Errors|AvroMessageReader).java"/>
 
     <suppress checks="CyclomaticComplexity"
-              files="(AbstractKafkaAvroDeserializer|AvroSchemaUtils|CompatibilityResource|KafkaSchemaRegistry|KafkaStoreReaderThread|AvroData|DownloadSchemaRegistryMojo|AvroMessageFormatter|MockSchemaRegistryClient|SchemaRegistrySerializer|SchemaValue|SubjectVersionsResource|ProtobufSchema|SchemaDiff|FieldSchemaDiff|MessageSchemaDiff|DynamicSchema|ProtobufMessageFormatter|ProtobufData).java"/>
+              files="(AbstractKafkaAvroDeserializer|AvroSchemaUtils|CompatibilityResource|KafkaSchemaRegistry|KafkaStoreReaderThread|AvroData|DownloadSchemaRegistryMojo|AvroMessageFormatter|MockSchemaRegistryClient|SchemaRegistrySerializer|SchemaValue|SubjectVersionsResource|ProtobufSchema|SchemaDiff|FieldSchemaDiff|MessageSchemaDiff|DynamicSchema|ProtobufMessageFormatter|ProtobufData|JsonSchema|JSON.*|JsonSchemaMessageFormatter|JsonSchemaConverter).java"/>
 
     <suppress checks="NPathComplexity"
-              files="(AvroData|DownloadSchemaRegistryMojo|AvroMessageFormatter|KafkaSchemaRegistry|Schema|SchemaValue|SchemaDiff|MessageSchemaDiff|ProtobufMessageFormatter|ProtobufData).java"/>
+              files="(AvroData|DownloadSchemaRegistryMojo|AvroMessageFormatter|KafkaSchemaRegistry|Schema|SchemaValue|SchemaDiff|MessageSchemaDiff|ProtobufMessageFormatter|ProtobufData|JsonSchemaMessageFormatter|JsonSchemaConverter).java"/>
 
     <suppress checks="JavaNCSS"
-              files="(AvroData|ProtobufData).java"/>
+              files="(AvroData|ProtobufData|SchemaDiff|NumberSchemaDiff|JsonSchemaConverter).java"/>
 
     <suppress checks="MethodLength"
               files="AvroData.java"/>
 
     <suppress checks="AbbreviationAsWordInName"
-              files=".*SchemaRegistryClient.java"/>
+              files="(.*SchemaRegistryClient|JSON.*).java"/>
 
     <suppress checks="MethodLength"
-              files="(SchemaRegistryConfig|ProtobufData).java"/>
+              files="(SchemaRegistryConfig|ProtobufData|JsonSchemaConverter).java"/>
 
     <suppress checks="BooleanExpressionComplexity"
               files="AvroData.java"/>

--- a/client-console-scripts/src/assembly/resources.xml
+++ b/client-console-scripts/src/assembly/resources.xml
@@ -10,6 +10,7 @@
       <outputDirectory></outputDirectory>
       <includes>
         <include>kafka-avro-console-*</include>
+        <include>kafka-json-schema-console-*</include>
         <include>kafka-protobuf-console-*</include>
         <include>schema-registry-run-class</include>
       </includes>

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaUtils.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaUtils.java
@@ -38,8 +38,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.confluent.kafka.schemaregistry.ParsedSchema;
-
 public class AvroSchemaUtils {
 
   private static final EncoderFactory encoderFactory = EncoderFactory.get();
@@ -129,13 +127,13 @@ public class AvroSchemaUtils {
     }
   }
 
-  public static Object toObject(JsonNode value, ParsedSchema parsedSchema) throws IOException {
+  public static Object toObject(JsonNode value, AvroSchema schema) throws IOException {
     try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
-      Schema schema = ((AvroSchema) parsedSchema).rawSchema();
+      Schema rawSchema = schema.rawSchema();
       jsonMapper.writeValue(out, value);
-      DatumReader<Object> reader = new GenericDatumReader<Object>(schema);
+      DatumReader<Object> reader = new GenericDatumReader<Object>(rawSchema);
       Object object = reader.read(null,
-          decoderFactory.jsonDecoder(schema, new ByteArrayInputStream(out.toByteArray()))
+          decoderFactory.jsonDecoder(rawSchema, new ByteArrayInputStream(out.toByteArray()))
       );
       return object;
     }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,6 +21,10 @@
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
+            <artifactId>kafka-json-schema-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
             <artifactId>kafka-protobuf-provider</artifactId>
         </dependency>
         <dependency>

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -77,6 +77,7 @@ import io.confluent.kafka.schemaregistry.exceptions.UnknownMasterException;
 import io.confluent.kafka.schemaregistry.id.IdGenerator;
 import io.confluent.kafka.schemaregistry.id.IncrementalIdGenerator;
 import io.confluent.kafka.schemaregistry.id.ZookeeperIdGenerator;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
 import io.confluent.kafka.schemaregistry.masterelector.kafka.KafkaGroupMasterElector;
 import io.confluent.kafka.schemaregistry.masterelector.zookeeper.ZookeeperMasterElector;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
@@ -188,7 +189,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
             SchemaProvider.class,
             schemaProviderConfigs);
     List<SchemaProvider> defaultSchemaProviders = Arrays.asList(
-        new AvroSchemaProvider(), new ProtobufSchemaProvider()
+        new AvroSchemaProvider(), new JsonSchemaProvider(), new ProtobufSchemaProvider()
     );
     for (SchemaProvider provider : defaultSchemaProviders) {
       provider.configure(schemaProviderConfigs);

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/json/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/json/RestApiTest.java
@@ -170,8 +170,8 @@ public class RestApiTest extends ClusterTestHarness {
     );
     Assert.assertEquals(
         "Registering a new schema should succeed",
-        (long) expectedId,
-        (long) registeredId
+        expectedId,
+        registeredId
     );
     Assert.assertEquals("Registered schema should be found",
         MAPPER.readTree(schemaString),

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/json/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/json/RestApiTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rest.json;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Random;
+
+import io.confluent.kafka.schemaregistry.ClusterTestHarness;
+import io.confluent.kafka.schemaregistry.client.rest.RestService;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+
+import static org.junit.Assert.assertEquals;
+
+public class RestApiTest extends ClusterTestHarness {
+
+  private static final Random random = new Random();
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  public RestApiTest() {
+    super(1, true);
+  }
+
+  @Override
+  protected Properties getSchemaRegistryProperties() {
+    Properties props = new Properties();
+    props.setProperty("schema.providers", JsonSchemaProvider.class.getName());
+    return props;
+  }
+
+  @Test
+  public void testBasic() throws Exception {
+    String subject1 = "testTopic1";
+    String subject2 = "testTopic2";
+    int schemasInSubject1 = 10;
+    List<Integer> allVersionsInSubject1 = new ArrayList<Integer>();
+    List<String> allSchemasInSubject1 = getRandomJsonSchemas(schemasInSubject1);
+    int schemasInSubject2 = 5;
+    List<Integer> allVersionsInSubject2 = new ArrayList<Integer>();
+    List<String> allSchemasInSubject2 = getRandomJsonSchemas(schemasInSubject2);
+    List<String> allSubjects = new ArrayList<String>();
+
+    // test getAllSubjects with no existing data
+    assertEquals("Getting all subjects should return empty",
+        allSubjects,
+        restApp.restClient.getAllSubjects()
+    );
+
+    // test registering and verifying new schemas in subject1
+    int schemaIdCounter = 1;
+    for (int i = 0; i < schemasInSubject1; i++) {
+      String schema = allSchemasInSubject1.get(i);
+      int expectedVersion = i + 1;
+      registerAndVerifySchema(restApp.restClient, schema, schemaIdCounter, subject1);
+      schemaIdCounter++;
+      allVersionsInSubject1.add(expectedVersion);
+    }
+    allSubjects.add(subject1);
+
+    // test re-registering existing schemas
+    for (int i = 0; i < schemasInSubject1; i++) {
+      int expectedId = i + 1;
+      String schemaString = allSchemasInSubject1.get(i);
+      int foundId = restApp.restClient.registerSchema(schemaString,
+          JsonSchema.TYPE,
+          Collections.emptyList(),
+          subject1
+      );
+      assertEquals("Re-registering an existing schema should return the existing version",
+          expectedId,
+          foundId
+      );
+    }
+
+    // test registering schemas in subject2
+    for (int i = 0; i < schemasInSubject2; i++) {
+      String schema = allSchemasInSubject2.get(i);
+      int expectedVersion = i + 1;
+      registerAndVerifySchema(restApp.restClient, schema, schemaIdCounter, subject2);
+      schemaIdCounter++;
+      allVersionsInSubject2.add(expectedVersion);
+    }
+    allSubjects.add(subject2);
+
+    // test getAllVersions with existing data
+    assertEquals(
+        "Getting all versions from subject1 should match all registered versions",
+        allVersionsInSubject1,
+        restApp.restClient.getAllVersions(subject1)
+    );
+    assertEquals(
+        "Getting all versions from subject2 should match all registered versions",
+        allVersionsInSubject2,
+        restApp.restClient.getAllVersions(subject2)
+    );
+
+    // test getAllSubjects with existing data
+    assertEquals("Getting all subjects should match all registered subjects",
+        allSubjects,
+        restApp.restClient.getAllSubjects()
+    );
+  }
+
+  @Test
+  public void testSchemaReferences() throws Exception {
+    Map<String, String> schemas = getJsonSchemaWithReferences();
+    String subject = "reference";
+    registerAndVerifySchema(restApp.restClient, schemas.get("ref.json"), 1, subject);
+
+    RegisterSchemaRequest request = new RegisterSchemaRequest();
+    request.setSchema(schemas.get("main.json"));
+    request.setSchemaType(JsonSchema.TYPE);
+    SchemaReference ref = new SchemaReference("ref.json", "reference", 1);
+    request.setReferences(Collections.singletonList(ref));
+    int registeredId = restApp.restClient.registerSchema(request, "referrer");
+    assertEquals("Registering a new schema should succeed", 2, registeredId);
+
+    SchemaString schemaString = restApp.restClient.getId(2);
+    // the newly registered schema should be immediately readable on the master
+    assertEquals("Registered schema should be found",
+        MAPPER.readTree(schemas.get("main.json")),
+        MAPPER.readTree(schemaString.getSchemaString())
+    );
+
+    assertEquals("Schema references should be found",
+        Collections.singletonList(ref),
+        schemaString.getReferences()
+    );
+  }
+
+  public static void registerAndVerifySchema(
+      RestService restService,
+      String schemaString,
+      int expectedId,
+      String subject
+  ) throws IOException, RestClientException {
+    int registeredId = restService.registerSchema(
+        schemaString,
+        JsonSchema.TYPE,
+        Collections.emptyList(),
+        subject
+    );
+    Assert.assertEquals(
+        "Registering a new schema should succeed",
+        (long) expectedId,
+        (long) registeredId
+    );
+    Assert.assertEquals("Registered schema should be found",
+        MAPPER.readTree(schemaString),
+        MAPPER.readTree(restService.getId(expectedId).getSchemaString())
+    );
+  }
+
+  public static List<String> getRandomJsonSchemas(int num) {
+    List<String> schemas = new ArrayList<>();
+    for (int i = 0; i < num; i++) {
+      String schema = "{\"type\":\"object\",\"properties\":{\"f"
+          + random.nextInt(Integer.MAX_VALUE)
+          + "\":"
+          + "{\"type\":\"string\"}},\"additionalProperties\":false}";
+      schemas.add(schema);
+    }
+    return schemas;
+  }
+
+  public static Map<String, String> getJsonSchemaWithReferences() {
+    Map<String, String> schemas = new HashMap<>();
+    String reference = "{\"type\":\"object\",\"additionalProperties\":false,\"definitions\":"
+        + "{\"ExternalType\":{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"}},"
+        + "\"additionalProperties\":false}}}";
+        /*
+        String reference = "{\n  \"type\": \"object\",\n"
+            + "  \"additionalProperties\": false,\n"
+            + "  \"definitions\": {\n"
+            + "    \"ExternalType\": {\n"
+            + "      \"type\": \"object\",\n"
+            + "      \"additionalProperties\": false,\n"
+            + "      \"properties\": {\n"
+            + "        \"name\": {\n"
+            + "          \"type\": \"string\"\n"
+            + "        }\n"
+            + "      }\n"
+            + "    }\n"
+            + "  }\n"
+            + "}\n";
+         */
+    schemas.put("ref.json", new JsonSchema(reference).canonicalString());
+    String schemaString = "{\"type\":\"object\",\"properties\":{\"Ref\":"
+        + "{\"$ref\":\"ref.json#/definitions/ExternalType\"}},\"additionalProperties\":false}";
+        /*
+        String schemaString = "{\n  \"type\": \"object\",\n"
+            + "  \"additionalProperties\": false,\n"
+            + "  \"properties\": {\n"
+            + "    \"Ref\": {\n"
+            + "      \"$ref\": \"ref.json#/definitions/ExternalType\"\n"
+            + "    }\n"
+            + "  }\n"
+            + "}\n";
+         */
+    schemas.put("main.json", schemaString);
+    return schemas;
+  }
+}
+

--- a/json-schema-converter/pom.xml
+++ b/json-schema-converter/pom.xml
@@ -68,4 +68,58 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.confluent</groupId>
+                <artifactId>kafka-connect-maven-plugin</artifactId>
+                <version>0.11.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>kafka-connect</goal>
+                        </goals>
+                        <configuration>
+                            <title>Kafka Connect JSON Schema Converter</title>
+                            <documentationUrl>https://docs.confluent.io/current/schema-registry/docs/connect.html</documentationUrl>
+                            <description>
+                                <![CDATA[The Kafka Connect JSON Schema Converter integrates with <a href="https://docs.confluent.io/current/schema-registry/docs/intro.html">Schema Registry</a> to convert data for Kafka Connect to and from JSON Schema format.]]>
+                            </description>
+                            <sourceUrl>https://github.com/confluentinc/schema-registry</sourceUrl>
+
+                            <supportProviderName>Confluent, Inc.</supportProviderName>
+                            <supportSummary>Confluent supports the JSON Schema Converter alongside community members as part of its Confluent Platform offering.</supportSummary>
+                            <supportUrl>https://docs.confluent.io/current/</supportUrl>
+                            <supportLogo>logos/confluent.png</supportLogo>
+
+                            <ownerUsername>confluentinc</ownerUsername>
+                            <ownerType>organization</ownerType>
+                            <ownerName>Confluent, Inc.</ownerName>
+                            <ownerUrl>https://confluent.io/</ownerUrl>
+                            <ownerLogo>logos/confluent.png</ownerLogo>
+
+                            <dockerNamespace>confluentinc</dockerNamespace>
+                            <dockerName>cp-kafka-connect</dockerName>
+                            <dockerTag>${project.version}</dockerTag>
+
+                            <componentTypes>
+                                <componentType>converter</componentType>
+                            </componentTypes>
+
+                            <tags>
+                                <tag>json schema</tag>
+                                <tag>schema registry</tag>
+                            </tags>
+
+                            <kafkaConnectApi>false</kafkaConnectApi>
+                            <singleMessageTransforms>false</singleMessageTransforms>
+                            <supportedEncodings>
+                                <supportedEncoding>json</supportedEncoding>
+                            </supportedEncodings>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/json-schema-converter/pom.xml
+++ b/json-schema-converter/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
-            <artifactId>kafka-avro-serializer</artifactId>
+            <artifactId>kafka-schema-serializer</artifactId>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>

--- a/json-schema-converter/pom.xml
+++ b/json-schema-converter/pom.xml
@@ -1,0 +1,71 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.confluent</groupId>
+        <artifactId>kafka-schema-registry-parent</artifactId>
+        <version>5.5.0-SNAPSHOT</version>
+    </parent>
+
+    <licenses>
+        <license>
+            <name>Confluent Community License</name>
+            <url>http://www.confluent.io/confluent-community-license</url>
+            <distribution>repo</distribution>
+        </license>
+        <license>
+            <name>Apache License 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <artifactId>kafka-connect-json-schema-converter</artifactId>
+    <packaging>jar</packaging>
+    <name>kafka-connect-json-schema-converter</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-json-schema-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-json-schema-serializer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-avro-serializer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-registry-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-json</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.everit-org.json-schema</groupId>
+            <artifactId>org.everit.json.schema</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverter.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverter.java
@@ -1,0 +1,1051 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.kafka.common.cache.Cache;
+import org.apache.kafka.common.cache.LRUCache;
+import org.apache.kafka.common.cache.SynchronizedCache;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.connect.data.ConnectSchema;
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.storage.Converter;
+import org.everit.json.schema.ArraySchema;
+import org.everit.json.schema.BooleanSchema;
+import org.everit.json.schema.CombinedSchema;
+import org.everit.json.schema.EnumSchema;
+import org.everit.json.schema.NullSchema;
+import org.everit.json.schema.NumberSchema;
+import org.everit.json.schema.ObjectSchema;
+import org.everit.json.schema.ReferenceSchema;
+import org.everit.json.schema.StringSchema;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import io.confluent.common.config.ConfigDef;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDe;
+import io.confluent.kafka.serializers.json.AbstractKafkaJsonSchemaDeserializer;
+import io.confluent.kafka.serializers.json.AbstractKafkaJsonSchemaSerializer;
+import io.confluent.kafka.serializers.json.JsonSchemaAndValue;
+import io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializerConfig;
+import io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializerConfig;
+
+/**
+ * Implementation of Converter that supports JSON with JSON Schema.
+ */
+public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Converter {
+
+  public static final String NAMESPACE = "io.confluent.connect.json";
+
+  public static final String KEY_FIELD = "key";
+  public static final String VALUE_FIELD = "value";
+
+  public static final String CONNECT_TYPE_PROP = "connect.type";
+  public static final String CONNECT_VERSION_PROP = "connect.version";
+  public static final String CONNECT_PARAMETERS_PROP = "connect.parameters";
+  public static final String CONNECT_INDEX_PROP = "connect.index";
+
+  public static final String CONNECT_TYPE_INT8 = "int8";
+  public static final String CONNECT_TYPE_INT16 = "int16";
+  public static final String CONNECT_TYPE_INT32 = "int32";
+  public static final String CONNECT_TYPE_INT64 = "int64";
+  public static final String CONNECT_TYPE_FLOAT32 = "float32";
+  public static final String CONNECT_TYPE_FLOAT64 = "float64";
+  public static final String CONNECT_TYPE_BYTES = "bytes";
+  public static final String CONNECT_TYPE_MAP = "map";
+
+  public static final String JSON_TYPE_ENUM = NAMESPACE + ".Enum";
+  public static final String JSON_TYPE_ENUM_PREFIX = JSON_TYPE_ENUM + ".";
+  public static final String JSON_TYPE_ONE_OF = NAMESPACE + ".OneOf";
+
+  private static final Map<Schema.Type, JsonToConnectTypeConverter> TO_CONNECT_CONVERTERS =
+      new EnumMap<>(
+      Schema.Type.class);
+
+  static {
+    TO_CONNECT_CONVERTERS.put(Schema.Type.BOOLEAN, (schema, value) -> value.booleanValue());
+    TO_CONNECT_CONVERTERS.put(Schema.Type.INT8, (schema, value) -> (byte) value.shortValue());
+    TO_CONNECT_CONVERTERS.put(Schema.Type.INT16, (schema, value) -> value.shortValue());
+    TO_CONNECT_CONVERTERS.put(Schema.Type.INT32, (schema, value) -> value.intValue());
+    TO_CONNECT_CONVERTERS.put(Schema.Type.INT64, (schema, value) -> value.longValue());
+    TO_CONNECT_CONVERTERS.put(Schema.Type.FLOAT32, (schema, value) -> value.floatValue());
+    TO_CONNECT_CONVERTERS.put(Schema.Type.FLOAT64, (schema, value) -> value.doubleValue());
+    TO_CONNECT_CONVERTERS.put(Schema.Type.BYTES, (schema, value) -> {
+      try {
+        Object o = value.binaryValue();
+        if (o == null) {
+          o = value.decimalValue();  // decimal logical type
+        }
+        return o;
+      } catch (IOException e) {
+        throw new DataException("Invalid bytes field", e);
+      }
+    });
+    TO_CONNECT_CONVERTERS.put(Schema.Type.STRING, (schema, value) -> value.textValue());
+    TO_CONNECT_CONVERTERS.put(Schema.Type.ARRAY, (schema, value) -> {
+      Schema elemSchema = schema == null ? null : schema.valueSchema();
+      ArrayList<Object> result = new ArrayList<>();
+      for (JsonNode elem : value) {
+        result.add(toConnectData(elemSchema, elem));
+      }
+      return result;
+    });
+    TO_CONNECT_CONVERTERS.put(Schema.Type.MAP, (schema, value) -> {
+      Schema keySchema = schema == null ? null : schema.keySchema();
+      Schema valueSchema = schema == null ? null : schema.valueSchema();
+
+      Map<Object, Object> result = new HashMap<>();
+      if (schema == null || (keySchema.type() == Schema.Type.STRING && !keySchema.isOptional())) {
+        if (!value.isObject()) {
+          throw new DataException(
+              "Maps with string fields should be encoded as JSON objects, but found "
+                  + value.getNodeType());
+        }
+        Iterator<Map.Entry<String, JsonNode>> fieldIt = value.fields();
+        while (fieldIt.hasNext()) {
+          Map.Entry<String, JsonNode> entry = fieldIt.next();
+          result.put(entry.getKey(), toConnectData(valueSchema, entry.getValue()));
+        }
+      } else {
+        if (!value.isArray()) {
+          throw new DataException(
+              "Maps with non-string fields should be encoded as JSON array of objects, but "
+                  + "found "
+                  + value.getNodeType());
+        }
+        for (JsonNode entry : value) {
+          if (!entry.isObject()) {
+            throw new DataException("Found invalid map entry instead of object: "
+                + entry.getNodeType());
+          }
+          if (entry.size() != 2) {
+            throw new DataException("Found invalid map entry, expected length 2 but found :" + entry
+                .size());
+          }
+          result.put(toConnectData(keySchema, entry.get(KEY_FIELD)),
+              toConnectData(valueSchema, entry.get(VALUE_FIELD))
+          );
+        }
+      }
+      return result;
+    });
+    TO_CONNECT_CONVERTERS.put(Schema.Type.STRUCT, (schema, value) -> {
+      if (schema.name() != null && schema.name().equals(JSON_TYPE_ONE_OF)) {
+        int index = 0;
+        for (Field field : schema.fields()) {
+          Schema fieldSchema = field.schema();
+
+          if (isInstanceOfSchemaTypeForSimpleSchema(fieldSchema, value)) {
+            return new Struct(schema.schema()).put(JSON_TYPE_ONE_OF + ".field." + index++,
+                toConnectData(fieldSchema, value)
+            );
+          }
+        }
+        throw new DataException("Did not find matching oneof field for data: " + value.toString());
+      } else {
+        if (!value.isObject()) {
+          throw new DataException("Structs should be encoded as JSON objects, but found "
+              + value.getNodeType());
+        }
+
+        Struct result = new Struct(schema.schema());
+        for (Field field : schema.fields()) {
+          result.put(field, toConnectData(field.schema(), value.get(field.name())));
+        }
+
+        return result;
+      }
+    });
+  }
+
+  private static boolean isInstanceOfSchemaTypeForSimpleSchema(Schema fieldSchema, JsonNode value) {
+    switch (fieldSchema.type()) {
+      case INT8:
+      case INT16:
+        return value.isShort();
+      case INT32:
+        return value.isInt();
+      case INT64:
+        return value.isLong();
+      case FLOAT32:
+        return value.isFloat();
+      case FLOAT64:
+        return value.isDouble();
+      case BOOLEAN:
+        return value.isBoolean();
+      case STRING:
+        return value.isTextual();
+      case BYTES:
+        return value.isBinary() || value.isBigDecimal();
+      case ARRAY:
+        return value.isArray();
+      case MAP:
+        return value.isObject() || value.isArray();
+      case STRUCT:
+        return value.isObject();
+      default:
+        throw new IllegalArgumentException("Unsupported type " + fieldSchema.type());
+    }
+  }
+
+  // Convert values in Kafka Connect form into their logical types. These logical converters are
+  // discovered by logical type
+  // names specified in the field
+  private static final HashMap<String, LogicalTypeConverter> TO_CONNECT_LOGICAL_CONVERTERS =
+      new HashMap<>();
+
+  static {
+    TO_CONNECT_LOGICAL_CONVERTERS.put(Decimal.LOGICAL_NAME, (schema, value) -> {
+      if (!(value instanceof BigDecimal)) {
+        throw new DataException(
+            "Invalid type for Decimal, underlying representation should be BigDecimal but was "
+                + value.getClass());
+      }
+      return value;
+    });
+
+    TO_CONNECT_LOGICAL_CONVERTERS.put(Date.LOGICAL_NAME, (schema, value) -> {
+      if (!(value instanceof Integer)) {
+        throw new DataException(
+            "Invalid type for Date, underlying representation should be int32 but was "
+                + value.getClass());
+      }
+      return Date.toLogical(schema, (int) value);
+    });
+
+    TO_CONNECT_LOGICAL_CONVERTERS.put(Time.LOGICAL_NAME, (schema, value) -> {
+      if (!(value instanceof Integer)) {
+        throw new DataException(
+            "Invalid type for Time, underlying representation should be int32 but was "
+                + value.getClass());
+      }
+      return Time.toLogical(schema, (int) value);
+    });
+
+    TO_CONNECT_LOGICAL_CONVERTERS.put(Timestamp.LOGICAL_NAME, (schema, value) -> {
+      if (!(value instanceof Long)) {
+        throw new DataException(
+            "Invalid type for Timestamp, underlying representation should be int64 but was " + value
+                .getClass());
+      }
+      return Timestamp.toLogical(schema, (long) value);
+    });
+  }
+
+  private static final HashMap<String, LogicalTypeConverter> TO_JSON_LOGICAL_CONVERTERS =
+      new HashMap<>();
+
+  static {
+    TO_JSON_LOGICAL_CONVERTERS.put(Decimal.LOGICAL_NAME, (schema, value) -> {
+      if (!(value instanceof BigDecimal)) {
+        throw new DataException("Invalid type for Decimal, expected BigDecimal but was "
+            + value.getClass());
+      }
+      return value;
+    });
+
+    TO_JSON_LOGICAL_CONVERTERS.put(Date.LOGICAL_NAME, (schema, value) -> {
+      if (!(value instanceof java.util.Date)) {
+        throw new DataException("Invalid type for Date, expected Date but was " + value.getClass());
+      }
+      return Date.fromLogical(schema, (java.util.Date) value);
+    });
+
+    TO_JSON_LOGICAL_CONVERTERS.put(Time.LOGICAL_NAME, (schema, value) -> {
+      if (!(value instanceof java.util.Date)) {
+        throw new DataException("Invalid type for Time, expected Date but was " + value.getClass());
+      }
+      return Time.fromLogical(schema, (java.util.Date) value);
+    });
+
+    TO_JSON_LOGICAL_CONVERTERS.put(Timestamp.LOGICAL_NAME, (schema, value) -> {
+      if (!(value instanceof java.util.Date)) {
+        throw new DataException("Invalid type for Timestamp, expected Date but was "
+            + value.getClass());
+      }
+      return Timestamp.fromLogical(schema, (java.util.Date) value);
+    });
+  }
+
+  private SchemaRegistryClient schemaRegistry;
+  private Serializer serializer;
+  private Deserializer deserializer;
+
+  private int cacheSize = JsonSchemaConverterConfig.SCHEMAS_CACHE_SIZE_DEFAULT;
+  private Cache<Schema, org.everit.json.schema.Schema> fromConnectSchemaCache;
+  private Cache<JsonSchema, Schema> toConnectSchemaCache;
+  private boolean isKey;
+
+  public JsonSchemaConverter() {
+  }
+
+  @VisibleForTesting
+  public JsonSchemaConverter(SchemaRegistryClient client) {
+    schemaRegistry = client;
+  }
+
+  public ConfigDef config() {
+    return JsonSchemaConverterConfig.configDef();
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    this.isKey = isKey;
+    JsonSchemaConverterConfig jsonSchemaConverterConfig = new JsonSchemaConverterConfig(configs);
+
+    if (schemaRegistry == null) {
+      schemaRegistry =
+          new CachedSchemaRegistryClient(jsonSchemaConverterConfig.getSchemaRegistryUrls(),
+          jsonSchemaConverterConfig.getMaxSchemasPerSubject(),
+          configs
+      );
+    }
+
+    serializer = new Serializer(configs, schemaRegistry);
+    deserializer = new Deserializer(configs, schemaRegistry);
+
+    cacheSize = jsonSchemaConverterConfig.schemaCacheSize();
+    fromConnectSchemaCache = new SynchronizedCache<>(new LRUCache<>(cacheSize));
+    toConnectSchemaCache = new SynchronizedCache<>(new LRUCache<>(cacheSize));
+  }
+
+  @Override
+  public byte[] fromConnectData(String topic, Schema schema, Object value) {
+    JsonSchema jsonSchema = new JsonSchema(fromConnectSchema(schema));
+    JsonNode jsonValue = fromConnectData(schema, value);
+    try {
+      return serializer.serialize(topic, isKey, jsonValue, jsonSchema);
+    } catch (SerializationException e) {
+      throw new DataException("Converting Kafka Connect data to byte[] failed due to "
+          + "serialization error: ",
+          e
+      );
+    }
+  }
+
+  /**
+   * Convert this object, in the org.apache.kafka.connect.data format, into a JSON object,
+   * returning both the schema
+   * and the converted object.
+   */
+  @VisibleForTesting
+  protected static JsonNode fromConnectData(Schema schema, Object logicalValue) {
+    if (logicalValue == null) {
+      if (schema == null) {
+        // Any schema is valid and we don't have a default, so treat this as an optional schema
+        return null;
+      }
+      if (schema.defaultValue() != null) {
+        return fromConnectData(schema, schema.defaultValue());
+      }
+      if (schema.isOptional()) {
+        return JsonNodeFactory.instance.nullNode();
+      }
+      throw new DataException(
+          "Conversion error: null value for field that is required and has no default value");
+    }
+
+    Object value = logicalValue;
+    if (schema != null && schema.name() != null) {
+      LogicalTypeConverter logicalConverter = TO_JSON_LOGICAL_CONVERTERS.get(schema.name());
+      if (logicalConverter != null) {
+        value = logicalConverter.convert(schema, logicalValue);
+      }
+    }
+
+    try {
+      final Schema.Type schemaType;
+      if (schema == null) {
+        schemaType = ConnectSchema.schemaType(value.getClass());
+        if (schemaType == null) {
+          throw new DataException("Java class "
+              + value.getClass()
+              + " does not have corresponding schema type.");
+        }
+      } else {
+        schemaType = schema.type();
+      }
+      switch (schemaType) {
+        case INT8:
+          // Use shortValue to create a ShortNode, otherwise an IntNode will be created
+          return JsonNodeFactory.instance.numberNode(((Byte) value).shortValue());
+        case INT16:
+          return JsonNodeFactory.instance.numberNode((Short) value);
+        case INT32:
+          return JsonNodeFactory.instance.numberNode((Integer) value);
+        case INT64:
+          return JsonNodeFactory.instance.numberNode((Long) value);
+        case FLOAT32:
+          return JsonNodeFactory.instance.numberNode((Float) value);
+        case FLOAT64:
+          return JsonNodeFactory.instance.numberNode((Double) value);
+        case BOOLEAN:
+          return JsonNodeFactory.instance.booleanNode((Boolean) value);
+        case STRING:
+          CharSequence charSeq = (CharSequence) value;
+          return JsonNodeFactory.instance.textNode(charSeq.toString());
+        case BYTES:
+          if (value instanceof byte[]) {
+            return JsonNodeFactory.instance.binaryNode((byte[]) value);
+          } else if (value instanceof ByteBuffer) {
+            return JsonNodeFactory.instance.binaryNode(((ByteBuffer) value).array());
+          } else if (value instanceof BigDecimal) {
+            return JsonNodeFactory.instance.numberNode(((BigDecimal) value));
+          } else {
+            throw new DataException("Invalid type for bytes type: " + value.getClass());
+          }
+        case ARRAY: {
+          Collection collection = (Collection) value;
+          ArrayNode list = JsonNodeFactory.instance.arrayNode();
+          for (Object elem : collection) {
+            Schema valueSchema = schema == null ? null : schema.valueSchema();
+            JsonNode fieldValue = fromConnectData(valueSchema, elem);
+            list.add(fieldValue);
+          }
+          return list;
+        }
+        case MAP: {
+          Map<?, ?> map = (Map<?, ?>) value;
+          // If true, using string keys and JSON object; if false, using non-string keys and
+          // Array-encoding
+          boolean objectMode;
+          if (schema == null) {
+            objectMode = true;
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+              if (!(entry.getKey() instanceof String)) {
+                objectMode = false;
+                break;
+              }
+            }
+          } else {
+            objectMode = schema.keySchema().type() == Schema.Type.STRING && !schema.keySchema()
+                .isOptional();
+          }
+          ObjectNode obj = null;
+          ArrayNode list = null;
+          if (objectMode) {
+            obj = JsonNodeFactory.instance.objectNode();
+          } else {
+            list = JsonNodeFactory.instance.arrayNode();
+          }
+          for (Map.Entry<?, ?> entry : map.entrySet()) {
+            Schema keySchema = schema == null ? null : schema.keySchema();
+            Schema valueSchema = schema == null ? null : schema.valueSchema();
+            JsonNode mapKey = fromConnectData(keySchema, entry.getKey());
+            JsonNode mapValue = fromConnectData(valueSchema, entry.getValue());
+
+            if (objectMode) {
+              obj.set(mapKey.asText(), mapValue);
+            } else {
+              ObjectNode o = JsonNodeFactory.instance.objectNode();
+              o.set(KEY_FIELD, mapKey);
+              o.set(VALUE_FIELD, mapValue);
+              list.add(o);
+            }
+          }
+          return objectMode ? obj : list;
+        }
+        case STRUCT: {
+          Struct struct = (Struct) value;
+          if (!struct.schema().equals(schema)) {
+            throw new DataException("Mismatching schema.");
+          }
+          //This handles the inverting of a union which is held as a struct, where each field is
+          // one of the union types.
+          if (JSON_TYPE_ONE_OF.equals(schema.name())) {
+            for (Field field : schema.fields()) {
+              Object object = struct.get(field);
+              if (object != null) {
+                return fromConnectData(field.schema(), object);
+              }
+            }
+            return fromConnectData(schema, null);
+          } else {
+            ObjectNode obj = JsonNodeFactory.instance.objectNode();
+            for (Field field : schema.fields()) {
+              obj.set(field.name(), fromConnectData(field.schema(), struct.get(field)));
+            }
+            return obj;
+          }
+        }
+        default:
+          break;
+      }
+
+      throw new DataException("Couldn't convert " + value + " to JSON.");
+    } catch (ClassCastException e) {
+      String schemaTypeStr = (schema != null) ? schema.type().toString() : "unknown schema";
+      throw new DataException("Invalid type for " + schemaTypeStr + ": " + value.getClass());
+    }
+  }
+
+  @Override
+  public SchemaAndValue toConnectData(String topic, byte[] value) {
+    try {
+      JsonSchemaAndValue deserialized = deserializer.deserialize(topic, isKey, value);
+
+      if (deserialized == null || deserialized.getValue() == null) {
+        return SchemaAndValue.NULL;
+      }
+
+      JsonSchema jsonSchema = deserialized.getSchema();
+      Schema schema = toConnectSchema(jsonSchema.rawSchema(), jsonSchema.version());
+      return new SchemaAndValue(schema, toConnectData(schema, (JsonNode) deserialized.getValue()));
+    } catch (SerializationException e) {
+      throw new DataException("Converting byte[] to Kafka Connect data failed due to "
+          + "serialization error: ",
+          e
+      );
+    }
+  }
+
+  @VisibleForTesting
+  protected static Object toConnectData(Schema schema, JsonNode jsonValue) {
+    final Schema.Type schemaType;
+    if (schema != null) {
+      schemaType = schema.type();
+      if (jsonValue.isNull()) {
+        if (schema.defaultValue() != null) {
+          return schema.defaultValue(); // any logical type conversions should already have been
+        }
+        // applied
+        if (schema.isOptional()) {
+          return null;
+        }
+        throw new DataException("Invalid null value for required " + schemaType + " field");
+      }
+    } else {
+      switch (jsonValue.getNodeType()) {
+        case NULL:
+          return null;
+        case BOOLEAN:
+          schemaType = Schema.Type.BOOLEAN;
+          break;
+        case NUMBER:
+          if (jsonValue.isIntegralNumber()) {
+            schemaType = Schema.Type.INT64;
+          } else {
+            schemaType = Schema.Type.FLOAT64;
+          }
+          break;
+        case ARRAY:
+          schemaType = Schema.Type.ARRAY;
+          break;
+        case OBJECT:
+          schemaType = Schema.Type.MAP;
+          break;
+        case STRING:
+          schemaType = Schema.Type.STRING;
+          break;
+
+        case BINARY:
+        case MISSING:
+        case POJO:
+        default:
+          schemaType = null;
+          break;
+      }
+    }
+
+    final JsonToConnectTypeConverter typeConverter = TO_CONNECT_CONVERTERS.get(schemaType);
+    if (typeConverter == null) {
+      throw new DataException("Unknown schema type: " + String.valueOf(schemaType));
+    }
+
+    Object converted = typeConverter.convert(schema, jsonValue);
+    if (schema != null && schema.name() != null) {
+      LogicalTypeConverter logicalConverter = TO_CONNECT_LOGICAL_CONVERTERS.get(schema.name());
+      if (logicalConverter != null) {
+        converted = logicalConverter.convert(schema, converted);
+      }
+    }
+    return converted;
+  }
+
+  protected org.everit.json.schema.Schema fromConnectSchema(Schema schema) {
+    if (schema == null) {
+      return null;
+    }
+    org.everit.json.schema.Schema cachedSchema = fromConnectSchemaCache.get(schema);
+    if (cachedSchema != null) {
+      return cachedSchema;
+    }
+    org.everit.json.schema.Schema resultSchema = fromConnectSchema(schema, null);
+    fromConnectSchemaCache.put(schema, resultSchema);
+    return resultSchema;
+  }
+
+  private org.everit.json.schema.Schema fromConnectSchema(Schema schema, Integer index) {
+    return fromConnectSchema(schema, index, false);
+  }
+
+  private org.everit.json.schema.Schema fromConnectSchema(
+      Schema schema, Integer index, boolean ignoreOptional
+  ) {
+    if (schema == null) {
+      return null;
+    }
+
+    org.everit.json.schema.Schema.Builder builder;
+    Map<String, Object> unprocessedProps = new HashMap<>();
+    switch (schema.type()) {
+      case INT8:
+        builder = NumberSchema.builder().requiresInteger(true);
+        unprocessedProps.put(CONNECT_TYPE_PROP, CONNECT_TYPE_INT8);
+        break;
+      case INT16:
+        builder = NumberSchema.builder().requiresInteger(true);
+        unprocessedProps.put(CONNECT_TYPE_PROP, CONNECT_TYPE_INT16);
+        break;
+      case INT32:
+        builder = NumberSchema.builder().requiresInteger(true);
+        unprocessedProps.put(CONNECT_TYPE_PROP, CONNECT_TYPE_INT32);
+        break;
+      case INT64:
+        builder = NumberSchema.builder().requiresInteger(true);
+        unprocessedProps.put(CONNECT_TYPE_PROP, CONNECT_TYPE_INT64);
+        break;
+      case FLOAT32:
+        builder = NumberSchema.builder().requiresInteger(false);
+        unprocessedProps.put(CONNECT_TYPE_PROP, CONNECT_TYPE_FLOAT32);
+        break;
+      case FLOAT64:
+        builder = NumberSchema.builder().requiresInteger(false);
+        unprocessedProps.put(CONNECT_TYPE_PROP, CONNECT_TYPE_FLOAT64);
+        break;
+      case BOOLEAN:
+        builder = BooleanSchema.builder();
+        break;
+      case STRING:
+        if (schema.parameters() != null && schema.parameters().containsKey(JSON_TYPE_ENUM)) {
+          EnumSchema.Builder enumBuilder = EnumSchema.builder();
+          for (Map.Entry<String, String> entry : schema.parameters().entrySet()) {
+            if (entry.getKey().startsWith(JSON_TYPE_ENUM_PREFIX)) {
+              enumBuilder.possibleValue(entry.getValue());
+            }
+          }
+          builder = enumBuilder;
+        } else {
+          builder = StringSchema.builder();
+        }
+        break;
+      case BYTES:
+        builder = Decimal.LOGICAL_NAME.equals(schema.name())
+                  ? NumberSchema.builder()
+                  : StringSchema.builder();
+        unprocessedProps.put(CONNECT_TYPE_PROP, CONNECT_TYPE_BYTES);
+        break;
+      case ARRAY:
+        builder = ArraySchema.builder().allItemSchema(fromConnectSchema(schema.valueSchema()));
+        break;
+      case MAP:
+        // JSON Schema only supports string keys
+        if (schema.keySchema().type() == Schema.Type.STRING && !schema.keySchema().isOptional()) {
+          org.everit.json.schema.Schema valueSchema = fromConnectSchema(schema.valueSchema());
+          builder = ObjectSchema.builder().schemaOfAdditionalProperties(valueSchema);
+          unprocessedProps.put(CONNECT_TYPE_PROP, CONNECT_TYPE_MAP);
+        } else {
+          ObjectSchema.Builder entryBuilder = ObjectSchema.builder();
+          org.everit.json.schema.Schema keySchema = fromConnectSchema(schema.keySchema(), 0);
+          org.everit.json.schema.Schema valueSchema = fromConnectSchema(schema.valueSchema(), 1);
+          entryBuilder.addPropertySchema(KEY_FIELD, keySchema);
+          entryBuilder.addPropertySchema(VALUE_FIELD, valueSchema);
+          builder = ArraySchema.builder().allItemSchema(entryBuilder.build());
+          unprocessedProps.put(CONNECT_TYPE_PROP, CONNECT_TYPE_MAP);
+        }
+        break;
+      case STRUCT:
+        if (JSON_TYPE_ONE_OF.equals(schema.name())) {
+          CombinedSchema.Builder combinedBuilder = CombinedSchema.builder();
+          combinedBuilder.criterion(CombinedSchema.ONE_CRITERION);
+          if (schema.isOptional()) {
+            combinedBuilder.subschema(NullSchema.INSTANCE);
+          }
+          for (Field field : schema.fields()) {
+            combinedBuilder.subschema(fromConnectSchema(nonOptional(field.schema()),
+                field.index(),
+                true
+            ));
+          }
+          builder = combinedBuilder;
+        } else if (schema.isOptional()) {
+          CombinedSchema.Builder combinedBuilder = CombinedSchema.builder();
+          combinedBuilder.criterion(CombinedSchema.ONE_CRITERION);
+          combinedBuilder.subschema(NullSchema.INSTANCE);
+          combinedBuilder.subschema(fromConnectSchema(nonOptional(schema)));
+          builder = combinedBuilder;
+        } else {
+          ObjectSchema.Builder objectBuilder = ObjectSchema.builder();
+          for (Field field : schema.fields()) {
+            org.everit.json.schema.Schema fieldSchema = fromConnectSchema(field.schema(),
+                field.index()
+            );
+            objectBuilder.addPropertySchema(field.name(), fieldSchema);
+          }
+          builder = objectBuilder;
+        }
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported type " + schema.type());
+    }
+
+    if (!(builder instanceof CombinedSchema.Builder)) {
+      if (schema.name() != null) {
+        builder.title(schema.name());
+      }
+      if (schema.version() != null) {
+        unprocessedProps.put(CONNECT_VERSION_PROP, schema.version());
+      }
+      if (schema.doc() != null) {
+        builder.description(schema.doc());
+      }
+      if (schema.parameters() != null) {
+        Map<String, String> parameters = schema.parameters()
+            .entrySet()
+            .stream()
+            .filter(e -> !e.getKey().startsWith(NAMESPACE))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        if (parameters.size() > 0) {
+          unprocessedProps.put(CONNECT_PARAMETERS_PROP, parameters);
+        }
+      }
+      if (schema.defaultValue() != null) {
+        builder.defaultValue(schema.defaultValue());
+      }
+
+      if (!ignoreOptional) {
+        if (schema.isOptional()) {
+          CombinedSchema.Builder combinedBuilder = CombinedSchema.builder();
+          combinedBuilder.criterion(CombinedSchema.ONE_CRITERION);
+          combinedBuilder.subschema(NullSchema.INSTANCE);
+          combinedBuilder.subschema(builder.unprocessedProperties(unprocessedProps).build());
+          if (index != null) {
+            combinedBuilder.unprocessedProperties(Collections.singletonMap(CONNECT_INDEX_PROP,
+                index
+            ));
+          }
+          builder = combinedBuilder;
+          unprocessedProps = new HashMap<>();
+        }
+      }
+    }
+    if (index != null) {
+      unprocessedProps.put(CONNECT_INDEX_PROP, index);
+    }
+    return builder.unprocessedProperties(unprocessedProps).build();
+  }
+
+  private static Schema nonOptional(Schema schema) {
+    return new ConnectSchema(schema.type(),
+        false,
+        schema.defaultValue(),
+        schema.name(),
+        schema.version(),
+        schema.doc(),
+        schema.parameters(),
+        fields(schema),
+        keySchema(schema),
+        valueSchema(schema)
+    );
+  }
+
+  private static List<Field> fields(Schema schema) {
+    Schema.Type type = schema.type();
+    if (Schema.Type.STRUCT.equals(type)) {
+      return schema.fields();
+    } else {
+      return null;
+    }
+  }
+
+  private static Schema keySchema(Schema schema) {
+    Schema.Type type = schema.type();
+    if (Schema.Type.MAP.equals(type)) {
+      return schema.keySchema();
+    } else {
+      return null;
+    }
+  }
+
+  private static Schema valueSchema(Schema schema) {
+    Schema.Type type = schema.type();
+    if (Schema.Type.MAP.equals(type) || Schema.Type.ARRAY.equals(type)) {
+      return schema.valueSchema();
+    } else {
+      return null;
+    }
+  }
+
+  private Schema toConnectSchema(JsonSchema schema) {
+    if (schema == null) {
+      return null;
+    }
+    Schema cachedSchema = toConnectSchemaCache.get(schema);
+    if (cachedSchema != null) {
+      return null;
+    }
+    Schema resultSchema = toConnectSchema(schema.rawSchema(), schema.version(), false);
+    toConnectSchemaCache.put(schema, resultSchema);
+    return resultSchema;
+  }
+
+  protected Schema toConnectSchema(org.everit.json.schema.Schema jsonSchema) {
+    return toConnectSchema(jsonSchema, null);
+  }
+
+  private Schema toConnectSchema(org.everit.json.schema.Schema jsonSchema, Integer version) {
+    return toConnectSchema(jsonSchema, version, false);
+  }
+
+  private Schema toConnectSchema(
+      org.everit.json.schema.Schema jsonSchema, Integer version, boolean forceOptional
+  ) {
+    if (jsonSchema == null) {
+      return null;
+    }
+
+    final SchemaBuilder builder;
+    if (jsonSchema instanceof BooleanSchema) {
+      builder = SchemaBuilder.bool();
+    } else if (jsonSchema instanceof NumberSchema) {
+      NumberSchema numberSchema = (NumberSchema) jsonSchema;
+      String type = (String) numberSchema.getUnprocessedProperties().get(CONNECT_TYPE_PROP);
+      if (type == null) {
+        builder = numberSchema.requiresInteger() ? SchemaBuilder.int64() : SchemaBuilder.float64();
+      } else {
+        switch (type) {
+          case CONNECT_TYPE_INT8:
+            builder = SchemaBuilder.int8();
+            break;
+          case CONNECT_TYPE_INT16:
+            builder = SchemaBuilder.int16();
+            break;
+          case CONNECT_TYPE_INT32:
+            builder = SchemaBuilder.int32();
+            break;
+          case CONNECT_TYPE_INT64:
+            builder = SchemaBuilder.int64();
+            break;
+          case CONNECT_TYPE_FLOAT32:
+            builder = SchemaBuilder.float32();
+            break;
+          case CONNECT_TYPE_FLOAT64:
+            builder = SchemaBuilder.float64();
+            break;
+          case CONNECT_TYPE_BYTES:  // decimal logical type
+            builder = SchemaBuilder.bytes();
+            break;
+          default:
+            throw new IllegalArgumentException("Unsupported type " + type);
+        }
+      }
+    } else if (jsonSchema instanceof StringSchema) {
+      String type = (String) jsonSchema.getUnprocessedProperties().get(CONNECT_TYPE_PROP);
+      builder = CONNECT_TYPE_BYTES.equals(type) ? SchemaBuilder.bytes() : SchemaBuilder.string();
+    } else if (jsonSchema instanceof EnumSchema) {
+      EnumSchema enumSchema = (EnumSchema) jsonSchema;
+      builder = SchemaBuilder.string();
+      builder.parameter(JSON_TYPE_ENUM,
+          ""
+      );  // JSON enums have no name, use empty string as placeholder
+      for (Object enumObj : enumSchema.getPossibleValuesAsList()) {
+        String enumSymbol = enumObj.toString();
+        builder.parameter(JSON_TYPE_ENUM_PREFIX + enumSymbol, enumSymbol);
+      }
+    } else if (jsonSchema instanceof CombinedSchema) {
+      CombinedSchema combinedSchema = (CombinedSchema) jsonSchema;
+      CombinedSchema.ValidationCriterion criterion = combinedSchema.getCriterion();
+      String name = null;
+      if (criterion == CombinedSchema.ONE_CRITERION) {
+        name = JSON_TYPE_ONE_OF;
+      } else {
+        throw new IllegalArgumentException("Unsupported criterion: " + criterion);
+      }
+      if (combinedSchema.getSubschemas().size() == 2) {
+        if (combinedSchema.getSubschemas().contains(NullSchema.INSTANCE)) {
+          for (org.everit.json.schema.Schema subSchema : combinedSchema.getSubschemas()) {
+            if (!subSchema.equals(NullSchema.INSTANCE)) {
+              return toConnectSchema(subSchema, version, true);
+            }
+          }
+        }
+      }
+      int index = 0;
+      builder = SchemaBuilder.struct().name(name);
+      for (org.everit.json.schema.Schema subSchema : combinedSchema.getSubschemas()) {
+        if (subSchema.equals(NullSchema.INSTANCE)) {
+          builder.optional();
+        } else {
+          String subFieldName = name + ".field." + index++;
+          builder.field(subFieldName, toConnectSchema(subSchema));
+        }
+      }
+    } else if (jsonSchema instanceof ArraySchema) {
+      ArraySchema arraySchema = (ArraySchema) jsonSchema;
+      org.everit.json.schema.Schema itemsSchema = arraySchema.getAllItemSchema();
+      if (itemsSchema == null) {
+        throw new DataException("Array schema did not specify the items type");
+      }
+      String type = (String) arraySchema.getUnprocessedProperties().get(CONNECT_TYPE_PROP);
+      if (CONNECT_TYPE_MAP.equals(type) && itemsSchema instanceof ObjectSchema) {
+        ObjectSchema objectSchema = (ObjectSchema) itemsSchema;
+        builder = SchemaBuilder.map(toConnectSchema(objectSchema.getPropertySchemas()
+                .get(KEY_FIELD)),
+            toConnectSchema(objectSchema.getPropertySchemas().get(VALUE_FIELD))
+        );
+      } else {
+        builder = SchemaBuilder.array(toConnectSchema(itemsSchema));
+      }
+    } else if (jsonSchema instanceof ObjectSchema) {
+      ObjectSchema objectSchema = (ObjectSchema) jsonSchema;
+      String type = (String) objectSchema.getUnprocessedProperties().get(CONNECT_TYPE_PROP);
+      if (CONNECT_TYPE_MAP.equals(type)) {
+        builder = SchemaBuilder.map(Schema.STRING_SCHEMA,
+            toConnectSchema(objectSchema.getSchemaOfAdditionalProperties())
+        );
+      } else {
+        builder = SchemaBuilder.struct();
+        Map<String, org.everit.json.schema.Schema> properties = objectSchema.getPropertySchemas();
+        SortedMap<Integer, Map.Entry<String, org.everit.json.schema.Schema>> sortedMap =
+            new TreeMap<>();
+        for (Map.Entry<String, org.everit.json.schema.Schema> property : properties.entrySet()) {
+          org.everit.json.schema.Schema subSchema = property.getValue();
+          Integer index = (Integer) subSchema.getUnprocessedProperties().get(CONNECT_INDEX_PROP);
+          if (index == null) {
+            index = sortedMap.size();
+          }
+          sortedMap.put(index, property);
+        }
+        for (Map.Entry<String, org.everit.json.schema.Schema> property : sortedMap.values()) {
+          String subFieldName = property.getKey();
+          org.everit.json.schema.Schema subSchema = property.getValue();
+          builder.field(subFieldName, toConnectSchema(subSchema));
+        }
+      }
+    } else if (jsonSchema instanceof ReferenceSchema) {
+      ReferenceSchema refSchema = (ReferenceSchema) jsonSchema;
+      return toConnectSchema(refSchema.getReferredSchema(), version);
+    } else {
+      throw new DataException("Unsupported schema type " + jsonSchema.getClass().getName());
+    }
+
+    String title = jsonSchema.getTitle();
+    if (title != null) {
+      builder.name(title);
+    }
+    // Included Kafka Connect version takes priority, fall back to schema registry version
+    Integer connectVersion = (Integer) jsonSchema.getUnprocessedProperties()
+        .get(CONNECT_VERSION_PROP);
+    if (connectVersion != null) {
+      builder.version(connectVersion);
+    } else if (version != null) {
+      builder.version(version);
+    }
+    String description = jsonSchema.getDescription();
+    if (description != null) {
+      builder.doc(description);
+    }
+    Map<String, String> parameters = (Map<String, String>) jsonSchema.getUnprocessedProperties()
+        .get(CONNECT_PARAMETERS_PROP);
+    if (parameters != null) {
+      builder.parameters(parameters);
+    }
+    if (jsonSchema.hasDefaultValue()) {
+      builder.defaultValue(jsonSchema.getDefaultValue());
+    }
+
+    if (forceOptional) {
+      builder.optional();
+    }
+
+    Schema result = builder.build();
+    return result;
+  }
+
+  private interface JsonToConnectTypeConverter {
+    Object convert(Schema schema, JsonNode value);
+  }
+
+  private interface LogicalTypeConverter {
+    Object convert(Schema schema, Object value);
+  }
+
+  private static class Serializer extends AbstractKafkaJsonSchemaSerializer {
+
+    public Serializer(SchemaRegistryClient client, boolean autoRegisterSchema) {
+      schemaRegistry = client;
+      this.autoRegisterSchema = autoRegisterSchema;
+    }
+
+    public Serializer(Map<String, ?> configs, SchemaRegistryClient client) {
+
+      this(client, false);
+      configure(new KafkaJsonSchemaSerializerConfig(configs));
+    }
+
+    public byte[] serialize(String topic, boolean isKey, Object value, JsonSchema schema) {
+      if (value == null) {
+        return null;
+      }
+      return serializeImpl(getSubjectName(topic, isKey, value, schema), value, schema);
+    }
+  }
+
+  private static class Deserializer extends AbstractKafkaJsonSchemaDeserializer {
+
+    public Deserializer(SchemaRegistryClient client) {
+      schemaRegistry = client;
+    }
+
+    public Deserializer(Map<String, ?> configs, SchemaRegistryClient client) {
+      this(client);
+      configure(new KafkaJsonSchemaDeserializerConfig(configs), null);
+    }
+
+    public JsonSchemaAndValue deserialize(String topic, boolean isKey, byte[] payload) {
+      return deserializeWithSchemaAndVersion(topic, isKey, payload);
+    }
+  }
+}

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverterConfig.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverterConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.json;
+
+import java.util.Map;
+
+import io.confluent.common.config.ConfigDef;
+import io.confluent.common.config.ConfigDef.Importance;
+import io.confluent.common.config.ConfigDef.Type;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+
+public class JsonSchemaConverterConfig extends AbstractKafkaSchemaSerDeConfig {
+
+  public static final String SCHEMAS_CACHE_SIZE_CONFIG = "schemas.cache.size";
+  public static final int SCHEMAS_CACHE_SIZE_DEFAULT = 1000;
+  private static final String SCHEMAS_CACHE_SIZE_DOC = "The maximum number of schemas that can be"
+      + " cached in this converter instance.";
+
+  private static final ConfigDef CONFIG;
+
+  static {
+    CONFIG = baseConfigDef();
+    CONFIG.define(
+        SCHEMAS_CACHE_SIZE_CONFIG,
+        Type.INT,
+        SCHEMAS_CACHE_SIZE_DEFAULT,
+        Importance.HIGH,
+        SCHEMAS_CACHE_SIZE_DOC
+    );
+  }
+
+  public static ConfigDef configDef() {
+    return CONFIG;
+  }
+
+  public JsonSchemaConverterConfig(Map<?, ?> props) {
+    super(CONFIG, props);
+  }
+
+  public int schemaCacheSize() {
+    return getInt(SCHEMAS_CACHE_SIZE_CONFIG);
+  }
+}

--- a/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaConverterTest.java
+++ b/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaConverterTest.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaUtils;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer;
+
+import static org.junit.Assert.assertEquals;
+
+public class JsonSchemaConverterTest {
+
+  private final ResourceLoader loader = ResourceLoader.DEFAULT;
+
+  private static final String TOPIC = "topic";
+
+  private static final Map<String, ?> SR_CONFIG =
+      Collections.singletonMap(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+      "localhost"
+  );
+
+  private final SchemaRegistryClient schemaRegistry;
+  private final JsonSchemaConverter converter;
+
+  public JsonSchemaConverterTest() {
+    schemaRegistry = new MockSchemaRegistryClient();
+    converter = new JsonSchemaConverter(schemaRegistry);
+  }
+
+  @Before
+  public void setUp() {
+    Map<String, String> config = new HashMap<>();
+    config.put("schema.registry.url", "http://fake-url");
+    converter.configure(config, false);
+  }
+
+  @Test
+  public void testPrimitive() {
+    SchemaAndValue original = new SchemaAndValue(Schema.BOOLEAN_SCHEMA, true);
+    byte[] converted = converter.fromConnectData(TOPIC, original.schema(), original.value());
+    SchemaAndValue schemaAndValue = converter.toConnectData(TOPIC, converted);
+    // Because of registration in schema registry and lookup, we'll have added a version number
+    SchemaAndValue expected = new SchemaAndValue(SchemaBuilder.bool().version(1).build(), true);
+    assertEquals(expected, schemaAndValue);
+  }
+
+  @Test
+  public void testComplex() {
+    SchemaBuilder builder = SchemaBuilder.struct()
+        .field("int8", Schema.INT8_SCHEMA)
+        .field("int16", Schema.INT16_SCHEMA)
+        .field("int32", Schema.INT32_SCHEMA)
+        .field("int64", Schema.INT64_SCHEMA)
+        .field("float32", Schema.FLOAT32_SCHEMA)
+        .field("float64", Schema.FLOAT64_SCHEMA)
+        .field("boolean", Schema.BOOLEAN_SCHEMA)
+        .field("string", Schema.STRING_SCHEMA)
+        .field("bytes", Schema.BYTES_SCHEMA)
+        .field("array", SchemaBuilder.array(Schema.STRING_SCHEMA).build())
+        .field("map", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).build());
+    Schema schema = builder.build();
+    Struct original = new Struct(schema).put("int8", (byte) 12)
+        .put("int16", (short) 12)
+        .put("int32", 12)
+        .put("int64", 12L)
+        .put("float32", 12.2f)
+        .put("float64", 12.2)
+        .put("boolean", true)
+        .put("string", "foo")
+        .put("bytes", "foo".getBytes())
+        .put("array", Arrays.asList("a", "b", "c"))
+        .put("map", Collections.singletonMap("field", 1));
+    // Because of registration in schema registry and lookup, we'll have added a version number
+    Schema expectedSchema = builder.version(1).build();
+    Struct expected = new Struct(expectedSchema).put("int8", (byte) 12)
+        .put("int16", (short) 12)
+        .put("int32", 12)
+        .put("int64", 12L)
+        .put("float32", 12.2f)
+        .put("float64", 12.2)
+        .put("boolean", true)
+        .put("string", "foo")
+        .put("bytes", "foo".getBytes())
+        .put("array", Arrays.asList("a", "b", "c"))
+        .put("map", Collections.singletonMap("field", 1));
+
+    byte[] converted = converter.fromConnectData(TOPIC, original.schema(), original);
+    SchemaAndValue schemaAndValue = converter.toConnectData(TOPIC, converted);
+    assertEquals(expected, schemaAndValue.value());
+  }
+
+  @Test
+  public void testNull() {
+    byte[] converted = converter.fromConnectData(TOPIC, Schema.OPTIONAL_BOOLEAN_SCHEMA, null);
+    SchemaAndValue schemaAndValue = converter.toConnectData(TOPIC, converted);
+    assertEquals(new SchemaAndValue(SchemaBuilder.bool().version(1).optional().build(), null),
+        schemaAndValue
+    );
+  }
+
+  @Test
+  public void testVersionExtractedForDefaultSubjectNameStrategy() throws Exception {
+    // Version info should be extracted even if the data was not created with Copycat. Manually
+    // register a few compatible schemas and validate that data serialized with our normal
+    // serializer can be read and gets version info inserted
+    String subject = TOPIC + "-value";
+    KafkaJsonSchemaSerializer serializer = new KafkaJsonSchemaSerializer(schemaRegistry,
+        ImmutableMap.of("schema.registry.url", "http://fake-url")
+    );
+    JsonSchemaConverter jsonConverter = new JsonSchemaConverter(schemaRegistry);
+    jsonConverter.configure(Collections.singletonMap("schema.registry.url", "http://fake-url"),
+        false
+    );
+    testVersionExtracted(subject, serializer, jsonConverter);
+  }
+
+  private void testVersionExtracted(
+      String subject, KafkaJsonSchemaSerializer serializer, JsonSchemaConverter jsonConverter
+  ) throws IOException, RestClientException {
+    JsonNode rawSchemaJson1 = loader.readJsonNode("key.json");
+    JsonNode rawSchemaJson2 = loader.readJsonNode("keyvalue.json");
+    schemaRegistry.register(subject, new JsonSchema(rawSchemaJson1));
+    schemaRegistry.register(subject, new JsonSchema(rawSchemaJson2));
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    ObjectNode objectNode1 = mapper.createObjectNode();
+    objectNode1.put("key", 15);
+
+    ObjectNode objectNode2 = mapper.createObjectNode();
+    objectNode2.put("key", 15);
+    objectNode2.put("value", "bar");
+
+    // Get serialized data
+    byte[] serializedRecord1 = serializer.serialize(TOPIC,
+        JsonSchemaUtils.envelope(rawSchemaJson1, objectNode1)
+    );
+    byte[] serializedRecord2 = serializer.serialize(TOPIC,
+        JsonSchemaUtils.envelope(rawSchemaJson2, objectNode2)
+    );
+
+    SchemaAndValue converted1 = jsonConverter.toConnectData(TOPIC, serializedRecord1);
+    assertEquals(1L, (long) converted1.schema().version());
+
+    SchemaAndValue converted2 = jsonConverter.toConnectData(TOPIC, serializedRecord2);
+    assertEquals(2L, (long) converted2.schema().version());
+  }
+
+  @Test
+  public void testVersionMaintained() {
+    // Version info provided from the Copycat schema should be maintained. This should be true
+    // regardless of any underlying schema registry versioning since the versions are explicitly
+    // specified by the connector.
+
+    // Use newer schema first
+    Schema newerSchema = SchemaBuilder.struct()
+        .version(2)
+        .field("orig", Schema.OPTIONAL_INT16_SCHEMA)
+        .field("new", Schema.OPTIONAL_INT16_SCHEMA)
+        .build();
+    SchemaAndValue newer = new SchemaAndValue(newerSchema,
+        new Struct(newerSchema).put("orig", (short) 1).put("new", (short) 2)
+    );
+    byte[] newerSerialized = converter.fromConnectData(TOPIC, newer.schema(), newer.value());
+
+    Schema olderSchema = SchemaBuilder.struct()
+        .version(1)
+        .field("orig", Schema.OPTIONAL_INT16_SCHEMA)
+        .build();
+    SchemaAndValue older = new SchemaAndValue(olderSchema,
+        new Struct(olderSchema).put("orig", (short) 1)
+    );
+    byte[] olderSerialized = converter.fromConnectData(TOPIC, older.schema(), older.value());
+
+    assertEquals(2L, (long) converter.toConnectData(TOPIC, newerSerialized).schema().version());
+    assertEquals(1L, (long) converter.toConnectData(TOPIC, olderSerialized).schema().version());
+  }
+
+  @Test
+  public void testSameSchemaMultipleTopicForValue() throws IOException, RestClientException {
+    SchemaRegistryClient schemaRegistry = new MockSchemaRegistryClient();
+    JsonSchemaConverter jsonConverter = new JsonSchemaConverter(schemaRegistry);
+    jsonConverter.configure(SR_CONFIG, false);
+    assertSameSchemaMultipleTopic(jsonConverter, schemaRegistry, false);
+  }
+
+  @Test
+  public void testSameSchemaMultipleTopicForKey() throws IOException, RestClientException {
+    SchemaRegistryClient schemaRegistry = new MockSchemaRegistryClient();
+    JsonSchemaConverter jsonConverter = new JsonSchemaConverter(schemaRegistry);
+    jsonConverter.configure(SR_CONFIG, true);
+    assertSameSchemaMultipleTopic(jsonConverter, schemaRegistry, true);
+  }
+
+  @Test
+  public void testExplicitlyNamedNestedMapsWithNonStringKeys() {
+    final Schema schema = SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA,
+        SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.OPTIONAL_INT32_SCHEMA)
+            .name("foo.bar")
+            .build()
+    ).name("biz.baz").version(1).build();
+    final JsonSchemaConverter jsonConverter =
+        new JsonSchemaConverter(new MockSchemaRegistryClient());
+    jsonConverter.configure(Collections.singletonMap(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+        "localhost"
+    ), false);
+    final Object value = Collections.singletonMap("foo", Collections.singletonMap("bar", 1));
+
+    final byte[] bytes = jsonConverter.fromConnectData("topic", schema, value);
+    final SchemaAndValue schemaAndValue = jsonConverter.toConnectData("topic", bytes);
+
+    assertEquals(schemaAndValue.schema(), schema);
+    assertEquals(schemaAndValue.value(), value);
+  }
+
+  private void assertSameSchemaMultipleTopic(
+      JsonSchemaConverter converter, SchemaRegistryClient schemaRegistry, boolean isKey
+  ) throws IOException, RestClientException {
+    JsonNode rawSchemaJson1 = loader.readJsonNode("key.json");
+    JsonNode rawSchemaJson2_1 = loader.readJsonNode("keyvalue.json");
+    JsonNode rawSchemaJson2_2 = loader.readJsonNode("keyvalue.json");
+    String subjectSuffix = isKey ? "key" : "value";
+    schemaRegistry.register("topic1-" + subjectSuffix, new JsonSchema(rawSchemaJson2_1));
+    schemaRegistry.register("topic2-" + subjectSuffix, new JsonSchema(rawSchemaJson1));
+    schemaRegistry.register("topic2-" + subjectSuffix, new JsonSchema(rawSchemaJson2_2));
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    ObjectNode objectNode1 = mapper.createObjectNode();
+    objectNode1.put("key", 15);
+    objectNode1.put("value", "bar");
+
+    ObjectNode objectNode2 = mapper.createObjectNode();
+    objectNode2.put("key", 15);
+    objectNode2.put("value", "bar");
+
+    KafkaJsonSchemaSerializer serializer = new KafkaJsonSchemaSerializer(schemaRegistry,
+        ImmutableMap.of("schema.registry.url", "http://fake-url")
+    );
+    byte[] serializedRecord1 = serializer.serialize("topic1",
+        JsonSchemaUtils.envelope(rawSchemaJson2_1, objectNode1)
+    );
+    byte[] serializedRecord2 = serializer.serialize("topic2",
+        JsonSchemaUtils.envelope(rawSchemaJson2_2, objectNode2)
+    );
+
+    SchemaAndValue converted1 = converter.toConnectData("topic1", serializedRecord1);
+    assertEquals(1L, (long) converted1.schema().version());
+
+    SchemaAndValue converted2 = converter.toConnectData("topic2", serializedRecord2);
+    assertEquals(2L, (long) converted2.schema().version());
+
+    converted2 = converter.toConnectData("topic2", serializedRecord2);
+    assertEquals(2L, (long) converted2.schema().version());
+  }
+}

--- a/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
+++ b/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
@@ -1,0 +1,782 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BinaryNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.DecimalNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.FloatNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.ShortNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.everit.json.schema.ArraySchema;
+import org.everit.json.schema.BooleanSchema;
+import org.everit.json.schema.CombinedSchema;
+import org.everit.json.schema.EnumSchema;
+import org.everit.json.schema.NullSchema;
+import org.everit.json.schema.NumberSchema;
+import org.everit.json.schema.ObjectSchema;
+import org.everit.json.schema.StringSchema;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
+
+import static io.confluent.connect.json.JsonSchemaConverter.CONNECT_TYPE_MAP;
+import static io.confluent.connect.json.JsonSchemaConverter.CONNECT_TYPE_PROP;
+import static io.confluent.connect.json.JsonSchemaConverter.JSON_TYPE_ENUM;
+import static io.confluent.connect.json.JsonSchemaConverter.JSON_TYPE_ONE_OF;
+import static io.confluent.connect.json.JsonSchemaConverter.KEY_FIELD;
+import static io.confluent.connect.json.JsonSchemaConverter.VALUE_FIELD;
+import static org.apache.kafka.connect.data.Decimal.LOGICAL_NAME;
+import static org.apache.kafka.connect.data.Decimal.SCALE_FIELD;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+public class JsonSchemaDataTest {
+
+  private static final Schema NAMED_MAP_SCHEMA = SchemaBuilder.map(Schema.STRING_SCHEMA,
+      Schema.INT32_SCHEMA
+  ).name("foo.bar").build();
+  private static final org.everit.json.schema.Schema NAMED_JSON_MAP_SCHEMA = ObjectSchema.builder()
+      .schemaOfAdditionalProperties(NumberSchema.builder()
+          .requiresInteger(true)
+          .unprocessedProperties(Collections.singletonMap("connect.type", "int32"))
+          .build())
+      .unprocessedProperties(Collections.singletonMap(CONNECT_TYPE_PROP, CONNECT_TYPE_MAP))
+      .title("foo.bar")
+      .build();
+
+  private JsonSchemaConverter jsonSchemaConverter = new JsonSchemaConverter();
+
+  public JsonSchemaDataTest() {
+    Map<String, Object> configs = new HashMap<>();
+    configs.put(JsonSchemaConverterConfig.SCHEMA_REGISTRY_URL_CONFIG, "mock://foo");
+    configs.put(JsonSchemaConverterConfig.SCHEMAS_CACHE_SIZE_CONFIG,
+        JsonSchemaConverterConfig.SCHEMAS_CACHE_SIZE_DEFAULT
+    );
+    jsonSchemaConverter.configure(configs, false);
+  }
+
+  // Connect -> JSON Schema
+
+  @Test
+  public void testFromConnectBoolean() {
+    BooleanSchema schema = BooleanSchema.builder().build();
+    checkNonObjectConversion(schema, BooleanNode.getTrue(), Schema.BOOLEAN_SCHEMA, true);
+  }
+
+  @Test
+  public void testFromConnectByte() {
+    NumberSchema schema = NumberSchema.builder()
+        .requiresInteger(true)
+        .unprocessedProperties(Collections.singletonMap("connect.type", "int8"))
+        .build();
+    checkNonObjectConversion(schema, ShortNode.valueOf((short) 12), Schema.INT8_SCHEMA, (byte) 12);
+  }
+
+  @Test
+  public void testFromConnectShort() {
+    NumberSchema schema = NumberSchema.builder()
+        .requiresInteger(true)
+        .unprocessedProperties(Collections.singletonMap("connect.type", "int16"))
+        .build();
+    checkNonObjectConversion(schema,
+        ShortNode.valueOf((short) 12),
+        Schema.INT16_SCHEMA,
+        (short) 12
+    );
+  }
+
+  @Test
+  public void testFromConnectInteger() {
+    NumberSchema schema = NumberSchema.builder()
+        .requiresInteger(true)
+        .unprocessedProperties(Collections.singletonMap("connect.type", "int32"))
+        .build();
+    checkNonObjectConversion(schema, IntNode.valueOf(12), Schema.INT32_SCHEMA, 12);
+  }
+
+  @Test
+  public void testFromConnectLong() {
+    NumberSchema schema = NumberSchema.builder()
+        .requiresInteger(true)
+        .unprocessedProperties(Collections.singletonMap("connect.type", "int64"))
+        .build();
+    checkNonObjectConversion(schema, LongNode.valueOf(12L), Schema.INT64_SCHEMA, 12L);
+  }
+
+  @Test
+  public void testFromConnectFloat() {
+    NumberSchema schema = NumberSchema.builder()
+        .unprocessedProperties(Collections.singletonMap("connect.type", "float32"))
+        .build();
+    checkNonObjectConversion(schema, FloatNode.valueOf(12.2f), Schema.FLOAT32_SCHEMA, 12.2f);
+  }
+
+  @Test
+  public void testFromConnectDouble() {
+    NumberSchema schema = NumberSchema.builder()
+        .unprocessedProperties(Collections.singletonMap("connect.type", "float64"))
+        .build();
+    checkNonObjectConversion(schema, DoubleNode.valueOf(12.2), Schema.FLOAT64_SCHEMA, 12.2);
+  }
+
+  @Test
+  public void testFromConnectBytes() throws Exception {
+    StringSchema schema = StringSchema.builder()
+        .unprocessedProperties(Collections.singletonMap("connect.type", "bytes"))
+        .build();
+    checkNonObjectConversion(schema,
+        BinaryNode.valueOf("foo".getBytes()),
+        Schema.BYTES_SCHEMA,
+        "foo".getBytes()
+    );
+  }
+
+  @Test
+  public void testFromConnectString() {
+    StringSchema schema = StringSchema.builder().build();
+    checkNonObjectConversion(schema, TextNode.valueOf("string"), Schema.STRING_SCHEMA, "string");
+  }
+
+  @Test
+  public void testFromConnectEnum() {
+    EnumSchema schema = EnumSchema.builder()
+        .possibleValue("one")
+        .possibleValue("two")
+        .possibleValue("three")
+        .build();
+    Schema connectSchema = new SchemaBuilder(Schema.Type.STRING).parameter(JSON_TYPE_ENUM, "")
+        .parameter(JSON_TYPE_ENUM + ".one", "one")
+        .parameter(JSON_TYPE_ENUM + ".two", "two")
+        .parameter(JSON_TYPE_ENUM + ".three", "three")
+        .build();
+
+    checkNonObjectConversion(schema, TextNode.valueOf("one"), connectSchema, "one");
+  }
+
+  @Test
+  public void testFromConnectUnion() {
+    NumberSchema firstSchema = NumberSchema.builder()
+        .requiresInteger(true)
+        .unprocessedProperties(ImmutableMap.of("connect.type", "int8", "connect.index", 0))
+        .build();
+    NumberSchema secondSchema = NumberSchema.builder()
+        .requiresInteger(true)
+        .unprocessedProperties(ImmutableMap.of("connect.type", "int16", "connect.index", 1))
+        .build();
+    CombinedSchema schema = CombinedSchema.oneOf(ImmutableList.of(firstSchema, secondSchema))
+        .build();
+    SchemaBuilder builder = SchemaBuilder.struct().name(JSON_TYPE_ONE_OF);
+    builder.field(JSON_TYPE_ONE_OF + ".field.0", Schema.INT8_SCHEMA);
+    builder.field(JSON_TYPE_ONE_OF + ".field.1", Schema.INT16_SCHEMA);
+    Schema connectSchema = builder.build();
+
+    Struct actual = new Struct(connectSchema).put(JSON_TYPE_ONE_OF + ".field.0", (byte) 12);
+    checkNonObjectConversion(schema, ShortNode.valueOf((short) 12), connectSchema, actual);
+  }
+
+  @Test
+  public void testFromConnectNumericDecimal() {
+    NumberSchema schema = NumberSchema.builder()
+        .title("org.apache.kafka.connect.data.Decimal")
+        .unprocessedProperties(ImmutableMap.of("connect.type",
+            "bytes",
+            "connect.version",
+            1,
+            "connect.parameters",
+            ImmutableMap.of("scale", "2")
+        ))
+        .build();
+    checkNonObjectConversion(schema,
+        DecimalNode.valueOf(new BigDecimal("1.56")),
+        Decimal.schema(2),
+        new BigDecimal(new BigInteger("156"), 2)
+    );
+  }
+
+  @Test
+  public void testFromConnectMapWithStringKey() {
+    Schema connectSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA);
+    NumberSchema numberSchema = NumberSchema.builder()
+        .requiresInteger(true)
+        .unprocessedProperties(Collections.singletonMap("connect.type", "int32"))
+        .build();
+    ObjectSchema expected = ObjectSchema.builder()
+        .schemaOfAdditionalProperties(numberSchema)
+        .unprocessedProperties(Collections.singletonMap("connect.type", "map"))
+        .build();
+
+    ObjectNode obj = JsonNodeFactory.instance.objectNode();
+    obj.set("hi", IntNode.valueOf(32));
+    checkNonObjectConversion(expected, obj, connectSchema, Collections.singletonMap("hi", 32));
+  }
+
+  @Test
+  public void testFromConnectMapWithOptionalKey() {
+    Schema connectSchema = SchemaBuilder.map(Schema.OPTIONAL_STRING_SCHEMA, Schema.INT32_SCHEMA);
+    StringSchema stringSchema = StringSchema.builder().build();
+    CombinedSchema keySchema = CombinedSchema.oneOf(ImmutableList.of(NullSchema.INSTANCE,
+        stringSchema
+    ))
+        .unprocessedProperties(ImmutableMap.of("connect.index", 0))
+        .build();
+    NumberSchema valueSchema = NumberSchema.builder()
+        .requiresInteger(true)
+        .unprocessedProperties(ImmutableMap.of("connect.index", 1, "connect.type", "int32"))
+        .build();
+    ObjectSchema entrySchema = ObjectSchema.builder()
+        .addPropertySchema(KEY_FIELD, keySchema)
+        .addPropertySchema(VALUE_FIELD, valueSchema)
+        .build();
+    ArraySchema expected = ArraySchema.builder()
+        .allItemSchema(entrySchema)
+        .unprocessedProperties(Collections.singletonMap("connect.type", "map"))
+        .build();
+
+    ObjectNode entry = JsonNodeFactory.instance.objectNode();
+    entry.set(KEY_FIELD, TextNode.valueOf("hi"));
+    entry.set(VALUE_FIELD, IntNode.valueOf(32));
+    ArrayNode array = JsonNodeFactory.instance.arrayNode().add(entry);
+    checkNonObjectConversion(expected, array, connectSchema, Collections.singletonMap("hi", 32));
+  }
+
+  @Test
+  public void testFromConnectMapWithNonStringKey() {
+    Schema connectSchema = SchemaBuilder.map(Schema.INT32_SCHEMA, Schema.INT32_SCHEMA);
+    NumberSchema keySchema = NumberSchema.builder()
+        .requiresInteger(true)
+        .unprocessedProperties(ImmutableMap.of("connect.index", 0, "connect.type", "int32"))
+        .build();
+    NumberSchema valueSchema = NumberSchema.builder()
+        .requiresInteger(true)
+        .unprocessedProperties(ImmutableMap.of("connect.index", 1, "connect.type", "int32"))
+        .build();
+    ObjectSchema entrySchema = ObjectSchema.builder()
+        .addPropertySchema(KEY_FIELD, keySchema)
+        .addPropertySchema(VALUE_FIELD, valueSchema)
+        .build();
+    ArraySchema expected = ArraySchema.builder()
+        .allItemSchema(entrySchema)
+        .unprocessedProperties(Collections.singletonMap("connect.type", "map"))
+        .build();
+
+    ObjectNode entry = JsonNodeFactory.instance.objectNode();
+    entry.set(KEY_FIELD, IntNode.valueOf(54));
+    entry.set(VALUE_FIELD, IntNode.valueOf(32));
+    ArrayNode array = JsonNodeFactory.instance.arrayNode().add(entry);
+    checkNonObjectConversion(expected, array, connectSchema, Collections.singletonMap(54, 32));
+  }
+
+  @Test
+  public void testFromNamedConnectMap() {
+    assertEquals(jsonSchemaConverter.fromConnectSchema(NAMED_MAP_SCHEMA), NAMED_JSON_MAP_SCHEMA);
+  }
+
+  private void checkNonObjectConversion(
+      org.everit.json.schema.Schema expectedSchema, Object expected, Schema schema, Object value
+  ) {
+    JsonSchema jsonSchema = new JsonSchema(jsonSchemaConverter.fromConnectSchema(schema));
+    JsonNode jsonValue = jsonSchemaConverter.fromConnectData(schema, value);
+    assertEquals(expectedSchema, jsonSchema.rawSchema());
+    assertEquals(expected, jsonValue);
+  }
+
+  // JSON Schema -> Connect: directly corresponding types
+
+  @Test
+  public void testToConnectBoolean() {
+    BooleanSchema schema = BooleanSchema.builder().build();
+    Schema expectedSchema = Schema.BOOLEAN_SCHEMA;
+    checkNonObjectConversion(expectedSchema, true, schema, BooleanNode.getTrue());
+  }
+
+  @Test
+  public void testToConnectInt32() {
+    NumberSchema schema = NumberSchema.builder()
+        .unprocessedProperties(Collections.singletonMap("connect.type", "int32"))
+        .build();
+    Schema expectedSchema = Schema.INT32_SCHEMA;
+    checkNonObjectConversion(expectedSchema, 12, schema, IntNode.valueOf(12));
+  }
+
+  @Test
+  public void testToConnectInt64() {
+    NumberSchema schema = NumberSchema.builder()
+        .unprocessedProperties(Collections.singletonMap("connect.type", "int64"))
+        .build();
+    Schema expectedSchema = Schema.INT64_SCHEMA;
+    checkNonObjectConversion(expectedSchema, 12L, schema, LongNode.valueOf(12L));
+  }
+
+  @Test
+  public void testToConnectFloat32() {
+    NumberSchema schema = NumberSchema.builder()
+        .unprocessedProperties(Collections.singletonMap("connect.type", "float32"))
+        .build();
+    Schema expectedSchema = Schema.FLOAT32_SCHEMA;
+    checkNonObjectConversion(expectedSchema, 12.f, schema, FloatNode.valueOf(12.f));
+  }
+
+  @Test
+  public void testToConnectFloat64() {
+    NumberSchema schema = NumberSchema.builder()
+        .unprocessedProperties(Collections.singletonMap("connect.type", "float64"))
+        .build();
+    Schema expectedSchema = Schema.FLOAT64_SCHEMA;
+    checkNonObjectConversion(expectedSchema, 12.0, schema, DoubleNode.valueOf(12.0));
+  }
+
+  @Test
+  public void testToConnectNullableStringNullvalue() {
+    CombinedSchema schema = CombinedSchema.builder()
+        .criterion(CombinedSchema.ONE_CRITERION)
+        .subschema(NullSchema.INSTANCE)
+        .subschema(StringSchema.builder().build())
+        .build();
+    Schema expectedSchema = Schema.OPTIONAL_STRING_SCHEMA;
+    checkNonObjectConversion(expectedSchema, null, schema, NullNode.getInstance());
+  }
+
+  @Test
+  public void testToConnectNullableString() {
+    CombinedSchema schema = CombinedSchema.builder()
+        .criterion(CombinedSchema.ONE_CRITERION)
+        .subschema(NullSchema.INSTANCE)
+        .subschema(StringSchema.builder().build())
+        .build();
+    Schema expectedSchema = Schema.OPTIONAL_STRING_SCHEMA;
+    checkNonObjectConversion(expectedSchema, "teststring", schema, TextNode.valueOf("teststring"));
+  }
+
+  @Test
+  public void testToConnectString() {
+    StringSchema schema = StringSchema.builder().build();
+    Schema expectedSchema = Schema.STRING_SCHEMA;
+    checkNonObjectConversion(expectedSchema, "teststring", schema, TextNode.valueOf("teststring"));
+  }
+
+  @Test
+  public void testToConnectBytes() {
+    StringSchema schema = StringSchema.builder()
+        .unprocessedProperties(Collections.singletonMap("connect.type", "bytes"))
+        .build();
+    Schema expectedSchema = Schema.BYTES_SCHEMA;
+    checkNonObjectConversion(expectedSchema,
+        "teststring".getBytes(),
+        schema,
+        BinaryNode.valueOf("teststring".getBytes())
+    );
+  }
+
+  @Test
+  public void testToConnectArray() {
+    NumberSchema numberSchema = NumberSchema.builder()
+        .unprocessedProperties(Collections.singletonMap("connect.type", "int8"))
+        .build();
+    ArraySchema schema = ArraySchema.builder().allItemSchema(numberSchema).build();
+    // Use a value type which ensures we test conversion of elements. int8 requires extra
+    // conversion steps but keeps the test simple.
+    Schema expectedSchema = SchemaBuilder.array(Schema.INT8_SCHEMA).build();
+    ArrayNode array = JsonNodeFactory.instance.arrayNode();
+    array.add(12).add(13);
+    checkNonObjectConversion(expectedSchema, Arrays.asList((byte) 12, (byte) 13), schema, array);
+  }
+
+  @Test
+  public void testToConnectMapStringKeys() {
+    NumberSchema numberSchema = NumberSchema.builder()
+        .unprocessedProperties(Collections.singletonMap("connect.type", "int8"))
+        .build();
+    ObjectSchema schema = ObjectSchema.builder()
+        .schemaOfAdditionalProperties(numberSchema)
+        .unprocessedProperties(Collections.singletonMap("connect.type", "map"))
+        .build();
+    // Use a value type which ensures we test conversion of elements. int8 requires extra
+    // conversion steps but keeps the test simple.
+    Schema expectedSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT8_SCHEMA).build();
+    ObjectNode map = JsonNodeFactory.instance.objectNode();
+    map.set("field", IntNode.valueOf(12));
+    checkNonObjectConversion(expectedSchema,
+        Collections.singletonMap("field", (byte) 12),
+        schema,
+        map
+    );
+  }
+
+  @Test
+  public void testToConnectMapNonStringKeys() {
+    NumberSchema keySchema = NumberSchema.builder()
+        .unprocessedProperties(Collections.singletonMap("connect.type", "int8"))
+        .build();
+    NumberSchema valueSchema = NumberSchema.builder()
+        .unprocessedProperties(Collections.singletonMap("connect.type", "int16"))
+        .build();
+    ObjectSchema mapSchema = ObjectSchema.builder()
+        .addPropertySchema("key", keySchema)
+        .addPropertySchema("value", valueSchema)
+        .build();
+    ArraySchema schema = ArraySchema.builder()
+        .allItemSchema(mapSchema)
+        .unprocessedProperties(Collections.singletonMap("connect.type", "map"))
+        .build();
+    Schema expectedSchema = SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.INT16_SCHEMA).build();
+    ObjectNode map = JsonNodeFactory.instance.objectNode();
+    map.set("key", IntNode.valueOf(12));
+    map.set("value", ShortNode.valueOf((short) 16));
+    ArrayNode array = JsonNodeFactory.instance.arrayNode();
+    array.add(map);
+    checkNonObjectConversion(expectedSchema,
+        Collections.singletonMap((byte) 12, (short) 16),
+        schema,
+        array
+    );
+  }
+
+  @Test
+  public void testToConnectRecord() {
+    NumberSchema numberSchema = NumberSchema.builder()
+        .unprocessedProperties(ImmutableMap.of("connect.index", 0, "connect.type", "int8"))
+        .build();
+    StringSchema stringSchema = StringSchema.builder()
+        .unprocessedProperties(ImmutableMap.of("connect.index", 1))
+        .build();
+    ObjectSchema schema = ObjectSchema.builder()
+        .addPropertySchema("int8", numberSchema)
+        .addPropertySchema("string", stringSchema)
+        .title("Record")
+        .build();
+    ObjectNode obj = JsonNodeFactory.instance.objectNode();
+    obj.set("int8", ShortNode.valueOf((short) 12));
+    obj.set("string", TextNode.valueOf("sample string"));
+    Schema expectedSchema = SchemaBuilder.struct()
+        .name("Record")
+        .field("int8", Schema.INT8_SCHEMA)
+        .field("string", Schema.STRING_SCHEMA)
+        .build();
+    Struct struct = new Struct(expectedSchema).put("int8", (byte) 12)
+        .put("string", "sample string");
+    checkNonObjectConversion(expectedSchema, struct, schema, obj);
+  }
+
+  @Test
+  public void testToConnectRecordWithOptionalValue() {
+    testToConnectRecordWithOptional("sample string");
+  }
+
+  @Test
+  public void testToConnectRecordWithOptionalNullValue() {
+    testToConnectRecordWithOptional(null);
+  }
+
+  private void testToConnectRecordWithOptional(String value) {
+    NumberSchema numberSchema = NumberSchema.builder()
+        .unprocessedProperties(ImmutableMap.of("connect.index", 0, "connect.type", "int8"))
+        .build();
+    StringSchema stringSchema = StringSchema.builder().build();
+    CombinedSchema combinedSchema = CombinedSchema.oneOf(ImmutableList.of(NullSchema.INSTANCE,
+        stringSchema
+    ))
+        .unprocessedProperties(ImmutableMap.of("connect.index", 1))
+        .build();
+    ObjectSchema schema = ObjectSchema.builder()
+        .addPropertySchema("int8", numberSchema)
+        .addPropertySchema("string", combinedSchema)
+        .title("Record")
+        .build();
+    ObjectNode obj = JsonNodeFactory.instance.objectNode();
+    obj.set("int8", ShortNode.valueOf((short) 12));
+    if (value == null) {
+      obj.set("string", NullNode.getInstance());
+    } else {
+      obj.set("string", TextNode.valueOf(value));
+    }
+    Schema expectedSchema = SchemaBuilder.struct()
+        .name("Record")
+        .field("int8", Schema.INT8_SCHEMA)
+        .field("string", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Struct struct = new Struct(expectedSchema).put("int8", (byte) 12).put("string", value);
+    checkNonObjectConversion(expectedSchema, struct, schema, obj);
+  }
+
+  @Test
+  public void testToConnectRecordWithOptionalArrayValue() {
+    testToConnectRecordWithOptionalArray(Arrays.asList("test"));
+  }
+
+  @Test
+  public void testToConnectRecordWithOptionalArrayNullValue() {
+    testToConnectRecordWithOptionalArray(null);
+  }
+
+  private void testToConnectRecordWithOptionalArray(java.util.List<String> value) {
+    StringSchema stringSchema = StringSchema.builder().build();
+    CombinedSchema combinedSchema1 = CombinedSchema.oneOf(ImmutableList.of(NullSchema.INSTANCE,
+        stringSchema
+    ))
+        .unprocessedProperties(ImmutableMap.of("connect.index", 0))
+        .build();
+    ArraySchema arraySchema = ArraySchema.builder().allItemSchema(stringSchema).build();
+    CombinedSchema combinedSchema2 = CombinedSchema.oneOf(ImmutableList.of(NullSchema.INSTANCE,
+        arraySchema
+    ))
+        .unprocessedProperties(ImmutableMap.of("connect.index", 1))
+        .build();
+    ObjectSchema schema = ObjectSchema.builder()
+        .addPropertySchema("string", combinedSchema1)
+        .addPropertySchema("array", combinedSchema2)
+        .title("Record")
+        .build();
+    ObjectNode obj = JsonNodeFactory.instance.objectNode();
+    obj.set("string", TextNode.valueOf("xx"));
+    if (value == null) {
+      obj.set("array", NullNode.getInstance());
+    } else {
+      ArrayNode arrayNode = JsonNodeFactory.instance.arrayNode();
+      for (String s : value) {
+        arrayNode.add(s);
+      }
+      obj.set("array", arrayNode);
+    }
+    Schema expectedSchema = SchemaBuilder.struct()
+        .name("Record")
+        .field("string", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("array", SchemaBuilder.array(Schema.STRING_SCHEMA).optional().build())
+        .build();
+    Struct struct = new Struct(expectedSchema).put("string", "xx").put("array", value);
+    checkNonObjectConversion(expectedSchema, struct, schema, obj);
+  }
+
+  @Test
+  public void testToConnectNestedRecordWithOptionalRecordValue() {
+    ObjectSchema nested = ObjectSchema.builder().addPropertySchema("string",
+        StringSchema.builder().unprocessedProperties(ImmutableMap.of("connect.index", 0)).build()
+    ).title("nestedRecord").build();
+    CombinedSchema combinedSchema = CombinedSchema.oneOf(ImmutableList.of(NullSchema.INSTANCE,
+        nested
+    ))
+        .unprocessedProperties(ImmutableMap.of("connect.index", 0))
+        .build();
+    ObjectSchema schema = ObjectSchema.builder()
+        .addPropertySchema("nestedRecord", combinedSchema)
+        .title("Record")
+        .build();
+    Schema expectedSchema = nestedRecordSchema();
+    ObjectNode nestedObj = JsonNodeFactory.instance.objectNode();
+    nestedObj.set("string", TextNode.valueOf("xx"));
+    ObjectNode obj = JsonNodeFactory.instance.objectNode();
+    obj.set("nestedRecord", nestedObj);
+    Struct struct = new Struct(expectedSchema).put("nestedRecord",
+        new Struct(recordWithStringSchema()).put("string", "xx")
+    );
+    checkNonObjectConversion(expectedSchema, struct, schema, obj);
+  }
+
+  @Test
+  public void testToConnectNestedRecordWithOptionalRecordNullValue() {
+    ObjectSchema nested = ObjectSchema.builder().addPropertySchema("string",
+        StringSchema.builder().unprocessedProperties(ImmutableMap.of("connect.index", 0)).build()
+    ).title("nestedRecord").build();
+    CombinedSchema combinedSchema = CombinedSchema.oneOf(ImmutableList.of(NullSchema.INSTANCE,
+        nested
+    ))
+        .unprocessedProperties(ImmutableMap.of("connect.index", 0))
+        .build();
+    ObjectSchema schema = ObjectSchema.builder()
+        .addPropertySchema("nestedRecord", combinedSchema)
+        .title("Record")
+        .build();
+    Schema expectedSchema = nestedRecordSchema();
+    ObjectNode obj = JsonNodeFactory.instance.objectNode();
+    obj.set("nestedRecord", NullNode.getInstance());
+    Struct struct = new Struct(expectedSchema).put("nestedRecord", null);
+    checkNonObjectConversion(expectedSchema, struct, schema, obj);
+  }
+
+  private Schema recordWithStringSchema() {
+    return SchemaBuilder.struct()
+        .optional()
+        .name("nestedRecord")
+        .field("string", Schema.STRING_SCHEMA)
+        .build();
+  }
+
+  private Schema nestedRecordSchema() {
+    return SchemaBuilder.struct()
+        .name("Record")
+        .field("nestedRecord", recordWithStringSchema())
+        .build();
+  }
+
+  @Test
+  public void testToConnectNumericDecimal() {
+    NumberSchema schema = NumberSchema.builder()
+        .title("org.apache.kafka.connect.data.Decimal")
+        .unprocessedProperties(ImmutableMap.of("connect.type",
+            "bytes",
+            "connect.parameters",
+            ImmutableMap.of("scale", "2")
+        ))
+        .build();
+    BigDecimal reference = new BigDecimal(new BigInteger("156"), 2);
+    Schema expectedSchema = SchemaBuilder.bytes()
+        .name(LOGICAL_NAME)
+        .parameter(SCALE_FIELD, Integer.toString(2))
+        .build();
+    checkNonObjectConversion(expectedSchema, reference, schema, DecimalNode.valueOf(reference));
+  }
+
+  @Test
+  public void testToConnectHighPrecisionNumericDecimal() {
+    NumberSchema schema = NumberSchema.builder()
+        .title("org.apache.kafka.connect.data.Decimal")
+        .unprocessedProperties(ImmutableMap.of("connect.type",
+            "bytes",
+            "connect.parameters",
+            ImmutableMap.of("scale", "17")
+        ))
+        .build();
+    // this number is too big to be kept in a float64!
+    BigDecimal reference = new BigDecimal("1.23456789123456789");
+    Schema expectedSchema = SchemaBuilder.bytes()
+        .name(LOGICAL_NAME)
+        .parameter(SCALE_FIELD, Integer.toString(17))
+        .build();
+    checkNonObjectConversion(expectedSchema, reference, schema, DecimalNode.valueOf(reference));
+  }
+
+  @Test
+  public void testToConnectEnum() {
+    EnumSchema schema = EnumSchema.builder()
+        .possibleValue("one")
+        .possibleValue("two")
+        .possibleValue("three")
+        .build();
+    Schema expectedSchema = new SchemaBuilder(Schema.Type.STRING).parameter(JSON_TYPE_ENUM, "")
+        .parameter(JSON_TYPE_ENUM + ".one", "one")
+        .parameter(JSON_TYPE_ENUM + ".two", "two")
+        .parameter(JSON_TYPE_ENUM + ".three", "three")
+        .build();
+
+    checkNonObjectConversion(expectedSchema, "one", schema, TextNode.valueOf("one"));
+  }
+
+  @Test
+  public void testToConnectUnion() {
+    NumberSchema firstSchema = NumberSchema.builder()
+        .unprocessedProperties(Collections.singletonMap("connect.type", "int8"))
+        .build();
+    NumberSchema secondSchema = NumberSchema.builder()
+        .unprocessedProperties(Collections.singletonMap("connect.type", "int16"))
+        .build();
+    CombinedSchema schema = CombinedSchema.oneOf(ImmutableList.of(firstSchema, secondSchema))
+        .build();
+    SchemaBuilder builder = SchemaBuilder.struct().name(JSON_TYPE_ONE_OF);
+    builder.field(JSON_TYPE_ONE_OF + ".field.0", Schema.INT8_SCHEMA);
+    builder.field(JSON_TYPE_ONE_OF + ".field.1", Schema.INT16_SCHEMA);
+    Schema expectedSchema = builder.build();
+
+    Struct expected = new Struct(expectedSchema).put(JSON_TYPE_ONE_OF + ".field.0", (byte) 12);
+    checkNonObjectConversion(expectedSchema, expected, schema, ShortNode.valueOf((short) 12));
+  }
+
+  @Test
+  public void testToConnectMapOptionalValue() {
+    testToConnectMapOptional("some value");
+  }
+
+  @Test
+  public void testToConnectMapOptionalNullValue() {
+    testToConnectMapOptional(null);
+  }
+
+  private void testToConnectMapOptional(String value) {
+    // Encoded as array of 2-tuple records. Use key and value types that require conversion to
+    // make sure conversion of each element actually occurs.
+    NumberSchema numberSchema = NumberSchema.builder()
+        .unprocessedProperties(ImmutableMap.of("connect.type", "int8"))
+        .build();
+    StringSchema stringSchema = StringSchema.builder().build();
+    CombinedSchema combinedSchema = CombinedSchema.oneOf(ImmutableList.of(NullSchema.INSTANCE,
+        stringSchema
+    )).build();
+    ObjectSchema entrySchema = ObjectSchema.builder()
+        .addPropertySchema("key", numberSchema)
+        .addPropertySchema("value", combinedSchema)
+        .build();
+    ArraySchema schema = ArraySchema.builder()
+        .allItemSchema(entrySchema)
+        .unprocessedProperties(ImmutableMap.of("connect.type", "map"))
+        .build();
+    ObjectNode obj = JsonNodeFactory.instance.objectNode();
+    obj.set("key", ShortNode.valueOf((short) 12));
+    if (value == null) {
+      obj.set("value", NullNode.getInstance());
+    } else {
+      obj.set("value", TextNode.valueOf(value));
+    }
+    ArrayNode array = JsonNodeFactory.instance.arrayNode();
+    array.add(obj);
+    // Use a value type which ensures we test conversion of elements. int8 requires extra
+    // conversion steps but keeps the test simple.
+    Schema expectedSchema = SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    checkNonObjectConversion(expectedSchema,
+        Collections.singletonMap((byte) 12, value),
+        schema,
+        array
+    );
+  }
+
+  @Test
+  public void testToNamedConnectMap() {
+    assertEquals(jsonSchemaConverter.toConnectSchema(NAMED_JSON_MAP_SCHEMA), NAMED_MAP_SCHEMA);
+  }
+
+  private void checkNonObjectConversion(
+      Schema expectedSchema, Object expected, org.everit.json.schema.Schema schema, JsonNode value
+  ) {
+    Schema connectSchema = jsonSchemaConverter.toConnectSchema(schema);
+    Object jsonValue = jsonSchemaConverter.toConnectData(connectSchema, value);
+    assertEquals(expectedSchema, connectSchema);
+    if (expected instanceof byte[]) {
+      assertArrayEquals((byte[]) expected, (byte[]) jsonValue);
+    } else {
+      assertEquals(expected, jsonValue);
+    }
+  }
+}

--- a/json-schema-converter/src/test/java/io/confluent/connect/json/ResourceLoader.java
+++ b/json-schema-converter/src/test/java/io/confluent/connect/json/ResourceLoader.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class ResourceLoader {
+
+  public static final ResourceLoader DEFAULT = new ResourceLoader("/io/confluent/connect/json/");
+
+  private final String rootPath;
+
+  public ResourceLoader(String rootPath) {
+    this.rootPath = requireNonNull(rootPath, "rootPath cannot be null");
+  }
+
+  public JSONObject readJSONObject(String relPath) {
+    InputStream stream = getStream(relPath);
+    return new JSONObject(new JSONTokener(stream));
+  }
+
+  public JsonNode readJsonNode(String relPath) throws IOException {
+    InputStream stream = getStream(relPath);
+    return new ObjectMapper().readTree(stream);
+  }
+
+  public InputStream getStream(String relPath) {
+    String absPath = rootPath + relPath;
+    InputStream rval = getClass().getResourceAsStream(absPath);
+    if (rval == null) {
+      throw new IllegalArgumentException(format("failed to load resource by relPath [%s].\n"
+          + "InputStream by path [%s] is null", relPath, absPath));
+    }
+    return rval;
+  }
+
+}

--- a/json-schema-converter/src/test/resources/io/confluent/connect/json/key.json
+++ b/json-schema-converter/src/test/resources/io/confluent/connect/json/key.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "key": {
+      "type": "integer"
+    }
+  }
+}

--- a/json-schema-converter/src/test/resources/io/confluent/connect/json/keyvalue.json
+++ b/json-schema-converter/src/test/resources/io/confluent/connect/json/keyvalue.json
@@ -1,0 +1,11 @@
+{
+  "type": "object",
+  "properties": {
+    "key": {
+      "type": "integer"
+    },
+    "value": {
+      "type": "string"
+    }
+  }
+}

--- a/json-schema-converter/src/test/resources/io/confluent/connect/json/objectschema.json
+++ b/json-schema-converter/src/test/resources/io/confluent/connect/json/objectschema.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "int64": {
+      "type": "integer"
+    },
+    "float64": {
+      "type": "number"
+    },
+    "boolean": {
+      "type": "boolean"
+    },
+    "string": {
+      "type": "string"
+    },
+    "array": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/json-schema-provider/pom.xml
+++ b/json-schema-provider/pom.xml
@@ -1,0 +1,69 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.confluent</groupId>
+        <artifactId>kafka-schema-registry-parent</artifactId>
+        <version>5.5.0-SNAPSHOT</version>
+    </parent>
+
+    <licenses>
+        <license>
+            <name>Confluent Community License</name>
+            <url>http://www.confluent.io/confluent-community-license</url>
+            <distribution>repo</distribution>
+        </license>
+        <license>
+            <name>Apache License 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <artifactId>kafka-json-schema-provider</artifactId>
+    <packaging>jar</packaging>
+    <name>kafka-json-schema-provider</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-registry-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.everit-org.json-schema</groupId>
+            <artifactId>org.everit.json.schema</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-parameter-names</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.kjetland</groupId>
+            <artifactId>mbknor-jackson-jsonschema_2.12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+
+package io.confluent.kafka.schemaregistry.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BinaryNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.NumericNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.google.common.annotations.VisibleForTesting;
+import org.everit.json.schema.Schema;
+import org.everit.json.schema.ValidationException;
+import org.everit.json.schema.loader.SchemaLoader;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.json.diff.Difference;
+import io.confluent.kafka.schemaregistry.json.diff.SchemaDiff;
+import io.confluent.kafka.schemaregistry.json.jackson.Jackson;
+
+public class JsonSchema implements ParsedSchema {
+
+  private static final Logger log = LoggerFactory.getLogger(JsonSchemaProvider.class);
+
+  public static final String TYPE = "JSON";
+
+  private static final Object NONE_MARKER = new Object();
+
+  private final Schema schemaObj;
+
+  private final Integer version;
+
+  private final List<SchemaReference> references;
+
+  private final Map<String, String> resolvedReferences;
+
+  private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+
+  @VisibleForTesting
+  public JsonSchema(JsonNode jsonNode) throws JsonProcessingException {
+    this(new ObjectMapper().writeValueAsString(jsonNode));
+  }
+
+  public JsonSchema(String schemaString) {
+    this(schemaString, Collections.emptyList(), Collections.emptyMap(), null);
+  }
+
+  public JsonSchema(
+      String schemaString,
+      List<SchemaReference> references,
+      Map<String, String> resolvedReferences,
+      Integer version
+  ) {
+    SchemaLoader.SchemaLoaderBuilder builder = SchemaLoader.builder();
+    if (resolvedReferences != null) {
+      try {
+        for (Map.Entry<String, String> dep : resolvedReferences.entrySet()) {
+          builder.registerSchemaByURI(new URI(dep.getKey()), new JSONObject(dep.getValue()));
+        }
+      } catch (URISyntaxException e) {
+        throw new IllegalArgumentException("Invalid dependency name", e);
+      }
+    }
+    builder.schemaJson(new JSONObject(schemaString));
+    SchemaLoader loader = builder.build();
+    this.schemaObj = loader.load().build();
+    this.version = version;
+    this.references = references;
+    this.resolvedReferences = resolvedReferences;
+  }
+
+  public JsonSchema(Schema schemaObj) {
+    this(schemaObj, null);
+  }
+
+  public JsonSchema(Schema schemaObj, Integer version) {
+    this.schemaObj = schemaObj;
+    this.version = version;
+    this.references = Collections.emptyList();
+    this.resolvedReferences = Collections.emptyMap();
+  }
+
+  public Schema rawSchema() {
+    return schemaObj;
+  }
+
+  @Override
+  public String schemaType() {
+    return TYPE;
+  }
+
+  @Override
+  public String name() {
+    return schemaObj.getTitle();
+  }
+
+  @Override
+  public String canonicalString() {
+    return schemaObj.toString();
+  }
+
+  public Integer version() {
+    return version;
+  }
+
+  @Override
+  public List<SchemaReference> references() {
+    return references;
+  }
+
+  public Map<String, String> resolvedReferences() {
+    return resolvedReferences;
+  }
+
+  public void validate(Object value) throws JsonProcessingException, ValidationException {
+    Object primitiveValue = NONE_MARKER;
+    if (isPrimitive(value)) {
+      primitiveValue = value;
+    } else if (value instanceof BinaryNode) {
+      primitiveValue = ((BinaryNode) value).asText();
+    } else if (value instanceof BooleanNode) {
+      primitiveValue = ((BooleanNode) value).asBoolean();
+    } else if (value instanceof NullNode) {
+      primitiveValue = null;
+    } else if (value instanceof NumericNode) {
+      primitiveValue = ((NumericNode) value).numberValue();
+    } else if (value instanceof TextNode) {
+      primitiveValue = ((TextNode) value).asText();
+    }
+    if (primitiveValue != NONE_MARKER) {
+      rawSchema().validate(primitiveValue);
+    } else {
+      Object jsonObject;
+      if (value instanceof ArrayNode) {
+        jsonObject = objectMapper.treeToValue(((ArrayNode) value), JSONArray.class);
+      } else if (value instanceof JsonNode) {
+        jsonObject = objectMapper.treeToValue(((JsonNode) value), JSONObject.class);
+      } else if (value.getClass().isArray()) {
+        jsonObject = objectMapper.convertValue(value, JSONArray.class);
+      } else {
+        jsonObject = objectMapper.convertValue(value, JSONObject.class);
+      }
+      rawSchema().validate(jsonObject);
+    }
+  }
+
+  private static boolean isPrimitive(Object value) {
+    return value == null
+        || value instanceof Boolean
+        || value instanceof Number
+        || value instanceof String;
+  }
+
+  @Override
+  public boolean isBackwardCompatible(ParsedSchema previousSchema) {
+    if (!schemaType().equals(previousSchema.schemaType())) {
+      return false;
+    }
+    final List<Difference> differences = SchemaDiff.compare(
+        ((JsonSchema) previousSchema).schemaObj,
+        schemaObj
+    );
+    final List<Difference> incompatibleDiffs = differences.stream()
+        .filter(diff -> !SchemaDiff.COMPATIBLE_CHANGES.contains(diff.getType()))
+        .collect(Collectors.toList());
+    boolean isCompatible = incompatibleDiffs.isEmpty();
+    if (!isCompatible) {
+      log.warn("Found incompatible change: {}", incompatibleDiffs.get(0));
+    }
+    return isCompatible;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    JsonSchema that = (JsonSchema) o;
+    return Objects.equals(schemaObj, that.schemaObj)
+        && Objects.equals(references, that.references)
+        && Objects.equals(version, that.version);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(schemaObj, references, version);
+  }
+
+  @Override
+  public String toString() {
+    return canonicalString();
+  }
+}

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -195,7 +195,16 @@ public class JsonSchema implements ParsedSchema {
         .collect(Collectors.toList());
     boolean isCompatible = incompatibleDiffs.isEmpty();
     if (!isCompatible) {
-      log.warn("Found incompatible change: {}", incompatibleDiffs.get(0));
+      boolean first = true;
+      for (Difference incompatibleDiff : incompatibleDiffs) {
+        if (first) {
+          // Log first incompatible change as warning
+          log.warn("Found incompatible change: {}", incompatibleDiff);
+          first = false;
+        } else {
+          log.debug("Found incompatible change: {}", incompatibleDiff);
+        }
+      }
     }
     return isCompatible;
   }

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaProvider.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.confluent.kafka.schemaregistry.AbstractSchemaProvider;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+
+public class JsonSchemaProvider extends AbstractSchemaProvider {
+
+  private static final Logger log = LoggerFactory.getLogger(JsonSchemaProvider.class);
+
+  @Override
+  public String schemaType() {
+    return JsonSchema.TYPE;
+  }
+
+  @Override
+  public Optional<ParsedSchema> parseSchema(String schemaString, List<SchemaReference> references) {
+    try {
+      return Optional.of(new JsonSchema(
+          schemaString,
+          references,
+          resolveReferences(references),
+          null
+      ));
+    } catch (Exception e) {
+      return Optional.empty();
+    }
+  }
+}

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaUtils.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaUtils.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 
-import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.json.jackson.Jackson;
 
 public class JsonSchemaUtils {
@@ -82,8 +81,8 @@ public class JsonSchemaUtils {
     return object;
   }
 
-  public static Object toObject(JsonNode value, ParsedSchema parsedSchema) throws IOException {
-    ((JsonSchema) parsedSchema).validate(value);
+  public static Object toObject(JsonNode value, JsonSchema schema) throws IOException {
+    schema.validate(value);
     return value;
   }
 

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaUtils.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaUtils.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.kjetland.jackson.jsonSchema.JsonSchemaConfig;
+import com.kjetland.jackson.jsonSchema.JsonSchemaGenerator;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.json.jackson.Jackson;
+
+public class JsonSchemaUtils {
+
+  private static final Object NONE_MARKER = new Object();
+
+  private static final ObjectMapper jsonMapper = Jackson.newObjectMapper();
+
+  static final String ENVELOPE_SCHEMA_FIELD_NAME = "schema";
+  static final String ENVELOPE_PAYLOAD_FIELD_NAME = "payload";
+
+  public static ObjectNode envelope(JsonNode schema, JsonNode payload) {
+    ObjectNode result = JsonNodeFactory.instance.objectNode();
+    result.set(ENVELOPE_SCHEMA_FIELD_NAME, schema);
+    result.set(ENVELOPE_PAYLOAD_FIELD_NAME, payload);
+    return result;
+  }
+
+  public static JsonSchema copyOf(JsonSchema schema) {
+    return new JsonSchema(schema.canonicalString(),
+        schema.references(),
+        schema.resolvedReferences(),
+        schema.version()
+    );
+  }
+
+  public static JsonSchema getSchema(Object object) {
+    if (object == null) {
+      return null;
+    }
+    if (object instanceof JsonNode) {
+      JsonNode jsonValue = (JsonNode) object;
+      if (jsonValue.isObject() && jsonValue.has(ENVELOPE_SCHEMA_FIELD_NAME)) {
+        return new JsonSchema(jsonValue.get(ENVELOPE_SCHEMA_FIELD_NAME).toString());
+      }
+    }
+    JsonSchemaConfig config = JsonSchemaConfig.nullableJsonSchemaDraft4();  // allow nulls
+    JsonSchemaGenerator jsonSchemaGenerator = new JsonSchemaGenerator(jsonMapper, config);
+    JsonNode jsonSchema = jsonSchemaGenerator.generateJsonSchema(object.getClass());
+    return new JsonSchema(jsonSchema.toString());
+  }
+
+  public static Object getValue(Object object) {
+    if (object == null) {
+      return null;
+    }
+    if (object instanceof JsonNode) {
+      JsonNode jsonValue = (JsonNode) object;
+      if (jsonValue.isObject() && jsonValue.has(ENVELOPE_PAYLOAD_FIELD_NAME)) {
+        return jsonValue.get(ENVELOPE_PAYLOAD_FIELD_NAME);
+      }
+    }
+    return object;
+  }
+
+  public static Object toObject(JsonNode value, ParsedSchema parsedSchema) throws IOException {
+    ((JsonSchema) parsedSchema).validate(value);
+    return value;
+  }
+
+  public static byte[] toJson(Object value) throws IOException {
+    if (value == null) {
+      return null;
+    }
+    StringWriter out = new StringWriter();
+    jsonMapper.writeValue(out, value);
+    String jsonString = out.toString();
+    return jsonString.getBytes(StandardCharsets.UTF_8);
+  }
+}

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/ArraySchemaDiff.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/ArraySchemaDiff.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json.diff;
+
+import org.everit.json.schema.ArraySchema;
+import org.everit.json.schema.Schema;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.ADDITIONAL_ITEMS_ADDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.ADDITIONAL_ITEMS_EXTENDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.ADDITIONAL_ITEMS_NARROWED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.ADDITIONAL_ITEMS_REMOVED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.ITEMS_ADDED_TO_CLOSED_CONTENT_MODEL;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.ITEMS_ADDED_TO_OPEN_CONTENT_MODEL;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.ITEMS_REMOVED_FROM_CLOSED_CONTENT_MODEL;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.ITEMS_REMOVED_FROM_OPEN_CONTENT_MODEL;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MAX_ITEMS_ADDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MAX_ITEMS_DECREASED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MAX_ITEMS_INCREASED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MAX_ITEMS_REMOVED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MIN_ITEMS_ADDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MIN_ITEMS_DECREASED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MIN_ITEMS_INCREASED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MIN_ITEMS_REMOVED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.UNIQUE_ITEMS_ADDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.UNIQUE_ITEMS_REMOVED;
+
+public class ArraySchemaDiff {
+  static void compare(final Context ctx, final ArraySchema original, final ArraySchema update) {
+    compareItemSchemaObject(ctx, original, update);
+    compareItemSchemaArray(ctx, original, update);
+    compareAdditionalItems(ctx, original, update);
+    compareAttributes(ctx, original, update);
+  }
+
+  private static void compareAttributes(
+      final Context ctx, final ArraySchema original, final ArraySchema update
+  ) {
+    if (!Objects.equals(original.getMaxItems(), update.getMaxItems())) {
+      if (original.getMaxItems() == null && update.getMaxItems() != null) {
+        ctx.addDifference("maxItems", MAX_ITEMS_ADDED);
+      } else if (original.getMaxItems() != null && update.getMaxItems() == null) {
+        ctx.addDifference("maxItems", MAX_ITEMS_REMOVED);
+      } else if (original.getMaxItems() < update.getMaxItems()) {
+        ctx.addDifference("maxItems", MAX_ITEMS_INCREASED);
+      } else if (original.getMaxItems() > update.getMaxItems()) {
+        ctx.addDifference("maxItems", MAX_ITEMS_DECREASED);
+      }
+    }
+    if (!Objects.equals(original.getMinItems(), update.getMinItems())) {
+      if (original.getMinItems() == null && update.getMinItems() != null) {
+        ctx.addDifference("minItems", MIN_ITEMS_ADDED);
+      } else if (original.getMinItems() != null && update.getMinItems() == null) {
+        ctx.addDifference("minItems", MIN_ITEMS_REMOVED);
+      } else if (original.getMinItems() < update.getMinItems()) {
+        ctx.addDifference("minItems", MIN_ITEMS_INCREASED);
+      } else if (original.getMinItems() > update.getMinItems()) {
+        ctx.addDifference("minItems", MIN_ITEMS_DECREASED);
+      }
+    }
+    if (original.needsUniqueItems() != update.needsUniqueItems()) {
+      if (original.needsUniqueItems()) {
+        ctx.addDifference("uniqueItems", UNIQUE_ITEMS_REMOVED);
+      } else {
+        ctx.addDifference("uniqueItems", UNIQUE_ITEMS_ADDED);
+      }
+    }
+  }
+
+  private static void compareAdditionalItems(
+      final Context ctx, final ArraySchema original, final ArraySchema update
+  ) {
+    try (Context.PathScope pathScope = ctx.enterPath("additionalItems")) {
+      if (original.permitsAdditionalItems() != update.permitsAdditionalItems()) {
+        if (original.permitsAdditionalItems()) {
+          ctx.addDifference(ADDITIONAL_ITEMS_REMOVED);
+        } else {
+          ctx.addDifference(ADDITIONAL_ITEMS_ADDED);
+        }
+      } else if (original.getSchemaOfAdditionalItems() == null
+          && update.getSchemaOfAdditionalItems() != null) {
+        ctx.addDifference(ADDITIONAL_ITEMS_NARROWED);
+      } else if (update.getSchemaOfAdditionalItems() == null
+          && original.getSchemaOfAdditionalItems() != null) {
+        ctx.addDifference(ADDITIONAL_ITEMS_EXTENDED);
+      } else {
+        SchemaDiff.compare(
+            ctx,
+            original.getSchemaOfAdditionalItems(),
+            update.getSchemaOfAdditionalItems()
+        );
+      }
+    }
+  }
+
+  private static void compareItemSchemaArray(
+      final Context ctx, final ArraySchema original, final ArraySchema update
+  ) {
+    List<Schema> originalSchemas = original.getItemSchemas();
+    if (originalSchemas == null) {
+      originalSchemas = Collections.emptyList();
+    }
+    List<Schema> updateSchemas = update.getItemSchemas();
+    if (updateSchemas == null) {
+      updateSchemas = Collections.emptyList();
+    }
+    int originalSize = originalSchemas.size();
+    int updateSize = updateSchemas.size();
+
+    if (originalSize < updateSize) {
+      ctx.addDifference(original.permitsAdditionalItems()
+                        ? ITEMS_ADDED_TO_OPEN_CONTENT_MODEL
+                        : ITEMS_ADDED_TO_CLOSED_CONTENT_MODEL);
+    } else if (originalSize > updateSize) {
+      ctx.addDifference(original.permitsAdditionalItems()
+                        ? ITEMS_REMOVED_FROM_OPEN_CONTENT_MODEL
+                        : ITEMS_REMOVED_FROM_CLOSED_CONTENT_MODEL);
+    }
+
+    final Iterator<Schema> originalIterator = originalSchemas.iterator();
+    final Iterator<Schema> updateIterator = updateSchemas.iterator();
+    int index = 0;
+    while (originalIterator.hasNext() && index < Math.min(originalSize, updateSize)) {
+      try (Context.PathScope pathScope = ctx.enterPath("items/" + index)) {
+        SchemaDiff.compare(ctx, originalIterator.next(), updateIterator.next());
+      }
+      index++;
+    }
+  }
+
+  private static void compareItemSchemaObject(
+      final Context ctx, final ArraySchema original, final ArraySchema update
+  ) {
+    try (Context.PathScope pathScope = ctx.enterPath("items")) {
+      SchemaDiff.compare(ctx, original.getAllItemSchema(), update.getAllItemSchema());
+    }
+  }
+}

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/CombinedSchemaDiff.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/CombinedSchemaDiff.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json.diff;
+
+import org.everit.json.schema.CombinedSchema;
+import org.everit.json.schema.Schema;
+
+import java.util.Iterator;
+
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.COMPOSITION_METHOD_CHANGED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.PRODUCT_TYPE_EXTENDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.PRODUCT_TYPE_NARROWED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.SUM_TYPE_EXTENDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.SUM_TYPE_NARROWED;
+
+class CombinedSchemaDiff {
+  static void compare(
+      final Context ctx,
+      final CombinedSchema original,
+      final CombinedSchema update
+  ) {
+    if (!original.getCriterion().equals(update.getCriterion())) {
+      ctx.addDifference(COMPOSITION_METHOD_CHANGED);
+    } else {
+      int originalSize = original.getSubschemas().size();
+      int updateSize = update.getSubschemas().size();
+      if (originalSize < updateSize) {
+        if (original.getCriterion() == CombinedSchema.ALL_CRITERION) {
+          ctx.addDifference(PRODUCT_TYPE_EXTENDED);
+        } else {
+          ctx.addDifference(SUM_TYPE_EXTENDED);
+        }
+      } else if (originalSize > updateSize) {
+        if (original.getCriterion() == CombinedSchema.ALL_CRITERION) {
+          ctx.addDifference(PRODUCT_TYPE_NARROWED);
+        } else {
+          ctx.addDifference(SUM_TYPE_NARROWED);
+        }
+      }
+
+      final Iterator<Schema> originalIterator = original.getSubschemas().iterator();
+      final Iterator<Schema> updateIterator = update.getSubschemas().iterator();
+      int index = 0;
+      while (originalIterator.hasNext() && index < Math.min(originalSize, updateSize)) {
+        try (Context.PathScope pathScope = ctx.enterPath(original.getCriterion() + "/" + index)) {
+          SchemaDiff.compare(ctx, originalIterator.next(), updateIterator.next());
+        }
+        index++;
+      }
+    }
+  }
+}

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/Context.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/Context.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json.diff;
+
+import org.everit.json.schema.Schema;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+
+public class Context {
+  private final Set<Difference.Type> compatibleChanges;
+  private final Set<Schema> schemas;
+  private final Deque<String> jsonPath;
+  private final List<Difference> diffs;
+
+  public Context(Set<Difference.Type> compatibleChanges) {
+    this.compatibleChanges = compatibleChanges;
+    this.schemas = Collections.newSetFromMap(new IdentityHashMap<>());
+    this.jsonPath = new ArrayDeque<>();
+    this.diffs = new ArrayList<>();
+  }
+
+  public Context getSubcontext() {
+    Context ctx = new Context(this.compatibleChanges);
+    ctx.schemas.addAll(this.schemas);
+    ctx.jsonPath.addAll(this.jsonPath);
+    return ctx;
+  }
+
+  public SchemaScope enterSchema(final Schema schema) {
+    return !schemas.contains(schema) ? new SchemaScope(schema) : null;
+  }
+
+  public class SchemaScope implements AutoCloseable {
+    private final Schema schema;
+
+    public SchemaScope(final Schema schema) {
+      this.schema = schema;
+      schemas.add(schema);
+    }
+
+    public void close() {
+      schemas.remove(schema);
+    }
+  }
+
+  public PathScope enterPath(final String path) {
+    return new PathScope(path);
+  }
+
+  public class PathScope implements AutoCloseable {
+    public PathScope(final String path) {
+      jsonPath.addLast(path);
+    }
+
+    public void close() {
+      jsonPath.removeLast();
+    }
+  }
+
+  public boolean isCompatible() {
+    boolean notCompatible = getDifferences().stream()
+        .map(Difference::getType)
+        .anyMatch(t -> !compatibleChanges.contains(t));
+    return !notCompatible;
+  }
+
+  public List<Difference> getDifferences() {
+    return diffs;
+  }
+
+  public void addDifference(final Difference.Type type) {
+    diffs.add(new Difference(type, jsonPathString(jsonPath)));
+  }
+
+  public void addDifference(final String attribute, final Difference.Type type) {
+    jsonPath.addLast(attribute);
+    addDifference(type);
+    jsonPath.removeLast();
+  }
+
+  public void addDifferences(final List<Difference> differences) {
+    diffs.addAll(differences);
+  }
+
+  private static String jsonPathString(final Deque<String> jsonPath) {
+    return "#/" + String.join("/", jsonPath);
+  }
+}

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/Difference.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/Difference.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json.diff;
+
+import java.util.Objects;
+
+public class Difference {
+  public enum Type {
+    ID_CHANGED, DESCRIPTION_CHANGED, TITLE_CHANGED, DEFAULT_CHANGED, SCHEMA_REMOVED,
+    TYPE_EXTENDED, TYPE_NARROWED, TYPE_CHANGED,
+
+    MAX_LENGTH_ADDED, MAX_LENGTH_REMOVED, MAX_LENGTH_INCREASED, MAX_LENGTH_DECREASED,
+    MIN_LENGTH_ADDED, MIN_LENGTH_REMOVED, MIN_LENGTH_INCREASED, MIN_LENGTH_DECREASED,
+    PATTERN_ADDED, PATTERN_REMOVED, PATTERN_CHANGED,
+
+    MAXIMUM_ADDED, MAXIMUM_REMOVED, MAXIMUM_INCREASED, MAXIMUM_DECREASED, MINIMUM_ADDED,
+    MINIMUM_REMOVED, MINIMUM_INCREASED, MINIMUM_DECREASED, EXCLUSIVE_MAXIMUM_ADDED,
+    EXCLUSIVE_MAXIMUM_REMOVED, EXCLUSIVE_MAXIMUM_INCREASED, EXCLUSIVE_MAXIMUM_DECREASED,
+    EXCLUSIVE_MINIMUM_ADDED, EXCLUSIVE_MINIMUM_REMOVED, EXCLUSIVE_MINIMUM_INCREASED,
+    EXCLUSIVE_MINIMUM_DECREASED, MULTIPLE_OF_ADDED, MULTIPLE_OF_REMOVED, MULTIPLE_OF_EXPANDED,
+    MULTIPLE_OF_REDUCED, MULTIPLE_OF_CHANGED,
+
+    REQUIRED_ATTRIBUTE_ADDED, REQUIRED_ATTRIBUTE_WITH_DEFAULT_ADDED, REQUIRED_ATTRIBUTE_REMOVED,
+    MAX_PROPERTIES_ADDED, MAX_PROPERTIES_REMOVED, MAX_PROPERTIES_INCREASED,
+    MAX_PROPERTIES_DECREASED, MIN_PROPERTIES_ADDED, MIN_PROPERTIES_REMOVED,
+    MIN_PROPERTIES_INCREASED, MIN_PROPERTIES_DECREASED, ADDITIONAL_PROPERTIES_ADDED,
+    ADDITIONAL_PROPERTIES_REMOVED, ADDITIONAL_PROPERTIES_EXTENDED, ADDITIONAL_PROPERTIES_NARROWED,
+    DEPENDENCY_ARRAY_ADDED, DEPENDENCY_ARRAY_REMOVED, DEPENDENCY_ARRAY_EXTENDED,
+    DEPENDENCY_ARRAY_NARROWED, DEPENDENCY_ARRAY_CHANGED, DEPENDENCY_SCHEMA_ADDED,
+    DEPENDENCY_SCHEMA_REMOVED, PROPERTY_ADDED_TO_OPEN_CONTENT_MODEL,
+    REQUIRED_PROPERTY_ADDED_TO_CLOSED_CONTENT_MODEL,
+    REQUIRED_PROPERTY_WITH_DEFAULT_ADDED_TO_CLOSED_CONTENT_MODEL,
+    OPTIONAL_PROPERTY_ADDED_TO_CLOSED_CONTENT_MODEL, PROPERTY_REMOVED_FROM_OPEN_CONTENT_MODEL,
+    PROPERTY_REMOVED_FROM_CLOSED_CONTENT_MODEL,
+
+    MAX_ITEMS_ADDED, MAX_ITEMS_REMOVED, MAX_ITEMS_INCREASED, MAX_ITEMS_DECREASED, MIN_ITEMS_ADDED,
+    MIN_ITEMS_REMOVED, MIN_ITEMS_INCREASED, MIN_ITEMS_DECREASED, UNIQUE_ITEMS_ADDED,
+    UNIQUE_ITEMS_REMOVED, ADDITIONAL_ITEMS_ADDED, ADDITIONAL_ITEMS_REMOVED,
+    ADDITIONAL_ITEMS_EXTENDED, ADDITIONAL_ITEMS_NARROWED, ITEMS_ADDED_TO_OPEN_CONTENT_MODEL,
+    ITEMS_ADDED_TO_CLOSED_CONTENT_MODEL, ITEMS_REMOVED_FROM_OPEN_CONTENT_MODEL,
+    ITEMS_REMOVED_FROM_CLOSED_CONTENT_MODEL,
+
+    ENUM_ARRAY_EXTENDED, ENUM_ARRAY_NARROWED, ENUM_ARRAY_CHANGED,
+
+    COMPOSITION_METHOD_CHANGED, PRODUCT_TYPE_EXTENDED, PRODUCT_TYPE_NARROWED, SUM_TYPE_EXTENDED,
+    SUM_TYPE_NARROWED
+  }
+
+  private final String jsonPath;
+  private final Type type;
+
+  public Difference(final Type type, final String jsonPath) {
+    this.jsonPath = jsonPath;
+    this.type = type;
+  }
+
+  public String getJsonPath() {
+    return jsonPath;
+  }
+
+  public Type getType() {
+    return type;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Difference that = (Difference) o;
+    return Objects.equals(jsonPath, that.jsonPath) && type == that.type;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(jsonPath, type);
+  }
+
+  @Override
+  public String toString() {
+    return "Difference{" + "jsonPath='" + jsonPath + '\'' + ", type=" + type + '}';
+  }
+}

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/EnumSchemaDiff.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/EnumSchemaDiff.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json.diff;
+
+import org.everit.json.schema.EnumSchema;
+
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.ENUM_ARRAY_CHANGED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.ENUM_ARRAY_EXTENDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.ENUM_ARRAY_NARROWED;
+
+class EnumSchemaDiff {
+  static void compare(
+      final Context ctx, final EnumSchema original, final EnumSchema update
+  ) {
+    if (!original.getPossibleValues().equals(update.getPossibleValues())) {
+      if (update.getPossibleValues().containsAll(original.getPossibleValues())) {
+        ctx.addDifference("enum", ENUM_ARRAY_EXTENDED);
+      } else if (original.getPossibleValues().containsAll(update.getPossibleValues())) {
+        ctx.addDifference("enum", ENUM_ARRAY_NARROWED);
+      } else {
+        ctx.addDifference("enum", ENUM_ARRAY_CHANGED);
+      }
+    }
+  }
+}

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/NumberSchemaDiff.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/NumberSchemaDiff.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json.diff;
+
+import org.everit.json.schema.NumberSchema;
+
+import java.util.Objects;
+
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.EXCLUSIVE_MAXIMUM_ADDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.EXCLUSIVE_MAXIMUM_DECREASED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.EXCLUSIVE_MAXIMUM_INCREASED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.EXCLUSIVE_MAXIMUM_REMOVED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.EXCLUSIVE_MINIMUM_ADDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.EXCLUSIVE_MINIMUM_DECREASED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.EXCLUSIVE_MINIMUM_INCREASED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.EXCLUSIVE_MINIMUM_REMOVED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MAXIMUM_ADDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MAXIMUM_DECREASED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MAXIMUM_INCREASED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MAXIMUM_REMOVED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MINIMUM_ADDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MINIMUM_DECREASED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MINIMUM_INCREASED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MINIMUM_REMOVED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MULTIPLE_OF_ADDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MULTIPLE_OF_CHANGED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MULTIPLE_OF_EXPANDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MULTIPLE_OF_REDUCED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MULTIPLE_OF_REMOVED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.TYPE_EXTENDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.TYPE_NARROWED;
+
+class NumberSchemaDiff {
+  static void compare(final Context ctx, final NumberSchema original, final NumberSchema update) {
+    if (!Objects.equals(original.getMaximum(), update.getMaximum())) {
+      if (original.getMaximum() == null && update.getMaximum() != null) {
+        ctx.addDifference("maximum", MAXIMUM_ADDED);
+      } else if (original.getMaximum() != null && update.getMaximum() == null) {
+        ctx.addDifference("maximum", MAXIMUM_REMOVED);
+      } else if (original.getMaximum().doubleValue() < update.getMaximum().doubleValue()) {
+        ctx.addDifference("maximum", MAXIMUM_INCREASED);
+      } else if (original.getMaximum().doubleValue() > update.getMaximum().doubleValue()) {
+        ctx.addDifference("maximum", MAXIMUM_DECREASED);
+      }
+    }
+    if (!Objects.equals(original.getMinimum(), update.getMinimum())) {
+      if (original.getMinimum() == null && update.getMinimum() != null) {
+        ctx.addDifference("minimum", MINIMUM_ADDED);
+      } else if (original.getMinimum() != null && update.getMinimum() == null) {
+        ctx.addDifference("minimum", MINIMUM_REMOVED);
+      } else if (original.getMinimum().doubleValue() < update.getMinimum().doubleValue()) {
+        ctx.addDifference("minimum", MINIMUM_INCREASED);
+      } else if (original.getMinimum().doubleValue() > update.getMinimum().doubleValue()) {
+        ctx.addDifference("minimum", MINIMUM_DECREASED);
+      }
+    }
+    if (!Objects.equals(original.getExclusiveMaximumLimit(), update.getExclusiveMaximumLimit())) {
+      if (original.getExclusiveMaximumLimit() == null
+          && update.getExclusiveMaximumLimit() != null) {
+        ctx.addDifference("exclusiveMaximum", EXCLUSIVE_MAXIMUM_ADDED);
+      } else if (original.getExclusiveMaximumLimit() != null
+          && update.getExclusiveMaximumLimit() == null) {
+        ctx.addDifference("exclusiveMaximum", EXCLUSIVE_MAXIMUM_REMOVED);
+      } else if (original.getExclusiveMaximumLimit().doubleValue()
+          < update.getExclusiveMaximumLimit().doubleValue()) {
+        ctx.addDifference("exclusiveMaximum", EXCLUSIVE_MAXIMUM_INCREASED);
+      } else if (original.getExclusiveMaximumLimit().doubleValue() > update.getMaximum()
+          .doubleValue()) {
+        ctx.addDifference("exclusiveMaximum", EXCLUSIVE_MAXIMUM_DECREASED);
+      }
+    }
+    if (!Objects.equals(original.getExclusiveMinimumLimit(), update.getExclusiveMinimumLimit())) {
+      if (original.getExclusiveMinimumLimit() == null
+          && update.getExclusiveMinimumLimit() != null) {
+        ctx.addDifference("exclusiveMinimum", EXCLUSIVE_MINIMUM_ADDED);
+      } else if (original.getExclusiveMinimumLimit() != null
+          && update.getExclusiveMinimumLimit() == null) {
+        ctx.addDifference("exclusiveMinimum", EXCLUSIVE_MINIMUM_REMOVED);
+      } else if (original.getExclusiveMinimumLimit().doubleValue()
+          < update.getExclusiveMinimumLimit().doubleValue()) {
+        ctx.addDifference("exclusiveMinimum", EXCLUSIVE_MINIMUM_INCREASED);
+      } else if (original.getExclusiveMinimumLimit().doubleValue()
+          > update.getExclusiveMinimumLimit().doubleValue()) {
+        ctx.addDifference("exclusiveMinimum", EXCLUSIVE_MINIMUM_DECREASED);
+      }
+    }
+    if (!Objects.equals(original.getMultipleOf(), update.getMultipleOf())) {
+      if (original.getMultipleOf() == null && update.getMultipleOf() != null) {
+        ctx.addDifference("multipleOf", MULTIPLE_OF_ADDED);
+      } else if (original.getMultipleOf() != null && update.getMultipleOf() == null) {
+        ctx.addDifference("multipleOf", MULTIPLE_OF_REMOVED);
+      } else if (update.getMultipleOf().intValue() % original.getMultipleOf().intValue() == 0) {
+        ctx.addDifference("multipleOf", MULTIPLE_OF_EXPANDED);
+      } else if (original.getMultipleOf().intValue() % update.getMultipleOf().intValue() == 0) {
+        ctx.addDifference("multipleOf", MULTIPLE_OF_REDUCED);
+      } else {
+        ctx.addDifference("multipleOf", MULTIPLE_OF_CHANGED);
+      }
+    }
+    if (original.requiresInteger() != update.requiresInteger()) {
+      if (original.requiresInteger()) {
+        ctx.addDifference(TYPE_EXTENDED);
+      } else {
+        ctx.addDifference(TYPE_NARROWED);
+      }
+    }
+  }
+}

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/ObjectSchemaDiff.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/ObjectSchemaDiff.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json.diff;
+
+import org.everit.json.schema.ObjectSchema;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.ADDITIONAL_PROPERTIES_ADDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.ADDITIONAL_PROPERTIES_EXTENDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.ADDITIONAL_PROPERTIES_NARROWED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.ADDITIONAL_PROPERTIES_REMOVED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.DEPENDENCY_ARRAY_ADDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.DEPENDENCY_ARRAY_CHANGED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.DEPENDENCY_ARRAY_EXTENDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.DEPENDENCY_ARRAY_NARROWED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.DEPENDENCY_ARRAY_REMOVED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.DEPENDENCY_SCHEMA_ADDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.DEPENDENCY_SCHEMA_REMOVED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MAX_PROPERTIES_ADDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MAX_PROPERTIES_DECREASED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MAX_PROPERTIES_INCREASED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MAX_PROPERTIES_REMOVED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MIN_PROPERTIES_ADDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MIN_PROPERTIES_DECREASED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MIN_PROPERTIES_INCREASED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MIN_PROPERTIES_REMOVED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.OPTIONAL_PROPERTY_ADDED_TO_CLOSED_CONTENT_MODEL;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.PROPERTY_ADDED_TO_OPEN_CONTENT_MODEL;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.PROPERTY_REMOVED_FROM_CLOSED_CONTENT_MODEL;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.PROPERTY_REMOVED_FROM_OPEN_CONTENT_MODEL;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.REQUIRED_ATTRIBUTE_ADDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.REQUIRED_ATTRIBUTE_REMOVED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.REQUIRED_ATTRIBUTE_WITH_DEFAULT_ADDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.REQUIRED_PROPERTY_ADDED_TO_CLOSED_CONTENT_MODEL;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.REQUIRED_PROPERTY_WITH_DEFAULT_ADDED_TO_CLOSED_CONTENT_MODEL;
+
+public class ObjectSchemaDiff {
+  static void compare(final Context ctx, final ObjectSchema original, final ObjectSchema update) {
+    compareRequired(ctx, original, update);
+    compareProperties(ctx, original, update);
+    compareDependencies(ctx, original, update);
+    compareAdditionalProperties(ctx, original, update);
+    compareAttributes(ctx, original, update);
+  }
+
+  private static void compareAttributes(
+      final Context ctx, final ObjectSchema original, final ObjectSchema update
+  ) {
+    if (!Objects.equals(original.getMaxProperties(), update.getMaxProperties())) {
+      if (original.getMaxProperties() == null && update.getMaxProperties() != null) {
+        ctx.addDifference("maxProperties", MAX_PROPERTIES_ADDED);
+      } else if (original.getMaxProperties() != null && update.getMaxProperties() == null) {
+        ctx.addDifference("maxProperties", MAX_PROPERTIES_REMOVED);
+      } else if (original.getMaxProperties() < update.getMaxProperties()) {
+        ctx.addDifference("maxProperties", MAX_PROPERTIES_INCREASED);
+      } else if (original.getMaxProperties() > update.getMaxProperties()) {
+        ctx.addDifference("maxProperties", MAX_PROPERTIES_DECREASED);
+      }
+    }
+    if (!Objects.equals(original.getMinProperties(), update.getMinProperties())) {
+      if (original.getMinProperties() == null && update.getMinProperties() != null) {
+        ctx.addDifference("minProperties", MIN_PROPERTIES_ADDED);
+      } else if (original.getMinProperties() != null && update.getMinProperties() == null) {
+        ctx.addDifference("minProperties", MIN_PROPERTIES_REMOVED);
+      } else if (original.getMinProperties() < update.getMinProperties()) {
+        ctx.addDifference("minProperties", MIN_PROPERTIES_INCREASED);
+      } else if (original.getMinProperties() > update.getMinProperties()) {
+        ctx.addDifference("minProperties", MIN_PROPERTIES_DECREASED);
+      }
+    }
+  }
+
+  private static void compareAdditionalProperties(
+      final Context ctx, final ObjectSchema original, final ObjectSchema update
+  ) {
+    try (Context.PathScope pathScope = ctx.enterPath("additionalProperties")) {
+      if (original.permitsAdditionalProperties() != update.permitsAdditionalProperties()) {
+        if (update.permitsAdditionalProperties()) {
+          ctx.addDifference(ADDITIONAL_PROPERTIES_ADDED);
+        } else {
+          ctx.addDifference(ADDITIONAL_PROPERTIES_REMOVED);
+        }
+      } else if (original.getSchemaOfAdditionalProperties() == null
+          && update.getSchemaOfAdditionalProperties() != null) {
+        ctx.addDifference(ADDITIONAL_PROPERTIES_NARROWED);
+      } else if (update.getSchemaOfAdditionalProperties() == null
+          && original.getSchemaOfAdditionalProperties() != null) {
+        ctx.addDifference(ADDITIONAL_PROPERTIES_EXTENDED);
+      } else {
+        SchemaDiff.compare(
+            ctx,
+            original.getSchemaOfAdditionalProperties(),
+            update.getSchemaOfAdditionalProperties()
+        );
+      }
+    }
+  }
+
+  private static void compareDependencies(
+      final Context ctx, final ObjectSchema original, final ObjectSchema update
+  ) {
+    try (Context.PathScope pathScope = ctx.enterPath("dependencies")) {
+      Set<String> propertyKeys = new HashSet<>(original.getPropertyDependencies().keySet());
+      propertyKeys.addAll(update.getPropertyDependencies().keySet());
+
+      for (String propertyKey : propertyKeys) {
+        try (Context.PathScope pathScope2 = ctx.enterPath(propertyKey)) {
+          if (!update.getPropertyDependencies().containsKey(propertyKey)) {
+            ctx.addDifference(DEPENDENCY_ARRAY_REMOVED);
+          } else if (!original.getPropertyDependencies().containsKey(propertyKey)) {
+            ctx.addDifference(DEPENDENCY_ARRAY_ADDED);
+          } else {
+            Set<String> originalDependencies = original.getPropertyDependencies().get(propertyKey);
+            Set<String> updateDependencies = original.getPropertyDependencies().get(propertyKey);
+            if (originalDependencies.equals(updateDependencies)) {
+              if (updateDependencies.containsAll(originalDependencies)) {
+                ctx.addDifference(DEPENDENCY_ARRAY_EXTENDED);
+              } else if (originalDependencies.containsAll(updateDependencies)) {
+                ctx.addDifference(DEPENDENCY_ARRAY_NARROWED);
+              } else {
+                ctx.addDifference(DEPENDENCY_ARRAY_CHANGED);
+              }
+            }
+          }
+        }
+      }
+
+      propertyKeys = new HashSet<>(original.getSchemaDependencies().keySet());
+      propertyKeys.addAll(update.getSchemaDependencies().keySet());
+
+      for (String propertyKey : propertyKeys) {
+        try (Context.PathScope pathScope2 = ctx.enterPath(propertyKey)) {
+          if (!update.getSchemaDependencies().containsKey(propertyKey)) {
+            ctx.addDifference(DEPENDENCY_SCHEMA_REMOVED);
+          } else if (!original.getSchemaDependencies().containsKey(propertyKey)) {
+            ctx.addDifference(DEPENDENCY_SCHEMA_ADDED);
+          } else {
+            SchemaDiff.compare(ctx,
+                original.getSchemaDependencies().get(propertyKey),
+                update.getSchemaDependencies().get(propertyKey)
+            );
+          }
+        }
+      }
+    }
+  }
+
+  private static void compareProperties(
+      final Context ctx, final ObjectSchema original, final ObjectSchema update
+  ) {
+    try (Context.PathScope pathScope = ctx.enterPath("properties")) {
+      Set<String> propertyKeys = new HashSet<>(original.getPropertySchemas().keySet());
+      propertyKeys.addAll(update.getPropertySchemas().keySet());
+
+      for (String propertyKey : propertyKeys) {
+        try (Context.PathScope pathScope2 = ctx.enterPath(propertyKey)) {
+          if (!update.getPropertySchemas().containsKey(propertyKey)) {
+            // We only consider the content model of the update
+            ctx.addDifference(isOpenContentModel(update)
+                              ? PROPERTY_REMOVED_FROM_OPEN_CONTENT_MODEL
+                              : PROPERTY_REMOVED_FROM_CLOSED_CONTENT_MODEL);
+          } else if (!original.getPropertySchemas().containsKey(propertyKey)) {
+            // We only consider the content model of the original
+            if (isOpenContentModel(original)) {
+              ctx.addDifference(PROPERTY_ADDED_TO_OPEN_CONTENT_MODEL);
+            } else {
+              if (update.getRequiredProperties().contains(propertyKey)) {
+                if (update.getPropertySchemas().get(propertyKey).hasDefaultValue()) {
+                  ctx.addDifference(REQUIRED_PROPERTY_WITH_DEFAULT_ADDED_TO_CLOSED_CONTENT_MODEL);
+                } else {
+                  ctx.addDifference(REQUIRED_PROPERTY_ADDED_TO_CLOSED_CONTENT_MODEL);
+                }
+              } else {
+                ctx.addDifference(OPTIONAL_PROPERTY_ADDED_TO_CLOSED_CONTENT_MODEL);
+              }
+            }
+          } else {
+            SchemaDiff.compare(ctx,
+                original.getPropertySchemas().get(propertyKey),
+                update.getPropertySchemas().get(propertyKey)
+            );
+          }
+        }
+      }
+    }
+  }
+
+  private static void compareRequired(
+      final Context ctx, final ObjectSchema original, final ObjectSchema update
+  ) {
+    try (Context.PathScope pathScope = ctx.enterPath("required")) {
+      for (String propertyKey : original.getPropertySchemas().keySet()) {
+        if (update.getPropertySchemas().containsKey(propertyKey)) {
+          try (Context.PathScope pathScope2 = ctx.enterPath(propertyKey)) {
+            boolean originalRequired = original.getRequiredProperties().contains(propertyKey);
+            boolean updateRequired = update.getRequiredProperties().contains(propertyKey);
+            if (originalRequired && !updateRequired) {
+              ctx.addDifference(REQUIRED_ATTRIBUTE_REMOVED);
+            } else if (!originalRequired && updateRequired) {
+              if (update.getPropertySchemas().get(propertyKey).hasDefaultValue()) {
+                ctx.addDifference(REQUIRED_ATTRIBUTE_WITH_DEFAULT_ADDED);
+              } else {
+                ctx.addDifference(REQUIRED_ATTRIBUTE_ADDED);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private static boolean isOpenContentModel(final ObjectSchema schema) {
+    return schema.getPatternProperties().size() > 0 || schema.permitsAdditionalProperties();
+  }
+}

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/ReferenceSchemaDiff.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/ReferenceSchemaDiff.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json.diff;
+
+import org.everit.json.schema.ReferenceSchema;
+
+public class ReferenceSchemaDiff {
+  static void compare(
+      final Context ctx, final ReferenceSchema original, final ReferenceSchema update
+  ) {
+    try (Context.PathScope pathScope2 = ctx.enterPath("$ref")) {
+      SchemaDiff.compare(ctx, original.getReferredSchema(), update.getReferredSchema());
+    }
+  }
+}

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiff.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiff.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json.diff;
+
+import org.everit.json.schema.ArraySchema;
+import org.everit.json.schema.CombinedSchema;
+import org.everit.json.schema.EmptySchema;
+import org.everit.json.schema.EnumSchema;
+import org.everit.json.schema.NumberSchema;
+import org.everit.json.schema.ObjectSchema;
+import org.everit.json.schema.ReferenceSchema;
+import org.everit.json.schema.Schema;
+import org.everit.json.schema.StringSchema;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import io.confluent.kafka.schemaregistry.json.diff.Difference.Type;
+
+public class SchemaDiff {
+  public static final Set<Difference.Type> COMPATIBLE_CHANGES;
+
+  static {
+    Set<Difference.Type> changes = new HashSet<>();
+
+    changes.add(Type.DESCRIPTION_CHANGED);
+    changes.add(Type.TITLE_CHANGED);
+    changes.add(Type.DEFAULT_CHANGED);
+    changes.add(Type.TYPE_EXTENDED);
+
+    changes.add(Type.MAX_LENGTH_INCREASED);
+    changes.add(Type.MAX_LENGTH_REMOVED);
+    changes.add(Type.MIN_LENGTH_DECREASED);
+    changes.add(Type.MIN_LENGTH_REMOVED);
+    changes.add(Type.PATTERN_REMOVED);
+
+    changes.add(Type.MAXIMUM_INCREASED);
+    changes.add(Type.MAXIMUM_REMOVED);
+    changes.add(Type.MINIMUM_DECREASED);
+    changes.add(Type.MINIMUM_REMOVED);
+    changes.add(Type.EXCLUSIVE_MAXIMUM_INCREASED);
+    changes.add(Type.EXCLUSIVE_MAXIMUM_REMOVED);
+    changes.add(Type.EXCLUSIVE_MINIMUM_DECREASED);
+    changes.add(Type.EXCLUSIVE_MINIMUM_REMOVED);
+    changes.add(Type.MULTIPLE_OF_REDUCED);
+    changes.add(Type.MULTIPLE_OF_REMOVED);
+
+    changes.add(Type.REQUIRED_ATTRIBUTE_WITH_DEFAULT_ADDED);
+    changes.add(Type.REQUIRED_ATTRIBUTE_REMOVED);
+    changes.add(Type.DEPENDENCY_ARRAY_NARROWED);
+    changes.add(Type.DEPENDENCY_ARRAY_REMOVED);
+    changes.add(Type.DEPENDENCY_SCHEMA_REMOVED);
+    changes.add(Type.MAX_PROPERTIES_INCREASED);
+    changes.add(Type.MAX_PROPERTIES_REMOVED);
+    changes.add(Type.MIN_PROPERTIES_DECREASED);
+    changes.add(Type.MIN_PROPERTIES_REMOVED);
+    changes.add(Type.ADDITIONAL_PROPERTIES_ADDED);
+    changes.add(Type.ADDITIONAL_PROPERTIES_EXTENDED);
+    changes.add(Type.REQUIRED_PROPERTY_WITH_DEFAULT_ADDED_TO_CLOSED_CONTENT_MODEL);
+    changes.add(Type.OPTIONAL_PROPERTY_ADDED_TO_CLOSED_CONTENT_MODEL);
+    changes.add(Type.PROPERTY_REMOVED_FROM_OPEN_CONTENT_MODEL);
+
+    changes.add(Type.MAX_ITEMS_INCREASED);
+    changes.add(Type.MAX_ITEMS_REMOVED);
+    changes.add(Type.MIN_ITEMS_DECREASED);
+    changes.add(Type.MIN_ITEMS_REMOVED);
+    changes.add(Type.UNIQUE_ITEMS_REMOVED);
+    changes.add(Type.ADDITIONAL_ITEMS_ADDED);
+    changes.add(Type.ADDITIONAL_ITEMS_EXTENDED);
+    changes.add(Type.ITEMS_ADDED_TO_CLOSED_CONTENT_MODEL);
+
+    changes.add(Type.ENUM_ARRAY_EXTENDED);
+
+    changes.add(Type.PRODUCT_TYPE_NARROWED);
+    changes.add(Type.SUM_TYPE_EXTENDED);
+
+    COMPATIBLE_CHANGES = Collections.unmodifiableSet(changes);
+  }
+
+  public static List<Difference> compare(final Schema original, final Schema update) {
+    final Context ctx = new Context(COMPATIBLE_CHANGES);
+    compare(ctx, original, update);
+    return ctx.getDifferences();
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  static void compare(final Context ctx, Schema original, Schema update) {
+    if (original == null && update == null) {
+      return;
+    } else if (original == null) {
+      throw new IllegalArgumentException("Original schema not provided");
+    } else if (update == null) {
+      ctx.addDifference(Type.SCHEMA_REMOVED);
+      return;
+    }
+
+    original = normalizeEmptySchema(original);
+    update = normalizeEmptySchema(update);
+
+    if (!(original instanceof CombinedSchema) && update instanceof CombinedSchema) {
+      CombinedSchema combinedSchema = (CombinedSchema) update;
+      // Special case of singleton unions
+      if (combinedSchema.getSubschemas().size() == 1) {
+        final Context subctx = ctx.getSubcontext();
+        compare(subctx, original, combinedSchema.getSubschemas().iterator().next());
+        if (subctx.isCompatible()) {
+          ctx.addDifferences(subctx.getDifferences());
+          return;
+        }
+      } else if (combinedSchema.getCriterion() == CombinedSchema.ONE_CRITERION
+          || combinedSchema.getCriterion() == CombinedSchema.ONE_CRITERION) {
+        for (Schema subschema : combinedSchema.getSubschemas()) {
+          final Context subctx = ctx.getSubcontext();
+          compare(subctx, original, subschema);
+          if (subctx.isCompatible()) {
+            ctx.addDifferences(subctx.getDifferences());
+            ctx.addDifference(Type.SUM_TYPE_EXTENDED);
+            return;
+          }
+        }
+      }
+    } else if (original instanceof CombinedSchema && !(update instanceof CombinedSchema)) {
+      // Special case of singleton unions
+      CombinedSchema combinedSchema = (CombinedSchema) original;
+      if (combinedSchema.getSubschemas().size() == 1) {
+        final Context subctx = ctx.getSubcontext();
+        compare(subctx, combinedSchema.getSubschemas().iterator().next(), update);
+        if (subctx.isCompatible()) {
+          ctx.addDifferences(subctx.getDifferences());
+          return;
+        }
+      }
+    }
+
+    if (!original.getClass().equals(update.getClass())) {
+      ctx.addDifference(Type.TYPE_CHANGED);
+      return;
+    }
+
+    try (Context.SchemaScope schemaScope = ctx.enterSchema(original)) {
+      if (schemaScope != null) {
+        if (!Objects.equals(original.getId(), update.getId())) {
+          ctx.addDifference(Type.ID_CHANGED);
+        }
+        if (!Objects.equals(original.getTitle(), update.getTitle())) {
+          ctx.addDifference(Type.TITLE_CHANGED);
+        }
+        if (!Objects.equals(original.getDescription(), update.getDescription())) {
+          ctx.addDifference(Type.DESCRIPTION_CHANGED);
+        }
+        if (!Objects.equals(original.getDefaultValue(), update.getDefaultValue())) {
+          ctx.addDifference(Type.DEFAULT_CHANGED);
+        }
+
+        if (original instanceof StringSchema) {
+          StringSchemaDiff.compare(ctx, (StringSchema) original, (StringSchema) update);
+        } else if (original instanceof NumberSchema) {
+          NumberSchemaDiff.compare(ctx, (NumberSchema) original, (NumberSchema) update);
+        } else if (original instanceof EnumSchema) {
+          EnumSchemaDiff.compare(ctx, (EnumSchema) original, (EnumSchema) update);
+        } else if (original instanceof CombinedSchema) {
+          CombinedSchemaDiff.compare(ctx, (CombinedSchema) original, (CombinedSchema) update);
+        } else if (original instanceof ObjectSchema) {
+          ObjectSchemaDiff.compare(ctx, (ObjectSchema) original, (ObjectSchema) update);
+        } else if (original instanceof ArraySchema) {
+          ArraySchemaDiff.compare(ctx, (ArraySchema) original, (ArraySchema) update);
+        } else if (original instanceof ReferenceSchema) {
+          ReferenceSchemaDiff.compare(ctx, (ReferenceSchema) original, (ReferenceSchema) update);
+        }
+      }
+    }
+  }
+
+  private static Schema normalizeEmptySchema(final Schema schema) {
+    return schema instanceof EmptySchema ? ObjectSchema.builder()
+        .id(schema.getId())
+        .title(schema.getTitle())
+        .description(schema.getDescription())
+        .build() : schema;
+  }
+}

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/StringSchemaDiff.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/StringSchemaDiff.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json.diff;
+
+import org.everit.json.schema.StringSchema;
+
+import java.util.Objects;
+
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MAX_LENGTH_ADDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MAX_LENGTH_DECREASED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MAX_LENGTH_INCREASED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MAX_LENGTH_REMOVED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MIN_LENGTH_ADDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MIN_LENGTH_DECREASED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MIN_LENGTH_INCREASED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.MIN_LENGTH_REMOVED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.PATTERN_ADDED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.PATTERN_CHANGED;
+import static io.confluent.kafka.schemaregistry.json.diff.Difference.Type.PATTERN_REMOVED;
+
+class StringSchemaDiff {
+  static void compare(final Context ctx, final StringSchema original, final StringSchema update) {
+    if (!Objects.equals(original.getMaxLength(), update.getMaxLength())) {
+      if (original.getMaxLength() == null && update.getMaxLength() != null) {
+        ctx.addDifference("maxLength", MAX_LENGTH_ADDED);
+      } else if (original.getMaxLength() != null && update.getMaxLength() == null) {
+        ctx.addDifference("maxLength", MAX_LENGTH_REMOVED);
+      } else if (original.getMaxLength() < update.getMaxLength()) {
+        ctx.addDifference("maxLength", MAX_LENGTH_INCREASED);
+      } else if (original.getMaxLength() > update.getMaxLength()) {
+        ctx.addDifference("maxLength", MAX_LENGTH_DECREASED);
+      }
+    }
+    if (!Objects.equals(original.getMinLength(), update.getMinLength())) {
+      if (original.getMinLength() == null && update.getMinLength() != null) {
+        ctx.addDifference("minLength", MIN_LENGTH_ADDED);
+      } else if (original.getMinLength() != null && update.getMinLength() == null) {
+        ctx.addDifference("minLength", MIN_LENGTH_REMOVED);
+      } else if (original.getMinLength() < update.getMinLength()) {
+        ctx.addDifference("minLength", MIN_LENGTH_INCREASED);
+      } else if (original.getMinLength() > update.getMinLength()) {
+        ctx.addDifference("minLength", MIN_LENGTH_DECREASED);
+      }
+    }
+    if (original.getPattern() == null && update.getPattern() != null) {
+      ctx.addDifference("pattern", PATTERN_ADDED);
+    } else if (original.getPattern() != null && update.getPattern() == null) {
+      ctx.addDifference("pattern", PATTERN_REMOVED);
+    } else if (original.getPattern() != null
+        && update.getPattern() != null
+        && !original.getPattern().pattern().equals(update.getPattern().pattern())) {
+      ctx.addDifference("pattern", PATTERN_CHANGED);
+    }
+  }
+}

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/JSONArrayDeserializer.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/JSONArrayDeserializer.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.util.ClassUtil;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.IOException;
+
+public class JSONArrayDeserializer extends StdDeserializer<JSONArray> {
+  private static final long serialVersionUID = 1L;
+
+  public static final JSONArrayDeserializer instance = new JSONArrayDeserializer();
+
+  public JSONArrayDeserializer() {
+    super(JSONArray.class);
+  }
+
+  @Override
+  public JSONArray deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    // 07-Jan-2019, tatu: As per [datatype-json-org#15], need to verify it's an Array
+    if (!p.isExpectedStartArrayToken()) {
+      final JsonToken t = p.currentToken();
+      return (JSONArray) ctxt.handleUnexpectedToken(handledType(),
+          t,
+          p,
+          "Unexpected token (%s), expected START_ARRAY for %s value",
+          t,
+          ClassUtil.nameOf(handledType())
+      );
+    }
+
+    JSONArray array = new JSONArray();
+    JsonToken t;
+    while ((t = p.nextToken()) != JsonToken.END_ARRAY) {
+      switch (t) {
+        case START_ARRAY:
+          array.put(deserialize(p, ctxt));
+          continue;
+        case START_OBJECT:
+          array.put(JSONObjectDeserializer.instance.deserialize(p, ctxt));
+          continue;
+        case VALUE_STRING:
+          array.put(p.getText());
+          continue;
+        case VALUE_NULL:
+          array.put(JSONObject.NULL);
+          continue;
+        case VALUE_TRUE:
+          array.put(Boolean.TRUE);
+          continue;
+        case VALUE_FALSE:
+          array.put(Boolean.FALSE);
+          continue;
+        case VALUE_NUMBER_INT:
+          // Note: added conversion of byte/short
+          Number num = p.getNumberValue();
+          if (num instanceof Byte || num instanceof Short) {
+            num = num.intValue();
+          }
+          array.put(num);
+          continue;
+        case VALUE_NUMBER_FLOAT:
+          array.put(p.getNumberValue());
+          continue;
+        case VALUE_EMBEDDED_OBJECT:
+          // Note: added conversion of byte[]
+          Object o = p.getEmbeddedObject();
+          if (o instanceof byte[]) {
+            o = p.getText();
+          }
+          array.put(o);
+          continue;
+        default:
+          return (JSONArray) ctxt.handleUnexpectedToken(handledType(), p);
+      }
+    }
+    return array;
+  }
+}

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/JSONArraySerializer.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/JSONArraySerializer.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.WritableTypeId;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+
+public class JSONArraySerializer extends JSONBaseSerializer<JSONArray> {
+  private static final long serialVersionUID = 1L;
+
+  public static final JSONArraySerializer instance = new JSONArraySerializer();
+
+  public JSONArraySerializer() {
+    super(JSONArray.class);
+  }
+
+  @Override // since 2.6
+  public boolean isEmpty(SerializerProvider provider, JSONArray value) {
+    return (value == null) || value.length() == 0;
+  }
+
+  @Override
+  public void serialize(
+      JSONArray value,
+      JsonGenerator g,
+      SerializerProvider provider
+  ) throws IOException {
+    g.writeStartArray();
+    serializeContents(value, g, provider);
+    g.writeEndArray();
+  }
+
+  @Override
+  public void serializeWithType(
+      JSONArray value, JsonGenerator g, SerializerProvider provider, TypeSerializer typeSer
+  ) throws IOException {
+    g.setCurrentValue(value);
+    WritableTypeId typeIdDef = typeSer.writeTypePrefix(g,
+        typeSer.typeId(value, JsonToken.START_ARRAY)
+    );
+    serializeContents(value, g, provider);
+    typeSer.writeTypeSuffix(g, typeIdDef);
+  }
+
+  @Override
+  public JsonNode getSchema(
+      SerializerProvider provider,
+      Type typeHint
+  ) throws JsonMappingException {
+    return createSchemaNode("array", true);
+  }
+
+  protected void serializeContents(
+      JSONArray value,
+      JsonGenerator g,
+      SerializerProvider provider
+  ) throws IOException {
+    for (int i = 0, len = value.length(); i < len; ++i) {
+      Object ob = value.opt(i);
+      if (ob == null || ob == JSONObject.NULL) {
+        g.writeNull();
+        continue;
+      }
+      Class<?> cls = ob.getClass();
+      if (cls == JSONObject.class) {
+        JSONObjectSerializer.instance.serialize((JSONObject) ob, g, provider);
+      } else if (cls == JSONArray.class) {
+        serialize((JSONArray) ob, g, provider);
+      } else if (cls == String.class) {
+        g.writeString((String) ob);
+      } else if (cls == Integer.class) {
+        g.writeNumber(((Integer) ob).intValue());
+      } else if (cls == Long.class) {
+        g.writeNumber(((Long) ob).longValue());
+      } else if (cls == Boolean.class) {
+        g.writeBoolean(((Boolean) ob).booleanValue());
+      } else if (cls == Double.class) {
+        g.writeNumber(((Double) ob).doubleValue());
+      } else if (JSONObject.class.isAssignableFrom(cls)) { // sub-class
+        JSONObjectSerializer.instance.serialize((JSONObject) ob, g, provider);
+      } else if (JSONArray.class.isAssignableFrom(cls)) { // sub-class
+        serialize((JSONArray) ob, g, provider);
+      } else {
+        provider.defaultSerializeValue(ob, g);
+      }
+    }
+  }
+}

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/JSONBaseSerializer.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/JSONBaseSerializer.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json.jackson;
+
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+abstract class JSONBaseSerializer<T> extends StdSerializer<T> {
+  private static final long serialVersionUID = 1L;
+
+  protected JSONBaseSerializer(Class<T> cls) {
+    super(cls);
+  }
+}

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/JSONObjectDeserializer.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/JSONObjectDeserializer.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+
+public class JSONObjectDeserializer extends StdDeserializer<JSONObject> {
+  private static final long serialVersionUID = 1L;
+
+  public static final JSONObjectDeserializer instance = new JSONObjectDeserializer();
+
+  public JSONObjectDeserializer() {
+    super(JSONObject.class);
+  }
+
+  @Override
+  public JSONObject deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+    JSONObject ob = new JSONObject();
+    JsonToken t = p.getCurrentToken();
+    if (t == JsonToken.START_OBJECT) {
+      t = p.nextToken();
+    }
+    for (; t == JsonToken.FIELD_NAME; t = p.nextToken()) {
+      String fieldName = p.getCurrentName();
+      t = p.nextToken();
+      try {
+        switch (t) {
+          case START_ARRAY:
+            ob.put(fieldName, JSONArrayDeserializer.instance.deserialize(p, ctxt));
+            continue;
+          case START_OBJECT:
+            ob.put(fieldName, deserialize(p, ctxt));
+            continue;
+          case VALUE_STRING:
+            ob.put(fieldName, p.getText());
+            continue;
+          case VALUE_NULL:
+            ob.put(fieldName, JSONObject.NULL);
+            continue;
+          case VALUE_TRUE:
+            ob.put(fieldName, Boolean.TRUE);
+            continue;
+          case VALUE_FALSE:
+            ob.put(fieldName, Boolean.FALSE);
+            continue;
+          case VALUE_NUMBER_INT:
+            // Note: added conversion of byte/short
+            Number num = p.getNumberValue();
+            if (num instanceof Byte || num instanceof Short) {
+              num = num.intValue();
+            }
+            ob.put(fieldName, num);
+            continue;
+          case VALUE_NUMBER_FLOAT:
+            ob.put(fieldName, p.getNumberValue());
+            continue;
+          case VALUE_EMBEDDED_OBJECT:
+            // Note: added conversion of byte[]
+            Object o = p.getEmbeddedObject();
+            if (o instanceof byte[]) {
+              o = p.getText();
+            }
+            ob.put(fieldName, o);
+            continue;
+          default:
+        }
+      } catch (JSONException e) {
+        throw ctxt.instantiationException(handledType(), e);
+      }
+      return (JSONObject) ctxt.handleUnexpectedToken(JSONObject.class, p);
+    }
+    return ob;
+  }
+}

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/JSONObjectSerializer.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/JSONObjectSerializer.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.type.WritableTypeId;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Iterator;
+
+public class JSONObjectSerializer extends JSONBaseSerializer<JSONObject> {
+  private static final long serialVersionUID = 1L;
+
+  public static final JSONObjectSerializer instance = new JSONObjectSerializer();
+
+  public JSONObjectSerializer() {
+    super(JSONObject.class);
+  }
+
+  @Override // since 2.6
+  public boolean isEmpty(SerializerProvider provider, JSONObject value) {
+    return (value == null) || value.length() == 0;
+  }
+
+  @Override
+  public void serialize(
+      JSONObject value,
+      JsonGenerator g,
+      SerializerProvider provider
+  ) throws IOException {
+    g.writeStartObject(value);
+    serializeContents(value, g, provider);
+    g.writeEndObject();
+  }
+
+  @Override
+  public void serializeWithType(
+      JSONObject value, JsonGenerator g, SerializerProvider provider, TypeSerializer typeSer
+  ) throws IOException {
+    g.setCurrentValue(value);
+    WritableTypeId typeIdDef = typeSer.writeTypePrefix(g,
+        typeSer.typeId(value, JsonToken.START_OBJECT)
+    );
+    serializeContents(value, g, provider);
+    typeSer.writeTypeSuffix(g, typeIdDef);
+
+  }
+
+  @Override
+  public JsonNode getSchema(
+      SerializerProvider provider,
+      Type typeHint
+  ) throws JsonMappingException {
+    return createSchemaNode("object", true);
+  }
+
+  protected void serializeContents(
+      JSONObject value,
+      JsonGenerator g,
+      SerializerProvider provider
+  ) throws IOException {
+    Iterator<?> it = value.keys();
+    while (it.hasNext()) {
+      String key = (String) it.next();
+      Object ob = value.opt(key);
+      if (ob == null || ob == JSONObject.NULL) {
+        if (provider.isEnabled(SerializationFeature.WRITE_NULL_MAP_VALUES)) {
+          g.writeNullField(key);
+        }
+        continue;
+      }
+      g.writeFieldName(key);
+      Class<?> cls = ob.getClass();
+      if (cls == JSONObject.class) {
+        serialize((JSONObject) ob, g, provider);
+      } else if (cls == JSONArray.class) {
+        JSONArraySerializer.instance.serialize((JSONArray) ob, g, provider);
+      } else if (cls == String.class) {
+        g.writeString((String) ob);
+      } else if (cls == Integer.class) {
+        g.writeNumber(((Integer) ob).intValue());
+      } else if (cls == Long.class) {
+        g.writeNumber(((Long) ob).longValue());
+      } else if (cls == Boolean.class) {
+        g.writeBoolean(((Boolean) ob).booleanValue());
+      } else if (cls == Double.class) {
+        g.writeNumber(((Double) ob).doubleValue());
+      } else if (JSONObject.class.isAssignableFrom(cls)) { // sub-class
+        serialize((JSONObject) ob, g, provider);
+      } else if (JSONArray.class.isAssignableFrom(cls)) { // sub-class
+        JSONArraySerializer.instance.serialize((JSONArray) ob, g, provider);
+      } else {
+        provider.defaultSerializeValue(ob, g);
+      }
+    }
+  }
+}

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/Jackson.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/Jackson.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json.jackson;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+
+/**
+ * A utility class for Jackson.
+ */
+public class Jackson {
+  private Jackson() { /* singleton */ }
+
+  /**
+   * Creates a new {@link ObjectMapper}.
+   */
+  public static ObjectMapper newObjectMapper() {
+    final ObjectMapper mapper = new ObjectMapper();
+
+    return configure(mapper);
+  }
+
+  /**
+   * Creates a new {@link ObjectMapper} with a custom
+   * {@link com.fasterxml.jackson.core.JsonFactory}.
+   *
+   * @param jsonFactory instance of {@link com.fasterxml.jackson.core.JsonFactory} to use
+   *     for the created {@link com.fasterxml.jackson.databind.ObjectMapper} instance.
+   */
+  public static ObjectMapper newObjectMapper(JsonFactory jsonFactory) {
+    final ObjectMapper mapper = new ObjectMapper(jsonFactory);
+
+    return configure(mapper);
+  }
+
+  private static ObjectMapper configure(ObjectMapper mapper) {
+    mapper.registerModule(new GuavaModule());
+    mapper.registerModule(new JodaModule());
+    mapper.registerModule(new ParameterNamesModule());
+    mapper.registerModule(new Jdk8Module());
+    mapper.registerModule(new JavaTimeModule());
+    mapper.registerModule(new JsonOrgModule());
+    mapper.disable(FAIL_ON_UNKNOWN_PROPERTIES);
+
+    return mapper;
+  }
+}

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/JsonOrgModule.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/JsonOrgModule.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json.jackson;
+
+import com.fasterxml.jackson.core.util.VersionUtil;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class JsonOrgModule extends SimpleModule {
+  private static final long serialVersionUID = 1;
+
+  private static final String NAME = "JsonOrgModule";
+
+  public JsonOrgModule() {
+    super(NAME, VersionUtil.versionFor(JsonOrgModule.class));
+    addDeserializer(JSONArray.class, JSONArrayDeserializer.instance);
+    addDeserializer(JSONObject.class, JSONObjectDeserializer.instance);
+    addSerializer(JSONArraySerializer.instance);
+    addSerializer(JSONObjectSerializer.instance);
+  }
+}

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.NumericNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.everit.json.schema.ValidationException;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class JsonSchemaTest {
+
+  private static ObjectMapper objectMapper = new ObjectMapper();
+
+  private static final String recordSchemaString = "{\"properties\": {\n"
+      + "     \"null\": {\"type\": \"null\"},\n"
+      + "     \"boolean\": {\"type\": \"boolean\"},\n"
+      + "     \"number\": {\"type\": \"number\"},\n"
+      + "     \"string\": {\"type\": \"string\"},\n"
+      + "  },\n"
+      + "  \"additionalProperties\": false\n"
+      + "}";
+
+  private static final JsonSchema recordSchema = new JsonSchema(recordSchemaString);
+
+  private static final String arraySchemaString = "{\"type\": \"array\", \"items\": { \"type\": "
+      + "\"string\" } }";
+
+  private static final JsonSchema arraySchema = new JsonSchema(arraySchemaString);
+
+  private static final String unionSchemaString = "{\n"
+      + "  \"oneOf\": [\n"
+      + "    { \"type\": \"string\", \"maxLength\": 5 },\n"
+      + "    { \"type\": \"number\", \"minimum\": 0 }\n"
+      + "  ]\n"
+      + "}";
+
+  private static final JsonSchema unionSchema = new JsonSchema(unionSchemaString);
+
+  private static final String enumSchemaString = "{ \"type\": \"string\", \"enum\": [\"red\", "
+      + "\"amber\", \"green\"] }";
+
+  private static final JsonSchema enumSchema = new JsonSchema(enumSchemaString);
+
+  @Test
+  public void testPrimitiveTypesToJsonSchema() throws Exception {
+    Object result = JsonSchemaUtils.toObject(null, createPrimitiveSchema("null"));
+    assertTrue(result == null);
+
+    result = JsonSchemaUtils.toObject(jsonTree("true"), createPrimitiveSchema("boolean"));
+    assertEquals(true, ((BooleanNode) result).asBoolean());
+
+    result = JsonSchemaUtils.toObject(jsonTree("false"), createPrimitiveSchema("boolean"));
+    assertEquals(false, ((BooleanNode) result).asBoolean());
+
+    result = JsonSchemaUtils.toObject(jsonTree("12"), createPrimitiveSchema("number"));
+    assertEquals(12, ((NumericNode) result).asInt());
+
+    result = JsonSchemaUtils.toObject(jsonTree("23.2"), createPrimitiveSchema("number"));
+    assertEquals(23.2, ((NumericNode) result).asDouble(), 0.1);
+
+    result = JsonSchemaUtils.toObject(jsonTree("\"a string\""), createPrimitiveSchema("string"));
+    assertEquals("a string", ((TextNode) result).asText());
+  }
+
+  @Test
+  public void testRecordToJsonSchema() throws Exception {
+    String json = "{\n"
+        + "    \"null\": null,\n"
+        + "    \"boolean\": true,\n"
+        + "    \"number\": 12,\n"
+        + "    \"string\": \"string\"\n"
+        + "}";
+
+    JsonNode result = (JsonNode) JsonSchemaUtils.toObject(jsonTree(json), recordSchema);
+    assertEquals(true, result.get("null").isNull());
+    assertEquals(true, result.get("boolean").booleanValue());
+    assertEquals(12, result.get("number").intValue());
+    assertEquals("string", result.get("string").textValue());
+  }
+
+  @Test(expected = ValidationException.class)
+  public void testInvalidRecordToJsonSchema() throws Exception {
+    String json = "{\n"
+        + "    \"null\": null,\n"
+        + "    \"boolean\": true,\n"
+        + "    \"number\": 12,\n"
+        + "    \"string\": \"string\",\n"
+        + "    \"badString\": \"string\"\n"
+        + "}";
+
+    JsonNode result = (JsonNode) JsonSchemaUtils.toObject(jsonTree(json), recordSchema);
+    assertEquals(true, result.get("null").isNull());
+    assertEquals(true, result.get("boolean").booleanValue());
+    assertEquals(12, result.get("number").intValue());
+    assertEquals("string", result.get("string").textValue());
+  }
+
+  @Test
+  public void testArrayToJsonSchema() throws Exception {
+    String json = "[\"one\", \"two\", \"three\"]";
+
+    Object result = JsonSchemaUtils.toObject(jsonTree(json), arraySchema);
+    ArrayNode arrayNode = (ArrayNode) result;
+    Iterator<JsonNode> elements = arrayNode.elements();
+    List<String> strings = new ArrayList<String>();
+    while (elements.hasNext()) {
+      strings.add(elements.next().textValue());
+    }
+    assertArrayEquals(new String[]{"one", "two", "three"}, strings.toArray());
+  }
+
+  @Test
+  public void testUnionToJsonSchema() throws Exception {
+    Object result = JsonSchemaUtils.toObject(jsonTree("\"test\""), unionSchema);
+    assertEquals("test", ((TextNode) result).asText());
+
+    result = JsonSchemaUtils.toObject(jsonTree("12"), unionSchema);
+    assertEquals(12, ((NumericNode) result).asInt());
+
+    try {
+      JsonSchemaUtils.toObject(jsonTree("-1"), unionSchema);
+      fail("Trying to use negative number should fail");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testEnumToJsonSchema() throws Exception {
+    Object result = JsonSchemaUtils.toObject(jsonTree("\"red\""), enumSchema);
+    assertEquals("red", ((TextNode) result).asText());
+
+    try {
+      JsonSchemaUtils.toObject(jsonTree("\"yellow\""), enumSchema);
+      fail("Trying to use non-enum should fail");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testPrimitiveTypesToJson() throws Exception {
+    JsonNode result = objectMapper.readTree(JsonSchemaUtils.toJson((int) 0));
+    assertTrue(result.isNumber());
+
+    result = objectMapper.readTree(JsonSchemaUtils.toJson((long) 0));
+    assertTrue(result.isNumber());
+
+    result = objectMapper.readTree(JsonSchemaUtils.toJson(0.1f));
+    assertTrue(result.isNumber());
+
+    result = objectMapper.readTree(JsonSchemaUtils.toJson(0.1));
+    assertTrue(result.isNumber());
+
+    result = objectMapper.readTree(JsonSchemaUtils.toJson(true));
+    assertTrue(result.isBoolean());
+
+    // "Primitive" here refers to JsonSchema primitive types, which are returned as standalone
+    // objects,
+    // which can't have attached schemas. This includes, for example, Strings and byte[] even
+    // though they are not Java primitives
+
+    result = objectMapper.readTree(JsonSchemaUtils.toJson("abcdefg"));
+    assertTrue(result.isTextual());
+    assertEquals("abcdefg", result.textValue());
+  }
+
+  @Test
+  public void testRecordToJson() throws Exception {
+    String json = "{\n"
+        + "    \"null\": null,\n"
+        + "    \"boolean\": true,\n"
+        + "    \"number\": 12,\n"
+        + "    \"string\": \"string\"\n"
+        + "}";
+    JsonNode data = new ObjectMapper().readTree(json);
+    JsonNode result = objectMapper.readTree(JsonSchemaUtils.toJson(data));
+    assertTrue(result.isObject());
+    assertTrue(result.get("null").isNull());
+    assertTrue(result.get("boolean").isBoolean());
+    assertEquals(true, result.get("boolean").booleanValue());
+    assertTrue(result.get("number").isIntegralNumber());
+    assertEquals(12, result.get("number").intValue());
+    assertTrue(result.get("string").isTextual());
+    assertEquals("string", result.get("string").textValue());
+  }
+
+  @Test
+  public void testArrayToJson() throws Exception {
+    String json = "[\"one\", \"two\", \"three\"]";
+    JsonNode data = new ObjectMapper().readTree(json);
+    JsonNode result = objectMapper.readTree(JsonSchemaUtils.toJson(data));
+
+    assertTrue(result.isArray());
+    assertEquals(3, result.size());
+    assertEquals(JsonNodeFactory.instance.textNode("one"), result.get(0));
+    assertEquals(JsonNodeFactory.instance.textNode("two"), result.get(1));
+    assertEquals(JsonNodeFactory.instance.textNode("three"), result.get(2));
+  }
+
+  private static JsonSchema createPrimitiveSchema(String type) {
+    String schemaString = String.format("{\"type\" : \"%s\"}", type);
+    return new JsonSchema(schemaString);
+  }
+
+  private static JsonNode jsonTree(String jsonData) {
+    try {
+      return objectMapper.readTree(jsonData);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to parse JSON", e);
+    }
+  }
+
+}

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/TestSchemaValidation.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/TestSchemaValidation.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json;
+
+
+import org.everit.json.schema.ArraySchema;
+import org.everit.json.schema.BooleanSchema;
+import org.everit.json.schema.CombinedSchema;
+import org.everit.json.schema.EnumSchema;
+import org.everit.json.schema.NumberSchema;
+import org.everit.json.schema.ObjectSchema;
+import org.everit.json.schema.Schema;
+import org.everit.json.schema.StringSchema;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import io.confluent.kafka.schemaregistry.SchemaValidator;
+import io.confluent.kafka.schemaregistry.SchemaValidatorBuilder;
+import io.confluent.kafka.schemaregistry.json.TestSchemas.ReaderWriter;
+
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.A_DINT_B_DINT_RECORD1;
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.A_INT_B_DINT_RECORD1;
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.A_INT_B_DINT_REQUIRED_RECORD1;
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.A_INT_B_INT_RECORD1;
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.A_INT_B_INT_REQUIRED_RECORD1;
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.A_INT_OPEN_RECORD1;
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.A_INT_RECORD1;
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.BOOLEAN_SCHEMA;
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.EMPTY_RECORD1;
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.ENUM1_ABC_SCHEMA;
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.ENUM1_AB_SCHEMA;
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.ENUM1_BC_SCHEMA;
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.INT_ARRAY_SCHEMA;
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.INT_SCHEMA;
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.NUMBER_ARRAY_SCHEMA;
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.NUMBER_SCHEMA;
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.STRING_ARRAY_SCHEMA;
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.STRING_INT_UNION_SCHEMA;
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.STRING_SCHEMA;
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.STRING_UNION_SCHEMA;
+import static io.confluent.kafka.schemaregistry.json.TestSchemas.list;
+
+public class TestSchemaValidation {
+
+  public static final List<ReaderWriter> COMPATIBLE_READER_WRITER_TEST_CASES =
+      list(new ReaderWriter(NUMBER_SCHEMA,
+          INT_SCHEMA
+      ),
+
+      new ReaderWriter(NUMBER_ARRAY_SCHEMA, INT_ARRAY_SCHEMA),
+
+      new ReaderWriter(ENUM1_ABC_SCHEMA, ENUM1_AB_SCHEMA),
+
+      new ReaderWriter(STRING_INT_UNION_SCHEMA, STRING_UNION_SCHEMA),
+      new ReaderWriter(STRING_INT_UNION_SCHEMA, STRING_SCHEMA),
+
+      // Special case of singleton unions
+      new ReaderWriter(STRING_UNION_SCHEMA, STRING_SCHEMA),
+      new ReaderWriter(STRING_SCHEMA, STRING_UNION_SCHEMA),
+
+      new ReaderWriter(A_INT_RECORD1, EMPTY_RECORD1),
+      new ReaderWriter(A_INT_B_DINT_RECORD1, A_INT_RECORD1),
+      new ReaderWriter(A_DINT_B_DINT_RECORD1, EMPTY_RECORD1),
+      new ReaderWriter(A_DINT_B_DINT_RECORD1, A_INT_RECORD1),
+
+      new ReaderWriter(A_INT_OPEN_RECORD1, A_INT_B_INT_RECORD1),
+      new ReaderWriter(A_INT_B_INT_RECORD1, A_INT_RECORD1),
+      new ReaderWriter(A_INT_B_DINT_REQUIRED_RECORD1, A_INT_RECORD1)
+  );
+
+  public static final List<ReaderWriter> INCOMPATIBLE_READER_WRITER_TEST_CASES =
+      list(new ReaderWriter(BOOLEAN_SCHEMA,
+          INT_SCHEMA
+      ),
+
+      new ReaderWriter(INT_SCHEMA, BOOLEAN_SCHEMA),
+      new ReaderWriter(INT_SCHEMA, NUMBER_SCHEMA),
+
+      new ReaderWriter(STRING_SCHEMA, BOOLEAN_SCHEMA),
+      new ReaderWriter(STRING_SCHEMA, INT_SCHEMA),
+
+      new ReaderWriter(INT_ARRAY_SCHEMA, NUMBER_ARRAY_SCHEMA),
+      new ReaderWriter(INT_ARRAY_SCHEMA, STRING_ARRAY_SCHEMA),
+
+      new ReaderWriter(ENUM1_AB_SCHEMA, ENUM1_ABC_SCHEMA),
+      new ReaderWriter(ENUM1_BC_SCHEMA, ENUM1_ABC_SCHEMA),
+
+      new ReaderWriter(INT_SCHEMA, ENUM1_AB_SCHEMA),
+      new ReaderWriter(ENUM1_AB_SCHEMA, INT_SCHEMA),
+
+      new ReaderWriter(STRING_UNION_SCHEMA, STRING_INT_UNION_SCHEMA),
+      new ReaderWriter(INT_SCHEMA, STRING_INT_UNION_SCHEMA),
+
+      new ReaderWriter(A_INT_B_INT_REQUIRED_RECORD1, A_INT_RECORD1)
+  );
+
+  SchemaValidatorBuilder builder = new SchemaValidatorBuilder();
+
+  Schema rec = ObjectSchema.builder()
+      .addPropertySchema("a", NumberSchema.builder().requiresInteger(true).defaultValue(1).build())
+      .addPropertySchema("b", NumberSchema.builder().requiresNumber(true).build())
+      .additionalProperties(false)
+      .build();
+  Schema rec2 = ObjectSchema.builder()
+      .addPropertySchema("a", NumberSchema.builder().requiresInteger(true).defaultValue(1).build())
+      .addPropertySchema("b", NumberSchema.builder().requiresNumber(true).build())
+      .addPropertySchema("c", NumberSchema.builder().requiresInteger(true).defaultValue(0).build())
+      .additionalProperties(false)
+      .build();
+  Schema rec3 = ObjectSchema.builder()
+      .addPropertySchema("b", NumberSchema.builder().requiresNumber(true).build())
+      .addPropertySchema("c", NumberSchema.builder().requiresInteger(true).defaultValue(0).build())
+      .additionalProperties(true)
+      .build();
+  Schema rec4 = ObjectSchema.builder()
+      .addPropertySchema("b", NumberSchema.builder().requiresNumber(true).build())
+      .addPropertySchema("c", NumberSchema.builder().requiresInteger(true).build())
+      .additionalProperties(false)
+      .build();
+
+  @Test
+  public void testAllTypes() {
+    Schema s = ObjectSchema.builder()
+        .addPropertySchema("boolF", BooleanSchema.builder().build())
+        .addRequiredProperty("boolF")
+        .addPropertySchema("intF", NumberSchema.builder().requiresInteger(true).build())
+        .addRequiredProperty("intF")
+        .addPropertySchema("numberF", NumberSchema.builder().requiresNumber(true).build())
+        .addRequiredProperty("numberF")
+        .addPropertySchema("stringF", StringSchema.builder().build())
+        .addRequiredProperty("stringF")
+        .addPropertySchema("enumF", EnumSchema.builder().possibleValue("S").build())
+        .addRequiredProperty("enumF")
+        .addPropertySchema(
+            "arrayF",
+            ArraySchema.builder().allItemSchema(StringSchema.builder().build()).build()
+        )
+        .addRequiredProperty("arrayF")
+        .addPropertySchema(
+            "recordF",
+            ObjectSchema.builder().addPropertySchema("f", NumberSchema.builder().build()).build()
+        )
+        .addRequiredProperty("recordF")
+        .addPropertySchema("bool0", BooleanSchema.builder().build())
+        .build();
+    testValidatorPasses(builder.mutualReadStrategy().validateLatest(), s, s);
+  }
+
+  @Test
+  public void testReadOnePrior() {
+    testValidatorPasses(builder.canReadStrategy().validateLatest(), rec3, rec);
+    testValidatorFails(builder.canReadStrategy().validateLatest(), rec4, rec);
+  }
+
+  @Test
+  public void testReadAllPrior() {
+    testValidatorPasses(builder.canReadStrategy().validateAll(), rec3, rec, rec2);
+    testValidatorFails(builder.canReadStrategy().validateAll(), rec4, rec, rec2, rec3);
+  }
+
+  @Test
+  public void testOnePriorCanRead() {
+    testValidatorPasses(builder.canBeReadStrategy().validateLatest(), rec, rec3);
+    testValidatorFails(builder.canBeReadStrategy().validateLatest(), rec, rec4);
+  }
+
+  @Test
+  public void testAllPriorCanRead() {
+    testValidatorPasses(builder.canBeReadStrategy().validateAll(), rec, rec3, rec2);
+    testValidatorFails(builder.canBeReadStrategy().validateAll(), rec, rec4, rec3, rec2);
+  }
+
+  @Test
+  public void testUnionWithIncompatibleElements() {
+    Schema union1 = CombinedSchema.builder()
+        .criterion(CombinedSchema.ONE_CRITERION)
+        .subschema(ArraySchema.builder().allItemSchema(rec).build())
+        .build();
+    Schema union2 = CombinedSchema.builder()
+        .criterion(CombinedSchema.ONE_CRITERION)
+        .subschema(ArraySchema.builder().allItemSchema(rec4).build())
+        .build();
+    testValidatorFails(builder.canReadStrategy().validateAll(), union2, union1);
+  }
+
+  @Test
+  public void testUnionWithCompatibleElements() {
+    Schema union1 = CombinedSchema.builder()
+        .criterion(CombinedSchema.ONE_CRITERION)
+        .subschema(ArraySchema.builder().allItemSchema(rec).build())
+        .build();
+    Schema union2 = CombinedSchema.builder()
+        .criterion(CombinedSchema.ONE_CRITERION)
+        .subschema(ArraySchema.builder().allItemSchema(rec3).build())
+        .build();
+    testValidatorPasses(builder.canReadStrategy().validateAll(), union2, union1);
+  }
+
+  @Test
+  public void testSchemaCompatibilitySuccesses() {
+    for (ReaderWriter tc : COMPATIBLE_READER_WRITER_TEST_CASES) {
+      testValidatorPasses(builder.canReadStrategy().validateAll(), tc.getReader(), tc.getWriter());
+    }
+  }
+
+  @Test
+  public void testSchemaCompatibilityFailures() {
+    for (ReaderWriter tc : INCOMPATIBLE_READER_WRITER_TEST_CASES) {
+      Schema reader = tc.getReader();
+      Schema writer = tc.getWriter();
+      SchemaValidator validator = builder.canReadStrategy().validateAll();
+      boolean valid = validator.validate(
+          new JsonSchema(reader),
+          Collections.singleton(new JsonSchema(writer))
+      );
+      Assert.assertFalse(valid);
+    }
+  }
+
+  private void testValidatorPasses(SchemaValidator validator, Schema schema, Schema... prev) {
+    ArrayList<JsonSchema> prior = new ArrayList<>();
+    for (int i = prev.length - 1; i >= 0; i--) {
+      prior.add(new JsonSchema(prev[i]));
+    }
+    validator.validate(new JsonSchema(schema), prior);
+  }
+
+  private void testValidatorFails(SchemaValidator validator, Schema schemaFails, Schema... prev) {
+    ArrayList<JsonSchema> prior = new ArrayList<>();
+    for (int i = prev.length - 1; i >= 0; i--) {
+      prior.add(new JsonSchema(prev[i]));
+    }
+    boolean valid = validator.validate(new JsonSchema(schemaFails), prior);
+    Assert.assertFalse(valid);
+  }
+}

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/TestSchemas.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/TestSchemas.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json;
+
+import org.everit.json.schema.ArraySchema;
+import org.everit.json.schema.BooleanSchema;
+import org.everit.json.schema.CombinedSchema;
+import org.everit.json.schema.EnumSchema;
+import org.everit.json.schema.NumberSchema;
+import org.everit.json.schema.ObjectSchema;
+import org.everit.json.schema.Schema;
+import org.everit.json.schema.StringSchema;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+/**
+ * Schemas used by other tests in this package. Therefore package protected.
+ */
+public class TestSchemas {
+
+  static final Schema BOOLEAN_SCHEMA = BooleanSchema.builder().build();
+  static final Schema INT_SCHEMA = NumberSchema.builder().requiresInteger(true).build();
+  static final Schema NUMBER_SCHEMA = NumberSchema.builder().requiresNumber(true).build();
+  static final Schema STRING_SCHEMA = StringSchema.builder().build();
+
+  static final Schema INT_ARRAY_SCHEMA = ArraySchema.builder().allItemSchema(INT_SCHEMA).build();
+  static final Schema NUMBER_ARRAY_SCHEMA = ArraySchema.builder()
+      .allItemSchema(NUMBER_SCHEMA)
+      .build();
+  static final Schema STRING_ARRAY_SCHEMA = ArraySchema.builder()
+      .allItemSchema(STRING_SCHEMA)
+      .build();
+
+  static final Schema ENUM1_AB_SCHEMA = EnumSchema.builder()
+      .possibleValue("A")
+      .possibleValue("B")
+      .build();
+  static final Schema ENUM1_ABC_SCHEMA = EnumSchema.builder()
+      .possibleValue("A")
+      .possibleValue("B")
+      .possibleValue("C")
+      .build();
+  static final Schema ENUM1_BC_SCHEMA = EnumSchema.builder()
+      .possibleValue("B")
+      .possibleValue("C")
+      .build();
+  static final Schema STRING_UNION_SCHEMA = CombinedSchema.builder()
+      .criterion(CombinedSchema.ONE_CRITERION)
+      .subschema(STRING_SCHEMA)
+      .build();
+  static final Schema STRING_INT_UNION_SCHEMA = CombinedSchema.builder()
+      .criterion(CombinedSchema.ONE_CRITERION)
+      .subschema(STRING_SCHEMA)
+      .subschema(INT_SCHEMA)
+      .build();
+
+  static final Schema EMPTY_RECORD1 = ObjectSchema.builder().additionalProperties(false).build();
+  static final Schema A_INT_RECORD1 = ObjectSchema.builder()
+      .addPropertySchema("a", NumberSchema.builder().requiresInteger(true).build())
+      .additionalProperties(false)
+      .build();
+  static final Schema A_INT_OPEN_RECORD1 = ObjectSchema.builder()
+      .addPropertySchema("a", NumberSchema.builder().requiresInteger(true).build())
+      .additionalProperties(true)
+      .build();
+  static final Schema A_INT_B_INT_RECORD1 = ObjectSchema.builder()
+      .addPropertySchema("a", NumberSchema.builder().requiresInteger(true).build())
+      .addPropertySchema("b", NumberSchema.builder().requiresInteger(true).build())
+      .additionalProperties(false)
+      .build();
+  static final Schema A_INT_B_INT_REQUIRED_RECORD1 = ObjectSchema.builder()
+      .addPropertySchema("a", NumberSchema.builder().requiresInteger(true).build())
+      .addPropertySchema("b", NumberSchema.builder().requiresInteger(true).build())
+      .addRequiredProperty("b")
+      .additionalProperties(false)
+      .build();
+  static final Schema A_INT_B_DINT_RECORD1 = ObjectSchema.builder()
+      .addPropertySchema("a", NumberSchema.builder().requiresInteger(true).build())
+      .addPropertySchema("b", NumberSchema.builder().requiresInteger(true).defaultValue(0).build())
+      .additionalProperties(false)
+      .build();
+  static final Schema A_INT_B_DINT_REQUIRED_RECORD1 = ObjectSchema.builder()
+      .addPropertySchema("a", NumberSchema.builder().requiresInteger(true).build())
+      .addPropertySchema("b", NumberSchema.builder().requiresInteger(true).defaultValue(0).build())
+      .addRequiredProperty("b")
+      .additionalProperties(false)
+      .build();
+  static final Schema A_DINT_B_DINT_RECORD1 = ObjectSchema.builder()
+      .addPropertySchema("a", NumberSchema.builder().requiresInteger(true).defaultValue(0).build())
+      .addPropertySchema("b", NumberSchema.builder().requiresInteger(true).defaultValue(0).build())
+      .additionalProperties(false)
+      .build();
+
+  static final class ReaderWriter {
+    private final Schema mReader;
+    private final Schema mWriter;
+
+    public ReaderWriter(final Schema reader, final Schema writer) {
+      mReader = reader;
+      mWriter = writer;
+    }
+
+    public Schema getReader() {
+      return mReader;
+    }
+
+    public Schema getWriter() {
+      return mWriter;
+    }
+  }
+
+  /**
+   * Borrowed from the Guava library.
+   */
+  @SafeVarargs
+  static <E> ArrayList<E> list(E... elements) {
+    final ArrayList<E> list = new ArrayList<>();
+    Collections.addAll(list, elements);
+    return list;
+  }
+}

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiffTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiffTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json.diff;
+
+import org.everit.json.schema.Schema;
+import org.everit.json.schema.loader.SchemaLoader;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class SchemaDiffTest {
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void checkJsonSchemaCompatibility() {
+    final JSONArray testCases = new JSONArray(readFile("diff-schema-examples.json"));
+
+    for (final Object testCaseObject : testCases) {
+      final JSONObject testCase = (JSONObject) testCaseObject;
+      final Schema original = SchemaLoader.load(testCase.getJSONObject("original_schema"));
+      final Schema update = SchemaLoader.load(testCase.getJSONObject("update_schema"));
+      final JSONArray changes = (JSONArray) testCase.get("changes");
+      boolean isCompatible = testCase.getBoolean("compatible");
+      final List<String> errorMessages = (List<String>) changes.toList()
+          .stream()
+          .map(Object::toString)
+          .collect(toList());
+      final String description = (String) testCase.get("description");
+
+      List<Difference> differences = SchemaDiff.compare(original, update);
+      final List<Difference> incompatibleDiffs = differences.stream()
+          .filter(diff -> !SchemaDiff.COMPATIBLE_CHANGES.contains(diff.getType()))
+          .collect(Collectors.toList());
+      assertThat(description,
+          differences.stream()
+              .map(change -> change.getType().toString() + " " + change.getJsonPath())
+              .collect(toList()),
+          is(errorMessages)
+      );
+      assertEquals(description, isCompatible, incompatibleDiffs.isEmpty());
+    }
+  }
+
+  @Test
+  public void testRecursiveCheck() {
+    final Schema original = SchemaLoader.load(new JSONObject(readFile("recursive-schema.json")));
+    final Schema newOne = SchemaLoader.load(new JSONObject(readFile("recursive-schema.json")));
+    Assert.assertTrue(SchemaDiff.compare(original, newOne).isEmpty());
+  }
+
+  @Test
+  public void testSchemaAddsProperties() {
+    final Schema first = SchemaLoader.load(new JSONObject("{}"));
+
+    final Schema second = SchemaLoader.load(new JSONObject(("{\"properties\": {}}")));
+    final List<Difference> changes = SchemaDiff.compare(first, second);
+    Assert.assertTrue(changes.isEmpty());
+  }
+
+  public static String readFile(String fileName) {
+    ClassLoader classLoader = ClassLoader.getSystemClassLoader();
+    InputStream is = classLoader.getResourceAsStream(fileName);
+    if (is != null) {
+      BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+      return reader.lines().collect(Collectors.joining(System.lineSeparator()));
+    }
+    return null;
+  }
+}

--- a/json-schema-provider/src/test/resources/diff-schema-examples.json
+++ b/json-schema-provider/src/test/resources/diff-schema-examples.json
@@ -1,0 +1,882 @@
+[
+  {
+    "description": "Detect changes to id",
+    "original_schema": {
+      "id": "something"
+    },
+    "update_schema": {
+      "id": "something_else"
+    },
+    "changes": [
+      "ID_CHANGED #/"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to title",
+    "original_schema": {
+      "title": "something"
+    },
+    "update_schema": {
+      "title": "something_else"
+    },
+    "changes": [
+      "TITLE_CHANGED #/"
+    ],
+    "compatible": true
+  },
+  {
+    "description": "Detect changes to description",
+    "original_schema": {
+      "description": "something"
+    },
+    "update_schema": {
+      "description": "something_else"
+    },
+    "changes": [
+      "DESCRIPTION_CHANGED #/"
+    ],
+    "compatible": true
+  },
+  {
+    "description": "Detect changes to simple schema type",
+    "original_schema": {
+      "type": "object"
+    },
+    "update_schema": {
+      "type": "array"
+    },
+    "changes": [
+      "TYPE_CHANGED #/"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to minLength string schema",
+    "original_schema": {
+      "type": "string",
+      "minLength": 10
+    },
+    "update_schema": {
+      "type": "string",
+      "minLength": 11
+    },
+    "changes": [
+      "MIN_LENGTH_INCREASED #/minLength"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to maxLength string schema",
+    "original_schema": {
+      "type": "string",
+      "maxLength": 10
+    },
+    "update_schema": {
+      "type": "string",
+      "maxLength": 12
+    },
+    "changes": [
+      "MAX_LENGTH_INCREASED #/maxLength"
+    ],
+    "compatible": true
+  },
+  {
+    "description": "Detect changes to pattern string schema",
+    "original_schema": {
+      "type": "string",
+      "pattern": "date-time"
+    },
+    "update_schema": {
+      "type": "string",
+      "pattern": "uuid"
+    },
+    "changes": [
+      "PATTERN_CHANGED #/pattern"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to pattern",
+    "original_schema": {
+      "type": "string",
+      "pattern": "date-time"
+    },
+    "update_schema": {
+      "type": "string",
+      "pattern": "date-time"
+    },
+    "changes": [],
+    "compatible": true
+  },
+  {
+    "description": "Detect changes to maximum number schema",
+    "original_schema": {
+      "type": "number",
+      "maximum": 10
+    },
+    "update_schema": {
+      "type": "number",
+      "maximum": 11
+    },
+    "changes": [
+      "MAXIMUM_INCREASED #/maximum"
+    ],
+    "compatible": true
+  },
+  {
+    "description": "Detect changes to minimum number schema",
+    "original_schema": {
+      "type": "number",
+      "minimum": 10
+    },
+    "update_schema": {
+      "type": "number",
+      "minimum": 11
+    },
+    "changes": [
+      "MINIMUM_INCREASED #/minimum"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to multipleOf number schema",
+    "original_schema": {
+      "type": "number",
+      "multipleOf": 10
+    },
+    "update_schema": {
+      "type": "number",
+      "multipleOf": 11
+    },
+    "changes": [
+      "MULTIPLE_OF_CHANGED #/multipleOf"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to number schema",
+    "original_schema": {
+      "type": "number"
+    },
+    "update_schema": {
+      "type": "integer"
+    },
+    "changes": [
+      "TYPE_NARROWED #/"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to enum schema",
+    "original_schema": {
+      "allOf": [
+        {
+          "type": "string"
+        },
+        {
+          "enum": [
+            "red"
+          ]
+        }
+      ]
+    },
+    "update_schema": {
+      "allOf": [
+        {
+          "type": "string"
+        },
+        {
+          "enum": [
+            "blue"
+          ]
+        }
+      ]
+    },
+    "changes": [
+      "ENUM_ARRAY_CHANGED #/allOf/1/enum"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to type array",
+    "original_schema": {
+      "type": [
+        "object"
+      ]
+    },
+    "update_schema": {
+      "type": [
+        "object",
+        "array"
+      ]
+    },
+    "changes": [
+      "SUM_TYPE_EXTENDED #/"
+    ],
+    "compatible": true
+  },
+  {
+    "description": "Detect changes to sub schemas",
+    "original_schema": {
+      "oneOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "update_schema": {
+      "oneOf": [
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "changes": [
+      "TYPE_CHANGED #/oneOf/0"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to number of sub schemas",
+    "original_schema": {
+      "oneOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "update_schema": {
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "changes": [
+      "SUM_TYPE_EXTENDED #/",
+      "TYPE_CHANGED #/oneOf/0"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to remove properties",
+    "original_schema": {
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      }
+    },
+    "update_schema": {
+      "properties": {
+        "bar": {
+          "type": "string"
+        }
+      }
+    },
+    "changes": [
+      "PROPERTY_ADDED_TO_OPEN_CONTENT_MODEL #/properties/bar",
+      "PROPERTY_REMOVED_FROM_OPEN_CONTENT_MODEL #/properties/foo"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect change type of properties",
+    "original_schema": {
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      }
+    },
+    "update_schema": {
+      "properties": {
+        "foo": {
+          "type": "number"
+        }
+      }
+    },
+    "changes": [
+      "TYPE_CHANGED #/properties/foo"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect optional property added to closed content model",
+    "original_schema": {
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "update_schema": {
+      "properties": {
+        "foo": {
+          "type": "string"
+        },
+        "bar": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false
+    },
+    "changes": [
+      "OPTIONAL_PROPERTY_ADDED_TO_CLOSED_CONTENT_MODEL #/properties/bar"
+    ],
+    "compatible": true
+  },
+  {
+    "description": "Detect property added to open content model",
+    "original_schema": {
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^S_": {
+          "type": "string"
+        },
+        "^I_": {
+          "type": "integer"
+        }
+      }
+    },
+    "update_schema": {
+      "properties": {
+        "foo": {
+          "type": "string"
+        },
+        "bar": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^S_": {
+          "type": "string"
+        },
+        "^I_": {
+          "type": "integer"
+        }
+      }
+    },
+    "changes": [
+      "PROPERTY_ADDED_TO_OPEN_CONTENT_MODEL #/properties/bar"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect property added to open content model",
+    "original_schema": {
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      }
+    },
+    "update_schema": {
+      "properties": {
+        "foo": {
+          "type": "string"
+        },
+        "bar": {
+          "type": "number"
+        }
+      }
+    },
+    "changes": [
+      "PROPERTY_ADDED_TO_OPEN_CONTENT_MODEL #/properties/bar"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to composed schema type",
+    "original_schema": {
+      "oneOf": [
+        {
+          "properties": {
+            "foo": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "update_schema": {
+      "oneOf": [
+        {
+          "properties": {
+            "foo": {
+              "type": "number"
+            }
+          }
+        }
+      ]
+    },
+    "changes": [
+      "TYPE_CHANGED #/oneOf/0/properties/foo"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to validation criteria in composed schema type",
+    "original_schema": {
+      "oneOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "update_schema": {
+      "allOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "changes": [
+      "COMPOSITION_METHOD_CHANGED #/"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to dependencies as array",
+    "original_schema": {
+      "properties": {
+        "foo": {
+          "type": "number"
+        },
+        "bar": {
+          "type": "string"
+        }
+      },
+      "dependencies": {
+        "foo": [
+          "bar"
+        ]
+      }
+    },
+    "update_schema": {
+      "properties": {
+        "foo": {
+          "type": "number"
+        },
+        "bar": {
+          "type": "string"
+        }
+      },
+      "dependencies": {
+        "bar": [
+          "foo"
+        ]
+      }
+    },
+    "changes": [
+      "DEPENDENCY_ARRAY_ADDED #/dependencies/bar",
+      "DEPENDENCY_ARRAY_REMOVED #/dependencies/foo"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect incompatible changes to dependencies schemas",
+    "original_schema": {
+      "dependencies": {
+        "foo": {
+          "type": "string"
+        }
+      }
+    },
+    "update_schema": {
+      "dependencies": {
+        "foo": {
+          "type": "number"
+        }
+      }
+    },
+    "changes": [
+      "TYPE_CHANGED #/dependencies/foo"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to dependencies properties",
+    "original_schema": {
+      "dependencies": {
+        "foo": {
+          "type": "string"
+        }
+      }
+    },
+    "update_schema": {
+      "dependencies": {
+        "bar": {
+          "type": "string"
+        }
+      }
+    },
+    "changes": [
+      "DEPENDENCY_SCHEMA_ADDED #/dependencies/bar",
+      "DEPENDENCY_SCHEMA_REMOVED #/dependencies/foo"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect required array to be removed",
+    "original_schema": {
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "foo"
+      ]
+    },
+    "update_schema": {
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      }
+    },
+    "changes": [
+      "REQUIRED_ATTRIBUTE_REMOVED #/required/foo"
+    ],
+    "compatible": true
+  },
+  {
+    "description": "Detect required array to be added",
+    "original_schema": {
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      }
+    },
+    "update_schema": {
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "foo"
+      ]
+    },
+    "changes": [
+      "REQUIRED_ATTRIBUTE_ADDED #/required/foo"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect required array to be changed",
+    "original_schema": {
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "foo"
+      ]
+    },
+    "update_schema": {
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "bar"
+      ]
+    },
+    "changes": [
+      "REQUIRED_ATTRIBUTE_REMOVED #/required/foo"
+    ],
+    "compatible": true
+  },
+  {
+    "description": "Detect changes to maxProperties",
+    "original_schema": {
+      "maxProperties": 2
+    },
+    "update_schema": {
+      "maxProperties": 1
+    },
+    "changes": [
+      "MAX_PROPERTIES_DECREASED #/maxProperties"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to minProperties",
+    "original_schema": {
+      "minProperties": 2
+    },
+    "update_schema": {
+      "minProperties": 1
+    },
+    "changes": [
+      "MIN_PROPERTIES_DECREASED #/minProperties"
+    ],
+    "compatible": true
+  },
+  {
+    "description": "Detect changes to all items schema",
+    "original_schema": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "update_schema": {
+      "type": "array"
+    },
+    "changes": [
+      "SCHEMA_REMOVED #/items"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to items schema list",
+    "original_schema": {
+      "type": "array",
+      "items": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "update_schema": {
+      "type": "array"
+    },
+    "changes": [
+      "ITEMS_REMOVED_FROM_OPEN_CONTENT_MODEL #/"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to items in the schema list",
+    "original_schema": {
+      "type": "array",
+      "items": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "update_schema": {
+      "type": "array",
+      "items": [
+        {
+          "type": "number"
+        }
+      ]
+    },
+    "changes": [
+      "TYPE_CHANGED #/items/0"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to maxItems",
+    "original_schema": {
+      "type": "array",
+      "maxItems": 2
+    },
+    "update_schema": {
+      "type": "array",
+      "maxItems": 1
+    },
+    "changes": [
+      "MAX_ITEMS_DECREASED #/maxItems"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to minItems",
+    "original_schema": {
+      "type": "array",
+      "minItems": 2
+    },
+    "update_schema": {
+      "type": "array",
+      "minItems": 1
+    },
+    "changes": [
+      "MIN_ITEMS_DECREASED #/minItems"
+    ],
+    "compatible": true
+  },
+  {
+    "description": "Detect unique items removed",
+    "original_schema": {
+      "type": "array",
+      "uniqueItems": true
+    },
+    "update_schema": {
+      "type": "array"
+    },
+    "changes": [
+      "UNIQUE_ITEMS_REMOVED #/uniqueItems"
+    ],
+    "compatible": true
+  },
+  {
+    "description": "Detect incompatible changes to reference schemas",
+    "original_schema": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/someRef"
+      },
+      "definitions": {
+        "someRef": {
+          "type": "string"
+        }
+      }
+    },
+    "update_schema": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/someRef"
+      },
+      "definitions": {
+        "someRef": {
+          "type": "number"
+        }
+      }
+    },
+    "changes": [
+      "TYPE_CHANGED #/items/$ref"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to boolean additional properties",
+    "original_schema": {
+      "additionalProperties": true
+    },
+    "update_schema": {
+      "additionalProperties": false
+    },
+    "changes": [
+      "ADDITIONAL_PROPERTIES_REMOVED #/additionalProperties"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect narrowing changes to additional properties schema",
+    "original_schema": {
+      "additionalProperties": true
+    },
+    "update_schema": {
+      "additionalProperties": {
+        "type": "number"
+      }
+    },
+    "changes": [
+      "ADDITIONAL_PROPERTIES_NARROWED #/additionalProperties"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to additional properties schema",
+    "original_schema": {
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "update_schema": {
+      "additionalProperties": {
+        "type": "number"
+      }
+    },
+    "changes": [
+      "TYPE_CHANGED #/additionalProperties"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to boolean additional items",
+    "original_schema": {
+      "additionalItems": true
+    },
+    "update_schema": {
+      "additionalItems": false
+    },
+    "changes": [
+      "ADDITIONAL_ITEMS_REMOVED #/additionalItems"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect changes to additional items schema",
+    "original_schema": {
+      "additionalItems": {
+        "type": "string"
+      }
+    },
+    "update_schema": {
+      "additionalItems": {
+        "type": "number"
+      }
+    },
+    "changes": [
+      "TYPE_CHANGED #/additionalItems"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect change to oneOf schema",
+    "original_schema": {
+      "type": "string"
+    },
+    "update_schema": {
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "changes": [
+      "SUM_TYPE_EXTENDED #/"
+    ],
+    "compatible": true
+  },
+  {
+    "description": "Detect change to oneOf schema",
+    "original_schema": {
+      "type": "string",
+      "maxLength": 3
+    },
+    "update_schema": {
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "changes": [
+      "MAX_LENGTH_REMOVED #/maxLength",
+      "SUM_TYPE_EXTENDED #/"
+    ],
+    "compatible": true
+  }
+]

--- a/json-schema-provider/src/test/resources/recursive-schema.json
+++ b/json-schema-provider/src/test/resources/recursive-schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "categories": {
+      "description": "Test recursive schema.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Category"
+      }
+    }
+  },
+  "required": [
+    "categories"
+  ],
+  "definitions": {
+    "Category": {
+      "description": "Test category",
+      "type": "object",
+      "properties": {
+        "category_id": {
+          "description": "Some description",
+          "type": "integer"
+        },
+        "categories": {
+          "description": "All subcategories within this category.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Category"
+          }
+        }
+      },
+      "required": [
+        "category_id",
+        "categories"
+      ]
+    }
+  }
+}

--- a/json-schema-serde/LICENSE
+++ b/json-schema-serde/LICENSE
@@ -1,0 +1,202 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/json-schema-serde/pom.xml
+++ b/json-schema-serde/pom.xml
@@ -1,0 +1,48 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.confluent</groupId>
+        <artifactId>kafka-schema-registry-parent</artifactId>
+        <version>5.5.0-SNAPSHOT</version>
+    </parent>
+
+    <licenses>
+        <license>
+            <name>Apache License 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <artifactId>kafka-streams-json-schema-serde</artifactId>
+    <packaging>jar</packaging>
+    <name>kafka-streams-json-schema-serde</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-json-schema-serializer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-registry-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/json-schema-serde/src/main/java/io/confluent/kafka/streams/serdes/json/KafkaJsonSchemaSerde.java
+++ b/json-schema-serde/src/main/java/io/confluent/kafka/streams/serdes/json/KafkaJsonSchemaSerde.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+
+package io.confluent.kafka.streams.serdes.json;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer;
+import io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializerConfig;
+import io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer;
+
+/**
+ * A schema-registry aware serde (serializer/deserializer) for Apache Kafka's Streams API that can
+ * be used for reading and writing data in JSON format.
+ */
+public class KafkaJsonSchemaSerde<T> implements Serde<T> {
+
+  private Class<T> specificClass;
+  private final Serde<T> inner;
+
+  public KafkaJsonSchemaSerde() {
+    inner = Serdes.serdeFrom(new KafkaJsonSchemaSerializer<>(),
+        new KafkaJsonSchemaDeserializer<>());
+  }
+
+  public KafkaJsonSchemaSerde(Class<T> specificClass) {
+    this.specificClass = specificClass;
+    inner = Serdes.serdeFrom(new KafkaJsonSchemaSerializer<>(),
+        new KafkaJsonSchemaDeserializer<>());
+  }
+
+  /**
+   * For testing purposes only.
+   */
+  public KafkaJsonSchemaSerde(final SchemaRegistryClient client) {
+    if (client == null) {
+      throw new IllegalArgumentException("schema registry client must not be null");
+    }
+    inner = Serdes.serdeFrom(new KafkaJsonSchemaSerializer<>(client),
+        new KafkaJsonSchemaDeserializer<>(client));
+  }
+
+  @Override
+  public Serializer<T> serializer() {
+    return inner.serializer();
+  }
+
+  @Override
+  public Deserializer<T> deserializer() {
+    return inner.deserializer();
+  }
+
+  @Override
+  public void configure(final Map<String, ?> serdeConfig, final boolean isSerdeForRecordKeys) {
+    inner.serializer().configure(serdeConfig, isSerdeForRecordKeys);
+    inner.deserializer().configure(withSpecificClass(serdeConfig, isSerdeForRecordKeys),
+        isSerdeForRecordKeys);
+  }
+
+  @Override
+  public void close() {
+    inner.serializer().close();
+    inner.deserializer().close();
+  }
+
+  private Map<String, Object> withSpecificClass(final Map<String, ?> config, boolean isKey) {
+    if (specificClass == null) {
+      return (Map<String, Object>) config;
+    }
+    Map<String, Object> newConfig =
+        config == null ? new HashMap<String, Object>() : new HashMap<>(config);
+    if (isKey) {
+      newConfig.put(
+          KafkaJsonSchemaDeserializerConfig.JSON_KEY_TYPE,
+          specificClass
+      );
+    } else {
+      newConfig.put(
+          KafkaJsonSchemaDeserializerConfig.JSON_VALUE_TYPE,
+          specificClass
+      );
+    }
+    return newConfig;
+  }
+
+}

--- a/json-schema-serializer/pom.xml
+++ b/json-schema-serializer/pom.xml
@@ -1,0 +1,70 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.confluent</groupId>
+        <artifactId>kafka-schema-registry-parent</artifactId>
+        <version>5.5.0-SNAPSHOT</version>
+    </parent>
+
+    <licenses>
+        <license>
+            <name>Confluent Community License</name>
+            <url>http://www.confluent.io/confluent-community-license</url>
+            <distribution>repo</distribution>
+        </license>
+        <license>
+            <name>Apache License 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <artifactId>kafka-json-schema-serializer</artifactId>
+    <packaging>jar</packaging>
+    <name>kafka-json-schema-serializer</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${kafka.scala.version}</artifactId>
+            <version>${kafka.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-json-schema-provider</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-avro-serializer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-json-serializer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-registry-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/json-schema-serializer/pom.xml
+++ b/json-schema-serializer/pom.xml
@@ -40,7 +40,7 @@
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
-            <artifactId>kafka-avro-serializer</artifactId>
+            <artifactId>kafka-schema-serializer</artifactId>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageFormatter.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageFormatter.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafka.formatter.json;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import kafka.common.MessageFormatter;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.config.ConfigException;
@@ -77,6 +78,7 @@ public class JsonSchemaMessageFormatter extends AbstractKafkaJsonSchemaDeseriali
   private byte[] lineSeparator = "\n".getBytes(StandardCharsets.UTF_8);
   private byte[] idSeparator = "\t".getBytes(StandardCharsets.UTF_8);
   private Deserializer keyDeserializer;
+  private final ObjectMapper objectMapper = Jackson.newObjectMapper();
 
   /**
    * Constructor needed by kafka console consumer.
@@ -202,7 +204,7 @@ public class JsonSchemaMessageFormatter extends AbstractKafkaJsonSchemaDeseriali
 
   private void writeTo(byte[] data, PrintStream output) throws IOException {
     Object object = deserialize(data);
-    output.print(Jackson.newObjectMapper().writeValueAsString(object));
+    output.print(objectMapper.writeValueAsString(object));
   }
 
   @Override

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageFormatter.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageFormatter.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.formatter.json;
+
+import kafka.common.MessageFormatter;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.serialization.Deserializer;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import io.confluent.kafka.schemaregistry.json.jackson.Jackson;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import io.confluent.kafka.serializers.json.AbstractKafkaJsonSchemaDeserializer;
+
+/**
+ * Example
+ * To use JsonSchemaMessageFormatter, first make sure that Zookeeper, Kafka and schema registry
+ * server are
+ * all started. Second, make sure the jar for JsonSchemaMessageFormatter and its dependencies are
+ * included
+ * in the classpath of kafka-console-consumer.sh. Then run the following command.
+ *
+ * <p>1. To read only the value of the messages in JSON
+ * bin/kafka-console-consumer.sh --consumer.config config/consumer.properties --topic t1 \
+ * --zookeeper localhost:2181 --formatter io.confluent.kafka.formatter.JsonSchemaMessageFormatter \
+ * --property schema.registry.url=http://localhost:8081
+ *
+ * <p>2. To read both the key and the value of the messages in JSON
+ * bin/kafka-console-consumer.sh --consumer.config config/consumer.properties --topic t1 \
+ * --zookeeper localhost:2181 --formatter io.confluent.kafka.formatter.JsonSchemaMessageFormatter \
+ * --property schema.registry.url=http://localhost:8081 \
+ * --property print.key=true
+ *
+ * <p>3. To read the key, value, and timestamp of the messages in JSON
+ * bin/kafka-console-consumer.sh --consumer.config config/consumer.properties --topic t1 \
+ * --zookeeper localhost:2181 --formatter io.confluent.kafka.formatter.JsonSchemaMessageFormatter \
+ * --property schema.registry.url=http://localhost:8081 \
+ * --property print.key=true \
+ * --property print.timestamp=true
+ */
+public class JsonSchemaMessageFormatter extends AbstractKafkaJsonSchemaDeserializer
+    implements MessageFormatter {
+
+  private static final byte[] NULL_BYTES = "null".getBytes(StandardCharsets.UTF_8);
+  private boolean printKey = false;
+  private boolean printTimestamp = false;
+  private boolean printIds = false;
+  private boolean printKeyId = false;
+  private boolean printValueId = false;
+  private byte[] keySeparator = "\t".getBytes(StandardCharsets.UTF_8);
+  private byte[] lineSeparator = "\n".getBytes(StandardCharsets.UTF_8);
+  private byte[] idSeparator = "\t".getBytes(StandardCharsets.UTF_8);
+  private Deserializer keyDeserializer;
+
+  /**
+   * Constructor needed by kafka console consumer.
+   */
+  public JsonSchemaMessageFormatter() {
+  }
+
+  /**
+   * For testing only.
+   */
+  JsonSchemaMessageFormatter(
+      SchemaRegistryClient schemaRegistryClient, Deserializer keyDeserializer
+  ) {
+    this.schemaRegistry = schemaRegistryClient;
+    this.keyDeserializer = keyDeserializer;
+  }
+
+  @Override
+  public void init(Properties props) {
+    if (props == null) {
+      throw new ConfigException("Missing schema registry url!");
+    }
+    String url = props.getProperty(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG);
+    if (url == null) {
+      throw new ConfigException("Missing schema registry url!");
+    }
+
+    Map<String, Object> originals = getPropertiesMap(props);
+    schemaRegistry = createSchemaRegistry(url, originals);
+
+    if (props.containsKey("print.timestamp")) {
+      printTimestamp = props.getProperty("print.timestamp").trim().toLowerCase().equals("true");
+    }
+    if (props.containsKey("print.key")) {
+      printKey = props.getProperty("print.key").trim().toLowerCase().equals("true");
+    }
+    if (props.containsKey("key.separator")) {
+      keySeparator = props.getProperty("key.separator").getBytes(StandardCharsets.UTF_8);
+    }
+    if (props.containsKey("line.separator")) {
+      lineSeparator = props.getProperty("line.separator").getBytes(StandardCharsets.UTF_8);
+    }
+    if (props.containsKey("key.deserializer")) {
+      try {
+        keyDeserializer = (Deserializer) Class.forName((String) props.get("key.deserializer"))
+            .newInstance();
+      } catch (Exception e) {
+        throw new ConfigException("Error initializing Key deserializer", e);
+      }
+    }
+    if (props.containsKey("print.schema.ids")) {
+      printIds = props.getProperty("print.schema.ids").trim().toLowerCase().equals("true");
+      if (printIds) {
+        printValueId = true;
+        if (keyDeserializer == null
+            || keyDeserializer instanceof AbstractKafkaJsonSchemaDeserializer) {
+          printKeyId = true;
+        }
+      }
+    }
+    if (props.containsKey("schema.id.separator")) {
+      idSeparator = props.getProperty("schema.id.separator").getBytes(StandardCharsets.UTF_8);
+    }
+  }
+
+  private Map<String, Object> getPropertiesMap(Properties props) {
+    Map<String, Object> originals = new HashMap<>();
+    for (final String name : props.stringPropertyNames()) {
+      originals.put(name, props.getProperty(name));
+    }
+    return originals;
+  }
+
+  @Override
+  public void writeTo(ConsumerRecord<byte[], byte[]> consumerRecord, PrintStream output) {
+    if (printTimestamp) {
+      try {
+        TimestampType timestampType = consumerRecord.timestampType();
+        if (timestampType != TimestampType.NO_TIMESTAMP_TYPE) {
+          output.write(String.format("%s:%d", timestampType, consumerRecord.timestamp())
+              .getBytes(StandardCharsets.UTF_8));
+        } else {
+          output.write("NO_TIMESTAMP".getBytes(StandardCharsets.UTF_8));
+        }
+        output.write(keySeparator);
+      } catch (IOException ioe) {
+        throw new SerializationException("Error while formatting the timestamp", ioe);
+      }
+    }
+    if (printKey) {
+      try {
+        if (keyDeserializer != null) {
+          Object deserializedKey = consumerRecord.key() == null
+                                   ? null
+                                   : keyDeserializer.deserialize(null, consumerRecord.key());
+          output.write(deserializedKey != null ? deserializedKey.toString()
+              .getBytes(StandardCharsets.UTF_8) : NULL_BYTES);
+        } else {
+          writeTo(consumerRecord.key(), output);
+        }
+        if (printKeyId) {
+          output.write(idSeparator);
+          int schemaId = schemaIdFor(consumerRecord.key());
+          output.print(schemaId);
+        }
+        output.write(keySeparator);
+      } catch (IOException ioe) {
+        throw new SerializationException("Error while formatting the key", ioe);
+      }
+    }
+    try {
+      writeTo(consumerRecord.value(), output);
+      if (printValueId) {
+        output.write(idSeparator);
+        int schemaId = schemaIdFor(consumerRecord.value());
+        output.print(schemaId);
+      }
+      output.write(lineSeparator);
+    } catch (IOException ioe) {
+      throw new SerializationException("Error while formatting the value", ioe);
+    }
+  }
+
+  private void writeTo(byte[] data, PrintStream output) throws IOException {
+    Object object = deserialize(data);
+    output.print(Jackson.newObjectMapper().writeValueAsString(object));
+  }
+
+  @Override
+  public void close() {
+    // nothing to do
+  }
+
+  private int schemaIdFor(byte[] payload) {
+    ByteBuffer buffer = ByteBuffer.wrap(payload);
+    if (buffer.get() != MAGIC_BYTE) {
+      throw new SerializationException("Unknown magic byte!");
+    }
+    return buffer.getInt();
+  }
+
+  private SchemaRegistryClient createSchemaRegistry(
+      String schemaRegistryUrl, Map<String, Object> originals
+  ) {
+    return schemaRegistry != null
+           ? schemaRegistry
+           : new CachedSchemaRegistryClient(Collections.singletonList(schemaRegistryUrl),
+               AbstractKafkaSchemaSerDeConfig.MAX_SCHEMAS_PER_SUBJECT_DEFAULT,
+               Collections.singletonList(new JsonSchemaProvider()),
+               originals
+           );
+  }
+}

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageReader.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageReader.java
@@ -16,6 +16,7 @@
 
 package io.confluent.kafka.formatter.json;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import kafka.common.KafkaException;
 import kafka.common.MessageReader;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -64,8 +65,7 @@ import io.confluent.kafka.serializers.json.AbstractKafkaJsonSchemaSerializer;
  * bin/kafka-console-producer.sh --broker-list localhost:9092 --topic t1 \
  * --line-reader io.confluent.kafka.formatter.JsonSchemaMessageReader \
  * --property schema.registry.url=http://localhost:8081 \
- * --property value.schema='{"type":"record","name":"myrecord","fields":[{"name":"f1",
- * "type":"string"}]}'
+ * --property value.schema='{"type":"object","properties":{"f1":{"type":"string"}}}'
  *
  * <p>In the shell, type in the following.
  * {"f1": "value1"}
@@ -76,7 +76,7 @@ import io.confluent.kafka.serializers.json.AbstractKafkaJsonSchemaSerializer;
  * --property schema.registry.url=http://localhost:8081 \
  * --property parse.key=true \
  * --property key.schema='{"type":"string"}' \
- * --property value.schema='{"type":"record","name":"myrecord","fields":[{"name":"f1",
+ * --property value.schema='{"type":"object","properties":{"f1":{"type":"string"}}}'
  * "type":"string"}]}'
  *
  * <p>In the shell, type in the following.
@@ -95,6 +95,7 @@ public class JsonSchemaMessageReader extends AbstractKafkaJsonSchemaSerializer
   private String keySubject = null;
   private String valueSubject = null;
   private Serializer keySerializer;
+  private final ObjectMapper objectMapper = Jackson.newObjectMapper();
 
   /**
    * Constructor needed by kafka console producer.
@@ -243,7 +244,7 @@ public class JsonSchemaMessageReader extends AbstractKafkaJsonSchemaSerializer
 
   private Object jsonToJsonNode(String jsonString) {
     try {
-      return Jackson.newObjectMapper().readTree(jsonString);
+      return objectMapper.readTree(jsonString);
     } catch (IOException | ValidationException e) {
       throw new SerializationException(String.format("Error serializing json %s", jsonString), e);
     }

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageReader.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageReader.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+
+package io.confluent.kafka.formatter.json;
+
+import kafka.common.KafkaException;
+import kafka.common.MessageReader;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Serializer;
+import org.everit.json.schema.ValidationException;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import io.confluent.kafka.schemaregistry.json.jackson.Jackson;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import io.confluent.kafka.serializers.json.AbstractKafkaJsonSchemaSerializer;
+
+/**
+ * Example
+ * To use JsonSchemaMessageReader, first make sure that Zookeeper, Kafka and schema registry
+ * server are
+ * all started. Second, make sure the jar for JsonSchemaMessageReader and its dependencies are
+ * included
+ * in the classpath of kafka-console-producer.sh. Then run the following
+ * command.
+ *
+ * <p>1. Send JSON Schema string as value. (make sure there is no space in the schema string)
+ * bin/kafka-console-producer.sh --broker-list localhost:9092 --topic t1 \
+ * --line-reader io.confluent.kafka.formatter.JsonSchemaMessageReader \
+ * --property schema.registry.url=http://localhost:8081 \
+ * --property value.schema='{"type":"string"}'
+ *
+ * <p>In the shell, type in the following.
+ * "a"
+ * "b"
+ *
+ * <p>2. Send JSON Schema record as value.
+ * bin/kafka-console-producer.sh --broker-list localhost:9092 --topic t1 \
+ * --line-reader io.confluent.kafka.formatter.JsonSchemaMessageReader \
+ * --property schema.registry.url=http://localhost:8081 \
+ * --property value.schema='{"type":"record","name":"myrecord","fields":[{"name":"f1",
+ * "type":"string"}]}'
+ *
+ * <p>In the shell, type in the following.
+ * {"f1": "value1"}
+ *
+ * <p>3. Send JSON Schema string as key and JSON Schema record as value.
+ * bin/kafka-console-producer.sh --broker-list localhost:9092 --topic t1 \
+ * --line-reader io.confluent.kafka.formatter.JsonSchemaMessageReader \
+ * --property schema.registry.url=http://localhost:8081 \
+ * --property parse.key=true \
+ * --property key.schema='{"type":"string"}' \
+ * --property value.schema='{"type":"record","name":"myrecord","fields":[{"name":"f1",
+ * "type":"string"}]}'
+ *
+ * <p>In the shell, type in the following.
+ * "key1" \t {"f1": "value1"}
+ */
+public class JsonSchemaMessageReader extends AbstractKafkaJsonSchemaSerializer
+    implements MessageReader {
+
+  private String topic = null;
+  private BufferedReader reader = null;
+  private Boolean parseKey = false;
+  private String keySeparator = "\t";
+  private boolean ignoreError = false;
+  private JsonSchema keySchema = null;
+  private JsonSchema valueSchema = null;
+  private String keySubject = null;
+  private String valueSubject = null;
+  private Serializer keySerializer;
+
+  /**
+   * Constructor needed by kafka console producer.
+   */
+  public JsonSchemaMessageReader() {
+  }
+
+  /**
+   * For testing only.
+   */
+  JsonSchemaMessageReader(
+      SchemaRegistryClient schemaRegistryClient,
+      JsonSchema keySchema,
+      JsonSchema valueSchema,
+      String topic,
+      boolean parseKey,
+      BufferedReader reader,
+      boolean autoRegister
+  ) {
+    this.schemaRegistry = schemaRegistryClient;
+    this.keySchema = keySchema;
+    this.valueSchema = valueSchema;
+    this.topic = topic;
+    this.keySubject = topic + "-key";
+    this.valueSubject = topic + "-value";
+    this.parseKey = parseKey;
+    this.reader = reader;
+    this.autoRegisterSchema = autoRegister;
+  }
+
+  @Override
+  public void init(java.io.InputStream inputStream, Properties props) {
+    topic = props.getProperty("topic");
+    if (props.containsKey("parse.key")) {
+      parseKey = props.getProperty("parse.key").trim().toLowerCase().equals("true");
+    }
+    if (props.containsKey("key.separator")) {
+      keySeparator = props.getProperty("key.separator");
+    }
+    if (props.containsKey("ignore.error")) {
+      ignoreError = props.getProperty("ignore.error").trim().toLowerCase().equals("true");
+    }
+    reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+    String url = props.getProperty(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG);
+    if (url == null) {
+      throw new ConfigException("Missing schema registry url!");
+    }
+
+    Map<String, Object> originals = getPropertiesMap(props);
+
+    schemaRegistry = new CachedSchemaRegistryClient(Collections.singletonList(url),
+        AbstractKafkaSchemaSerDeConfig.MAX_SCHEMAS_PER_SUBJECT_DEFAULT,
+        Collections.singletonList(new JsonSchemaProvider()),
+        originals
+    );
+    if (!props.containsKey("value.schema")) {
+      throw new ConfigException("Must provide the JSON schema string in value.schema");
+    }
+    String valueSchemaString = props.getProperty("value.schema");
+    valueSchema = new JsonSchema(valueSchemaString);
+
+    keySerializer = getKeySerializer(props);
+
+    if (needsKeySchema()) {
+      if (!props.containsKey("key.schema")) {
+        throw new ConfigException("Must provide the JSON schema string in key.schema");
+      }
+      String keySchemaString = props.getProperty("key.schema");
+      keySchema = new JsonSchema(keySchemaString);
+    }
+    keySubject = topic + "-key";
+    valueSubject = topic + "-value";
+    if (props.containsKey("auto.register")) {
+      this.autoRegisterSchema = Boolean.parseBoolean(props.getProperty("auto.register").trim());
+    } else {
+      this.autoRegisterSchema = true;
+    }
+  }
+
+  private Serializer getKeySerializer(Properties props) throws ConfigException {
+    if (props.containsKey("key.serializer")) {
+      try {
+        return (Serializer) Class.forName((String) props.get("key.serializer")).newInstance();
+      } catch (Exception e) {
+        throw new ConfigException("Error initializing Key serializer", e);
+      }
+    } else {
+      return null;
+    }
+  }
+
+  private boolean needsKeySchema() {
+    return parseKey && keySerializer == null;
+  }
+
+  private Map<String, Object> getPropertiesMap(Properties props) {
+    Map<String, Object> originals = new HashMap<>();
+    for (final String name : props.stringPropertyNames()) {
+      originals.put(name, props.getProperty(name));
+    }
+    return originals;
+  }
+
+  @Override
+  public ProducerRecord<byte[], byte[]> readMessage() {
+    try {
+      String line = reader.readLine();
+      if (line == null) {
+        return null;
+      }
+      if (!parseKey) {
+        Object value = jsonToJsonNode(line);
+        byte[] serializedValue = serializeImpl(valueSubject, value, valueSchema);
+        return new ProducerRecord<>(topic, serializedValue);
+      } else {
+        int keyIndex = line.indexOf(keySeparator);
+        if (keyIndex < 0) {
+          if (ignoreError) {
+            Object value = jsonToJsonNode(line);
+            byte[] serializedValue = serializeImpl(valueSubject, value, valueSchema);
+            return new ProducerRecord<>(topic, serializedValue);
+          } else {
+            throw new KafkaException("No key found in line " + line);
+          }
+        } else {
+          String keyString = line.substring(0, keyIndex);
+          String valueString = (keyIndex + keySeparator.length() > line.length())
+                               ? ""
+                               : line.substring(keyIndex + keySeparator.length());
+          byte[] serializedKey;
+          if (keySerializer != null) {
+            serializedKey = keySerializer.serialize(topic, keyString);
+          } else {
+            Object key = jsonToJsonNode(keyString);
+            serializedKey = serializeImpl(keySubject, key, keySchema);
+          }
+          Object value = jsonToJsonNode(valueString);
+          byte[] serializedValue = serializeImpl(valueSubject, value, valueSchema);
+          return new ProducerRecord<>(topic, serializedKey, serializedValue);
+        }
+      }
+    } catch (IOException e) {
+      throw new KafkaException("Error reading from input", e);
+    }
+  }
+
+  private Object jsonToJsonNode(String jsonString) {
+    try {
+      return Jackson.newObjectMapper().readTree(jsonString);
+    } catch (IOException | ValidationException e) {
+      throw new SerializationException(String.format("Error serializing json %s", jsonString), e);
+    }
+  }
+
+  @Override
+  public void close() {
+    // nothing to do
+  }
+}

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+
+package io.confluent.kafka.serializers.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import kafka.utils.VerifiableProperties;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.errors.SerializationException;
+import org.everit.json.schema.ValidationException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaUtils;
+import io.confluent.kafka.schemaregistry.json.jackson.Jackson;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDe;
+
+public abstract class AbstractKafkaJsonSchemaDeserializer<T> extends AbstractKafkaSchemaSerDe {
+  protected ObjectMapper objectMapper = Jackson.newObjectMapper();
+  protected Class<T> type;
+  protected boolean validate = true;
+
+  /**
+   * Sets properties for this deserializer without overriding the schema registry client itself.
+   * Useful for testing, where a mock client is injected.
+   */
+  @SuppressWarnings("unchecked")
+  protected void configure(KafkaJsonSchemaDeserializerConfig config, Class<T> type) {
+    configureClientProperties(config, new JsonSchemaProvider());
+    this.type = type;
+
+    boolean failUnknownProperties =
+        config.getBoolean(KafkaJsonSchemaDeserializerConfig.FAIL_UNKNOWN_PROPERTIES);
+    this.objectMapper.configure(
+        DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+        failUnknownProperties
+    );
+    this.validate = config.getBoolean(KafkaJsonSchemaSerializerConfig.FAIL_INVALID_SCHEMA);
+  }
+
+  protected KafkaJsonSchemaDeserializerConfig deserializerConfig(Map<String, ?> props) {
+    try {
+      return new KafkaJsonSchemaDeserializerConfig(props);
+    } catch (io.confluent.common.config.ConfigException e) {
+      throw new ConfigException(e.getMessage());
+    }
+  }
+
+  protected KafkaJsonSchemaDeserializerConfig deserializerConfig(VerifiableProperties props) {
+    return new KafkaJsonSchemaDeserializerConfig(props.props());
+  }
+
+  private ByteBuffer getByteBuffer(byte[] payload) {
+    ByteBuffer buffer = ByteBuffer.wrap(payload);
+    if (buffer.get() != MAGIC_BYTE) {
+      throw new SerializationException("Unknown magic byte!");
+    }
+    return buffer;
+  }
+
+  /**
+   * Deserializes the payload without including schema information for primitive types, maps, and
+   * arrays. Just the resulting deserialized object is returned.
+   *
+   * <p>This behavior is the norm for Decoders/Deserializers.
+   *
+   * @param payload serialized data
+   * @return the deserialized object
+   */
+  protected T deserialize(byte[] payload) throws SerializationException {
+    return (T) deserialize(false, null, null, payload);
+  }
+
+  // The Object return type is a bit messy, but this is the simplest way to have
+  // flexible decoding and not duplicate deserialization code multiple times for different variants.
+  protected Object deserialize(
+      boolean includeSchemaAndVersion, String topic, Boolean isKey, byte[] payload
+  ) throws SerializationException {
+
+    // Even if the caller requests schema & version, if the payload is null we cannot include it.
+    // The caller must handle this case.
+    if (payload == null) {
+      return null;
+    }
+
+    int id = -1;
+    try {
+      ByteBuffer buffer = getByteBuffer(payload);
+      id = buffer.getInt();
+      JsonSchema schema = ((JsonSchema) schemaRegistry.getSchemaById(id));
+      String subject = null;
+      if (includeSchemaAndVersion) {
+        subject = subjectName(topic, isKey, schema);
+        schema = schemaForDeserialize(id, schema, subject, isKey);
+      }
+
+      int length = buffer.limit() - 1 - idSize;
+      int start = buffer.position() + buffer.arrayOffset();
+
+      Object value = type != null
+                     ? objectMapper.readValue(buffer.array(), start, length, type)
+                     : objectMapper.readTree(new ByteArrayInputStream(buffer.array(),
+                         start,
+                         length
+                     ));
+
+      if (validate) {
+        try {
+          schema.validate(value);
+        } catch (JsonProcessingException | ValidationException e) {
+          throw new SerializationException("JSON "
+              + value
+              + " does not match schema "
+              + schema.canonicalString(), e);
+        }
+      }
+
+      if (includeSchemaAndVersion) {
+        // Annotate the schema with the version. Note that we only do this if the schema +
+        // version are requested, i.e. in Kafka Connect converters. This is critical because that
+        // code *will not* rely on exact schema equality. Regular deserializers *must not* include
+        // this information because it would return schemas which are not equivalent.
+        //
+        // Note, however, that we also do not fill in the connect.version field. This allows the
+        // Converter to let a version provided by a Kafka Connect source take priority over the
+        // schema registry's ordering (which is implicit by auto-registration time rather than
+        // explicit from the Connector).
+
+        Integer version = schemaVersion(topic, isKey, id, subject, schema, value);
+        return new JsonSchemaAndValue(new JsonSchema(
+            schema.canonicalString(),
+            schema.references(),
+            schema.resolvedReferences(),
+            version
+        ), value);
+      }
+
+      return value;
+    } catch (IOException | RuntimeException e) {
+      throw new SerializationException("Error deserializing Protobuf message for id " + id, e);
+    } catch (RestClientException e) {
+      throw new SerializationException("Error retrieving Protobuf schema for id " + id, e);
+    }
+  }
+
+  private Integer schemaVersion(
+      String topic, Boolean isKey, int id, String subject, JsonSchema schema, Object value
+  ) throws IOException, RestClientException {
+    Integer version;
+    if (isDeprecatedSubjectNameStrategy(isKey)) {
+      subject = getSubjectName(topic, isKey, value, schema);
+      JsonSchema subjectSchema = (JsonSchema) schemaRegistry.getSchemaBySubjectAndId(subject, id);
+      version = schemaRegistry.getVersion(subject, subjectSchema);
+    } else {
+      //we already got the subject name
+      version = schemaRegistry.getVersion(subject, schema);
+    }
+    return version;
+  }
+
+  private String subjectName(String topic, Boolean isKey, JsonSchema schemaFromRegistry) {
+    return isDeprecatedSubjectNameStrategy(isKey)
+           ? null
+           : getSubjectName(topic, isKey, null, schemaFromRegistry);
+  }
+
+  private JsonSchema schemaForDeserialize(
+      int id, JsonSchema schemaFromRegistry, String subject, Boolean isKey
+  ) throws IOException, RestClientException {
+    return isDeprecatedSubjectNameStrategy(isKey)
+           ? JsonSchemaUtils.copyOf(schemaFromRegistry)
+           : (JsonSchema) schemaRegistry.getSchemaBySubjectAndId(subject, id);
+  }
+
+  protected JsonSchemaAndValue deserializeWithSchemaAndVersion(
+      String topic, boolean isKey, byte[] payload
+  ) throws SerializationException {
+    return (JsonSchemaAndValue) deserialize(true, topic, isKey, payload);
+  }
+}

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
@@ -71,14 +71,6 @@ public abstract class AbstractKafkaJsonSchemaDeserializer<T> extends AbstractKaf
     return new KafkaJsonSchemaDeserializerConfig(props.props());
   }
 
-  private ByteBuffer getByteBuffer(byte[] payload) {
-    ByteBuffer buffer = ByteBuffer.wrap(payload);
-    if (buffer.get() != MAGIC_BYTE) {
-      throw new SerializationException("Unknown magic byte!");
-    }
-    return buffer;
-  }
-
   /**
    * Deserializes the payload without including schema information for primitive types, maps, and
    * arrays. Just the resulting deserialized object is returned.

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaSerializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaSerializer.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.serializers.json;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.errors.SerializationException;
+import org.everit.json.schema.ValidationException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import io.confluent.kafka.schemaregistry.json.jackson.Jackson;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDe;
+
+public abstract class AbstractKafkaJsonSchemaSerializer<T> extends AbstractKafkaSchemaSerDe {
+
+  protected boolean autoRegisterSchema;
+  protected ObjectMapper objectMapper = Jackson.newObjectMapper();
+  protected boolean validate = true;
+
+  protected void configure(KafkaJsonSchemaSerializerConfig config) {
+    configureClientProperties(config, new JsonSchemaProvider());
+    this.autoRegisterSchema = config.autoRegisterSchema();
+    boolean prettyPrint = config.getBoolean(KafkaJsonSchemaSerializerConfig.JSON_INDENT_OUTPUT);
+    this.objectMapper.configure(SerializationFeature.INDENT_OUTPUT, prettyPrint);
+    this.validate = config.getBoolean(KafkaJsonSchemaSerializerConfig.FAIL_INVALID_SCHEMA);
+  }
+
+  protected KafkaJsonSchemaSerializerConfig serializerConfig(Map<String, ?> props) {
+    try {
+      return new KafkaJsonSchemaSerializerConfig(props);
+    } catch (io.confluent.common.config.ConfigException e) {
+      throw new ConfigException(e.getMessage());
+    }
+  }
+
+  protected byte[] serializeImpl(
+      String subject,
+      T object,
+      JsonSchema schema
+  ) throws SerializationException {
+    // null needs to treated specially since the client most likely just wants to send
+    // an individual null value instead of making the subject a null type. Also, null in
+    // Kafka has a special meaning for deletion in a topic with the compact retention policy.
+    // Therefore, we will bypass schema registration and return a null value in Kafka, instead
+    // of an encoded null.
+    if (object == null) {
+      return null;
+    }
+    String restClientErrorMsg = "";
+    try {
+      int id;
+      if (autoRegisterSchema) {
+        restClientErrorMsg = "Error registering JSON schema: ";
+        id = schemaRegistry.register(subject, schema);
+      } else {
+        restClientErrorMsg = "Error retrieving JSON schema: ";
+        id = schemaRegistry.getId(subject, schema);
+      }
+      if (validate) {
+        try {
+          schema.validate(object);
+        } catch (JsonProcessingException | ValidationException e) {
+          throw new SerializationException("JSON "
+              + object
+              + " does not match schema "
+              + schema.canonicalString(), e);
+        }
+      }
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      out.write(MAGIC_BYTE);
+      out.write(ByteBuffer.allocate(idSize).putInt(id).array());
+      out.write(objectMapper.writeValueAsBytes(object));
+      byte[] bytes = out.toByteArray();
+      out.close();
+      return bytes;
+    } catch (IOException | RuntimeException e) {
+      throw new SerializationException("Error serializing JSON message", e);
+    } catch (RestClientException e) {
+      throw new SerializationException(restClientErrorMsg + schema, e);
+    }
+  }
+}

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/JsonSchemaAndValue.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/JsonSchemaAndValue.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+
+package io.confluent.kafka.serializers.json;
+
+import java.util.Objects;
+
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
+
+public class JsonSchemaAndValue {
+
+  private final JsonSchema schema;
+  private final Object value;
+
+  public JsonSchemaAndValue(JsonSchema schema, Object value) {
+    this.schema = schema;
+    this.value = value;
+  }
+
+  public JsonSchema getSchema() {
+    return schema;
+  }
+
+  public Object getValue() {
+    return value;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    JsonSchemaAndValue that = (JsonSchemaAndValue) o;
+    return Objects.equals(schema, that.schema) && Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(schema, value);
+  }
+}

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaDeserializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaDeserializer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+
+package io.confluent.kafka.serializers.json;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.kafka.common.serialization.Deserializer;
+
+import java.util.Map;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+
+/**
+ * Generic JSON deserializer.
+ */
+public class KafkaJsonSchemaDeserializer<T> extends AbstractKafkaJsonSchemaDeserializer<T>
+    implements Deserializer<T> {
+
+  private boolean isKey;
+
+  /**
+   * Constructor used by Kafka consumer.
+   */
+  public KafkaJsonSchemaDeserializer() {
+  }
+
+  public KafkaJsonSchemaDeserializer(SchemaRegistryClient client) {
+    schemaRegistry = client;
+  }
+
+  @VisibleForTesting
+  public KafkaJsonSchemaDeserializer(
+      SchemaRegistryClient client,
+      Map<String, ?> props,
+      Class<T> type
+  ) {
+    schemaRegistry = client;
+    configure(deserializerConfig(props), type);
+  }
+
+  @Override
+  public void configure(Map<String, ?> props, boolean isKey) {
+    configure(new KafkaJsonSchemaDeserializerConfig(props), isKey);
+  }
+
+  @SuppressWarnings("unchecked")
+  protected void configure(KafkaJsonSchemaDeserializerConfig config, boolean isKey) {
+    this.isKey = isKey;
+    if (isKey) {
+      configure(
+          config,
+          (Class<T>) config.getClass(KafkaJsonSchemaDeserializerConfig.JSON_KEY_TYPE)
+      );
+    } else {
+      configure(
+          config,
+          (Class<T>) config.getClass(KafkaJsonSchemaDeserializerConfig.JSON_VALUE_TYPE)
+      );
+    }
+  }
+
+  @Override
+  public T deserialize(String ignored, byte[] bytes) {
+    return deserialize(bytes);
+  }
+
+  @Override
+  public void close() {
+
+  }
+}

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaDeserializerConfig.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaDeserializerConfig.java
@@ -43,6 +43,11 @@ public class KafkaJsonSchemaDeserializerConfig extends AbstractKafkaSchemaSerDeC
   public static final String JSON_VALUE_TYPE_DOC = "Classname of the type that the message value "
       + "should be deserialized to";
 
+  public static final String TYPE_PROPERTY = "type.property";
+  public static final String TYPE_PROPERTY_DEFAULT = "javaType";
+  public static final String TYPE_PROPERTY_DOC = "Property on the JSON Schema that contains the "
+      + "fully-qualified classname";
+
   private static ConfigDef config;
 
   static {
@@ -66,6 +71,11 @@ public class KafkaJsonSchemaDeserializerConfig extends AbstractKafkaSchemaSerDeC
         JSON_VALUE_TYPE_DEFAULT,
         ConfigDef.Importance.MEDIUM,
         JSON_VALUE_TYPE_DOC
+    ).define(TYPE_PROPERTY,
+        ConfigDef.Type.STRING,
+        TYPE_PROPERTY_DEFAULT,
+        ConfigDef.Importance.MEDIUM,
+        TYPE_PROPERTY_DOC
     );
   }
 

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaDeserializerConfig.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaDeserializerConfig.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+
+package io.confluent.kafka.serializers.json;
+
+import java.util.Map;
+
+import io.confluent.common.config.ConfigDef;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+
+public class KafkaJsonSchemaDeserializerConfig extends AbstractKafkaSchemaSerDeConfig {
+
+  public static final String FAIL_UNKNOWN_PROPERTIES = "json.fail.unknown.properties";
+  public static final boolean FAIL_UNKNOWN_PROPERTIES_DEFAULT = true;
+  public static final String FAIL_UNKNOWN_PROPERTIES_DOC = "Whether to fail deserialization if "
+      + "unknown JSON properties are encountered";
+
+  public static final String FAIL_INVALID_SCHEMA = "json.fail.invalid.schema";
+  public static final boolean FAIL_INVALID_SCHEMA_DEFAULT = false;
+  public static final String FAIL_INVALID_SCHEMA_DOC = "Whether to fail deserialization if the "
+      + "payload does not match the schema";
+
+  public static final String JSON_KEY_TYPE = "json.key.type";
+  public static final String JSON_KEY_TYPE_DEFAULT = Object.class.getName();
+  public static final String JSON_KEY_TYPE_DOC = "Classname of the type that the message key "
+      + "should be deserialized to";
+
+  public static final String JSON_VALUE_TYPE = "json.value.type";
+  public static final String JSON_VALUE_TYPE_DEFAULT = Object.class.getName();
+  public static final String JSON_VALUE_TYPE_DOC = "Classname of the type that the message value "
+      + "should be deserialized to";
+
+  private static ConfigDef config;
+
+  static {
+    config = baseConfigDef().define(FAIL_UNKNOWN_PROPERTIES,
+        ConfigDef.Type.BOOLEAN,
+        FAIL_UNKNOWN_PROPERTIES_DEFAULT,
+        ConfigDef.Importance.LOW,
+        FAIL_UNKNOWN_PROPERTIES_DOC
+    ).define(FAIL_INVALID_SCHEMA,
+        ConfigDef.Type.BOOLEAN,
+        FAIL_INVALID_SCHEMA_DEFAULT,
+        ConfigDef.Importance.MEDIUM,
+        FAIL_INVALID_SCHEMA_DOC
+    ).define(JSON_KEY_TYPE,
+        ConfigDef.Type.CLASS,
+        JSON_KEY_TYPE_DEFAULT,
+        ConfigDef.Importance.MEDIUM,
+        JSON_KEY_TYPE_DOC
+    ).define(JSON_VALUE_TYPE,
+        ConfigDef.Type.CLASS,
+        JSON_VALUE_TYPE_DEFAULT,
+        ConfigDef.Importance.MEDIUM,
+        JSON_VALUE_TYPE_DOC
+    );
+  }
+
+  public KafkaJsonSchemaDeserializerConfig(Map<?, ?> props) {
+    super(config, props);
+  }
+
+}

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+
+package io.confluent.kafka.serializers.json;
+
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.util.Map;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaUtils;
+
+public class KafkaJsonSchemaSerializer<T> extends AbstractKafkaJsonSchemaSerializer<T>
+    implements Serializer<T> {
+
+  private boolean isKey;
+
+  /**
+   * Constructor used by Kafka producer.
+   */
+  public KafkaJsonSchemaSerializer() {
+  }
+
+  public KafkaJsonSchemaSerializer(SchemaRegistryClient client) {
+    schemaRegistry = client;
+  }
+
+  public KafkaJsonSchemaSerializer(SchemaRegistryClient client, Map<String, ?> props) {
+    schemaRegistry = client;
+    configure(serializerConfig(props));
+  }
+
+  @Override
+  public void configure(Map<String, ?> config, boolean isKey) {
+    this.isKey = isKey;
+    configure(new KafkaJsonSchemaSerializerConfig(config));
+  }
+
+  @Override
+  public byte[] serialize(String topic, T record) {
+    if (record == null) {
+      return null;
+    }
+    JsonSchema schema = JsonSchemaUtils.getSchema(record);
+    Object value = JsonSchemaUtils.getValue(record);
+    return serializeImpl(getSubjectName(topic, isKey, value, schema), (T) value, schema);
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializerConfig.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializerConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.serializers.json;
+
+import java.util.Map;
+
+import io.confluent.common.config.ConfigDef;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+
+public class KafkaJsonSchemaSerializerConfig extends AbstractKafkaSchemaSerDeConfig {
+
+  public static final String FAIL_INVALID_SCHEMA = "json.fail.invalid.schema";
+  public static final boolean FAIL_INVALID_SCHEMA_DEFAULT = true;
+  public static final String FAIL_INVALID_SCHEMA_DOC = "Whether to fail deserialization if the "
+      + "payload does not match the schema";
+
+  public static final String JSON_INDENT_OUTPUT = "json.indent.output";
+  public static final boolean JSON_INDENT_OUTPUT_DEFAULT = false;
+  public static final String JSON_INDENT_OUTPUT_DOC = "Whether JSON output should be indented "
+      + "(\"pretty-printed\")";
+
+  private static ConfigDef config;
+
+  static {
+    config = baseConfigDef().define(FAIL_INVALID_SCHEMA,
+        ConfigDef.Type.BOOLEAN,
+        FAIL_INVALID_SCHEMA_DEFAULT,
+        ConfigDef.Importance.MEDIUM,
+        FAIL_INVALID_SCHEMA_DOC
+    ).define(JSON_INDENT_OUTPUT,
+        ConfigDef.Type.BOOLEAN,
+        JSON_INDENT_OUTPUT_DEFAULT,
+        ConfigDef.Importance.LOW,
+        JSON_INDENT_OUTPUT_DOC
+    );
+  }
+
+  public KafkaJsonSchemaSerializerConfig(Map<?, ?> props) {
+    super(config, props);
+  }
+
+}

--- a/json-schema-serializer/src/test/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializerTest.java
+++ b/json-schema-serializer/src/test/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializerTest.java
@@ -16,6 +16,8 @@
 package io.confluent.kafka.serializers.json;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaString;
 import org.apache.kafka.common.errors.SerializationException;
 import org.junit.Test;
 
@@ -105,6 +107,10 @@ public class KafkaJsonSchemaSerializerTest {
     byte[] bytes = serializer.serialize("foo", user);
     Object deserialized = getDeserializer(User.class).deserialize(topic, bytes);
     assertEquals(user, deserialized);
+
+    // Test for javaType property
+    deserialized = getDeserializer(null).deserialize(topic, bytes);
+    assertEquals(user, deserialized);
   }
 
   @Test(expected = SerializationException.class)
@@ -116,6 +122,9 @@ public class KafkaJsonSchemaSerializerTest {
     assertEquals(user, deserialized);
   }
 
+  // Generate javaType property
+  @JsonSchemaInject(strings = {@JsonSchemaString(path="javaType",
+      value="io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializerTest$User")})
   public static class User {
     @JsonProperty
     public String firstName;

--- a/json-schema-serializer/src/test/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializerTest.java
+++ b/json-schema-serializer/src/test/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializerTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.serializers.json;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.kafka.common.errors.SerializationException;
+import org.junit.Test;
+
+import javax.validation.constraints.Min;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class KafkaJsonSchemaSerializerTest {
+
+  private final Properties config;
+  private final SchemaRegistryClient schemaRegistry;
+  private KafkaJsonSchemaSerializer<Object> serializer;
+  private KafkaJsonSchemaDeserializer<Object> deserializer;
+  private final String topic;
+
+  public KafkaJsonSchemaSerializerTest() {
+    config = new Properties();
+    config.put(KafkaJsonSchemaSerializerConfig.AUTO_REGISTER_SCHEMAS, true);
+    config.put(KafkaJsonSchemaSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "bogus");
+    schemaRegistry = new MockSchemaRegistryClient();
+    serializer = new KafkaJsonSchemaSerializer<>(schemaRegistry, new HashMap(config));
+    deserializer = getDeserializer(Object.class);
+    topic = "test";
+  }
+
+  private <T> KafkaJsonSchemaDeserializer<T> getDeserializer(Class<T> cls) {
+    return new KafkaJsonSchemaDeserializer<>(schemaRegistry, new HashMap(config), cls);
+  }
+
+  @Test
+  public void testKafkaJsonSchemaSerializer() {
+    byte[] bytes;
+
+    bytes = serializer.serialize(topic, null);
+    assertEquals(null, deserializer.deserialize(topic, bytes));
+
+    bytes = serializer.serialize(topic, true);
+    assertEquals(true, deserializer.deserialize(topic, bytes));
+
+    bytes = serializer.serialize(topic, 123);
+    assertEquals(123, deserializer.deserialize(topic, bytes));
+
+    bytes = serializer.serialize(topic, 345L);
+    // JSON can't distinguish longs
+    assertEquals(345, deserializer.deserialize(topic, bytes));
+
+    bytes = serializer.serialize(topic, 1.23f);
+    // JSON can't distinguish doubles
+    assertEquals(1.23, deserializer.deserialize(topic, bytes));
+
+    bytes = serializer.serialize(topic, 2.34d);
+    assertEquals(2.34, deserializer.deserialize(topic, bytes));
+
+    bytes = serializer.serialize(topic, "abc");
+    assertEquals("abc", deserializer.deserialize(topic, bytes));
+  }
+
+  @Test
+  public void serializeNull() {
+    assertNull(serializer.serialize("foo", null));
+  }
+
+  @Test
+  public void serializeMap() throws Exception {
+    Map<String, Object> message = new HashMap<>();
+    message.put("foo", "bar");
+    message.put("baz", 354.99);
+
+    byte[] bytes = serializer.serialize("foo", message);
+    Object deserialized = deserializer.deserialize(topic, bytes);
+    assertEquals(message, deserialized);
+  }
+
+  @Test
+  public void serializeUser() throws Exception {
+    User user = new User("john", "doe", (short) 50);
+
+    byte[] bytes = serializer.serialize("foo", user);
+    Object deserialized = getDeserializer(User.class).deserialize(topic, bytes);
+    assertEquals(user, deserialized);
+  }
+
+  @Test(expected = SerializationException.class)
+  public void serializeInvalidUser() throws Exception {
+    User user = new User("john", "doe", (short) -1, "jack");
+
+    byte[] bytes = serializer.serialize("foo", user);
+    Object deserialized = getDeserializer(User.class).deserialize(topic, bytes);
+    assertEquals(user, deserialized);
+  }
+
+  public static class User {
+    @JsonProperty
+    public String firstName;
+    @JsonProperty
+    public String lastName;
+    @JsonProperty
+    @Min(0)
+    public short age;
+    @JsonProperty
+    public Optional<String> nickName;
+
+    public User() {}
+
+    public User(String firstName, String lastName, short age) {
+      this(firstName, lastName, age, null);
+    }
+
+    public User(String firstName, String lastName, short age, String nickName) {
+      this.firstName = firstName;
+      this.lastName = lastName;
+      this.age = age;
+      this.nickName = Optional.ofNullable(nickName);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      User user = (User) o;
+      return age == user.age
+          && Objects.equals(firstName, user.firstName)
+          && Objects.equals(lastName, user.lastName)
+          && Objects.equals(nickName, user.nickName);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(firstName, lastName, age, nickName);
+    }
+  }
+}

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -39,6 +39,10 @@
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
+            <artifactId>kafka-json-schema-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
             <artifactId>kafka-protobuf-provider</artifactId>
         </dependency>
         <dependency>

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
@@ -32,6 +32,7 @@ import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 
 public abstract class SchemaRegistryMojo extends AbstractMojo {
@@ -84,7 +85,7 @@ public abstract class SchemaRegistryMojo extends AbstractMojo {
 
   private List<SchemaProvider> defaultSchemaProviders() {
     return Arrays.asList(
-        new AvroSchemaProvider(), new ProtobufSchemaProvider()
+        new AvroSchemaProvider(), new JsonSchemaProvider(), new ProtobufSchemaProvider()
     );
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,10 @@
         <module>protobuf-provider</module>
         <module>protobuf-serializer</module>
         <module>protobuf-serde</module>
+        <module>json-schema-converter</module>
+        <module>json-schema-provider</module>
+        <module>json-schema-serializer</module>
+        <module>json-schema-serde</module>
     </modules>
 
     <properties>
@@ -80,6 +84,10 @@
             <id>confluent</id>
             <name>Confluent</name>
             <url>${confluent.maven.repo}</url>
+        </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
     </repositories>
 
@@ -104,6 +112,36 @@
                 <groupId>com.squareup.wire</groupId>
                 <artifactId>wire-schema</artifactId>
                 <version>${wire.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-guava</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-parameter-names</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.everit-org.json-schema</groupId>
+                <artifactId>org.everit.json.schema</artifactId>
+                <version>1.12.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.kjetland</groupId>
+                <artifactId>mbknor-jackson-jsonschema_2.12</artifactId>
+                <version>1.0.36</version>
             </dependency>
             <dependency>
                 <groupId>uk.co.jemos.podam</groupId>
@@ -178,6 +216,21 @@
                 <artifactId>kafka-protobuf-serializer</artifactId>
                 <version>${project.version}</version>
                 <type>test-jar</type>
+            </dependency>
+            <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>kafka-connect-json-schema-converter</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>kafka-json-schema-provider</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.confluent</groupId>
+                <artifactId>kafka-json-schema-serializer</artifactId>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.xml.ws</groupId>


### PR DESCRIPTION
Adds JSON Schema support to Schema Registry, including

- a `JsonSchema` plugin that provides compatibility checking
- `KafkaJsonSchemaSerializer` and `KafkaJsonSchemaDeserializer` for use with Java Kafka Consumers and Producers
- `JsonSchemaConverter` for use with Kafka Connect
- `KafkaJsonSchemaSerde` for use with Kafka Streams