### PR TITLE
MINOR: Add support for primitive Avro Serde

### DIFF
--- a/avro-converter/pom.xml
+++ b/avro-converter/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/avro-data/pom.xml
+++ b/avro-data/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/avro-serde/pom.xml
+++ b/avro-serde/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/PrimitiveAvroSerde.java
+++ b/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/PrimitiveAvroSerde.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package io.confluent.kafka.streams.serdes.avro;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.util.Map;
+
+/**
+ * A schema-registry aware serde (serializer/deserializer) for Apache Kafka's Streams API that can
+ * be used for reading and writing data of Avro primitive types.  This serde's "specific Avro"
+ * counterpart is {@link SpecificAvroSerde} and "generic Avro" counterpart is {@link
+ * GenericAvroSerde}.
+ *
+ * <p>This serde reads and writes data according to the wire format defined at
+ * http://docs.confluent.io/current/schema-registry/docs/serializer-formatter.html#wire-format. It
+ * requires access to a Confluent Schema Registry endpoint, which you must {@link
+ * PrimitiveAvroSerde#configure(Map, boolean)} via the parameter "schema.registry.url".</p>
+ *
+ * <p><strong>Usage</strong></p>
+ *
+ * <p>Example for configuring this serde as a Kafka Streams application's default serde for both
+ * record keys and record values:</p>
+ *
+ * <p>
+ * <pre>{@code
+ * Properties streamsConfiguration = new Properties();
+ * streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, PrimitiveAvroSerde.class);
+ * streamsConfiguration.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, PrimitiveAvroSerde.class);
+ * streamsConfiguration.put(
+ *     AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+ *     "http://confluent-schema-registry-server:8081/");
+ * }</pre>
+ * </p>
+ *
+ * <p>
+ * In practice, it's expected that the {@link PrimitiveAvroSerde} primary use case will be keys.
+ * </p>
+ *
+ * <p>Example for explicitly overriding the application's default serdes (whatever they were
+ * configured to) so that only specific operations such as {@code KStream#to()} use this serde:</p>
+ *
+ * <p>
+ * <pre>{@code
+ * Serde<Long> longAvroSerde = new PrimitiveAvroSerde<Long>();
+ * boolean isKeySerde = true;
+ * longAvroSerde.configure(
+ *     Collections.singletonMap(
+ *         AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+ *         "http://confluent-schema-registry-server:8081/"),
+ *     isKeySerde);
+ *
+ * Serde<GenericRecord> genericAvroSerde = new GenericAvroSerde();
+ * isKeySerde = false;
+ * genericAvroSerde.configure(
+ * Collections.singletonMap(
+ * AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+ *  "http://confluent-schema-registry-server:8081/"),
+ *  isKeySerde);
+ *
+ * KStream<Long, GenericRecord> stream = builder.stream("my-input-topic",
+ * Consumed.with(longAvroSerde, genericAvroSerde));
+ *
+ * }</pre>
+ * </p>
+ */
+
+// need to have this as KafkaAvro(De)Serializer uses type Object
+@SuppressWarnings("unchecked")
+public class PrimitiveAvroSerde<T> implements Serde<T> {
+
+  private final Serde<T> inner;
+
+  public PrimitiveAvroSerde() {
+    inner = (Serde<T>) Serdes.serdeFrom(new KafkaAvroSerializer(), new KafkaAvroDeserializer());
+  }
+
+  /**
+   * For testing purposes only.
+   */
+  public PrimitiveAvroSerde(final SchemaRegistryClient client) {
+    if (client == null) {
+      throw new IllegalArgumentException("schema registry client must not be null");
+    }
+    inner = (Serde<T>) Serdes.serdeFrom(
+        new KafkaAvroSerializer(client),
+        new KafkaAvroDeserializer(client)
+    );
+
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    inner.serializer().configure(configs, isKey);
+    inner.deserializer().configure(configs, isKey);
+  }
+
+  @Override
+  public void close() {
+    inner.serializer().close();
+    inner.deserializer().close();
+  }
+
+  @Override
+  public Serializer<T> serializer() {
+    return inner.serializer();
+  }
+
+  @Override
+  public Deserializer<T> deserializer() {
+    return inner.deserializer();
+  }
+}

--- a/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/PrimitiveAvroSerde.java
+++ b/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/PrimitiveAvroSerde.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Confluent Inc.
+ * Copyright 2020 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/avro-serde/src/test/java/io/confluent/kafka/streams/serdes/avro/PrimitiveAvroSerdeTest.java
+++ b/avro-serde/src/test/java/io/confluent/kafka/streams/serdes/avro/PrimitiveAvroSerdeTest.java
@@ -89,6 +89,7 @@ public class PrimitiveAvroSerdeTest {
 
     // Then
     assertThat(roundTrippedFloatRecord, equalTo(floatRecord));
+    floatSerde.close();
   }
 
   @Test

--- a/avro-serde/src/test/java/io/confluent/kafka/streams/serdes/avro/PrimitiveAvroSerdeTest.java
+++ b/avro-serde/src/test/java/io/confluent/kafka/streams/serdes/avro/PrimitiveAvroSerdeTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.kafka.streams.serdes.avro;
 
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;

--- a/avro-serde/src/test/java/io/confluent/kafka/streams/serdes/avro/PrimitiveAvroSerdeTest.java
+++ b/avro-serde/src/test/java/io/confluent/kafka/streams/serdes/avro/PrimitiveAvroSerdeTest.java
@@ -1,0 +1,147 @@
+package io.confluent.kafka.streams.serdes.avro;
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class PrimitiveAvroSerdeTest {
+
+  private static final String ANY_TOPIC = "any-topic";
+
+  private static <T> PrimitiveAvroSerde<T>
+  createConfiguredSerdeForRecordValues() {
+    SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
+    PrimitiveAvroSerde<T> serde = new PrimitiveAvroSerde<>(schemaRegistryClient);
+    Map<String, Object> serdeConfig = new HashMap<>();
+    serdeConfig.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "fake");
+    serde.configure(serdeConfig, false);
+    return serde;
+  }
+
+  @Test
+  public void shouldRoundTripStringRecords() {
+    final PrimitiveAvroSerde<String> stringSerde = createConfiguredSerdeForRecordValues();
+
+    final String stringRecord = "test";
+
+    // When
+    final String roundTrippedRecord = stringSerde.deserializer().deserialize(
+        ANY_TOPIC,
+        stringSerde.serializer().serialize(ANY_TOPIC, stringRecord));
+
+    // Then
+    assertThat(roundTrippedRecord, equalTo(stringRecord));
+
+    stringSerde.close();
+  }
+
+  @Test
+  public void shouldRoundTripLongRecords() {
+    final PrimitiveAvroSerde<Long> longSerde = createConfiguredSerdeForRecordValues();
+
+    final Long longRecord = 50000L;
+
+    // When
+    Long roundTrippedLongRecord = longSerde.deserializer().deserialize(
+        ANY_TOPIC,
+        longSerde.serializer().serialize(ANY_TOPIC, longRecord));
+
+    // Then
+    assertThat(roundTrippedLongRecord, equalTo(longRecord));
+
+    longSerde.close();
+  }
+
+  @Test
+  public void shouldRoundTripIntegerRecords() {
+    final PrimitiveAvroSerde<Integer> integerSerde = createConfiguredSerdeForRecordValues();
+
+    final Integer intRecord = 50000;
+
+    // When
+    Integer roundTrippedIntegerRecord = integerSerde.deserializer().deserialize(
+        ANY_TOPIC,
+        integerSerde.serializer().serialize(ANY_TOPIC, intRecord));
+
+    // Then
+    assertThat(roundTrippedIntegerRecord, equalTo(intRecord));
+    integerSerde.close();
+  }
+
+  @Test
+  public void shouldRoundTripFloatRecords() {
+    final PrimitiveAvroSerde<Float> floatSerde = createConfiguredSerdeForRecordValues();
+
+    final Float floatRecord = 50000.0F;
+
+    // When
+    Float roundTrippedFloatRecord = floatSerde.deserializer().deserialize(
+        ANY_TOPIC,
+        floatSerde.serializer().serialize(ANY_TOPIC, floatRecord));
+
+    // Then
+    assertThat(roundTrippedFloatRecord, equalTo(floatRecord));
+  }
+
+  @Test
+  public void shouldRoundTripDoubleRecords() {
+    final PrimitiveAvroSerde<Double> doubleSerde = createConfiguredSerdeForRecordValues();
+
+    final Double doubleRecord = 50000.0D;
+
+    // When
+    Double roundTrippedDoubleRecord = doubleSerde.deserializer().deserialize(
+        ANY_TOPIC,
+        doubleSerde.serializer().serialize(ANY_TOPIC, doubleRecord));
+
+    // Then
+    assertThat(roundTrippedDoubleRecord, equalTo(doubleRecord));
+    doubleSerde.close();
+  }
+
+  @Test
+  public void shouldRoundTripBooleanRecords() {
+    final PrimitiveAvroSerde<Boolean> booleanSerde = createConfiguredSerdeForRecordValues();
+
+    final Boolean booleanRecord = true;
+
+    // When
+    Boolean roundTrippedBooleanRecord = booleanSerde.deserializer().deserialize(
+        ANY_TOPIC,
+        booleanSerde.serializer().serialize(ANY_TOPIC, booleanRecord));
+
+    // Then
+    assertThat(roundTrippedBooleanRecord, equalTo(booleanRecord));
+    booleanSerde.close();
+  }
+
+  @Test
+  public void shouldRoundTripNullRecordsToNull() {
+    // Given
+    PrimitiveAvroSerde<String> serde = createConfiguredSerdeForRecordValues();
+
+    // When
+    String roundtrippedRecord = serde.deserializer().deserialize(
+        ANY_TOPIC, serde.serializer().serialize(ANY_TOPIC, null));
+    // Then
+    assertThat(roundtrippedRecord, nullValue());
+
+    // Cleanup
+    serde.close();
+  }
+
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldFailWhenInstantiatedWithNullSchemaRegistryClient() {
+    new PrimitiveAvroSerde<Long>(null);
+  }
+
+}

--- a/avro-serializer/pom.xml
+++ b/avro-serializer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/client-console-scripts/pom.xml
+++ b/client-console-scripts/pom.xml
@@ -7,7 +7,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-schema-registry</artifactId>

--- a/json-schema-converter/pom.xml
+++ b/json-schema-converter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/json-schema-provider/pom.xml
+++ b/json-schema-provider/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/json-schema-serde/pom.xml
+++ b/json-schema-serde/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/json-schema-serializer/pom.xml
+++ b/json-schema-serializer/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/json-serializer/pom.xml
+++ b/json-serializer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/licenses-and-notices.html
+++ b/licenses-and-notices.html
@@ -90,33 +90,33 @@ th {
 <TD><A HREF="http://pholser.github.com/jopt-simple">jopt-simple-4.9</A></TD><TD>jar</TD><TD>4.9</TD><TD><A HREF="http://www.opensource.org/licenses/mit-license.php">The MIT License</A><br></TD></TR>
 <TR>
 <<<<<<< HEAD
-<TD>kafka-avro-serializer-5.5.0-SNAPSHOT</TD><TD>jar</TD><TD>5.5.0-SNAPSHOT</TD><TD></TD></TR>
+<TD>kafka-avro-serializer-6.0.0-SNAPSHOT</TD><TD>jar</TD><TD>6.0.0-SNAPSHOT</TD><TD></TD></TR>
 <TR>
-<TD>kafka-clients-5.5.0-ccs-SNAPSHOT</TD><TD>jar</TD><TD></TD><TD><A HREF="licenses/LICENSE-kafka-clients-5.5.0-ccs-SNAPSHOT.txt">included file</A></TD></TR>
+<TD>kafka-clients-6.0.0-ccs-SNAPSHOT</TD><TD>jar</TD><TD></TD><TD><A HREF="licenses/LICENSE-kafka-clients-6.0.0-ccs-SNAPSHOT.txt">included file</A></TD></TR>
 <TR>
-<TD>kafka-connect-avro-converter-5.5.0-SNAPSHOT</TD><TD>jar</TD><TD>5.5.0-SNAPSHOT</TD><TD></TD></TR>
+<TD>kafka-connect-avro-converter-6.0.0-SNAPSHOT</TD><TD>jar</TD><TD>6.0.0-SNAPSHOT</TD><TD></TD></TR>
 <TR>
-<TD>kafka-json-serializer-5.5.0-SNAPSHOT</TD><TD>jar</TD><TD>5.5.0-SNAPSHOT</TD><TD></TD></TR>
+<TD>kafka-json-serializer-6.0.0-SNAPSHOT</TD><TD>jar</TD><TD>6.0.0-SNAPSHOT</TD><TD></TD></TR>
 <TR>
-<TD>kafka-schema-registry-5.5.0-SNAPSHOT</TD><TD>jar</TD><TD>5.5.0-SNAPSHOT</TD><TD></TD></TR>
+<TD>kafka-schema-registry-6.0.0-SNAPSHOT</TD><TD>jar</TD><TD>6.0.0-SNAPSHOT</TD><TD></TD></TR>
 <TR>
-<TD>kafka-schema-registry-client-5.5.0-SNAPSHOT</TD><TD>jar</TD><TD>5.5.0-SNAPSHOT</TD><TD></TD></TR>
+<TD>kafka-schema-registry-client-6.0.0-SNAPSHOT</TD><TD>jar</TD><TD>6.0.0-SNAPSHOT</TD><TD></TD></TR>
 <TR>
-<TD>kafka_2.11-5.5.0-ccs-SNAPSHOT</TD><TD>jar</TD><TD></TD><TD><A HREF="licenses/LICENSE-kafka_2.11-5.5.0-ccs-SNAPSHOT.txt">included file</A></TD></TR>
+<TD>kafka_2.11-6.0.0-ccs-SNAPSHOT</TD><TD>jar</TD><TD></TD><TD><A HREF="licenses/LICENSE-kafka_2.11-6.0.0-ccs-SNAPSHOT.txt">included file</A></TD></TR>
 =======
-<TD>kafka-avro-serializer-5.5.0-SNAPSHOT</TD><TD>jar</TD><TD>5.5.0-SNAPSHOT</TD><TD></TD></TR>
+<TD>kafka-avro-serializer-6.0.0-SNAPSHOT</TD><TD>jar</TD><TD>6.0.0-SNAPSHOT</TD><TD></TD></TR>
 <TR>
-<TD>kafka-clients-5.5.0-ccs-SNAPSHOT</TD><TD>jar</TD><TD></TD><TD><A HREF="licenses/LICENSE-kafka-clients-5.5.0-ccs-SNAPSHOT.txt">included file</A></TD></TR>
+<TD>kafka-clients-6.0.0-ccs-SNAPSHOT</TD><TD>jar</TD><TD></TD><TD><A HREF="licenses/LICENSE-kafka-clients-6.0.0-ccs-SNAPSHOT.txt">included file</A></TD></TR>
 <TR>
-<TD>kafka-connect-avro-converter-5.5.0-SNAPSHOT</TD><TD>jar</TD><TD>5.5.0-SNAPSHOT</TD><TD></TD></TR>
+<TD>kafka-connect-avro-converter-6.0.0-SNAPSHOT</TD><TD>jar</TD><TD>6.0.0-SNAPSHOT</TD><TD></TD></TR>
 <TR>
-<TD>kafka-json-serializer-5.5.0-SNAPSHOT</TD><TD>jar</TD><TD>5.5.0-SNAPSHOT</TD><TD></TD></TR>
+<TD>kafka-json-serializer-6.0.0-SNAPSHOT</TD><TD>jar</TD><TD>6.0.0-SNAPSHOT</TD><TD></TD></TR>
 <TR>
-<TD>kafka-schema-registry-5.5.0-SNAPSHOT</TD><TD>jar</TD><TD>5.5.0-SNAPSHOT</TD><TD></TD></TR>
+<TD>kafka-schema-registry-6.0.0-SNAPSHOT</TD><TD>jar</TD><TD>6.0.0-SNAPSHOT</TD><TD></TD></TR>
 <TR>
-<TD>kafka-schema-registry-client-5.5.0-SNAPSHOT</TD><TD>jar</TD><TD>5.5.0-SNAPSHOT</TD><TD></TD></TR>
+<TD>kafka-schema-registry-client-6.0.0-SNAPSHOT</TD><TD>jar</TD><TD>6.0.0-SNAPSHOT</TD><TD></TD></TR>
 <TR>
-<TD>kafka_2.11-5.5.0-ccs-SNAPSHOT</TD><TD>jar</TD><TD></TD><TD><A HREF="licenses/LICENSE-kafka_2.11-5.5.0-ccs-SNAPSHOT.txt">included file</A></TD></TR>
+<TD>kafka_2.11-6.0.0-ccs-SNAPSHOT</TD><TD>jar</TD><TD></TD><TD><A HREF="licenses/LICENSE-kafka_2.11-6.0.0-ccs-SNAPSHOT.txt">included file</A></TD></TR>
 >>>>>>> 5.1.x
 <TR>
 <TD><A HREF="http://logging.apache.org/log4j/1.2/">log4j-1.2.17</A></TD><TD>jar</TD><TD>1.2.17</TD><TD><A HREF="http://www.apache.org/licenses/LICENSE-2.0.txt">Apache 2.0</A><br></TD></TR>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/package-kafka-serde-tools/pom.xml
+++ b/package-kafka-serde-tools/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/package-schema-registry/pom.xml
+++ b/package-schema-registry/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-schema-registry-package</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>rest-utils-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-schema-registry-parent</artifactId>

--- a/protobuf-converter/pom.xml
+++ b/protobuf-converter/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/protobuf-provider/pom.xml
+++ b/protobuf-provider/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/protobuf-serde/pom.xml
+++ b/protobuf-serde/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/protobuf-serializer/pom.xml
+++ b/protobuf-serializer/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <licenses>

--- a/schema-registry-console-scripts/pom.xml
+++ b/schema-registry-console-scripts/pom.xml
@@ -7,7 +7,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.confluent</groupId>

--- a/schema-serializer/pom.xml
+++ b/schema-serializer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-schema-registry-parent</artifactId>
-        <version>5.5.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <licenses>


### PR DESCRIPTION
This PR adds support for Avro Serde for primitive Avro values.  While it's possible to create the serde (https://stackoverflow.com/questions/51955921/serde-class-for-avro-primitive-type/54667002#54667002), I think it would be a better user experience to provide this out of the box.