### PR TITLE
DG-323: Fix SchemaMessageReader NPE if parse.key is enabled

### DIFF
--- a/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageReader.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageReader.java
@@ -115,11 +115,6 @@ public abstract class SchemaMessageReader<T> implements MessageReader {
 
     Serializer keySerializer = getKeySerializer(props);
 
-    if (needsKeySchema()) {
-      String keySchemaString = getSchemaString(props, true);
-      List<SchemaReference> keyRefs = getSchemaReferences(props, true);
-      keySchema = parseSchema(schemaRegistry, keySchemaString, keyRefs);
-    }
     keySubject = topic + "-key";
     valueSubject = topic + "-value";
     boolean autoRegisterSchema;
@@ -131,6 +126,12 @@ public abstract class SchemaMessageReader<T> implements MessageReader {
 
     if (this.serializer == null) {
       this.serializer = createSerializer(schemaRegistry, autoRegisterSchema, keySerializer);
+    }
+
+    if (needsKeySchema()) {
+      String keySchemaString = getSchemaString(props, true);
+      List<SchemaReference> keyRefs = getSchemaReferences(props, true);
+      keySchema = parseSchema(schemaRegistry, keySchemaString, keyRefs);
     }
   }
 


### PR DESCRIPTION
If schema validation is enabled via property parse.key, the serializer object will be used before being initialized, causing a NPE:

`java.lang.NullPointerException
	at io.confluent.kafka.formatter.SchemaMessageReader.needsKeySchema(SchemaMessageReader.java:189)
	at io.confluent.kafka.formatter.SchemaMessageReader.init(SchemaMessageReader.java:118)
	at kafka.tools.ConsoleProducer$.main(ConsoleProducer.scala:43)
	at kafka.tools.ConsoleProducer.main(ConsoleProducer.scala)`

Moving the order of initialization fixes this.
