### PR TITLE
Fixes #1134: Add non-AVRO Int and Long key support

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
@@ -28,8 +28,6 @@ import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.ShortSerializer;
-import org.apache.kafka.common.serialization.FloatSerializer;
-import org.apache.kafka.common.serialization.DoubleSerializer;
 import org.apache.kafka.common.serialization.Serializer;
 
 
@@ -208,14 +206,6 @@ public class AvroMessageReader extends AbstractKafkaAvroSerializer implements Me
     if (serializerClass == ShortSerializer.class) {
       Short shortKey = Short.parseShort(keyString);
       return keySerializer.serialize(topic, shortKey);
-    }
-    if (serializerClass == FloatSerializer.class) {
-      Float floatKey = Float.parseFloat(keyString);
-      return keySerializer.serialize(topic, floatKey);
-    }
-    if (serializerClass == DoubleSerializer.class) {
-      Double doubleKey = Double.parseDouble(keyString);
-      return keySerializer.serialize(topic, doubleKey);
     }
     return keySerializer.serialize(topic, keyString);
   }

--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
@@ -192,19 +192,16 @@ public class AvroMessageReader extends AbstractKafkaAvroSerializer implements Me
   }
 
   private byte[] serializeNonAvroKey(String keyString) {
-    byte[] serializedKey;
-
     Class serializerClass = keySerializer.getClass();
     if (serializerClass == LongSerializer.class) {
       Long longKey = Long.parseLong(keyString);
-      serializedKey = keySerializer.serialize(topic, longKey);
-    } else if (serializerClass == IntegerSerializer.class) {
-      Integer intKey = Integer.parseInt(keyString);
-      serializedKey = keySerializer.serialize(topic, intKey);
-    } else {
-      serializedKey = keySerializer.serialize(topic, keyString);
+      return keySerializer.serialize(topic, longKey);
     }
-    return serializedKey;
+    if (serializerClass == IntegerSerializer.class) {
+      Integer intKey = Integer.parseInt(keyString);
+      return keySerializer.serialize(topic, intKey);
+    }
+    return keySerializer.serialize(topic, keyString);
   }
 
   @Override

--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.ShortSerializer;
 import org.apache.kafka.common.serialization.Serializer;
 
 import java.io.BufferedReader;
@@ -200,6 +201,10 @@ public class AvroMessageReader extends AbstractKafkaAvroSerializer implements Me
     if (serializerClass == IntegerSerializer.class) {
       Integer intKey = Integer.parseInt(keyString);
       return keySerializer.serialize(topic, intKey);
+    }
+    if (serializerClass == ShortSerializer.class) {
+      Short shortKey = Short.parseShort(keyString);
+      return keySerializer.serialize(topic, shortKey);
     }
     return keySerializer.serialize(topic, keyString);
   }

--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
@@ -28,7 +28,10 @@ import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.ShortSerializer;
+import org.apache.kafka.common.serialization.FloatSerializer;
+import org.apache.kafka.common.serialization.DoubleSerializer;
 import org.apache.kafka.common.serialization.Serializer;
+
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -205,6 +208,14 @@ public class AvroMessageReader extends AbstractKafkaAvroSerializer implements Me
     if (serializerClass == ShortSerializer.class) {
       Short shortKey = Short.parseShort(keyString);
       return keySerializer.serialize(topic, shortKey);
+    }
+    if (serializerClass == FloatSerializer.class) {
+      Float floatKey = Float.parseFloat(keyString);
+      return keySerializer.serialize(topic, floatKey);
+    }
+    if (serializerClass == DoubleSerializer.class) {
+      Double doubleKey = Double.parseDouble(keyString);
+      return keySerializer.serialize(topic, doubleKey);
     }
     return keySerializer.serialize(topic, keyString);
   }

--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
@@ -218,7 +218,19 @@ public class AvroMessageReader extends AbstractKafkaAvroSerializer implements Me
 
           byte[] serializedKey;
           if (keySerializer != null) {
-            serializedKey = keySerializer.serialize(topic, keyString);
+            String simpleName = keySerializer.getClass().getSimpleName();
+            switch (simpleName) {
+              case "LongSerializer":
+                Long longKey = Long.parseLong(keyString);
+                serializedKey = keySerializer.serialize(topic, longKey);
+                break;
+              case "IntSerializer":
+                Integer intKey = Integer.parseInt(keyString);
+                serializedKey = keySerializer.serialize(topic, intKey);
+                break;
+              default:
+                serializedKey = keySerializer.serialize(topic, keyString);
+            }
           } else {
             Object key = jsonToAvro(keyString, keySchema);
             serializedKey = serializeImpl(keySubject, key);


### PR DESCRIPTION
Enables non-avro 8-byte Long and 4-byte Int types for keys using corresponding serializers.

Addresses:

https://github.com/confluentinc/schema-registry/issues/1134
https://issues.apache.org/jira/browse/KAFKA-2526

To enable use cli options like:
--property key.serializer=org.apache.kafka.common.serialization.LongSerializer


-------------------------------------------------------------------------------------------------------
If you find this PR useful, consider supporting it with a $9/mo sponsorship at:
https://github.com/sponsors/rudi-cilibrasi
