### PR TITLE
Fix compile error due to KIP-515 (ZK TLS)

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -611,7 +611,7 @@ public class SchemaRegistryConfig extends RestConfig {
    * returns whether or not the user has enabled ZooKeeper ACLs.
    */
   public boolean checkZkAclConfig() {
-    if (getBoolean(ZOOKEEPER_SET_ACL_CONFIG) && !JaasUtils.isZkSecurityEnabled()) {
+    if (getBoolean(ZOOKEEPER_SET_ACL_CONFIG) && !JaasUtils.isZkSaslEnabled()) {
       throw new ConfigException(ZOOKEEPER_SET_ACL_CONFIG
                                 + " is set to true but ZooKeeper's "
                                 + "JAAS SASL configuration is not configured.");


### PR DESCRIPTION
This fixes a compile error that was created when [KIP-515 (Enable ZK client to use the new TLS supported authentication)](https://cwiki.apache.org/confluence/display/KAFKA/KIP-515%3A+Enable+ZK+client+to+use+the+new+TLS+supported+authentication) changed the name of a method that was not part of the public Kafka clients API.

This PR does not address the fact that Schema Registry will be unable to connect to a TLS-enabled ZooKeeper instance -- that will have to be fixed separately.