### PR TITLE
MINOR: fix error handling with empty err stream

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -277,7 +277,11 @@ public class RestService implements Configurable {
       } else {
         ErrorMessage errorMessage;
         try (InputStream es = connection.getErrorStream()) {
-          errorMessage = jsonDeserializer.readValue(es, ErrorMessage.class);
+          if (es != null) {
+            errorMessage = jsonDeserializer.readValue(es, ErrorMessage.class);
+          } else {
+            errorMessage = new ErrorMessage(JSON_PARSE_ERROR_CODE, "Error");
+          }
         } catch (JsonProcessingException e) {
           errorMessage = new ErrorMessage(JSON_PARSE_ERROR_CODE, e.getMessage());
         }


### PR DESCRIPTION
This is to accommodate an upgrade to Jackson 2.10.2