### PR TITLE
CC-7027: Revert to legacy serialization of Decimal logical type on incompatible scale/precision

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -941,7 +941,7 @@ public class AvroData {
               Integer.parseInt(precisionString);
           int scale = scaleString == null ? 0 : Integer.parseInt(scaleString);
           if (scale < 0 || scale > precision) {
-            log.debug(
+            log.trace(
                 "Scale and precision of {} and {} cannot be serialized as native Avro logical " 
                     + "decimal type; reverting to legacy serialization method",
                 scale,

--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -951,6 +951,9 @@ public class AvroData {
             // scale is either negative or greater than the precision as this violates the Avro spec
             // and causes the Avro library to throw an exception, so we fall back in this case to
             // using the legacy method for encoding decimal logical type information.
+            // Can't add a key/value pair with the CONNECT_AVRO_DECIMAL_PRECISION_PROP key to the
+            // schema's parameters since the parameters for Connect schemas are immutable, so we
+            // just track this in a local boolean variable instead.
             forceLegacyDecimal = true;
           } else {
             org.apache.avro.LogicalTypes.decimal(precision, scale).addToSchema(baseSchema);


### PR DESCRIPTION
[Jira](https://confluentinc.atlassian.net/browse/CC-7027)

The changes to the Avro converter logic in https://github.com/confluentinc/schema-registry/pull/1124 cause issues with upstream producers, such as the JDBC connector, that publish data with a scale larger than its precision. Although this technically violates the Avro spec for the logical decimal type (which states that the scale must be between zero and the precision for the schema, inclusive), in practice this hasn't caused issues and has flown under the radar as values for those kinds of schemas have been correctly serialized and deserialized by the Avro converter.

In order to provide a fix for users of the Avro converter that may be affected by this change, I'd like to propose that we fall back on the legacy schema conversion logic we've used in the past for handling logical decimal types in the event that a schema with precision and scale incompatible with the Avro spec is encountered. This actually lines up safely with the Avro spec, which allows users to add custom annotations to their schemas in cases such as these and allows us to create our own serialization logic for the decimal type.

Values published to Kafka with these types of schemas will still cause issues with downstream consumers such as Hive that have their own requirements for scale and precision of decimals, but that should not be made any more or less likely by the merging of https://github.com/confluentinc/schema-registry/pull/1124 or the changes in this PR.