### PR TITLE
Fix null schema type

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
@@ -20,14 +20,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-
-import javax.ws.rs.DefaultValue;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-
-import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Schema implements Comparable<Schema> {
@@ -43,13 +40,13 @@ public class Schema implements Comparable<Schema> {
   public Schema(@JsonProperty("subject") String subject,
                 @JsonProperty("version") Integer version,
                 @JsonProperty("id") Integer id,
-                @JsonProperty("schemaType") @DefaultValue("AVRO") String schemaType,
+                @JsonProperty("schemaType") String schemaType,
                 @JsonProperty("references") List<SchemaReference> references,
                 @JsonProperty("schema") String schema) {
     this.subject = subject;
     this.version = version;
     this.id = id;
-    this.schemaType = schemaType;
+    this.schemaType = schemaType != null ? schemaType : AvroSchema.TYPE;
     this.references = references != null ? references : Collections.emptyList();
     this.schema = schema;
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
@@ -32,8 +32,8 @@ public class Schema implements Comparable<Schema> {
   private String subject;
   private Integer version;
   private Integer id;
-  private String schemaType = AvroSchema.TYPE;
-  private List<SchemaReference> references = Collections.emptyList();
+  private String schemaType;
+  private List<SchemaReference> references;
   private String schema;
 
   @JsonCreator

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaValue.java
@@ -18,22 +18,17 @@ package io.confluent.kafka.schemaregistry.storage;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import io.confluent.kafka.schemaregistry.avro.AvroSchema;
-
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.annotations.VisibleForTesting;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaTypeConverter;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import javax.validation.constraints.Min;
-import javax.ws.rs.DefaultValue;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
-import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaTypeConverter;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class SchemaValue implements Comparable<SchemaValue>, SchemaRegistryValue {
@@ -68,14 +63,14 @@ public class SchemaValue implements Comparable<SchemaValue>, SchemaRegistryValue
   public SchemaValue(@JsonProperty("subject") String subject,
                      @JsonProperty("version") Integer version,
                      @JsonProperty("id") Integer id,
-                     @JsonProperty("schemaType") @DefaultValue("AVRO") String schemaType,
+                     @JsonProperty("schemaType") String schemaType,
                      @JsonProperty("references") List<SchemaReference> references,
                      @JsonProperty("schema") String schema,
                      @JsonProperty("deleted") boolean deleted) {
     this.subject = subject;
     this.version = version;
     this.id = id;
-    this.schemaType = schemaType;
+    this.schemaType = schemaType != null ? schemaType : AvroSchema.TYPE;
     this.references = references != null ? references : Collections.emptyList();
     this.schema = schema;
     this.deleted = deleted;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaValue.java
@@ -128,7 +128,7 @@ public class SchemaValue implements Comparable<SchemaValue>, SchemaRegistryValue
 
   @JsonProperty("schemaType")
   public void setSchemaType(String schemaType) {
-    this.schemaType = schemaType;
+    this.schemaType = schemaType != null ? schemaType : AvroSchema.TYPE;
   }
 
   @JsonProperty("references")

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/SchemaValuesTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/SchemaValuesTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import org.junit.Test;
 
 import io.confluent.kafka.schemaregistry.storage.exceptions.SerializationException;
@@ -48,7 +49,7 @@ public class SchemaValuesTest {
     assertSchemaValue(subject, version, 1,
                       "{\"type\":\"record\",\"name\":\"myrecord\","
                       + "\"fields\":[{\"name\":\"f1067572235\",\"type\":\"string\"}]}",
-                      false, schemaValue);
+                      AvroSchema.TYPE, false, schemaValue);
 
   }
 
@@ -74,7 +75,7 @@ public class SchemaValuesTest {
     assertSchemaValue(subject, version, 1,
                       "{\"type\":\"record\",\"name\":\"myrecord\","
                       + "\"fields\":[{\"name\":\"f1067572235\",\"type\":\"string\"}]}",
-                      false, schemaValue);
+                      AvroSchema.TYPE, false, schemaValue);
 
   }
 
@@ -100,7 +101,7 @@ public class SchemaValuesTest {
     assertSchemaValue(subject, version, 1,
                       "{\"type\":\"record\",\"name\":\"myrecord\","
                       + "\"fields\":[{\"name\":\"f1067572235\",\"type\":\"string\"}]}",
-                      true, schemaValue);
+                      AvroSchema.TYPE,true, schemaValue);
 
   }
 
@@ -129,14 +130,14 @@ public class SchemaValuesTest {
   }
 
   private void assertSchemaValue(String subject, int version, int schemaId,
-                                 String schema, boolean deleted, SchemaValue schemaValue) {
-
+                                 String schema, String type, boolean deleted,
+                                 SchemaValue schemaValue) {
     assertNotNull("Not Null", schemaValue);
     assertEquals("Subject Matches", subject, schemaValue.getSubject());
     assertEquals("Version matches", (Integer) version, schemaValue.getVersion());
     assertEquals("SchemaId matches", (Integer) schemaId, schemaValue.getId());
     assertEquals("Schema Matches", schema, schemaValue.getSchema());
+    assertEquals("Type matches", type, schemaValue.getSchemaType());
     assertEquals("Delete Flag Matches", deleted, schemaValue.isDeleted());
-
   }
 }


### PR DESCRIPTION
The DefaultValue annotation does not properly work while deserializing Schema and SchemaValue objects from JSON. This simple PR addresses the problem.