### PR TITLE
DG-321 Fix NPE in equals method

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaValue.java
@@ -186,7 +186,7 @@ public class SchemaValue implements Comparable<SchemaValue>, SchemaRegistryValue
     if (!this.id.equals(that.getId())) {
       return false;
     }
-    if (!this.schemaType.equals(that.getSchemaType())) {
+    if (schemaType != null ? !schemaType.equals(that.schemaType) : that.schemaType != null) {
       return false;
     }
     if (!this.references.equals(that.getReferences())) {
@@ -207,7 +207,7 @@ public class SchemaValue implements Comparable<SchemaValue>, SchemaRegistryValue
     int result = subject.hashCode();
     result = 31 * result + version;
     result = 31 * result + id.intValue();
-    result = 31 * result + schemaType.hashCode();
+    result = 31 * result + (schemaType != null ? schemaType.hashCode() : 0);
     result = 31 * result + schema.hashCode();
     result = 31 * result + references.hashCode();
     result = 31 * result + (deleted ? 1 : 0);


### PR DESCRIPTION
This is a follow up PR to avoid NPE in the equals/hashCode methods.
Currently the equals/hashCode methods are not being used in normal
control flow but may be used in future tests.