### PR TITLE
Fix NPE cases in AbstractSchemaProvider.resolveReferences

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/AbstractSchemaProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/AbstractSchemaProvider.java
@@ -49,12 +49,13 @@ public abstract class AbstractSchemaProvider implements SchemaProvider {
   }
 
   private void resolveReferences(List<SchemaReference> references, Map<String, String> schemas) {
-    if (references == null) {
-      return;
-    }
     for (SchemaReference reference : references) {
       String subject = reference.getSubject();
       Schema schema = schemaVersionFetcher().getByVersion(subject, reference.getVersion(), true);
+      if (schema == null) {
+        throw new IllegalStateException("No schema reference found for subject \"" + subject
+                + "\" and version " + reference.getVersion());
+      }
       resolveReferences(schema.getReferences(), schemas);
       schemas.put(reference.getName(), schema.getSchema());
     }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaProvider.java
@@ -15,16 +15,18 @@
 
 package io.confluent.kafka.schemaregistry.avro;
 
-import org.apache.avro.SchemaParseException;
-
 import java.util.List;
 import java.util.Optional;
 
 import io.confluent.kafka.schemaregistry.AbstractSchemaProvider;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AvroSchemaProvider extends AbstractSchemaProvider {
+
+  private static final Logger log = LoggerFactory.getLogger(AvroSchemaProvider.class);
 
   @Override
   public String schemaType() {
@@ -37,7 +39,8 @@ public class AvroSchemaProvider extends AbstractSchemaProvider {
     try {
       return Optional.of(
           new AvroSchema(schemaString, references, resolveReferences(references), null));
-    } catch (SchemaParseException e) {
+    } catch (Exception e) {
+      log.warn("Could not parse schema", e);
       return Optional.empty();
     }
   }

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaProvider.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaProvider.java
@@ -44,6 +44,7 @@ public class JsonSchemaProvider extends AbstractSchemaProvider {
           null
       ));
     } catch (Exception e) {
+      log.warn("Could not parse schema", e);
       return Optional.empty();
     }
   }

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaProvider.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaProvider.java
@@ -22,8 +22,12 @@ import java.util.Optional;
 import io.confluent.kafka.schemaregistry.AbstractSchemaProvider;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ProtobufSchemaProvider extends AbstractSchemaProvider {
+
+  private static final Logger log = LoggerFactory.getLogger(ProtobufSchemaProvider.class);
 
   @Override
   public String schemaType() {
@@ -40,7 +44,8 @@ public class ProtobufSchemaProvider extends AbstractSchemaProvider {
           null,
           null
       ));
-    } catch (IllegalStateException e) {
+    } catch (Exception e) {
+      log.warn("Could not parse schema", e);
       return Optional.empty();
     }
   }


### PR DESCRIPTION
The SR may not be able to resolve all references passed to it during a register operation. This PR catches these cases and gracefully fails the op.