### PR TITLE
Update Metadata::bootstrap signature

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/KafkaGroupMasterElector.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/KafkaGroupMasterElector.java
@@ -120,7 +120,7 @@ public class KafkaGroupMasterElector implements MasterElector, SchemaRegistryReb
           = config.getList(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG);
       List<InetSocketAddress> addresses = ClientUtils.parseAndValidateAddresses(bootstrapServers,
           clientConfig.getString(CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG));
-      this.metadata.bootstrap(addresses, time.milliseconds());
+      this.metadata.bootstrap(addresses);
       String metricGrpPrefix = "kafka.schema.registry";
 
       ChannelBuilder channelBuilder = ClientUtils.createChannelBuilder(clientConfig, time);


### PR DESCRIPTION
Recent merge of AK -> CCS 5.4 updates the api to not take timestamp.
This change updates the code to do same. The same code is present in
master, so this follows same pattern.