### PR TITLE
Add API to retrieve supported schema types

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -88,6 +88,9 @@ public class RestService implements Configurable {
   private static final TypeReference<SchemaString> GET_SCHEMA_BY_ID_RESPONSE_TYPE =
       new TypeReference<SchemaString>() {
       };
+  private static final TypeReference<List<String>> GET_SCHEMA_TYPES_TYPE =
+      new TypeReference<List<String>>() {
+      };
   private static final TypeReference<JsonNode> GET_SCHEMA_ONLY_BY_VERSION_RESPONSE_TYPE =
       new TypeReference<JsonNode>() {
       };
@@ -641,6 +644,20 @@ public class RestService implements Configurable {
 
     SchemaString response = httpRequest(path, "GET", null, requestProperties,
                                         GET_SCHEMA_BY_ID_RESPONSE_TYPE);
+    return response;
+  }
+
+  public List<String> getSchemaTypes() throws IOException, RestClientException {
+    return getSchemaTypes(DEFAULT_REQUEST_PROPERTIES);
+  }
+
+  public List<String> getSchemaTypes(Map<String, String> requestProperties)
+      throws IOException, RestClientException {
+    UriBuilder builder = UriBuilder.fromPath("/schemas/types");
+    String path = builder.toString();
+
+    List<String> response = httpRequest(path, "GET", null, requestProperties,
+        GET_SCHEMA_TYPES_TYPE);
     return response;
   }
 

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -390,6 +390,31 @@ paths:
           description: "Error code 40403 -- Schema not found\n"
         500:
           description: "Error code 50001 -- Error in the backend data store\n"
+  /schemas/types:
+    get:
+      summary: "Get the schema types supported by this registry."
+      description: ""
+      operationId: "getSchemaTypes"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              type: "string"
+            uniqueItems: true
+        500:
+          description: "Error code 50001 -- Error in the backend data store\n"
   /subjects:
     get:
       summary: "Get a list of registered subjects."

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
@@ -113,4 +113,13 @@ public class SchemasResource {
 
     return subjects;
   }
+
+  @GET
+  @Path("/types")
+  @ApiOperation("Get the schema types supported by this registry.")
+  @ApiResponses(value = {
+      @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store\n")})
+  public Set<String> getSchemaTypes() {
+    return schemaRegistry.schemaTypes();
+  }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -389,6 +389,10 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     }
   }
 
+  public Set<String> schemaTypes() {
+    return providers.keySet();
+  }
+
   @Override
   public int register(String subject,
                       Schema schema)

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
@@ -29,6 +29,8 @@ public interface SchemaRegistry extends SchemaVersionFetcher {
 
   void init() throws SchemaRegistryException;
 
+  Set<String> schemaTypes();
+
   int register(String subject, Schema schema) throws SchemaRegistryException;
 
   default Schema getByVersion(String subject, int version, boolean returnDeletedSchema) {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 
 import static io.confluent.kafka.schemaregistry.CompatibilityLevel.FORWARD;
@@ -324,6 +325,12 @@ public class RestApiTest extends ClusterTestHarness {
     // if fetchMaxId is not provided then the maxId is null
     assertNull(restApp.restClient.getId(1).getMaxId());
     assertEquals(Integer.valueOf(latestId), restApp.restClient.getId(1, true).getMaxId());
+  }
+
+  @Test
+  public void testGetSchemaTypes() throws Exception {
+    assertEquals(new HashSet<>(Arrays.asList("AVRO", "JSON", "PROTOBUF")),
+        new HashSet<>(restApp.restClient.getSchemaTypes()));
   }
 
   @Test


### PR DESCRIPTION
This is to help clients to know which schema types are supported by a particular instance of SR.