### PR TITLE
API update for Jetty 9.4.26.v20200117

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/JsonErrorHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/JsonErrorHandler.java
@@ -51,7 +51,7 @@ public class JsonErrorHandler extends ErrorHandler {
         .getStatus(), reason);
 
     baseRequest.setHandled(true);
-    baseRequest.getResponse().closeOutput();
+    baseRequest.getResponse().completeOutput();
   }
 
   @Override


### PR DESCRIPTION
There was a minor API renaming in recent versions of Jetty.