### PR TITLE
Convert Protobuf enum values to String

### DIFF
--- a/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufData.java
+++ b/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufData.java
@@ -174,7 +174,9 @@ public class ProtobufData {
           final String stringValue = (String) value; // Check for correct type
           if (schema.parameters() != null && schema.parameters().containsKey(PROTOBUF_TYPE_ENUM)) {
             String tag = schema.parameters().get(PROTOBUF_TYPE_ENUM_PREFIX + stringValue);
-            return Integer.parseInt(tag);
+            if (tag != null) {
+              return Integer.parseInt(tag);
+            }
           }
           return stringValue;
         }

--- a/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufData.java
+++ b/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufData.java
@@ -415,7 +415,6 @@ public class ProtobufData {
       } else if (fieldSchema.parameters() != null && fieldSchema.parameters()
           .containsKey(PROTOBUF_TYPE_ENUM)) {
         message.addEnumDefinition(enumDefinitionFromConnectSchema(schema, fieldSchema));
-
       } else if (type.equals(GOOGLE_PROTOBUF_TIMESTAMP_FULL_NAME)) {
         DynamicSchema.Builder timestampSchema = DynamicSchema.newBuilder();
         timestampSchema.setSyntax(ProtobufSchema.PROTO3);

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
@@ -252,7 +252,7 @@ public class ProtobufDataTest {
             .build()
     );
     builder.field("status",
-        SchemaBuilder.int32()
+        SchemaBuilder.string()
             .name("Status")
             .optional()
             .parameter(PROTOBUF_TYPE_TAG, String.valueOf(5))
@@ -310,7 +310,7 @@ public class ProtobufDataTest {
     experiments.add("second experiment");
     result.put("experiments_active", experiments);
 
-    result.put("status", 1); // INACTIVE
+    result.put("status", "INACTIVE");
     result.put("map_type", getTestKeyValueMap());
 
     Struct inner = new Struct(schema.field("inner").schema());
@@ -339,7 +339,7 @@ public class ProtobufDataTest {
     experiments.add("second experiment");
     result.put("experiments_active", experiments);
 
-    result.put("status", 1); // INACTIVE
+    result.put("status", "INACTIVE");
     result.put("map_type", getTestKeyValueMap());
 
     Struct inner = new Struct(schema.field("inner").schema());
@@ -357,7 +357,7 @@ public class ProtobufDataTest {
     List<String> experiments = new ArrayList<>();
     result.put("experiments_active", experiments);
 
-    result.put("status", 0);
+    result.put("status", "ACTIVE");
     result.put("map_type", new HashMap<>());
 
     return result;


### PR DESCRIPTION
When enum values are converted from Connect back to Protobuf,
they are converted to int32 to maintain binary compatibility.