### PR TITLE
Fixes for map handling in Protobuf plugin

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -28,7 +28,7 @@
               files="(AvroData|DownloadSchemaRegistryMojo|AvroMessageFormatter|KafkaSchemaRegistry|Schema|SchemaValue|SchemaDiff|MessageSchemaDiff|ProtobufMessageFormatter|ProtobufData|JsonSchemaMessageFormatter|JsonSchemaConverter).java"/>
 
     <suppress checks="JavaNCSS"
-              files="(AvroData|ProtobufData|SchemaDiff|NumberSchemaDiff|JsonSchemaConverter|KafkaSchemaRegistry).java"/>
+              files="(AvroData|ProtobufData|SchemaDiff|NumberSchemaDiff|JsonSchemaConverter|KafkaSchemaRegistry|ProtobufSchema).java"/>
 
     <suppress checks="MethodLength"
               files="AvroData.java"/>

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
@@ -49,6 +49,9 @@ public interface ParsedSchema {
    * @return the formatted string
    */
   default String formattedString(String format) {
+    if (format == null || format.trim().isEmpty()) {
+      return canonicalString();
+    }
     throw new IllegalArgumentException("Format not supported: " + format);
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
@@ -44,6 +44,15 @@ public interface ParsedSchema {
   String canonicalString();
 
   /**
+   * Returns a formatted string according to a type-specific format.
+   *
+   * @return the formatted string
+   */
+  default String formattedString(String format) {
+    throw new IllegalArgumentException("Format not supported: " + format);
+  }
+
+  /**
    * Returns a list of schema references.
    *
    * @return the schema references

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -339,6 +339,10 @@ paths:
         required: true
         type: "integer"
         format: "int32"
+      - name: "format"
+        in: "query"
+        required: false
+        type: "string"
       - name: "fetchMaxId"
         in: "query"
         required: false

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
@@ -66,12 +66,13 @@ public class SchemasResource {
   public SchemaString getSchema(
       @ApiParam(value = "Globally unique identifier of the schema", required = true)
       @PathParam("id") Integer id,
+      @DefaultValue("") @QueryParam("format") String format,
       @DefaultValue("false") @QueryParam("fetchMaxId") boolean fetchMaxId) {
     SchemaString schema = null;
     String errorMessage = "Error while retrieving schema with id " + id + " from the schema "
                           + "registry";
     try {
-      schema = schemaRegistry.get(id, fetchMaxId);
+      schema = schemaRegistry.get(id, format, fetchMaxId);
     } catch (SchemaRegistryStoreException e) {
       log.debug(errorMessage, e);
       throw Errors.storeException(errorMessage, e);

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <json-schema.version>1.12.1</json-schema.version>
         <protobuf.version>3.11.1</protobuf.version>
-        <wire.version>3.0.2</wire.version>
+        <wire.version>3.0.3</wire.version>
     </properties>
 
     <repositories>

--- a/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufData.java
+++ b/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufData.java
@@ -59,7 +59,6 @@ import static io.confluent.connect.protobuf.ProtobufDataConfig.SCHEMAS_CACHE_SIZ
 public class ProtobufData {
 
   public static final String NAMESPACE = "io.confluent.connect.protobuf";
-  public static final String PROTO3 = "proto3";
 
   public static final String DEFAULT_SCHEMA_NAME = "ConnectDefault";
   public static final String MAP_ENTRY_SUFFIX = ProtobufSchema.MAP_ENTRY_SUFFIX;  // Suffix used
@@ -307,7 +306,7 @@ public class ProtobufData {
     }
     try {
       DynamicSchema.Builder schema = DynamicSchema.newBuilder();
-      schema.setSyntax(PROTO3);
+      schema.setSyntax(ProtobufSchema.PROTO3);
       String name = getNameOrDefault(rootElem.name());
       schema.addMessageDefinition(messageDefinitionFromConnectSchema(schema, name, rootElem));
       return schema.build();
@@ -411,7 +410,7 @@ public class ProtobufData {
         message.addEnumDefinition(enumDefinitionFromConnectSchema(schema, fieldSchema));
       } else if (type.equals(GOOGLE_PROTOBUF_TIMESTAMP_FULL_NAME)) {
         DynamicSchema.Builder timestampSchema = DynamicSchema.newBuilder();
-        timestampSchema.setSyntax(PROTO3);
+        timestampSchema.setSyntax(ProtobufSchema.PROTO3);
         timestampSchema.setName(GOOGLE_PROTOBUF_TIMESTAMP_LOCATION);
         timestampSchema.setPackage(GOOGLE_PROTOBUF_PACKAGE);
         timestampSchema.addMessageDefinition(timestampDefinition());

--- a/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufData.java
+++ b/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufData.java
@@ -183,6 +183,9 @@ public class ProtobufData {
         }
         case ARRAY:
           final Collection<?> listValue = (Collection<?>) value;
+          if (listValue.isEmpty()) {
+            return null;
+          }
           List<Object> newListValue = new ArrayList<>();
           for (Object o : listValue) {
             newListValue.add(fromConnectData(schema.valueSchema(), scope, o, protobufSchema));

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
@@ -154,6 +154,17 @@ public class ProtobufDataTest {
     return message.build();
   }
 
+  private NestedMessage createEmptyNestedTestProto() throws ParseException {
+    NestedMessage.Builder message = NestedMessage.newBuilder();
+    return message.build();
+  }
+
+  private Map<String, String> getTestKeyValueMap() {
+    Map<String, String> result = new HashMap<>();
+    result.put("Hello", "World");
+    return result;
+  }
+
   private Schema getExpectedNestedTestProtoSchemaStringUserId() {
     return getExpectedNestedTestProtoSchema();
   }
@@ -280,12 +291,6 @@ public class ProtobufDataTest {
     return builder.build();
   }
 
-  private Map<String, String> getTestKeyValueMap() {
-    Map<String, String> result = new HashMap<>();
-    result.put("Hello", "World");
-    return result;
-  }
-
   private Struct getExpectedNestedProtoResultStringUserId() throws ParseException {
     Schema schema = getExpectedNestedTestProtoSchemaStringUserId();
     Struct result = new Struct(schema.schema());
@@ -341,6 +346,20 @@ public class ProtobufDataTest {
     inner.put("id", "");
     inner.put("ids", new ArrayList<>());
     result.put("inner", inner);
+    return result;
+  }
+
+  private Struct getExpectedEmptyNestedTestProtoResult() throws ParseException {
+    Schema schema = getExpectedNestedTestProtoSchema();
+    Struct result = new Struct(schema.schema());
+    result.put("is_active", false);
+
+    List<String> experiments = new ArrayList<>();
+    result.put("experiments_active", experiments);
+
+    result.put("status", 0);
+    result.put("map_type", new HashMap<>());
+
     return result;
   }
 
@@ -420,6 +439,18 @@ public class ProtobufDataTest {
     Schema expectedSchema = getExpectedNestedTestProtoSchemaIntUserId();
     assertSchemasEqual(expectedSchema, result.schema());
     Struct expected = getExpectedNestedTestProtoResultIntUserId();
+    assertSchemasEqual(expected.schema(), ((Struct) result.value()).schema());
+    assertEquals(expected.schema(), ((Struct) result.value()).schema());
+    assertEquals(expected, result.value());
+  }
+
+  @Test
+  public void testToConnectDataWithEmptyNestedProtobufMessage() throws Exception {
+    NestedMessage message = createEmptyNestedTestProto();
+    SchemaAndValue result = getSchemaAndValue(message);
+    Schema expectedSchema = getExpectedNestedTestProtoSchema();
+    assertSchemasEqual(expectedSchema, result.schema());
+    Struct expected = getExpectedEmptyNestedTestProtoResult();
     assertSchemasEqual(expected.schema(), ((Struct) result.value()).schema());
     assertEquals(expected.schema(), ((Struct) result.value()).schema());
     assertEquals(expected, result.value());
@@ -629,6 +660,16 @@ public class ProtobufDataTest {
   @Test
   public void testFromConnectDataWithNestedProtobufMessageAndIntUserId() throws Exception {
     NestedMessage nestedMessage = createNestedTestProtoIntUserId();
+    SchemaAndValue schemaAndValue = getSchemaAndValue(nestedMessage);
+    byte[] messageBytes = getMessageBytes(schemaAndValue);
+    Message message = NestedTestProto.NestedMessage.parseFrom(messageBytes);
+
+    assertArrayEquals(messageBytes, message.toByteArray());
+  }
+
+  @Test
+  public void testFromConnectDataWithEmptyNestedProtobufMessage() throws Exception {
+    NestedMessage nestedMessage = createEmptyNestedTestProto();
     SchemaAndValue schemaAndValue = getSchemaAndValue(nestedMessage);
     byte[] messageBytes = getMessageBytes(schemaAndValue);
     Message message = NestedTestProto.NestedMessage.parseFrom(messageBytes);

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
@@ -159,12 +159,6 @@ public class ProtobufDataTest {
     return message.build();
   }
 
-  private Map<String, String> getTestKeyValueMap() {
-    Map<String, String> result = new HashMap<>();
-    result.put("Hello", "World");
-    return result;
-  }
-
   private Schema getExpectedNestedTestProtoSchemaStringUserId() {
     return getExpectedNestedTestProtoSchema();
   }
@@ -289,6 +283,12 @@ public class ProtobufDataTest {
             .build()
     );
     return builder.build();
+  }
+
+  private Map<String, String> getTestKeyValueMap() {
+    Map<String, String> result = new HashMap<>();
+    result.put("Hello", "World");
+    return result;
   }
 
   private Struct getExpectedNestedProtoResultStringUserId() throws ParseException {

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
@@ -190,6 +190,11 @@ public class ProtobufDataTest {
         "id",
       SchemaBuilder.string().optional().parameter(PROTOBUF_TYPE_TAG, String.valueOf(1)).build()
     );
+    innerMessageBuilder.field(
+        "ids",
+        SchemaBuilder.array(SchemaBuilder.int32().optional().build())
+            .optional().parameter(PROTOBUF_TYPE_TAG, String.valueOf(2)).build()
+    );
     return innerMessageBuilder;
   }
 
@@ -305,6 +310,7 @@ public class ProtobufDataTest {
 
     Struct inner = new Struct(schema.field("inner").schema());
     inner.put("id", "");
+    inner.put("ids", new ArrayList<>());
     result.put("inner", inner);
     return result;
   }
@@ -333,6 +339,7 @@ public class ProtobufDataTest {
 
     Struct inner = new Struct(schema.field("inner").schema());
     inner.put("id", "");
+    inner.put("ids", new ArrayList<>());
     result.put("inner", inner);
     return result;
   }

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
@@ -697,10 +697,10 @@ public class ProtobufDataTest {
     assertEquals("string", fieldElem.getType());
     fieldElem = messageElem.getFields().get(10);
     assertEquals("map", fieldElem.getName());
-    assertEquals("ConnectDefault1.ConnectDefault2Entry", fieldElem.getType());
+    assertEquals("ConnectDefault2Entry", fieldElem.getType());
     fieldElem = messageElem.getFields().get(11);
     assertEquals("mapNonStringKeys", fieldElem.getName());
-    assertEquals("ConnectDefault1.ConnectDefault3Entry", fieldElem.getType());
+    assertEquals("ConnectDefault3Entry", fieldElem.getType());
 
     Descriptors.FieldDescriptor fieldDescriptor = message.getDescriptorForType()
         .findFieldByName("int8");

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -80,9 +80,10 @@ public class ProtobufSchema implements ParsedSchema {
 
   public static final String TYPE = "PROTOBUF";
 
+  public static final String SERIALIZED_FORMAT = "serialized";
+
   public static final String PROTO2 = "proto2";
   public static final String PROTO3 = "proto3";
-  public static final String PROTO_FORMAT = "proto";
 
   public static final String DEFAULT_NAME = "default";
   public static final String MAP_ENTRY_SUFFIX = "Entry";  // Suffix used by protoc
@@ -731,7 +732,7 @@ public class ProtobufSchema implements ParsedSchema {
 
   @Override
   public String formattedString(String format) {
-    if (PROTO_FORMAT.equals(format)) {
+    if (SERIALIZED_FORMAT.equals(format)) {
       FileDescriptorProto file = toDynamicSchema().getFileDescriptorProto();
       return base64Encoder.encodeToString(file.toByteArray());
     }

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -565,7 +565,7 @@ public class ProtobufSchema implements ParsedSchema {
       }
       for (TypeElement typeElem : rootElem.getTypes()) {
         if (typeElem instanceof MessageElement) {
-          MessageDefinition message = toDynamicMessage(schema, (MessageElement) typeElem);
+          MessageDefinition message = toDynamicMessage((MessageElement) typeElem);
           schema.addMessageDefinition(message);
         } else if (typeElem instanceof EnumElement) {
           EnumDefinition enumer = toDynamicEnum((EnumElement) typeElem);
@@ -609,14 +609,13 @@ public class ProtobufSchema implements ParsedSchema {
   }
 
   private static MessageDefinition toDynamicMessage(
-      DynamicSchema.Builder schema,
       MessageElement messageElem
   ) {
     log.trace("*** message: {}", messageElem.getName());
     MessageDefinition.Builder message = MessageDefinition.newBuilder(messageElem.getName());
     for (TypeElement type : messageElem.getNestedTypes()) {
       if (type instanceof MessageElement) {
-        message.addMessageDefinition(toDynamicMessage(schema, (MessageElement) type));
+        message.addMessageDefinition(toDynamicMessage((MessageElement) type));
       } else if (type instanceof EnumElement) {
         message.addEnumDefinition(toDynamicEnum((EnumElement) type));
       }

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -694,7 +694,7 @@ public class ProtobufSchema implements ParsedSchema {
     return message.build();
   }
 
-  private static Optional<OptionElement> findOption(String name, List<OptionElement> options) {
+  public static Optional<OptionElement> findOption(String name, List<OptionElement> options) {
     return options.stream().filter(o -> o.getName().equals(name)).findFirst();
   }
 

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -50,8 +50,6 @@ import kotlin.ranges.IntRange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
@@ -734,22 +732,10 @@ public class ProtobufSchema implements ParsedSchema {
   @Override
   public String formattedString(String format) {
     if (PROTO_FORMAT.equals(format)) {
-      return fileDescriptorProtoToString();
+      FileDescriptorProto file = toDynamicSchema().getFileDescriptorProto();
+      return base64Encoder.encodeToString(file.toByteArray());
     }
     throw new IllegalArgumentException("Unsupported format " + format);
-  }
-
-  private String fileDescriptorProtoToString() {
-    try {
-      ByteArrayOutputStream out = new ByteArrayOutputStream();
-      FileDescriptorProto file = toDynamicSchema().getFileDescriptorProto();
-      file.writeTo(out);
-      byte[] bytes = out.toByteArray();
-      out.close();
-      return base64Encoder.encodeToString(bytes);
-    } catch (IOException e) {
-      throw new IllegalStateException("Could not format protobuf", e);
-    }
   }
 
   public Integer version() {

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/diff/FieldSchemaDiff.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/diff/FieldSchemaDiff.java
@@ -38,11 +38,11 @@ public class FieldSchemaDiff {
   }
 
   static void compareTypes(final Context ctx, ProtoType original, ProtoType update) {
-    Optional<ProtoType> originalMap = ctx.getMap(original.simpleName(), true);
+    Optional<ProtoType> originalMap = ctx.getMap(original.getSimpleName(), true);
     if (originalMap.isPresent()) {
       original = originalMap.get();
     }
-    Optional<ProtoType> updateMap = ctx.getMap(update.simpleName(), false);
+    Optional<ProtoType> updateMap = ctx.getMap(update.getSimpleName(), false);
     if (updateMap.isPresent()) {
       update = updateMap.get();
     }
@@ -89,8 +89,8 @@ public class FieldSchemaDiff {
   }
 
   static void compareMapTypes(final Context ctx, final ProtoType original, final ProtoType update) {
-    compareTypes(ctx, original.keyType(), update.keyType());
-    compareTypes(ctx, original.valueType(), update.valueType());
+    compareTypes(ctx, original.getKeyType(), update.getKeyType());
+    compareTypes(ctx, original.getValueType(), update.getValueType());
   }
 
   static Kind kind(final Context ctx, ProtoType type, boolean isOriginal) {
@@ -99,7 +99,7 @@ public class FieldSchemaDiff {
     } else if (type.isMap()) {
       return Kind.MAP;
     } else {
-      if (ctx.containsEnum(type.simpleName(), isOriginal)) {
+      if (ctx.containsEnum(type.getSimpleName(), isOriginal)) {
         return Kind.SCALAR;
       }
       return Kind.NAMED;
@@ -112,7 +112,7 @@ public class FieldSchemaDiff {
 
   // Group the scalars, see https://developers.google.com/protocol-buffers/docs/proto3#updating
   static ScalarKind scalarKind(final Context ctx, ProtoType type, boolean isOriginal) {
-    if (ctx.containsEnum(type.simpleName(), isOriginal)) {
+    if (ctx.containsEnum(type.getSimpleName(), isOriginal)) {
       return ScalarKind.GENERAL_NUMBER;
     }
     switch (type.toString()) {

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/diff/FieldSchemaDiff.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/diff/FieldSchemaDiff.java
@@ -39,9 +39,13 @@ public class FieldSchemaDiff {
 
   static void compareTypes(final Context ctx, ProtoType original, ProtoType update) {
     Optional<ProtoType> originalMap = ctx.getMap(original.simpleName(), true);
-    if (originalMap.isPresent()) original = originalMap.get();
+    if (originalMap.isPresent()) {
+      original = originalMap.get();
+    }
     Optional<ProtoType> updateMap = ctx.getMap(update.simpleName(), false);
-    if (updateMap.isPresent()) update = updateMap.get();
+    if (updateMap.isPresent()) {
+      update = updateMap.get();
+    }
 
     Kind originalKind = kind(ctx, original, true);
     Kind updateKind = kind(ctx, update, false);

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/diff/FieldSchemaDiff.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/diff/FieldSchemaDiff.java
@@ -20,6 +20,7 @@ import com.squareup.wire.schema.ProtoType;
 import com.squareup.wire.schema.internal.parser.FieldElement;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static io.confluent.kafka.schemaregistry.protobuf.diff.Difference.Type.FIELD_KIND_CHANGED;
 import static io.confluent.kafka.schemaregistry.protobuf.diff.Difference.Type.FIELD_NAMED_TYPE_CHANGED;
@@ -36,7 +37,12 @@ public class FieldSchemaDiff {
     compareTypes(ctx, originalType, updateType);
   }
 
-  static void compareTypes(final Context ctx, final ProtoType original, final ProtoType update) {
+  static void compareTypes(final Context ctx, ProtoType original, ProtoType update) {
+    Optional<ProtoType> originalMap = ctx.getMap(original.simpleName(), true);
+    if (originalMap.isPresent()) original = originalMap.get();
+    Optional<ProtoType> updateMap = ctx.getMap(update.simpleName(), false);
+    if (updateMap.isPresent()) update = updateMap.get();
+
     Kind originalKind = kind(ctx, original, true);
     Kind updateKind = kind(ctx, update, false);
     if (!Objects.equals(originalKind, updateKind)) {

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/dynamic/DynamicSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/dynamic/DynamicSchema.java
@@ -90,6 +90,15 @@ public class DynamicSchema {
   // --- public ---
 
   /**
+   * Gets the protobuf file descriptor proto
+   *
+   * @return the file descriptor proto
+   */
+  public FileDescriptorProto getFileDescriptorProto() {
+    return mFileDescSet.getFile(0);
+  }
+
+  /**
    * Creates a new dynamic message builder for the given message type
    *
    * @param msgTypeName the message type name

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -27,9 +27,14 @@ import com.squareup.wire.schema.internal.parser.ProtoFileElement;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import io.confluent.kafka.schemaregistry.CompatibilityLevel;
+import io.confluent.kafka.schemaregistry.protobuf.diff.Difference;
 import io.confluent.kafka.schemaregistry.protobuf.diff.ResourceLoader;
+import io.confluent.kafka.schemaregistry.protobuf.diff.SchemaDiff;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -372,16 +377,24 @@ public class ProtobufSchemaTest {
     ProtobufSchema schema = new ProtobufSchema(original.toSchema());
     String fileProto = schema.formattedString(ProtobufSchema.PROTO_FORMAT);
     ProtobufSchema schema2 = new ProtobufSchema(fileProto);
+    assertTrue(schema.isCompatible(
+        CompatibilityLevel.BACKWARD, Collections.singletonList(schema2)));
     fileProto = schema2.formattedString(ProtobufSchema.PROTO_FORMAT);
     ProtobufSchema schema3 = new ProtobufSchema(fileProto);
+    assertTrue(schema2.isCompatible(
+        CompatibilityLevel.BACKWARD, Collections.singletonList(schema3)));
     assertEquals(schema2, schema3);
 
     original = resourceLoader.readObj("NestedTestProto.proto");
     schema = new ProtobufSchema(original.toSchema());
     fileProto = schema.formattedString(ProtobufSchema.PROTO_FORMAT);
     schema2 = new ProtobufSchema(fileProto);
+    assertTrue(schema.isCompatible(
+        CompatibilityLevel.BACKWARD, Collections.singletonList(schema2)));
     fileProto = schema2.formattedString(ProtobufSchema.PROTO_FORMAT);
     schema3 = new ProtobufSchema(fileProto);
+    assertTrue(schema2.isCompatible(
+        CompatibilityLevel.BACKWARD, Collections.singletonList(schema3)));
     assertEquals(schema2, schema3);
   }
 

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -23,10 +23,13 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.DynamicMessage;
+import com.squareup.wire.schema.internal.parser.ProtoFileElement;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
+
+import io.confluent.kafka.schemaregistry.protobuf.diff.ResourceLoader;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -358,6 +361,28 @@ public class ProtobufSchemaTest {
     assertEquals("one", fieldNode.get("first").asText());
     assertNotNull(fieldNode.get("second"));
     assertEquals("two", fieldNode.get("second").asText());
+  }
+
+  @Test
+  public void testFileDescriptorProto() throws Exception {
+    ResourceLoader resourceLoader = new ResourceLoader(
+        "/io/confluent/kafka/schemaregistry/protobuf/diff/");
+
+    ProtoFileElement original = resourceLoader.readObj("TestProto.proto");
+    ProtobufSchema schema = new ProtobufSchema(original.toSchema());
+    String fileProto = schema.formattedString(ProtobufSchema.PROTO_FORMAT);
+    ProtobufSchema schema2 = new ProtobufSchema(fileProto);
+    fileProto = schema2.formattedString(ProtobufSchema.PROTO_FORMAT);
+    ProtobufSchema schema3 = new ProtobufSchema(fileProto);
+    assertEquals(schema2, schema3);
+
+    original = resourceLoader.readObj("NestedTestProto.proto");
+    schema = new ProtobufSchema(original.toSchema());
+    fileProto = schema.formattedString(ProtobufSchema.PROTO_FORMAT);
+    schema2 = new ProtobufSchema(fileProto);
+    fileProto = schema2.formattedString(ProtobufSchema.PROTO_FORMAT);
+    schema3 = new ProtobufSchema(fileProto);
+    assertEquals(schema2, schema3);
   }
 
   private static JsonNode jsonTree(String jsonData) {

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -24,6 +24,7 @@ import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.DynamicMessage;
 import com.squareup.wire.schema.internal.parser.ProtoFileElement;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -334,7 +335,7 @@ public class ProtobufSchemaTest {
 
   @Test
   public void testMapToJson() throws Exception {
-    DynamicMessage.Builder mapBuilder = mapSchema.newMessageBuilder("TestMapEntry");
+    DynamicMessage.Builder mapBuilder = mapSchema.newMessageBuilder("TestMap.TestMapEntry");
     Descriptor mapDesc = mapBuilder.getDescriptorForType();
     FieldDescriptor keyField = mapDesc.findFieldByName("key");
     mapBuilder.setField(keyField, "first");
@@ -342,7 +343,7 @@ public class ProtobufSchemaTest {
     mapBuilder.setField(valueField, "one");
     DynamicMessage mapEntry = mapBuilder.build();
 
-    DynamicMessage.Builder mapBuilder2 = mapSchema.newMessageBuilder("TestMapEntry");
+    DynamicMessage.Builder mapBuilder2 = mapSchema.newMessageBuilder("TestMap.TestMapEntry");
     Descriptor mapDesc2 = mapBuilder2.getDescriptorForType();
     FieldDescriptor keyField2 = mapDesc2.findFieldByName("key");
     mapBuilder2.setField(keyField2, "second");

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -29,12 +29,9 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import io.confluent.kafka.schemaregistry.CompatibilityLevel;
-import io.confluent.kafka.schemaregistry.protobuf.diff.Difference;
 import io.confluent.kafka.schemaregistry.protobuf.diff.ResourceLoader;
-import io.confluent.kafka.schemaregistry.protobuf.diff.SchemaDiff;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -24,7 +24,6 @@ import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.DynamicMessage;
 import com.squareup.wire.schema.internal.parser.ProtoFileElement;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -373,11 +372,11 @@ public class ProtobufSchemaTest {
 
     ProtoFileElement original = resourceLoader.readObj("TestProto.proto");
     ProtobufSchema schema = new ProtobufSchema(original.toSchema());
-    String fileProto = schema.formattedString(ProtobufSchema.PROTO_FORMAT);
+    String fileProto = schema.formattedString(ProtobufSchema.SERIALIZED_FORMAT);
     ProtobufSchema schema2 = new ProtobufSchema(fileProto);
     assertTrue(schema.isCompatible(
         CompatibilityLevel.BACKWARD, Collections.singletonList(schema2)));
-    fileProto = schema2.formattedString(ProtobufSchema.PROTO_FORMAT);
+    fileProto = schema2.formattedString(ProtobufSchema.SERIALIZED_FORMAT);
     ProtobufSchema schema3 = new ProtobufSchema(fileProto);
     assertTrue(schema2.isCompatible(
         CompatibilityLevel.BACKWARD, Collections.singletonList(schema3)));
@@ -385,11 +384,11 @@ public class ProtobufSchemaTest {
 
     original = resourceLoader.readObj("NestedTestProto.proto");
     schema = new ProtobufSchema(original.toSchema());
-    fileProto = schema.formattedString(ProtobufSchema.PROTO_FORMAT);
+    fileProto = schema.formattedString(ProtobufSchema.SERIALIZED_FORMAT);
     schema2 = new ProtobufSchema(fileProto);
     assertTrue(schema.isCompatible(
         CompatibilityLevel.BACKWARD, Collections.singletonList(schema2)));
-    fileProto = schema2.formattedString(ProtobufSchema.PROTO_FORMAT);
+    fileProto = schema2.formattedString(ProtobufSchema.SERIALIZED_FORMAT);
     schema3 = new ProtobufSchema(fileProto);
     assertTrue(schema2.isCompatible(
         CompatibilityLevel.BACKWARD, Collections.singletonList(schema3)));

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/diff/ResourceLoader.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/diff/ResourceLoader.java
@@ -39,7 +39,7 @@ public class ResourceLoader {
   @SuppressWarnings("unchecked")
   public ProtoFileElement readObj(String relPath) throws IOException {
     String data = toString(relPath);
-    return ProtoParser.parse(Location.get("unknown"), data);
+    return ProtoParser.Companion.parse(Location.get("unknown"), data);
   }
 
   public String toString(String relPath) {

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/diff/SchemaDiffTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/diff/SchemaDiffTest.java
@@ -48,8 +48,10 @@ public class SchemaDiffTest {
       final ObjectNode testCase = (ObjectNode) nodes.get(i);
       String originalSchema = testCase.get("original_schema").asText();
       String updateSchema = testCase.get("update_schema").asText();
-      ProtoFileElement original = ProtoParser.parse(Location.get("unknown"), originalSchema);
-      ProtoFileElement update = ProtoParser.parse(Location.get("unknown"), updateSchema);
+      ProtoFileElement original = ProtoParser.Companion.parse(
+          Location.get("unknown"), originalSchema);
+      ProtoFileElement update = ProtoParser.Companion.parse(
+          Location.get("unknown"), updateSchema);
       final ArrayNode changes = (ArrayNode) testCase.get("changes");
       boolean isCompatible = testCase.get("compatible").asBoolean();
       final List<String> errorMessages = new ArrayList<>();

--- a/protobuf-provider/src/test/resources/io/confluent/kafka/schemaregistry/protobuf/diff/NestedTestProto.proto
+++ b/protobuf-provider/src/test/resources/io/confluent/kafka/schemaregistry/protobuf/diff/NestedTestProto.proto
@@ -4,6 +4,7 @@ package io.confluent.kafka.serializers.protobuf.test;
 
 option java_package = "io.confluent.kafka.serializers.protobuf.test";
 option java_outer_classname = "NestedTestProto";
+option java_multiple_files = false;
 
 message UserId {
     oneof user_id {
@@ -44,6 +45,16 @@ message NestedMessage {
     InnerMessage inner = 8;
 
     message InnerMessage {
-        string id = 1;
+        string id = 1 [json_name="id"];
+        repeated int32 ids = 2 [packed=true];
     }
+
+    enum InnerEnum {
+        option allow_alias = true;
+        ZERO = 0;
+        ONE = 1;
+    }
+
+    reserved 14, 15, 9 to 11;
+    reserved "foo", "bar";
 }

--- a/protobuf-provider/src/test/resources/io/confluent/kafka/schemaregistry/protobuf/diff/NestedTestProto.proto
+++ b/protobuf-provider/src/test/resources/io/confluent/kafka/schemaregistry/protobuf/diff/NestedTestProto.proto
@@ -52,7 +52,7 @@ message NestedMessage {
     enum InnerEnum {
         option allow_alias = true;
         ZERO = 0;
-        ONE = 1;
+        ALSO_ZERO = 0;
     }
 
     reserved 14, 15, 9 to 11;

--- a/protobuf-provider/src/test/resources/io/confluent/kafka/schemaregistry/protobuf/diff/NestedTestProto.proto
+++ b/protobuf-provider/src/test/resources/io/confluent/kafka/schemaregistry/protobuf/diff/NestedTestProto.proto
@@ -1,0 +1,49 @@
+syntax = "proto3";
+
+package io.confluent.kafka.serializers.protobuf.test;
+
+option java_package = "io.confluent.kafka.serializers.protobuf.test";
+option java_outer_classname = "NestedTestProto";
+
+message UserId {
+    oneof user_id {
+        string kafka_user_id = 1;
+        int32 other_user_id = 2;
+        MessageId another_id = 3;
+    }
+}
+
+message MessageId {
+    string id = 1;
+}
+
+enum Status {
+    ACTIVE = 0;
+    INACTIVE = 1;
+}
+
+message ComplexType {
+    oneof some_val {
+        string one_id = 1;
+        int32 other_id = 2;
+    }
+    bool is_active = 3;
+}
+
+/*
+ * Complex message using nested protos and repeated fields
+ */
+message NestedMessage {
+    UserId user_id = 1;
+    bool is_active = 2;
+    repeated string experiments_active = 3;
+    int64 updated_at = 4;
+    Status status = 5;
+    ComplexType complex_type = 6;
+    map<string, string> map_type = 7;
+    InnerMessage inner = 8;
+
+    message InnerMessage {
+        string id = 1;
+    }
+}

--- a/protobuf-serializer/src/test/java/io/confluent/kafka/serializers/protobuf/test/NestedTestProto.java
+++ b/protobuf-serializer/src/test/java/io/confluent/kafka/serializers/protobuf/test/NestedTestProto.java
@@ -2794,21 +2794,143 @@ public final class NestedTestProto {
               io.confluent.kafka.serializers.protobuf.test.NestedTestProto.NestedMessage.class, io.confluent.kafka.serializers.protobuf.test.NestedTestProto.NestedMessage.Builder.class);
     }
 
+    /**
+     * Protobuf enum {@code io.confluent.kafka.serializers.protobuf.test.NestedMessage.InnerEnum}
+     */
+    public enum InnerEnum
+        implements com.google.protobuf.ProtocolMessageEnum {
+      /**
+       * <code>ZERO = 0;</code>
+       */
+      ZERO(0),
+      UNRECOGNIZED(-1),
+      ;
+
+      /**
+       * <code>ALSO_ZERO = 0;</code>
+       */
+      public static final InnerEnum ALSO_ZERO = ZERO;
+      /**
+       * <code>ZERO = 0;</code>
+       */
+      public static final int ZERO_VALUE = 0;
+      /**
+       * <code>ALSO_ZERO = 0;</code>
+       */
+      public static final int ALSO_ZERO_VALUE = 0;
+
+
+      public final int getNumber() {
+        if (this == UNRECOGNIZED) {
+          throw new java.lang.IllegalArgumentException(
+              "Can't get the number of an unknown enum value.");
+        }
+        return value;
+      }
+
+      /**
+       * @param value The numeric wire value of the corresponding enum entry.
+       * @return The enum associated with the given numeric wire value.
+       * @deprecated Use {@link #forNumber(int)} instead.
+       */
+      @java.lang.Deprecated
+      public static InnerEnum valueOf(int value) {
+        return forNumber(value);
+      }
+
+      /**
+       * @param value The numeric wire value of the corresponding enum entry.
+       * @return The enum associated with the given numeric wire value.
+       */
+      public static InnerEnum forNumber(int value) {
+        switch (value) {
+          case 0: return ZERO;
+          default: return null;
+        }
+      }
+
+      public static com.google.protobuf.Internal.EnumLiteMap<InnerEnum>
+          internalGetValueMap() {
+        return internalValueMap;
+      }
+      private static final com.google.protobuf.Internal.EnumLiteMap<
+          InnerEnum> internalValueMap =
+            new com.google.protobuf.Internal.EnumLiteMap<InnerEnum>() {
+              public InnerEnum findValueByNumber(int number) {
+                return InnerEnum.forNumber(number);
+              }
+            };
+
+      public final com.google.protobuf.Descriptors.EnumValueDescriptor
+          getValueDescriptor() {
+        return getDescriptor().getValues().get(ordinal());
+      }
+      public final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptorForType() {
+        return getDescriptor();
+      }
+      public static final com.google.protobuf.Descriptors.EnumDescriptor
+          getDescriptor() {
+        return io.confluent.kafka.serializers.protobuf.test.NestedTestProto.NestedMessage.getDescriptor().getEnumTypes().get(0);
+      }
+
+      private static final InnerEnum[] VALUES = {
+        ZERO, ALSO_ZERO, 
+      };
+
+      public static InnerEnum valueOf(
+          com.google.protobuf.Descriptors.EnumValueDescriptor desc) {
+        if (desc.getType() != getDescriptor()) {
+          throw new java.lang.IllegalArgumentException(
+            "EnumValueDescriptor is not for this type.");
+        }
+        if (desc.getIndex() == -1) {
+          return UNRECOGNIZED;
+        }
+        return VALUES[desc.getIndex()];
+      }
+
+      private final int value;
+
+      private InnerEnum(int value) {
+        this.value = value;
+      }
+
+      // @@protoc_insertion_point(enum_scope:io.confluent.kafka.serializers.protobuf.test.NestedMessage.InnerEnum)
+    }
+
     public interface InnerMessageOrBuilder extends
         // @@protoc_insertion_point(interface_extends:io.confluent.kafka.serializers.protobuf.test.NestedMessage.InnerMessage)
         com.google.protobuf.MessageOrBuilder {
 
       /**
-       * <code>string id = 1;</code>
+       * <code>string id = 1[json_name = "id"];</code>
        * @return The id.
        */
       java.lang.String getId();
       /**
-       * <code>string id = 1;</code>
+       * <code>string id = 1[json_name = "id"];</code>
        * @return The bytes for id.
        */
       com.google.protobuf.ByteString
           getIdBytes();
+
+      /**
+       * <code>repeated int32 ids = 2 [packed = true];</code>
+       * @return A list containing the ids.
+       */
+      java.util.List<java.lang.Integer> getIdsList();
+      /**
+       * <code>repeated int32 ids = 2 [packed = true];</code>
+       * @return The count of ids.
+       */
+      int getIdsCount();
+      /**
+       * <code>repeated int32 ids = 2 [packed = true];</code>
+       * @param index The index of the element to return.
+       * @return The ids at the given index.
+       */
+      int getIds(int index);
     }
     /**
      * Protobuf type {@code io.confluent.kafka.serializers.protobuf.test.NestedMessage.InnerMessage}
@@ -2824,6 +2946,7 @@ public final class NestedTestProto {
       }
       private InnerMessage() {
         id_ = "";
+        ids_ = emptyIntList();
       }
 
       @java.lang.Override
@@ -2846,6 +2969,7 @@ public final class NestedTestProto {
         if (extensionRegistry == null) {
           throw new java.lang.NullPointerException();
         }
+        int mutable_bitField0_ = 0;
         com.google.protobuf.UnknownFieldSet.Builder unknownFields =
             com.google.protobuf.UnknownFieldSet.newBuilder();
         try {
@@ -2860,6 +2984,27 @@ public final class NestedTestProto {
                 java.lang.String s = input.readStringRequireUtf8();
 
                 id_ = s;
+                break;
+              }
+              case 16: {
+                if (!((mutable_bitField0_ & 0x00000001) != 0)) {
+                  ids_ = newIntList();
+                  mutable_bitField0_ |= 0x00000001;
+                }
+                ids_.addInt(input.readInt32());
+                break;
+              }
+              case 18: {
+                int length = input.readRawVarint32();
+                int limit = input.pushLimit(length);
+                if (!((mutable_bitField0_ & 0x00000001) != 0) && input.getBytesUntilLimit() > 0) {
+                  ids_ = newIntList();
+                  mutable_bitField0_ |= 0x00000001;
+                }
+                while (input.getBytesUntilLimit() > 0) {
+                  ids_.addInt(input.readInt32());
+                }
+                input.popLimit(limit);
                 break;
               }
               default: {
@@ -2877,6 +3022,9 @@ public final class NestedTestProto {
           throw new com.google.protobuf.InvalidProtocolBufferException(
               e).setUnfinishedMessage(this);
         } finally {
+          if (((mutable_bitField0_ & 0x00000001) != 0)) {
+            ids_.makeImmutable(); // C
+          }
           this.unknownFields = unknownFields.build();
           makeExtensionsImmutable();
         }
@@ -2897,7 +3045,7 @@ public final class NestedTestProto {
       public static final int ID_FIELD_NUMBER = 1;
       private volatile java.lang.Object id_;
       /**
-       * <code>string id = 1;</code>
+       * <code>string id = 1[json_name = "id"];</code>
        * @return The id.
        */
       public java.lang.String getId() {
@@ -2913,7 +3061,7 @@ public final class NestedTestProto {
         }
       }
       /**
-       * <code>string id = 1;</code>
+       * <code>string id = 1[json_name = "id"];</code>
        * @return The bytes for id.
        */
       public com.google.protobuf.ByteString
@@ -2930,6 +3078,33 @@ public final class NestedTestProto {
         }
       }
 
+      public static final int IDS_FIELD_NUMBER = 2;
+      private com.google.protobuf.Internal.IntList ids_;
+      /**
+       * <code>repeated int32 ids = 2 [packed = true];</code>
+       * @return A list containing the ids.
+       */
+      public java.util.List<java.lang.Integer>
+          getIdsList() {
+        return ids_;
+      }
+      /**
+       * <code>repeated int32 ids = 2 [packed = true];</code>
+       * @return The count of ids.
+       */
+      public int getIdsCount() {
+        return ids_.size();
+      }
+      /**
+       * <code>repeated int32 ids = 2 [packed = true];</code>
+       * @param index The index of the element to return.
+       * @return The ids at the given index.
+       */
+      public int getIds(int index) {
+        return ids_.getInt(index);
+      }
+      private int idsMemoizedSerializedSize = -1;
+
       private byte memoizedIsInitialized = -1;
       @java.lang.Override
       public final boolean isInitialized() {
@@ -2944,8 +3119,16 @@ public final class NestedTestProto {
       @java.lang.Override
       public void writeTo(com.google.protobuf.CodedOutputStream output)
                           throws java.io.IOException {
+        getSerializedSize();
         if (!getIdBytes().isEmpty()) {
           com.google.protobuf.GeneratedMessageV3.writeString(output, 1, id_);
+        }
+        if (getIdsList().size() > 0) {
+          output.writeUInt32NoTag(18);
+          output.writeUInt32NoTag(idsMemoizedSerializedSize);
+        }
+        for (int i = 0; i < ids_.size(); i++) {
+          output.writeInt32NoTag(ids_.getInt(i));
         }
         unknownFields.writeTo(output);
       }
@@ -2958,6 +3141,20 @@ public final class NestedTestProto {
         size = 0;
         if (!getIdBytes().isEmpty()) {
           size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, id_);
+        }
+        {
+          int dataSize = 0;
+          for (int i = 0; i < ids_.size(); i++) {
+            dataSize += com.google.protobuf.CodedOutputStream
+              .computeInt32SizeNoTag(ids_.getInt(i));
+          }
+          size += dataSize;
+          if (!getIdsList().isEmpty()) {
+            size += 1;
+            size += com.google.protobuf.CodedOutputStream
+                .computeInt32SizeNoTag(dataSize);
+          }
+          idsMemoizedSerializedSize = dataSize;
         }
         size += unknownFields.getSerializedSize();
         memoizedSize = size;
@@ -2976,6 +3173,8 @@ public final class NestedTestProto {
 
         if (!getId()
             .equals(other.getId())) return false;
+        if (!getIdsList()
+            .equals(other.getIdsList())) return false;
         if (!unknownFields.equals(other.unknownFields)) return false;
         return true;
       }
@@ -2989,6 +3188,10 @@ public final class NestedTestProto {
         hash = (19 * hash) + getDescriptor().hashCode();
         hash = (37 * hash) + ID_FIELD_NUMBER;
         hash = (53 * hash) + getId().hashCode();
+        if (getIdsCount() > 0) {
+          hash = (37 * hash) + IDS_FIELD_NUMBER;
+          hash = (53 * hash) + getIdsList().hashCode();
+        }
         hash = (29 * hash) + unknownFields.hashCode();
         memoizedHashCode = hash;
         return hash;
@@ -3124,6 +3327,8 @@ public final class NestedTestProto {
           super.clear();
           id_ = "";
 
+          ids_ = emptyIntList();
+          bitField0_ = (bitField0_ & ~0x00000001);
           return this;
         }
 
@@ -3150,7 +3355,13 @@ public final class NestedTestProto {
         @java.lang.Override
         public io.confluent.kafka.serializers.protobuf.test.NestedTestProto.NestedMessage.InnerMessage buildPartial() {
           io.confluent.kafka.serializers.protobuf.test.NestedTestProto.NestedMessage.InnerMessage result = new io.confluent.kafka.serializers.protobuf.test.NestedTestProto.NestedMessage.InnerMessage(this);
+          int from_bitField0_ = bitField0_;
           result.id_ = id_;
+          if (((bitField0_ & 0x00000001) != 0)) {
+            ids_.makeImmutable();
+            bitField0_ = (bitField0_ & ~0x00000001);
+          }
+          result.ids_ = ids_;
           onBuilt();
           return result;
         }
@@ -3203,6 +3414,16 @@ public final class NestedTestProto {
             id_ = other.id_;
             onChanged();
           }
+          if (!other.ids_.isEmpty()) {
+            if (ids_.isEmpty()) {
+              ids_ = other.ids_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+            } else {
+              ensureIdsIsMutable();
+              ids_.addAll(other.ids_);
+            }
+            onChanged();
+          }
           this.mergeUnknownFields(other.unknownFields);
           onChanged();
           return this;
@@ -3231,10 +3452,11 @@ public final class NestedTestProto {
           }
           return this;
         }
+        private int bitField0_;
 
         private java.lang.Object id_ = "";
         /**
-         * <code>string id = 1;</code>
+         * <code>string id = 1[json_name = "id"];</code>
          * @return The id.
          */
         public java.lang.String getId() {
@@ -3250,7 +3472,7 @@ public final class NestedTestProto {
           }
         }
         /**
-         * <code>string id = 1;</code>
+         * <code>string id = 1[json_name = "id"];</code>
          * @return The bytes for id.
          */
         public com.google.protobuf.ByteString
@@ -3267,7 +3489,7 @@ public final class NestedTestProto {
           }
         }
         /**
-         * <code>string id = 1;</code>
+         * <code>string id = 1[json_name = "id"];</code>
          * @param value The id to set.
          * @return This builder for chaining.
          */
@@ -3282,7 +3504,7 @@ public final class NestedTestProto {
           return this;
         }
         /**
-         * <code>string id = 1;</code>
+         * <code>string id = 1[json_name = "id"];</code>
          * @return This builder for chaining.
          */
         public Builder clearId() {
@@ -3292,7 +3514,7 @@ public final class NestedTestProto {
           return this;
         }
         /**
-         * <code>string id = 1;</code>
+         * <code>string id = 1[json_name = "id"];</code>
          * @param value The bytes for id to set.
          * @return This builder for chaining.
          */
@@ -3304,6 +3526,85 @@ public final class NestedTestProto {
   checkByteStringIsUtf8(value);
           
           id_ = value;
+          onChanged();
+          return this;
+        }
+
+        private com.google.protobuf.Internal.IntList ids_ = emptyIntList();
+        private void ensureIdsIsMutable() {
+          if (!((bitField0_ & 0x00000001) != 0)) {
+            ids_ = mutableCopy(ids_);
+            bitField0_ |= 0x00000001;
+           }
+        }
+        /**
+         * <code>repeated int32 ids = 2 [packed = true];</code>
+         * @return A list containing the ids.
+         */
+        public java.util.List<java.lang.Integer>
+            getIdsList() {
+          return ((bitField0_ & 0x00000001) != 0) ?
+                   java.util.Collections.unmodifiableList(ids_) : ids_;
+        }
+        /**
+         * <code>repeated int32 ids = 2 [packed = true];</code>
+         * @return The count of ids.
+         */
+        public int getIdsCount() {
+          return ids_.size();
+        }
+        /**
+         * <code>repeated int32 ids = 2 [packed = true];</code>
+         * @param index The index of the element to return.
+         * @return The ids at the given index.
+         */
+        public int getIds(int index) {
+          return ids_.getInt(index);
+        }
+        /**
+         * <code>repeated int32 ids = 2 [packed = true];</code>
+         * @param index The index to set the value at.
+         * @param value The ids to set.
+         * @return This builder for chaining.
+         */
+        public Builder setIds(
+            int index, int value) {
+          ensureIdsIsMutable();
+          ids_.setInt(index, value);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated int32 ids = 2 [packed = true];</code>
+         * @param value The ids to add.
+         * @return This builder for chaining.
+         */
+        public Builder addIds(int value) {
+          ensureIdsIsMutable();
+          ids_.addInt(value);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated int32 ids = 2 [packed = true];</code>
+         * @param values The ids to add.
+         * @return This builder for chaining.
+         */
+        public Builder addAllIds(
+            java.lang.Iterable<? extends java.lang.Integer> values) {
+          ensureIdsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, ids_);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated int32 ids = 2 [packed = true];</code>
+         * @return This builder for chaining.
+         */
+        public Builder clearIds() {
+          ids_ = emptyIntList();
+          bitField0_ = (bitField0_ & ~0x00000001);
           onChanged();
           return this;
         }
@@ -5011,7 +5312,7 @@ public final class NestedTestProto {
       "H\000B\t\n\007user_id\"\027\n\tMessageId\022\n\n\002id\030\001 \001(\t\"R" +
       "\n\013ComplexType\022\020\n\006one_id\030\001 \001(\tH\000\022\022\n\010other" +
       "_id\030\002 \001(\005H\000\022\021\n\tis_active\030\003 \001(\010B\n\n\010some_v" +
-      "al\"\315\004\n\rNestedMessage\022E\n\007user_id\030\001 \001(\01324." +
+      "al\"\250\005\n\rNestedMessage\022E\n\007user_id\030\001 \001(\01324." +
       "io.confluent.kafka.serializers.protobuf." +
       "test.UserId\022\021\n\tis_active\030\002 \001(\010\022\032\n\022experi" +
       "ments_active\030\003 \003(\t\022.\n\nupdated_at\030\004 \001(\0132\032" +
@@ -5025,10 +5326,12 @@ public final class NestedTestProto {
       " \001(\0132H.io.confluent.kafka.serializers.pr" +
       "otobuf.test.NestedMessage.InnerMessage\032." +
       "\n\014MapTypeEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001" +
-      "(\t:\0028\001\032\032\n\014InnerMessage\022\n\n\002id\030\001 \001(\t*\"\n\006St" +
-      "atus\022\n\n\006ACTIVE\020\000\022\014\n\010INACTIVE\020\001B?\n,io.con" +
-      "fluent.kafka.serializers.protobuf.testB\017" +
-      "NestedTestProtob\006proto3"
+      "(\t:\0028\001\032/\n\014InnerMessage\022\016\n\002id\030\001 \001(\tR\002id\022\017" +
+      "\n\003ids\030\002 \003(\005B\002\020\001\"(\n\tInnerEnum\022\010\n\004ZERO\020\000\022\r" +
+      "\n\tALSO_ZERO\020\000\032\002\020\001J\004\010\016\020\017J\004\010\017\020\020J\004\010\t\020\014R\003foo" +
+      "R\003bar*\"\n\006Status\022\n\n\006ACTIVE\020\000\022\014\n\010INACTIVE\020" +
+      "\001BA\n,io.confluent.kafka.serializers.prot" +
+      "obuf.testB\017NestedTestProtoP\000b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -5070,7 +5373,7 @@ public final class NestedTestProto {
     internal_static_io_confluent_kafka_serializers_protobuf_test_NestedMessage_InnerMessage_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_io_confluent_kafka_serializers_protobuf_test_NestedMessage_InnerMessage_descriptor,
-        new java.lang.String[] { "Id", });
+        new java.lang.String[] { "Id", "Ids", });
     com.google.protobuf.TimestampProto.getDescriptor();
   }
 

--- a/protobuf-serializer/src/test/proto/NestedTestProto.proto
+++ b/protobuf-serializer/src/test/proto/NestedTestProto.proto
@@ -6,6 +6,7 @@ package io.confluent.kafka.serializers.protobuf.test;
 
 option java_package = "io.confluent.kafka.serializers.protobuf.test";
 option java_outer_classname = "NestedTestProto";
+option java_multiple_files = false;
 
 message UserId {
     oneof user_id {
@@ -46,6 +47,16 @@ message NestedMessage {
     InnerMessage inner = 8;
 
     message InnerMessage {
-        string id = 1;
+        string id = 1 [json_name="id"];
+        repeated int32 ids = 2 [packed=true];
     }
+
+    enum InnerEnum {
+        option allow_alias = true;
+        ZERO = 0;
+        ONE = 1;
+    }
+
+    reserved 14, 15, 9 to 11;
+    reserved "foo", "bar";
 }

--- a/protobuf-serializer/src/test/proto/NestedTestProto.proto
+++ b/protobuf-serializer/src/test/proto/NestedTestProto.proto
@@ -54,7 +54,7 @@ message NestedMessage {
     enum InnerEnum {
         option allow_alias = true;
         ZERO = 0;
-        ONE = 1;
+        ALSO_ZERO = 0;
     }
 
     reserved 14, 15, 9 to 11;


### PR DESCRIPTION
- Generate map entry messages as nested messages
- Ensure map_entry option is preserved
- Fix compatibility check for generated map entry message
- Support reading base64-encoded FileDescriptorProto
- Expand NestedTestProto example with more Protobuf features
- Add unit tests for empty messages for ProtobufConverter
- Upgrade square wire to 3.0.3
- Add support for /schemas/ids/{id}?format=serialized for Protobuf