### PR TITLE
Handle null schemaValues during schemaTombstoned

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
@@ -138,6 +138,9 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
 
   @Override
   public void schemaTombstoned(SchemaKey schemaKey, SchemaValue schemaValue) {
+    if (schemaValue == null) {
+      return;
+    }
     Map<String, Integer> subjectVersions = guidToSubjectVersions.get(schemaValue.getId());
     if (subjectVersions == null || subjectVersions.isEmpty()) {
       return;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupCache.java
@@ -79,7 +79,7 @@ public interface LookupCache<K,V> extends Store<K,V> {
    * Callback that is invoked when a schema is tombstoned.
    *
    * @param schemaKey   the tombstoned SchemaKey; never {@code null}
-   * @param schemaValue the tombstoned SchemaValue; never {@code null}
+   * @param schemaValue the tombstoned SchemaValue
    */
   void schemaTombstoned(SchemaKey schemaKey, SchemaValue schemaValue);
 


### PR DESCRIPTION
'schemaValue' can be null in invocations to LookupCache.schemaTombstoned, causing a NPE and taking down the SR. This PR addresses this scenario.