### PR TITLE
MINOR: rename connect-statuses in sample config

### DIFF
--- a/config/connect-avro-distributed.properties
+++ b/config/connect-avro-distributed.properties
@@ -30,7 +30,7 @@ value.converter.schema.registry.url=http://localhost:8081
 # The following properties set the names of these three internal topics for storing configs, offsets, and status.
 config.storage.topic=connect-configs
 offset.storage.topic=connect-offsets
-status.storage.topic=connect-statuses
+status.storage.topic=connect-status
 
 # The following properties set the replication factor for the three internal topics, defaulting to 3 for each
 # and therefore requiring a minimum of 3 brokers in the cluster. Since we want the examples to run with


### PR DESCRIPTION
This line:

`schema-registry/connect-avro-distributed.properties:status.storage.topic=connect-statuses`

has been renamed as:

`schema-registry/connect-avro-distributed.properties:status.storage.topic=connect-status`

For consistency with the rest of the platform

Customers who are already using the existing config as-is will want to change it back to the old value.