### PR TITLE
DG-351 Handle Null JSON Schema with properties

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/AbstractSchemaProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/AbstractSchemaProvider.java
@@ -50,6 +50,11 @@ public abstract class AbstractSchemaProvider implements SchemaProvider {
 
   private void resolveReferences(List<SchemaReference> references, Map<String, String> schemas) {
     for (SchemaReference reference : references) {
+      if (reference.getName() == null
+          || reference.getSubject() == null
+          || reference.getVersion() == null) {
+        throw new IllegalStateException("Invalid reference: " + reference);
+      }
       String subject = reference.getSubject();
       Schema schema = schemaVersionFetcher().getByVersion(subject, reference.getVersion(), true);
       if (schema == null) {

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
@@ -869,18 +869,23 @@ public class JsonSchemaData {
         throw new IllegalArgumentException("Unsupported criterion: " + criterion);
       }
       if (combinedSchema.getSubschemas().size() == 2) {
-        if (combinedSchema.getSubschemas().contains(NullSchema.INSTANCE)) {
-          for (org.everit.json.schema.Schema subSchema : combinedSchema.getSubschemas()) {
-            if (!subSchema.equals(NullSchema.INSTANCE)) {
-              return toConnectSchema(subSchema, version, true);
-            }
+        boolean foundNullSchema = false;
+        org.everit.json.schema.Schema nonNullSchema = null;
+        for (org.everit.json.schema.Schema subSchema : combinedSchema.getSubschemas()) {
+          if (subSchema instanceof NullSchema) {
+            foundNullSchema = true;
+          } else {
+            nonNullSchema = subSchema;
           }
+        }
+        if (foundNullSchema) {
+          return toConnectSchema(nonNullSchema, version, true);
         }
       }
       int index = 0;
       builder = SchemaBuilder.struct().name(name);
       for (org.everit.json.schema.Schema subSchema : combinedSchema.getSubschemas()) {
-        if (subSchema.equals(NullSchema.INSTANCE)) {
+        if (subSchema instanceof NullSchema) {
           builder.optional();
         } else {
           String subFieldName = name + ".field." + index++;

--- a/json-schema-converter/src/test/java/io/confluent/connect/json/AdditionalJsonSchemaDataTest.java
+++ b/json-schema-converter/src/test/java/io/confluent/connect/json/AdditionalJsonSchemaDataTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.json;
+
+import org.apache.kafka.connect.data.Schema;
+import org.junit.Test;
+
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
+
+import static org.junit.Assert.assertEquals;
+
+public class AdditionalJsonSchemaDataTest {
+
+  private JsonSchemaData jsonSchemaData = new JsonSchemaData();
+
+  private static String optionalStringWithTitleForNullSchema = "{\n"
+      + "  \"oneOf\": [\n"
+      + "    { \n"
+      + "      \"title\": \"Not included\",\n"
+      + "      \"type\": \"null\" \n"
+      + "    },\n"
+      + "    { \"type\": \"string\" }\n"
+      + "  ]\n"
+      + "}";
+
+  public AdditionalJsonSchemaDataTest() {
+  }
+
+  @Test
+  public void testToConnectOptionalStringWithTitleForNullSchema() throws Exception {
+    org.everit.json.schema.Schema schema =
+        new JsonSchema(optionalStringWithTitleForNullSchema).rawSchema();
+    Schema connectSchema = jsonSchemaData.toConnectSchema(schema);
+    Schema expectedSchema = Schema.OPTIONAL_STRING_SCHEMA;
+    assertEquals(expectedSchema, connectSchema);
+  }
+}

--- a/json-schema-provider/src/test/resources/diff-schema-examples.json
+++ b/json-schema-provider/src/test/resources/diff-schema-examples.json
@@ -1133,6 +1133,26 @@
     "compatible": true
   },
   {
+    "description": "Detect change to optional oneOf schema",
+    "original_schema": {
+      "type": "null"
+    },
+    "update_schema": {
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "changes": [
+      "SUM_TYPE_EXTENDED #/"
+    ],
+    "compatible": true
+  },
+  {
     "description": "Detect change to oneOf schema",
     "original_schema": {
       "oneOf": [


### PR DESCRIPTION
Previously we were checking if a JSON Schema is a NullSchema by checking against a singleton NullSchema.INSTANCE.  This fails if the NullSchema has additional properties.  This fix checks for a NullSchema using `instanceof`.