### PR TITLE
Fix cyclic schema references

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.avro;
 
+import io.confluent.kafka.serializers.NonRecordContainer;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericEnumSymbol;
@@ -43,6 +44,8 @@ import org.codehaus.jackson.node.IntNode;
 import org.codehaus.jackson.node.JsonNodeFactory;
 import org.codehaus.jackson.node.NumericNode;
 import org.codehaus.jackson.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -60,10 +63,6 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-
-import io.confluent.kafka.serializers.NonRecordContainer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Utilities for converting between our runtime data format and Avro, and (de)serializing that data.
@@ -1522,6 +1521,9 @@ public class AvroData {
     AvroSchemaAndVersion schemaAndVersion = new AvroSchemaAndVersion(schema, version);
     Schema cachedSchema = toConnectSchemaCache.get(schemaAndVersion);
     if (cachedSchema != null) {
+      if (schema.getType() == org.apache.avro.Schema.Type.RECORD) {
+          toConnectContext.cycleReferences.put(schema, new CyclicSchemaWrapper(cachedSchema));
+      }
       return cachedSchema;
     }
 

--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -1522,7 +1522,10 @@ public class AvroData {
     Schema cachedSchema = toConnectSchemaCache.get(schemaAndVersion);
     if (cachedSchema != null) {
       if (schema.getType() == org.apache.avro.Schema.Type.RECORD) {
-          toConnectContext.cycleReferences.put(schema, new CyclicSchemaWrapper(cachedSchema));
+        // cycleReferences is only populated with record type schemas. We need to initialize it here
+        // with the top-level record schema, as would happen if we did not hit the cache. This
+        // schema has the version information set, thus it properly works with schemaEquals.
+        toConnectContext.cycleReferences.put(schema, new CyclicSchemaWrapper(cachedSchema));
       }
       return cachedSchema;
     }

--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -16,7 +16,6 @@
 
 package io.confluent.connect.avro;
 
-import io.confluent.kafka.serializers.NonRecordContainer;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericEnumSymbol;
@@ -44,8 +43,6 @@ import org.codehaus.jackson.node.IntNode;
 import org.codehaus.jackson.node.JsonNodeFactory;
 import org.codehaus.jackson.node.NumericNode;
 import org.codehaus.jackson.node.ObjectNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -63,6 +60,10 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+
+import io.confluent.kafka.serializers.NonRecordContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utilities for converting between our runtime data format and Avro, and (de)serializing that data.

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -2295,16 +2295,22 @@ public class AvroDataTest {
             "  ]\n" +
             "}\n";
 
+    AvroDataConfig avroDataConfig = new AvroDataConfig.Builder()
+            .with(AvroDataConfig.CONNECT_META_DATA_CONFIG, false)
+            .build();
+    AvroData graphAvroData = new AvroData(avroDataConfig);
+
     // Use the generated Connect schema
-    org.apache.avro.Schema schema = avroData.fromConnectSchema(avroData.toConnectSchema(
+    org.apache.avro.Schema schema = graphAvroData.fromConnectSchema(graphAvroData.toConnectSchema(
             new org.apache.avro.Schema.Parser().parse(schemaStr)));
 
+    Integer version = 1;
+
     GenericRecord person = getUnionCycleRecord(schema);
-    SchemaAndValue sv = avroData.toConnectData(schema, person);
+    SchemaAndValue sv = graphAvroData.toConnectData(schema, person, version);
 
-    assertEquals(sv, avroData.toConnectData(schema, getUnionCycleRecord(schema)));
-
-    assertEquals(person, avroData.fromConnectData(sv.schema(), sv.value()));
+    assertEquals(sv, graphAvroData.toConnectData(schema, getUnionCycleRecord(schema), version));
+    assertEquals(person, graphAvroData.fromConnectData(sv.schema(), sv.value()));
   }
 
   private GenericRecord getUnionCycleRecord(org.apache.avro.Schema connectSchema) {


### PR DESCRIPTION
Initializes the AvroConverter cycleReferences map in cases where the connect cache is being hit. Without this, repetitive calls to the converter can yield different results.