### PR TITLE
DG-358 Ensure schema provider is set in SR clients

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
@@ -17,6 +17,7 @@
 package io.confluent.connect.avro;
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.serializers.AbstractKafkaAvroDeserializer;
@@ -34,6 +35,7 @@ import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.storage.Converter;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -65,6 +67,7 @@ public class AvroConverter implements Converter {
       schemaRegistry = new CachedSchemaRegistryClient(
           avroConverterConfig.getSchemaRegistryUrls(),
           avroConverterConfig.getMaxSchemasPerSubject(),
+          Collections.singletonList(new AvroSchemaProvider()),
           configs,
           avroConverterConfig.requestHeaders()
       );

--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
@@ -25,8 +25,6 @@ import org.apache.kafka.common.serialization.Serializer;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.SchemaProvider;
@@ -34,7 +32,6 @@ import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerializer;
 
 /**
@@ -111,15 +108,8 @@ public class AvroMessageReader extends SchemaMessageReader<Object> {
   }
 
   @Override
-  protected ParsedSchema parseSchema(
-      SchemaRegistryClient schemaRegistry,
-      String schema,
-      List<SchemaReference> references
-  ) {
-    SchemaProvider provider = new AvroSchemaProvider();
-    provider.configure(Collections.singletonMap(SchemaProvider.SCHEMA_VERSION_FETCHER_CONFIG,
-        schemaRegistry));
-    return provider.parseSchema(schema, references).get();
+  protected SchemaProvider getProvider() {
+    return new AvroSchemaProvider();
   }
 
   @Override

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -13,7 +13,7 @@
               files="SchemaRegistryCoordinator.java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(AbstractKafkaAvroDeserializer|AbstractKafkaAvroSerializer|RestService|Errors|SchemaRegistryRestApplication|KafkaSchemaRegistry|KafkaStore|AvroData|KafkaGroupMasterElector|ProtobufSchema|ProtobufData|JsonSchemaData|InMemoryCache|SchemaMessageReader).java"/>
+              files="(AbstractKafkaAvroDeserializer|AbstractKafkaAvroSerializer|RestService|Errors|SchemaRegistryRestApplication|KafkaSchemaRegistry|KafkaStore|AvroData|KafkaGroupMasterElector|ProtobufSchema|ProtobufData|JsonSchemaData|InMemoryCache|SchemaMessageReader|JsonSchemaConverter).java"/>
 
     <suppress checks="ClassFanOutComplexity"
               files="(RestService|KafkaSchemaRegistry|KafkaStore|KafkaStoreReaderThread|AvroData|KafkaGroupMasterElector).java"/>

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverter.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverter.java
@@ -23,11 +23,13 @@ import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.storage.Converter;
 
+import java.util.Collections;
 import java.util.Map;
 
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDe;
 import io.confluent.kafka.serializers.json.AbstractKafkaJsonSchemaDeserializer;
 import io.confluent.kafka.serializers.json.AbstractKafkaJsonSchemaSerializer;
@@ -61,10 +63,12 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
     JsonSchemaConverterConfig jsonSchemaConverterConfig = new JsonSchemaConverterConfig(configs);
 
     if (schemaRegistry == null) {
-      schemaRegistry =
-          new CachedSchemaRegistryClient(jsonSchemaConverterConfig.getSchemaRegistryUrls(),
+      schemaRegistry = new CachedSchemaRegistryClient(
+          jsonSchemaConverterConfig.getSchemaRegistryUrls(),
           jsonSchemaConverterConfig.getMaxSchemasPerSubject(),
-          configs
+          Collections.singletonList(new JsonSchemaProvider()),
+          configs,
+          jsonSchemaConverterConfig.requestHeaders()
       );
     }
 

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageReader.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageReader.java
@@ -25,15 +25,12 @@ import org.everit.json.schema.ValidationException;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
 
 import io.confluent.kafka.formatter.SchemaMessageReader;
 import io.confluent.kafka.formatter.SchemaMessageSerializer;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
 import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
 import io.confluent.kafka.schemaregistry.json.jackson.Jackson;
@@ -116,15 +113,8 @@ public class JsonSchemaMessageReader extends SchemaMessageReader<JsonNode>
   }
 
   @Override
-  protected ParsedSchema parseSchema(
-      SchemaRegistryClient schemaRegistry,
-      String schema,
-      List<SchemaReference> references
-  ) {
-    SchemaProvider provider = new JsonSchemaProvider();
-    provider.configure(Collections.singletonMap(SchemaProvider.SCHEMA_VERSION_FETCHER_CONFIG,
-        schemaRegistry));
-    return provider.parseSchema(schema, references).get();
+  protected SchemaProvider getProvider() {
+    return new JsonSchemaProvider();
   }
 
   @Override

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
@@ -64,7 +64,8 @@ public abstract class SchemaRegistryMojo extends AbstractMojo {
       List<SchemaProvider> providers = schemaProviders != null && !schemaProviders.isEmpty()
                                        ? schemaProviders()
                                        : defaultSchemaProviders();
-      this.client = new CachedSchemaRegistryClient(this.schemaRegistryUrls,
+      this.client = new CachedSchemaRegistryClient(
+          this.schemaRegistryUrls,
           1000,
           providers,
           config

--- a/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufConverter.java
+++ b/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufConverter.java
@@ -23,11 +23,13 @@ import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.storage.Converter;
 
+import java.util.Collections;
 import java.util.Map;
 
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import io.confluent.kafka.serializers.protobuf.AbstractKafkaProtobufDeserializer;
 import io.confluent.kafka.serializers.protobuf.AbstractKafkaProtobufSerializer;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializerConfig;
@@ -61,10 +63,12 @@ public class ProtobufConverter implements Converter {
     ProtobufConverterConfig protobufConverterConfig = new ProtobufConverterConfig(configs);
 
     if (schemaRegistry == null) {
-      schemaRegistry =
-          new CachedSchemaRegistryClient(protobufConverterConfig.getSchemaRegistryUrls(),
+      schemaRegistry = new CachedSchemaRegistryClient(
+          protobufConverterConfig.getSchemaRegistryUrls(),
           protobufConverterConfig.getMaxSchemasPerSubject(),
-          configs
+          Collections.singletonList(new ProtobufSchemaProvider()),
+          configs,
+          protobufConverterConfig.requestHeaders()
       );
     }
 

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/formatter/protobuf/ProtobufMessageReader.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/formatter/protobuf/ProtobufMessageReader.java
@@ -21,15 +21,12 @@ import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Serializer;
 
 import java.io.BufferedReader;
-import java.util.Collections;
-import java.util.List;
 
 import io.confluent.kafka.formatter.SchemaMessageReader;
 import io.confluent.kafka.formatter.SchemaMessageSerializer;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils;
@@ -87,15 +84,8 @@ public class ProtobufMessageReader extends SchemaMessageReader<Message> {
   }
 
   @Override
-  protected ParsedSchema parseSchema(
-      SchemaRegistryClient schemaRegistry,
-      String schema,
-      List<SchemaReference> references
-  ) {
-    SchemaProvider provider = new ProtobufSchemaProvider();
-    provider.configure(Collections.singletonMap(SchemaProvider.SCHEMA_VERSION_FETCHER_CONFIG,
-        schemaRegistry));
-    return provider.parseSchema(schema, references).get();
+  protected SchemaProvider getProvider() {
+    return new ProtobufSchemaProvider();
   }
 
   @Override


### PR DESCRIPTION
This also fixes an issue where request headers were not always
getting passed to the SR client from the converter config.