### PR TITLE
fix: `connect.default` on long avro field

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -28,6 +28,7 @@ import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.util.internal.JacksonUtils;
 import org.apache.kafka.common.cache.Cache;
 import org.apache.kafka.common.cache.LRUCache;
 import org.apache.kafka.common.cache.SynchronizedCache;
@@ -1806,7 +1807,7 @@ public class AvroData {
     }
 
     if (fieldDefaultVal == null) {
-      fieldDefaultVal = schema.getObjectProp(CONNECT_DEFAULT_VALUE_PROP);
+      fieldDefaultVal = JacksonUtils.toJsonNode(schema.getObjectProp(CONNECT_DEFAULT_VALUE_PROP));
     }
     if (fieldDefaultVal != null) {
       builder.defaultValue(

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -1911,6 +1911,58 @@ public class AvroDataTest {
   }
 
   @Test
+  public void testIntWithConnectDefault() {
+    final String s = "{"
+        + "  \"type\": \"record\","
+        + "  \"name\": \"SomeThing\","
+        + "  \"namespace\": \"com.acme.property\","
+        + "  \"fields\": ["
+        + "    {"
+        + "      \"name\": \"f\","
+        + "      \"type\": {"
+        + "        \"type\": \"int\","
+        + "        \"connect.default\": 42,"
+        + "        \"connect.version\": 1"
+        + "      }"
+        + "    }"
+        + "  ]"
+        + "}";
+
+    org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(s);
+
+    AvroData avroData = new AvroData(0);
+    Schema schema = avroData.toConnectSchema(avroSchema);
+
+    assertEquals(42, schema.field("f").schema().defaultValue());
+  }
+
+  @Test
+  public void testLongWithConnectDefault() {
+    final String s = "{"
+        + "  \"type\": \"record\","
+        + "  \"name\": \"SomeThing\","
+        + "  \"namespace\": \"com.acme.property\","
+        + "  \"fields\": ["
+        + "    {"
+        + "      \"name\": \"f\","
+        + "      \"type\": {"
+        + "        \"type\": \"long\","
+        + "        \"connect.default\": 42,"
+        + "        \"connect.version\": 1"
+        + "      }"
+        + "    }"
+        + "  ]"
+        + "}";
+
+    org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser().parse(s);
+
+    AvroData avroData = new AvroData(0);
+    Schema schema = avroData.toConnectSchema(avroSchema);
+
+    assertEquals(42L, schema.field("f").schema().defaultValue());
+  }
+
+  @Test
   public void testArrayOfRecordWithNullNamespace() {
     org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.array().items()
             .record("item").fields()


### PR DESCRIPTION
fixes: https://github.com/confluentinc/schema-registry/issues/1376

**Changes already reviewed under https://github.com/confluentinc/schema-registry/pull/1377, this is just changing the base to 5.4.x, as requested**

If an Avro schema has a `connect.default` property on a `long` field, e.g.

```json
{
    "name": "date_created",
    "type": [
      {
        "type": "long",
        "connect.version": 1,
        "connect.default": 0,
        "connect.name": "io.debezium.time.Timestamp"
      },
      "null"
    ],
    "default": 0
  }
```

Them `AvroData.toConnectSchema` throws:

```
org.apache.kafka.connect.errors.DataException: Invalid type for INT64: class java.lang.Integer
```

This bug was introduced in the upgrade to Avro 1.9.

The cause is that the call to get the value of `connect.default` was switched from `schema.getJsonProp`, which returned a IntNode, to `schema.getObjectProp`, which returns an int.  Later code that uses this default value differentiates between JsonNode's and non-JsonNodes.

* Non-JsonNodes are treated literally.  As the default is small enough to fit into an int, but the type is a long, the code throws the DataException.
* JsonNodes have their value extracted using type coercion, to ensure the default value matches the schema type.

The fix is to convert the returned default value back into a JsonNode so that the type coercion can happen.