### PR TITLE
MINOR: pass provider to MockSchemaRegistryClient

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -59,13 +59,14 @@ public abstract class AbstractKafkaSchemaSerDe {
     Map<String, Object> originals = config.originalsWithPrefix("");
     if (null == schemaRegistry) {
       String mockScope = validateAndMaybeGetMockScope(urls);
+      List<SchemaProvider> providers = Collections.singletonList(provider);
       if (mockScope != null) {
-        schemaRegistry = MockSchemaRegistry.getClientForScope(mockScope);
+        schemaRegistry = MockSchemaRegistry.getClientForScope(mockScope, providers);
       } else {
         schemaRegistry = new CachedSchemaRegistryClient(
             urls,
             maxSchemaObject,
-            Collections.singletonList(provider),
+            providers,
             originals,
             config.requestHeaders()
         );

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/testutil/MockSchemaRegistry.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/testutil/MockSchemaRegistry.java
@@ -16,10 +16,12 @@
 
 package io.confluent.kafka.schemaregistry.testutil;
 
+import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -59,6 +61,27 @@ public final class MockSchemaRegistry {
     synchronized (SCOPED_CLIENTS) {
       if (!SCOPED_CLIENTS.containsKey(scope)) {
         SCOPED_CLIENTS.put(scope, new MockSchemaRegistryClient());
+      }
+    }
+    return SCOPED_CLIENTS.get(scope);
+  }
+
+  /**
+   * Get a client for a mocked Schema Registry. The {@code scope} represents a particular registry,
+   * so operations on one scope will never affect another.
+   *
+   * @param scope Identifies a logically independent Schema Registry instance. It's similar to a
+   *              schema registry URL, in that two different Schema Registry deployments have two
+   *              different URLs, except that these registries are only mocked, so they have no
+   *              actual URL.
+   * @param providers A list of schema providers.
+   * @return A client for the specified scope.
+   */
+  public static SchemaRegistryClient getClientForScope(final String scope,
+                                                       List<SchemaProvider> providers) {
+    synchronized (SCOPED_CLIENTS) {
+      if (!SCOPED_CLIENTS.containsKey(scope)) {
+        SCOPED_CLIENTS.put(scope, new MockSchemaRegistryClient(providers));
       }
     }
     return SCOPED_CLIENTS.get(scope);


### PR DESCRIPTION
Pass the schema provider to the MockSchemaRegistryClient when using mocks.