### PR TITLE
DG-399 Use envelope in JsonSchemaUtils.toObject

### DIFF
--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -164,6 +164,10 @@ public class JsonSchema implements ParsedSchema {
     );
   }
 
+  public JsonNode toJsonNode() {
+    return jsonNode;
+  }
+
   @Override
   public Schema rawSchema() {
     if (jsonNode == null) {

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaUtils.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaUtils.java
@@ -30,12 +30,14 @@ import io.confluent.kafka.schemaregistry.json.jackson.Jackson;
 
 public class JsonSchemaUtils {
 
-  private static final Object NONE_MARKER = new Object();
-
   private static final ObjectMapper jsonMapper = Jackson.newObjectMapper();
 
   static final String ENVELOPE_SCHEMA_FIELD_NAME = "schema";
   static final String ENVELOPE_PAYLOAD_FIELD_NAME = "payload";
+
+  public static ObjectNode envelope(JsonSchema schema, JsonNode payload) {
+    return envelope(schema.toJsonNode(), payload);
+  }
 
   public static ObjectNode envelope(JsonNode schema, JsonNode payload) {
     ObjectNode result = JsonNodeFactory.instance.objectNode();
@@ -90,7 +92,7 @@ public class JsonSchemaUtils {
     if (validate) {
       schema.validate(value);
     }
-    return value;
+    return envelope(schema, value);
   }
 
   public static byte[] toJson(Object value) throws IOException {

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.NumericNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.everit.json.schema.ValidationException;
@@ -70,22 +71,28 @@ public class JsonSchemaTest {
 
   @Test
   public void testPrimitiveTypesToJsonSchema() throws Exception {
-    Object result = JsonSchemaUtils.toObject(null, createPrimitiveSchema("null"));
-    assertTrue(result == null);
+    Object envelope = JsonSchemaUtils.toObject(null, createPrimitiveSchema("null"));
+    JsonNode result = (JsonNode) JsonSchemaUtils.getValue(envelope);
+    assertEquals(NullNode.getInstance(), result);
 
-    result = JsonSchemaUtils.toObject(jsonTree("true"), createPrimitiveSchema("boolean"));
+    envelope = JsonSchemaUtils.toObject(jsonTree("true"), createPrimitiveSchema("boolean"));
+    result = (JsonNode) JsonSchemaUtils.getValue(envelope);
     assertEquals(true, ((BooleanNode) result).asBoolean());
 
-    result = JsonSchemaUtils.toObject(jsonTree("false"), createPrimitiveSchema("boolean"));
+    envelope = JsonSchemaUtils.toObject(jsonTree("false"), createPrimitiveSchema("boolean"));
+    result = (JsonNode) JsonSchemaUtils.getValue(envelope);
     assertEquals(false, ((BooleanNode) result).asBoolean());
 
-    result = JsonSchemaUtils.toObject(jsonTree("12"), createPrimitiveSchema("number"));
+    envelope = JsonSchemaUtils.toObject(jsonTree("12"), createPrimitiveSchema("number"));
+    result = (JsonNode) JsonSchemaUtils.getValue(envelope);
     assertEquals(12, ((NumericNode) result).asInt());
 
-    result = JsonSchemaUtils.toObject(jsonTree("23.2"), createPrimitiveSchema("number"));
+    envelope = JsonSchemaUtils.toObject(jsonTree("23.2"), createPrimitiveSchema("number"));
+    result = (JsonNode) JsonSchemaUtils.getValue(envelope);
     assertEquals(23.2, ((NumericNode) result).asDouble(), 0.1);
 
-    result = JsonSchemaUtils.toObject(jsonTree("\"a string\""), createPrimitiveSchema("string"));
+    envelope = JsonSchemaUtils.toObject(jsonTree("\"a string\""), createPrimitiveSchema("string"));
+    result = (JsonNode) JsonSchemaUtils.getValue(envelope);
     assertEquals("a string", ((TextNode) result).asText());
   }
 
@@ -98,7 +105,8 @@ public class JsonSchemaTest {
         + "    \"string\": \"string\"\n"
         + "}";
 
-    JsonNode result = (JsonNode) JsonSchemaUtils.toObject(jsonTree(json), recordSchema);
+    JsonNode envelope = (JsonNode) JsonSchemaUtils.toObject(jsonTree(json), recordSchema);
+    JsonNode result = (JsonNode) JsonSchemaUtils.getValue(envelope);
     assertEquals(true, result.get("null").isNull());
     assertEquals(true, result.get("boolean").booleanValue());
     assertEquals(12, result.get("number").intValue());
@@ -115,7 +123,8 @@ public class JsonSchemaTest {
         + "    \"badString\": \"string\"\n"
         + "}";
 
-    JsonNode result = (JsonNode) JsonSchemaUtils.toObject(jsonTree(json), recordSchema);
+    JsonNode envelope = (JsonNode) JsonSchemaUtils.toObject(jsonTree(json), recordSchema);
+    JsonNode result = (JsonNode) JsonSchemaUtils.getValue(envelope);
     assertEquals(true, result.get("null").isNull());
     assertEquals(true, result.get("boolean").booleanValue());
     assertEquals(12, result.get("number").intValue());
@@ -126,7 +135,8 @@ public class JsonSchemaTest {
   public void testArrayToJsonSchema() throws Exception {
     String json = "[\"one\", \"two\", \"three\"]";
 
-    Object result = JsonSchemaUtils.toObject(jsonTree(json), arraySchema);
+    Object envelope = JsonSchemaUtils.toObject(jsonTree(json), arraySchema);
+    JsonNode result = (JsonNode) JsonSchemaUtils.getValue(envelope);
     ArrayNode arrayNode = (ArrayNode) result;
     Iterator<JsonNode> elements = arrayNode.elements();
     List<String> strings = new ArrayList<String>();
@@ -138,10 +148,12 @@ public class JsonSchemaTest {
 
   @Test
   public void testUnionToJsonSchema() throws Exception {
-    Object result = JsonSchemaUtils.toObject(jsonTree("\"test\""), unionSchema);
+    Object envelope = JsonSchemaUtils.toObject(jsonTree("\"test\""), unionSchema);
+    JsonNode result = (JsonNode) JsonSchemaUtils.getValue(envelope);
     assertEquals("test", ((TextNode) result).asText());
 
-    result = JsonSchemaUtils.toObject(jsonTree("12"), unionSchema);
+    envelope = JsonSchemaUtils.toObject(jsonTree("12"), unionSchema);
+    result = (JsonNode) JsonSchemaUtils.getValue(envelope);
     assertEquals(12, ((NumericNode) result).asInt());
 
     try {
@@ -154,7 +166,8 @@ public class JsonSchemaTest {
 
   @Test
   public void testEnumToJsonSchema() throws Exception {
-    Object result = JsonSchemaUtils.toObject(jsonTree("\"red\""), enumSchema);
+    Object envelope = JsonSchemaUtils.toObject(jsonTree("\"red\""), enumSchema);
+    JsonNode result = (JsonNode) JsonSchemaUtils.getValue(envelope);
     assertEquals("red", ((TextNode) result).asText());
 
     try {

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
@@ -57,7 +57,7 @@ public abstract class AbstractKafkaJsonSchemaDeserializer<T> extends AbstractKaf
         DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
         failUnknownProperties
     );
-    this.validate = config.getBoolean(KafkaJsonSchemaSerializerConfig.FAIL_INVALID_SCHEMA);
+    this.validate = config.getBoolean(KafkaJsonSchemaDeserializerConfig.FAIL_INVALID_SCHEMA);
     this.typeProperty = config.getString(KafkaJsonSchemaDeserializerConfig.TYPE_PROPERTY);
   }
 


### PR DESCRIPTION
This method is mainly used by the REST Proxy and tests.
The return value is passed to KafkaJsonSchemaSerializer.
By wrapping the schema and payload in an envelope, the
serializer will use the schema from the envelope rather
than trying to generate one based on the JsonNode (which
will be incorrect).