### PR TITLE
DG-24: Add more detailed logs during POST and DELETE ops

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -93,6 +93,9 @@ public class CompatibilityResource {
           + "under the specified subject", required = true)@PathParam("version") String version,
       @ApiParam(value = "Schema", required = true)
       @NotNull RegisterSchemaRequest request) {
+    log.info("Testing schema subject {} compatibility between existing version {} and "
+             + "specified version {}, id {}, type {}",
+             subject, version, request.getVersion(), request.getId(), request.getSchemaType());
     // returns true if posted schema is compatible with the specified version. "latest" is 
     // a special version
     Map<String, String> headerProperties = new HashMap<String, String>();

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -304,6 +304,7 @@ public class SubjectVersionsResource {
       @Context HttpHeaders headers,
       @ApiParam(value = "Name of the Subject", required = true)@PathParam("subject") String subject,
       @ApiParam(value = VERSION_PARAM_DESC, required = true)@PathParam("version") String version) {
+    log.info("Deleting schema version '{}' from subject '{}'", version, subject);
     VersionId versionId = null;
     try {
       versionId = new VersionId(version);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -306,7 +306,7 @@ public class SubjectVersionsResource {
       @Context HttpHeaders headers,
       @ApiParam(value = "Name of the Subject", required = true)@PathParam("subject") String subject,
       @ApiParam(value = VERSION_PARAM_DESC, required = true)@PathParam("version") String version) {
-    log.info("Deleting schema version '{}' from subject '{}'", version, subject);
+    log.info("Deleting schema version {} from subject {}", version, subject);
     VersionId versionId = null;
     try {
       versionId = new VersionId(version);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -244,6 +244,8 @@ public class SubjectVersionsResource {
         @PathParam("subject") String subjectName,
       @ApiParam(value = "Schema", required = true)
       @NotNull RegisterSchemaRequest request) {
+    log.info("Registering new schema: subject {}, version {}, id {}, type {}",
+             subjectName, request.getVersion(), request.getId(), request.getSchemaType());
 
     Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
         headers, schemaRegistry.config().whitelistHeaders());

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -87,6 +87,8 @@ public class SubjectsResource {
       @QueryParam("deleted") boolean lookupDeletedSchema,
       @ApiParam(value = "Schema", required = true)
       @NotNull RegisterSchemaRequest request) {
+    log.info("Schema lookup under subject {}, deleted {}, type {}",
+             subject, lookupDeletedSchema, request.getSchemaType());
     // returns version if the schema exists. Otherwise returns 404
     Schema schema = new Schema(
         subject,
@@ -146,7 +148,7 @@ public class SubjectsResource {
       @Context HttpHeaders headers,
       @ApiParam(value = "the name of the subject", required = true)
         @PathParam("subject") String subject) {
-    log.info("Deleting subject '{}'", subject);
+    log.info("Deleting subject {}", subject);
     List<Integer> deletedVersions;
     try {
       if (!schemaRegistry.hasSubjects(subject)) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -146,6 +146,7 @@ public class SubjectsResource {
       @Context HttpHeaders headers,
       @ApiParam(value = "the name of the subject", required = true)
         @PathParam("subject") String subject) {
+    log.info("Deleting subject '{}'", subject);
     List<Integer> deletedVersions;
     try {
       if (!schemaRegistry.hasSubjects(subject)) {


### PR DESCRIPTION
Logs basic request information during POST and DELETE actions for a smoother support story.