### PR TITLE
Performance: Use singleton ObjectMapper

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaUtils.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaUtils.java
@@ -39,11 +39,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
+
 public class AvroSchemaUtils {
 
   private static final EncoderFactory encoderFactory = EncoderFactory.get();
   private static final DecoderFactory decoderFactory = DecoderFactory.get();
-  private static final ObjectMapper jsonMapper = new ObjectMapper();
+  private static final ObjectMapper jsonMapper = JacksonMapper.INSTANCE;
 
   private static final Map<String, Schema> primitiveSchemas;
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -67,6 +67,7 @@ import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientExcept
 import io.confluent.kafka.schemaregistry.client.rest.utils.UrlList;
 import io.confluent.kafka.schemaregistry.client.security.basicauth.BasicAuthCredentialProvider;
 import io.confluent.kafka.schemaregistry.client.security.bearerauth.BearerAuthCredentialProviderFactory;
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 
 /**
  * Rest access layer for sending requests to the schema registry.
@@ -143,7 +144,7 @@ public class RestService implements Configurable {
   private static final int HTTP_READ_TIMEOUT_MS = 60000;
 
   private static final int JSON_PARSE_ERROR_CODE = 50005;
-  private static ObjectMapper jsonDeserializer = new ObjectMapper();
+  private static ObjectMapper jsonDeserializer = JacksonMapper.INSTANCE;
 
   private static final String AUTHORIZATION_HEADER = "Authorization";
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaString.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaString.java
@@ -18,7 +18,6 @@ package io.confluent.kafka.schemaregistry.client.rest.entities;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.annotations.VisibleForTesting;
 import io.swagger.annotations.ApiModelProperty;
@@ -28,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class SchemaString {
@@ -46,7 +46,7 @@ public class SchemaString {
   }
 
   public static SchemaString fromJson(String json) throws IOException {
-    return new ObjectMapper().readValue(json, SchemaString.class);
+    return JacksonMapper.INSTANCE.readValue(json, SchemaString.class);
   }
 
   @ApiModelProperty(value = "Schema type")
@@ -95,6 +95,6 @@ public class SchemaString {
   }
 
   public String toJson() throws IOException {
-    return new ObjectMapper().writeValueAsString(this);
+    return JacksonMapper.INSTANCE.writeValueAsString(this);
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/CompatibilityCheckResponse.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/CompatibilityCheckResponse.java
@@ -17,16 +17,17 @@
 package io.confluent.kafka.schemaregistry.client.rest.entities.requests;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
+
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 
 public class CompatibilityCheckResponse {
 
   private boolean isCompatible;
 
   public static CompatibilityCheckResponse fromJson(String json) throws IOException {
-    return new ObjectMapper().readValue(json, CompatibilityCheckResponse.class);
+    return JacksonMapper.INSTANCE.readValue(json, CompatibilityCheckResponse.class);
   }
 
   @JsonProperty("is_compatible")
@@ -40,7 +41,7 @@ public class CompatibilityCheckResponse {
   }
 
   public String toJson() throws IOException {
-    return new ObjectMapper().writeValueAsString(this);
+    return JacksonMapper.INSTANCE.writeValueAsString(this);
   }
 
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/ConfigUpdateRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/ConfigUpdateRequest.java
@@ -17,18 +17,19 @@
 package io.confluent.kafka.schemaregistry.client.rest.entities.requests;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.swagger.annotations.ApiModelProperty;
 
 import java.io.IOException;
+
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 
 public class ConfigUpdateRequest {
 
   private String compatibilityLevel;
 
   public static ConfigUpdateRequest fromJson(String json) throws IOException {
-    return new ObjectMapper().readValue(json, ConfigUpdateRequest.class);
+    return JacksonMapper.INSTANCE.readValue(json, ConfigUpdateRequest.class);
   }
 
   @ApiModelProperty(value = "Compatability Level",
@@ -45,6 +46,6 @@ public class ConfigUpdateRequest {
   }
 
   public String toJson() throws IOException {
-    return new ObjectMapper().writeValueAsString(this);
+    return JacksonMapper.INSTANCE.writeValueAsString(this);
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/ModeGetResponse.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/ModeGetResponse.java
@@ -17,16 +17,17 @@
 package io.confluent.kafka.schemaregistry.client.rest.entities.requests;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
+
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 
 public class ModeGetResponse {
 
   private String mode;
 
   public static ModeGetResponse fromJson(String json) throws IOException {
-    return new ObjectMapper().readValue(json, ModeGetResponse.class);
+    return JacksonMapper.INSTANCE.readValue(json, ModeGetResponse.class);
   }
 
   public ModeGetResponse(@JsonProperty("mode") String mode) {
@@ -44,6 +45,6 @@ public class ModeGetResponse {
   }
 
   public String toJson() throws IOException {
-    return new ObjectMapper().writeValueAsString(this);
+    return JacksonMapper.INSTANCE.writeValueAsString(this);
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/ModeUpdateRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/ModeUpdateRequest.java
@@ -17,16 +17,17 @@
 package io.confluent.kafka.schemaregistry.client.rest.entities.requests;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
+
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 
 public class ModeUpdateRequest {
 
   private String mode;
 
   public static ModeUpdateRequest fromJson(String json) throws IOException {
-    return new ObjectMapper().readValue(json, ModeUpdateRequest.class);
+    return JacksonMapper.INSTANCE.readValue(json, ModeUpdateRequest.class);
   }
 
   @JsonProperty("mode")
@@ -40,6 +41,6 @@ public class ModeUpdateRequest {
   }
 
   public String toJson() throws IOException {
-    return new ObjectMapper().writeValueAsString(this);
+    return JacksonMapper.INSTANCE.writeValueAsString(this);
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaRequest.java
@@ -18,7 +18,6 @@ package io.confluent.kafka.schemaregistry.client.rest.entities.requests;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import java.io.IOException;
@@ -27,6 +26,7 @@ import java.util.Objects;
 
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaTypeConverter;
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class RegisterSchemaRequest {
@@ -38,7 +38,7 @@ public class RegisterSchemaRequest {
   private String schema;
 
   public static RegisterSchemaRequest fromJson(String json) throws IOException {
-    return new ObjectMapper().readValue(json, RegisterSchemaRequest.class);
+    return JacksonMapper.INSTANCE.readValue(json, RegisterSchemaRequest.class);
   }
 
   @JsonProperty("version")
@@ -130,7 +130,7 @@ public class RegisterSchemaRequest {
   }
 
   public String toJson() throws IOException {
-    return new ObjectMapper().writeValueAsString(this);
+    return JacksonMapper.INSTANCE.writeValueAsString(this);
   }
 
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaResponse.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaResponse.java
@@ -17,16 +17,17 @@
 package io.confluent.kafka.schemaregistry.client.rest.entities.requests;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
+
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 
 public class RegisterSchemaResponse {
 
   private int id;
 
   public static RegisterSchemaResponse fromJson(String json) throws IOException {
-    return new ObjectMapper().readValue(json, RegisterSchemaResponse.class);
+    return JacksonMapper.INSTANCE.readValue(json, RegisterSchemaResponse.class);
   }
 
   @JsonProperty("id")
@@ -40,6 +41,6 @@ public class RegisterSchemaResponse {
   }
 
   public String toJson() throws IOException {
-    return new ObjectMapper().writeValueAsString(this);
+    return JacksonMapper.INSTANCE.writeValueAsString(this);
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/utils/JacksonMapper.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/utils/JacksonMapper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * A utility class wrapping a generic ObjectMapper singleton.
+ */
+public class JacksonMapper {
+  public static final ObjectMapper INSTANCE = new ObjectMapper();
+}

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryProtocol.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryProtocol.java
@@ -16,12 +16,12 @@
 package io.confluent.kafka.schemaregistry.masterelector.kafka;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import io.confluent.kafka.schemaregistry.storage.SchemaRegistryIdentity;
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 
 /**
  * This class implements the protocol for Schema Registry instances in a Kafka group. It includes
@@ -74,7 +74,7 @@ class SchemaRegistryProtocol {
       try {
         byte[] jsonBytes = new byte[json.remaining()];
         json.get(jsonBytes);
-        return new ObjectMapper().readValue(jsonBytes, Assignment.class);
+        return JacksonMapper.INSTANCE.readValue(jsonBytes, Assignment.class);
       } catch (IOException e) {
         throw new IllegalArgumentException("Error deserializing identity information", e);
       }
@@ -106,7 +106,7 @@ class SchemaRegistryProtocol {
 
     public ByteBuffer toJsonBytes() {
       try {
-        return ByteBuffer.wrap(new ObjectMapper().writeValueAsBytes(this));
+        return ByteBuffer.wrap(JacksonMapper.INSTANCE.writeValueAsBytes(this));
       } catch (IOException e) {
         throw new IllegalArgumentException("Error serializing identity information", e);
       }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistryIdentity.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistryIdentity.java
@@ -17,12 +17,12 @@ package io.confluent.kafka.schemaregistry.storage;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 
 /**
  * The identity of a schema registry instance. The master will store the json representation of its
@@ -52,14 +52,14 @@ public class SchemaRegistryIdentity {
   }
 
   public static SchemaRegistryIdentity fromJson(String json) throws IOException {
-    return new ObjectMapper().readValue(json, SchemaRegistryIdentity.class);
+    return JacksonMapper.INSTANCE.readValue(json, SchemaRegistryIdentity.class);
   }
 
   public static SchemaRegistryIdentity fromJson(ByteBuffer json) {
     try {
       byte[] jsonBytes = new byte[json.remaining()];
       json.get(jsonBytes);
-      return new ObjectMapper().readValue(jsonBytes, SchemaRegistryIdentity.class);
+      return JacksonMapper.INSTANCE.readValue(jsonBytes, SchemaRegistryIdentity.class);
     } catch (IOException e) {
       throw new IllegalArgumentException("Error deserializing identity information", e);
     }
@@ -170,12 +170,12 @@ public class SchemaRegistryIdentity {
   }
 
   public String toJson() throws IOException {
-    return new ObjectMapper().writeValueAsString(this);
+    return JacksonMapper.INSTANCE.writeValueAsString(this);
   }
 
   public ByteBuffer toJsonBytes() {
     try {
-      return ByteBuffer.wrap(new ObjectMapper().writeValueAsBytes(this));
+      return ByteBuffer.wrap(JacksonMapper.INSTANCE.writeValueAsBytes(this));
     } catch (IOException e) {
       throw new IllegalArgumentException("Error serializing identity information", e);
     }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/serialization/SchemaRegistrySerializer.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/serialization/SchemaRegistrySerializer.java
@@ -17,7 +17,6 @@ package io.confluent.kafka.schemaregistry.storage.serialization;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Map;
@@ -37,6 +36,7 @@ import io.confluent.kafka.schemaregistry.storage.SchemaRegistryKey;
 import io.confluent.kafka.schemaregistry.storage.SchemaRegistryKeyType;
 import io.confluent.kafka.schemaregistry.storage.SchemaRegistryValue;
 import io.confluent.kafka.schemaregistry.storage.exceptions.SerializationException;
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 
 public class SchemaRegistrySerializer
     implements Serializer<SchemaRegistryKey, SchemaRegistryValue> {
@@ -52,7 +52,7 @@ public class SchemaRegistrySerializer
   @Override
   public byte[] serializeKey(SchemaRegistryKey key) throws SerializationException {
     try {
-      return new ObjectMapper().writeValueAsBytes(key);
+      return JacksonMapper.INSTANCE.writeValueAsBytes(key);
     } catch (IOException e) {
       throw new SerializationException("Error while serializing schema key" + key.toString(),
                                        e);
@@ -66,7 +66,7 @@ public class SchemaRegistrySerializer
   @Override
   public byte[] serializeValue(SchemaRegistryValue value) throws SerializationException {
     try {
-      return new ObjectMapper().writeValueAsBytes(value);
+      return JacksonMapper.INSTANCE.writeValueAsBytes(value);
     } catch (IOException e) {
       throw new SerializationException(
           "Error while serializing value schema value " + value.toString(),
@@ -81,21 +81,21 @@ public class SchemaRegistrySerializer
     try {
       try {
         Map<Object, Object> keyObj = null;
-        keyObj = new ObjectMapper().readValue(key,
-                                              new TypeReference<Map<Object, Object>>() {});
+        keyObj = JacksonMapper.INSTANCE.readValue(
+            key, new TypeReference<Map<Object, Object>>() {});
         keyType = SchemaRegistryKeyType.forName((String) keyObj.get("keytype"));
         if (keyType == SchemaRegistryKeyType.CONFIG) {
-          schemaKey = new ObjectMapper().readValue(key, ConfigKey.class);
+          schemaKey = JacksonMapper.INSTANCE.readValue(key, ConfigKey.class);
         } else if (keyType == SchemaRegistryKeyType.MODE) {
-          schemaKey = new ObjectMapper().readValue(key, ModeKey.class);
+          schemaKey = JacksonMapper.INSTANCE.readValue(key, ModeKey.class);
         } else if (keyType == SchemaRegistryKeyType.NOOP) {
-          schemaKey = new ObjectMapper().readValue(key, NoopKey.class);
+          schemaKey = JacksonMapper.INSTANCE.readValue(key, NoopKey.class);
         } else if (keyType == SchemaRegistryKeyType.DELETE_SUBJECT) {
-          schemaKey = new ObjectMapper().readValue(key, DeleteSubjectKey.class);
+          schemaKey = JacksonMapper.INSTANCE.readValue(key, DeleteSubjectKey.class);
         } else if (keyType == SchemaRegistryKeyType.CLEAR_SUBJECT) {
-          schemaKey = new ObjectMapper().readValue(key, ClearSubjectKey.class);
+          schemaKey = JacksonMapper.INSTANCE.readValue(key, ClearSubjectKey.class);
         } else if (keyType == SchemaRegistryKeyType.SCHEMA) {
-          schemaKey = new ObjectMapper().readValue(key, SchemaKey.class);
+          schemaKey = JacksonMapper.INSTANCE.readValue(key, SchemaKey.class);
           validateMagicByte((SchemaKey) schemaKey);
         }
       } catch (JsonProcessingException e) {
@@ -130,32 +130,32 @@ public class SchemaRegistrySerializer
     SchemaRegistryValue schemaRegistryValue = null;
     if (key.getKeyType().equals(SchemaRegistryKeyType.CONFIG)) {
       try {
-        schemaRegistryValue = new ObjectMapper().readValue(value, ConfigValue.class);
+        schemaRegistryValue = JacksonMapper.INSTANCE.readValue(value, ConfigValue.class);
       } catch (IOException e) {
         throw new SerializationException("Error while deserializing config", e);
       }
     } else if (key.getKeyType().equals(SchemaRegistryKeyType.MODE)) {
       try {
-        schemaRegistryValue = new ObjectMapper().readValue(value, ModeValue.class);
+        schemaRegistryValue = JacksonMapper.INSTANCE.readValue(value, ModeValue.class);
       } catch (IOException e) {
         throw new SerializationException("Error while deserializing schema", e);
       }
     } else if (key.getKeyType().equals(SchemaRegistryKeyType.SCHEMA)) {
       try {
         validateMagicByte((SchemaKey) key);
-        schemaRegistryValue = new ObjectMapper().readValue(value, SchemaValue.class);
+        schemaRegistryValue = JacksonMapper.INSTANCE.readValue(value, SchemaValue.class);
       } catch (IOException e) {
         throw new SerializationException("Error while deserializing schema", e);
       }
     } else if (key.getKeyType().equals(SchemaRegistryKeyType.DELETE_SUBJECT)) {
       try {
-        schemaRegistryValue = new ObjectMapper().readValue(value, DeleteSubjectValue.class);
+        schemaRegistryValue = JacksonMapper.INSTANCE.readValue(value, DeleteSubjectValue.class);
       } catch (IOException e) {
         throw new SerializationException("Error while deserializing Delete Subject message", e);
       }
     } else if (key.getKeyType().equals(SchemaRegistryKeyType.CLEAR_SUBJECT)) {
       try {
-        schemaRegistryValue = new ObjectMapper().readValue(value, ClearSubjectValue.class);
+        schemaRegistryValue = JacksonMapper.INSTANCE.readValue(value, ClearSubjectValue.class);
       } catch (IOException e) {
         throw new SerializationException("Error while deserializing Clear Subject message", e);
       }

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageFormatter.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageFormatter.java
@@ -59,7 +59,7 @@ import io.confluent.kafka.serializers.json.AbstractKafkaJsonSchemaDeserializer;
  */
 public class JsonSchemaMessageFormatter extends SchemaMessageFormatter<JsonNode> {
 
-  private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+  private static final ObjectMapper objectMapper = Jackson.newObjectMapper();
 
   /**
    * Constructor needed by kafka console consumer.

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageReader.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageReader.java
@@ -82,7 +82,7 @@ import io.confluent.kafka.serializers.json.AbstractKafkaJsonSchemaSerializer;
 public class JsonSchemaMessageReader extends SchemaMessageReader<JsonNode>
     implements MessageReader {
 
-  private final ObjectMapper objectMapper = Jackson.newObjectMapper();
+  private static final ObjectMapper objectMapper = Jackson.newObjectMapper();
 
   /**
    * Constructor needed by kafka console producer.

--- a/json-serializer/src/main/java/io/confluent/kafka/serializers/KafkaJsonDeserializer.java
+++ b/json-serializer/src/main/java/io/confluent/kafka/serializers/KafkaJsonDeserializer.java
@@ -51,8 +51,8 @@ public class KafkaJsonDeserializer<T> implements Deserializer<T> {
     boolean
         failUnknownProperties =
         config.getBoolean(KafkaJsonDeserializerConfig.FAIL_UNKNOWN_PROPERTIES);
-    this.objectMapper
-        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, failUnknownProperties);
+    this.objectMapper.configure(
+        DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, failUnknownProperties);
   }
 
   @SuppressWarnings("unchecked")

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaUtils.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaUtils.java
@@ -27,9 +27,11 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
+
 public class ProtobufSchemaUtils {
 
-  private static final ObjectMapper jsonMapper = new ObjectMapper();
+  private static final ObjectMapper jsonMapper = JacksonMapper.INSTANCE;
 
   public static ProtobufSchema copyOf(ProtobufSchema schema) {
     return schema.copy();

--- a/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageReader.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageReader.java
@@ -17,7 +17,6 @@
 package io.confluent.kafka.formatter;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import kafka.common.KafkaException;
 import kafka.common.MessageReader;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -41,6 +40,7 @@ import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 
 public abstract class SchemaMessageReader<T> implements MessageReader {
@@ -114,7 +114,7 @@ public abstract class SchemaMessageReader<T> implements MessageReader {
     List<SchemaReference> valueRefs = Collections.emptyList();
     if (props.containsKey("value.refs")) {
       try {
-        valueRefs = new ObjectMapper().readValue(
+        valueRefs = JacksonMapper.INSTANCE.readValue(
             props.getProperty("value.refs"),
             new TypeReference<List<SchemaReference>>() {}
         );
@@ -134,7 +134,7 @@ public abstract class SchemaMessageReader<T> implements MessageReader {
       List<SchemaReference> keyRefs = Collections.emptyList();
       if (props.containsKey("key.refs")) {
         try {
-          keyRefs = new ObjectMapper().readValue(
+          keyRefs = JacksonMapper.INSTANCE.readValue(
               props.getProperty("key.refs"),
               new TypeReference<List<SchemaReference>>() {}
           );


### PR DESCRIPTION
Creating ObjectMapper is expensive - a static singleton (which
is thread-safe) should be used if possible