### PR TITLE
MINOR: cleanup references to Avro in errors

### DIFF
--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -104,8 +104,8 @@ paths:
           description: "Error code 40401 -- Subject not found\nError code 40402 --\
             \ Version not found"
         422:
-          description: "Error code 42201 -- Invalid Avro schema\nError code 42202\
-            \ -- Invalid version"
+          description: "Error code 42201 -- Invalid schema or schema type\nError code\
+            \ 42202 -- Invalid version"
         500:
           description: "Error code 50001 -- Error in the backend data store"
   /config:
@@ -561,9 +561,9 @@ paths:
           schema:
             $ref: "#/definitions/RegisterSchemaResponse"
         409:
-          description: "Incompatible Avro schema"
+          description: "Incompatible schema"
         422:
-          description: "Error code 42201 -- Invalid Avro schema"
+          description: "Error code 42201 -- Invalid schema or schema type"
         500:
           description: "Error code 50001 -- Error in the backend data store\nError\
             \ code 50002 -- Operation timed out\nError code 50003 -- Error while forwarding\
@@ -661,8 +661,8 @@ paths:
           description: "Error code 50001 -- Error in the backend data store"
   /subjects/{subject}/versions/{version}/schema:
     get:
-      summary: "Get the avro schema for the specified version of this subject. The\
-        \ unescaped schema only is returned."
+      summary: "Get the schema for the specified version of this subject. The unescaped\
+        \ schema only is returned."
       description: ""
       operationId: "getSchemaOnly"
       consumes:

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/Errors.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/Errors.java
@@ -70,14 +70,14 @@ public class Errors {
         String.format(SCHEMA_NOT_FOUND_MESSAGE_FORMAT, id), SCHEMA_NOT_FOUND_ERROR_CODE);
   }
 
-  public static RestIncompatibleAvroSchemaException incompatibleSchemaException(String message,
-                                                                                Throwable cause) {
-    return new RestIncompatibleAvroSchemaException(message,
-                                                   RestIncompatibleAvroSchemaException.DEFAULT_ERROR_CODE,
+  public static RestIncompatibleSchemaException incompatibleSchemaException(String message,
+                                                                            Throwable cause) {
+    return new RestIncompatibleSchemaException(message,
+                                                   RestIncompatibleSchemaException.DEFAULT_ERROR_CODE,
                                                    cause);
   }
 
-  public static RestInvalidSchemaException invalidAvroException(String message, Throwable cause) {
+  public static RestInvalidSchemaException invalidSchemaException(String message, Throwable cause) {
     return new RestInvalidSchemaException(message);
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/RestIncompatibleSchemaException.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/RestIncompatibleSchemaException.java
@@ -23,16 +23,16 @@ import io.confluent.rest.exceptions.RestException;
  * An exception thrown when the registered schema is not compatible with the latest schema according
  * to the compatibility level.
  */
-public class RestIncompatibleAvroSchemaException extends RestException {
+public class RestIncompatibleSchemaException extends RestException {
 
   public static final int DEFAULT_ERROR_CODE =
       Response.Status.CONFLICT.getStatusCode();
 
-  public RestIncompatibleAvroSchemaException(String message, int errorCode) {
+  public RestIncompatibleSchemaException(String message, int errorCode) {
     this(message, errorCode, null);
   }
 
-  public RestIncompatibleAvroSchemaException(String message, int errorCode, Throwable cause) {
+  public RestIncompatibleSchemaException(String message, int errorCode, Throwable cause) {
     super(message, Response.Status.CONFLICT.getStatusCode(), errorCode, cause);
   }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -77,7 +77,7 @@ public class CompatibilityResource {
   @ApiResponses(value = {
       @ApiResponse(code = 404, message = "Error code 40401 -- Subject not found\n"
           + "Error code 40402 -- Version not found"),
-      @ApiResponse(code = 422, message = "Error code 42201 -- Invalid Avro schema\n"
+      @ApiResponse(code = 422, message = "Error code 42201 -- Invalid schema or schema type\n"
           + "Error code 42202 -- Invalid version"),
       @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store") })
   @PerformanceMetric("compatibility.subjects.versions.verify")
@@ -130,7 +130,7 @@ public class CompatibilityResource {
             schemaForSpecifiedVersion
         );
       } catch (InvalidSchemaException e) {
-        throw Errors.invalidAvroException("Invalid input schema " + request.getSchema(), e);
+        throw Errors.invalidSchemaException("Invalid input schema " + request.getSchema(), e);
       } catch (SchemaRegistryStoreException e) {
         throw Errors.storeException(
             "Error while getting compatibility level for subject " + subject, e);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -125,7 +125,7 @@ public class SubjectVersionsResource {
   @GET
   @Path("/{version}/schema")
   @PerformanceMetric("subjects.versions.get-schema.only")
-  @ApiOperation(value = "Get the avro schema for the specified version of this subject. "
+  @ApiOperation(value = "Get the schema for the specified version of this subject. "
       + "The unescaped schema only is returned.")
   @ApiResponses(value = {@ApiResponse(code = 404, message =
       "Error code 40401 -- Subject not found\n"
@@ -197,8 +197,8 @@ public class SubjectVersionsResource {
       + "the primary. If the primary is not available, the client will get an error code "
       + "indicating that the forwarding has failed.", response = RegisterSchemaResponse.class)
   @ApiResponses(value = {
-      @ApiResponse(code = 409, message = "Incompatible Avro schema"),
-      @ApiResponse(code = 422, message = "Error code 42201 -- Invalid Avro schema"),
+      @ApiResponse(code = 409, message = "Incompatible schema"),
+      @ApiResponse(code = 422, message = "Error code 42201 -- Invalid schema or schema type"),
       @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store\n"
           + "Error code 50002 -- Operation timed out\n"
           + "Error code 50003 -- Error while forwarding the request to the primary")})
@@ -225,7 +225,7 @@ public class SubjectVersionsResource {
     try {
       id = schemaRegistry.registerOrForward(subjectName, schema, headerProperties);
     } catch (InvalidSchemaException e) {
-      throw Errors.invalidAvroException("Input schema is an invalid Avro schema", e);
+      throw Errors.invalidSchemaException("Input schema is an invalid schema", e);
     } catch (OperationNotPermittedException e) {
       throw Errors.operationNotPermittedException(e.getMessage());
     } catch (SchemaRegistryTimeoutException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -793,7 +793,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     }
     SchemaProvider provider = providers.get(schemaType);
     if (provider == null) {
-      throw new IllegalArgumentException("Invalid schema type " + schemaType);
+      throw new InvalidSchemaException("Invalid schema type " + schemaType);
     }
     ParsedSchema parsedSchema = provider.parseSchema(schema.getSchema(), schema.getReferences())
         .orElseThrow(() -> new InvalidSchemaException("Invalid schema " + schema));
@@ -1091,10 +1091,6 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
 
     List<ParsedSchema> prevParsedSchemas = new ArrayList<>(previousSchemas.size());
     for (Schema previousSchema : previousSchemas) {
-      if (previousSchema == null) {
-        throw new InvalidSchemaException(
-            "Existing schema " + previousSchema + " is not a valid Avro schema");
-      }
       ParsedSchema prevParsedSchema = parseSchema(previousSchema);
       prevParsedSchemas.add(prevParsedSchema);
     }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiCompatibilityTest.java
@@ -18,7 +18,7 @@ import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.avro.AvroUtils;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-import io.confluent.kafka.schemaregistry.rest.exceptions.RestIncompatibleAvroSchemaException;
+import io.confluent.kafka.schemaregistry.rest.exceptions.RestIncompatibleSchemaException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidSchemaException;
 import org.junit.Test;
 
@@ -57,7 +57,7 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     } catch (RestClientException e) {
       // this is expected.
       assertEquals("Should get a conflict status",
-                   RestIncompatibleAvroSchemaException.DEFAULT_ERROR_CODE,
+                   RestIncompatibleSchemaException.DEFAULT_ERROR_CODE,
                    e.getStatus());
     }
 
@@ -111,7 +111,7 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     } catch (RestClientException e) {
       // this is expected.
       assertEquals("Should get a conflict status",
-                   RestIncompatibleAvroSchemaException.DEFAULT_ERROR_CODE,
+                   RestIncompatibleSchemaException.DEFAULT_ERROR_CODE,
                    e.getStatus());
     }
 
@@ -193,7 +193,7 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     } catch (RestClientException e) {
       // this is expected.
       assertEquals("Should get a conflict status",
-                   RestIncompatibleAvroSchemaException.DEFAULT_ERROR_CODE,
+                   RestIncompatibleSchemaException.DEFAULT_ERROR_CODE,
                    e.getStatus());
     }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiModeTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiModeTest.java
@@ -22,8 +22,6 @@ import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.avro.AvroUtils;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-import io.confluent.kafka.schemaregistry.rest.exceptions.RestIncompatibleAvroSchemaException;
-import io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidSchemaException;
 import io.confluent.rest.exceptions.RestConstraintViolationException;
 
 import static org.junit.Assert.assertEquals;

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTransitiveCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTransitiveCompatibilityTest.java
@@ -18,7 +18,7 @@ import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.avro.AvroUtils;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-import io.confluent.kafka.schemaregistry.rest.exceptions.RestIncompatibleAvroSchemaException;
+import io.confluent.kafka.schemaregistry.rest.exceptions.RestIncompatibleSchemaException;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -73,7 +73,7 @@ public class RestApiTransitiveCompatibilityTest extends ClusterTestHarness {
     } catch (RestClientException e) {
       // this is expected.
       assertEquals("Should get a conflict status",
-                   RestIncompatibleAvroSchemaException.DEFAULT_ERROR_CODE,
+                   RestIncompatibleSchemaException.DEFAULT_ERROR_CODE,
                    e.getStatus());
     }
   }


### PR DESCRIPTION
Clean up some references to Avro since we support other schema types.