### PR TITLE
DG-349 Ensure schema key version matches schema value

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -366,7 +366,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
           schema.setVersion(newVersion);
         }
 
-        SchemaKey schemaKey = new SchemaKey(subject, newVersion);
+        SchemaKey schemaKey = new SchemaKey(subject, schema.getVersion());
         if (schemaId >= 0) {
           schema.setId(schemaId);
           kafkaStore.put(schemaKey, new SchemaValue(schema));


### PR DESCRIPTION
During IMPORT mode, the SchemaKey version may get out of sync with the SchemaValue version in the case that old schemas are no longer available.