### PR TITLE
DG-352 Remove unnecessary slf4j dependency

### DIFF
--- a/protobuf-converter/pom.xml
+++ b/protobuf-converter/pom.xml
@@ -67,10 +67,6 @@
             <artifactId>protobuf-java-util</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
This unnecessary dependency is causing slf4j warnings to be emitted to stdout.