### PR TITLE
fix: enum always resolves to default value

### DIFF
--- a/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufData.java
+++ b/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufData.java
@@ -173,9 +173,10 @@ public class ProtobufData {
         case STRING: {
           final String stringValue = (String) value; // Check for correct type
           if (schema.parameters() != null && schema.parameters().containsKey(PROTOBUF_TYPE_ENUM)) {
+            String enumType = schema.parameters().get(PROTOBUF_TYPE_ENUM);
             String tag = schema.parameters().get(PROTOBUF_TYPE_ENUM_PREFIX + stringValue);
             if (tag != null) {
-              return protobufSchema.getEnumValue(stringValue, Integer.parseInt(tag));
+              return protobufSchema.getEnumValue(scope + enumType, Integer.parseInt(tag));
             }
           }
           return stringValue;

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
@@ -719,7 +719,7 @@ public class ProtobufDataTest {
         .put("array", Arrays.asList("a", "b", "c"))
         .put("map", Collections.singletonMap("field", 1))
         .put("mapNonStringKeys", Collections.singletonMap(1, 1))
-        .put("enum", "ACTIVE");
+        .put("enum", "INACTIVE");
 
     ProtobufSchemaAndValue convertedRecord = new ProtobufData().fromConnectData(schema, struct);
     ProtobufSchema protobufSchema = convertedRecord.getSchema();
@@ -807,7 +807,7 @@ public class ProtobufDataTest {
     fieldDescriptor = message.getDescriptorForType().findFieldByName("enum");
     EnumValueDescriptor enumValueDescriptor =
         (EnumValueDescriptor) message.getField(fieldDescriptor);
-    assertEquals("ACTIVE", enumValueDescriptor.getName());
+    assertEquals("INACTIVE", enumValueDescriptor.getName());
   }
 
   @Test


### PR DESCRIPTION
The way `ProtobufData` currently resolves Protobuf enums passes in the enum name and index instead of the enum type and index, which causes it to always resolve to `null` and therefore return the default value. This change passes in the correct enum name instead.

The tests were using the default value, so they weren't catching it.

**NOTE:** I'm not sure how we're supposed to be resolving the scope here. This PR always assumes that the scope is the same as the resolving state, which might not be right.