### PR TITLE
DG-308 Check the cache of refs before retrieval

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/AbstractSchemaProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/AbstractSchemaProvider.java
@@ -56,13 +56,17 @@ public abstract class AbstractSchemaProvider implements SchemaProvider {
         throw new IllegalStateException("Invalid reference: " + reference);
       }
       String subject = reference.getSubject();
-      Schema schema = schemaVersionFetcher().getByVersion(subject, reference.getVersion(), true);
-      if (schema == null) {
-        throw new IllegalStateException("No schema reference found for subject \"" + subject
-                + "\" and version " + reference.getVersion());
+      if (!schemas.containsKey(reference.getName())) {
+        Schema schema = schemaVersionFetcher().getByVersion(subject, reference.getVersion(), true);
+        if (schema == null) {
+          throw new IllegalStateException("No schema reference found for subject \""
+              + subject
+              + "\" and version "
+              + reference.getVersion());
+        }
+        resolveReferences(schema.getReferences(), schemas);
+        schemas.put(reference.getName(), schema.getSchema());
       }
-      resolveReferences(schema.getReferences(), schemas);
-      schemas.put(reference.getName(), schema.getSchema());
     }
   }
 }


### PR DESCRIPTION
This will also prevent infinite loops in the case of
cyclic references (which most formats reject).