### PR TITLE
Use AK for master election if possible

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -570,7 +570,7 @@ public class SchemaRegistryConfig extends RestConfig {
           + KAFKASTORE_CONNECTION_URL_CONFIG + " or " + KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG
       );
     }
-    return !haveStoreConnectionUrl;
+    return haveBootstrapServers;
   }
 
   public String bootstrapBrokers() {


### PR DESCRIPTION
Before if both ZK and AK are specified in the properties file, we would use ZK for master election.  This is to use AK instead (since ZK master election is being deprecated).