### PR TITLE
DG-321 Omit schemaType field when storing Avro schemas

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaValue.java
@@ -16,10 +16,12 @@
 package io.confluent.kafka.schemaregistry.storage;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.annotations.VisibleForTesting;
 import org.hibernate.validator.constraints.NotEmpty;
 
@@ -31,7 +33,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaTypeConverter;
 
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class SchemaValue implements Comparable<SchemaValue>, SchemaRegistryValue {
 
   @NotEmpty
@@ -122,6 +126,7 @@ public class SchemaValue implements Comparable<SchemaValue>, SchemaRegistryValue
   }
 
   @JsonProperty("schemaType")
+  @JsonSerialize(converter = SchemaTypeConverter.class)
   public String getSchemaType() {
     return this.schemaType;
   }


### PR DESCRIPTION
Schemas generated with SR 5.5 include a schemaType field, which prevents
SR 5.4 from reading them.  The fix is the same as with the REST APIs,
which is to store the Avro schema without a schemaType field (Protobuf
and JSON Schema will still have this field).  This will allow users to
downgrade from 5.5 to 5.4 and read any Avro schemas generated with 5.5
(of course Protobuf/JSON Schema schemas generated with 5.5 will still
not be able to be read by 5.4).