### PR TITLE
Allow unknown properties while deserializing SchemaRegistryProtocol.Assignment

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryProtocol.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryProtocol.java
@@ -16,13 +16,13 @@
 
 package io.confluent.kafka.schemaregistry.masterelector.kafka;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.kafka.schemaregistry.storage.SchemaRegistryIdentity;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-
-import io.confluent.kafka.schemaregistry.storage.SchemaRegistryIdentity;
 
 /**
  * This class implements the protocol for Schema Registry instances in a Kafka group. It includes
@@ -48,6 +48,7 @@ class SchemaRegistryProtocol {
     return Assignment.fromJson(buffer);
   }
 
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public static class Assignment {
     public static final int CURRENT_VERSION = 1;
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryProtocolTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryProtocolTest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafka.schemaregistry.masterelector.kafka;
+
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+public class SchemaRegistryProtocolTest {
+
+  @Test
+  public void testDeserialization() {
+    SchemaRegistryProtocol.Assignment assignment =
+            new SchemaRegistryProtocol.Assignment((short) 0, "master", null);
+    ByteBuffer bytes = assignment.toJsonBytes();
+    assert bytes != null;
+  }
+}

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryProtocolTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/masterelector/kafka/SchemaRegistryProtocolTest.java
@@ -20,13 +20,20 @@ import org.junit.Test;
 
 import java.nio.ByteBuffer;
 
+import static org.junit.Assert.assertNotNull;
+
 public class SchemaRegistryProtocolTest {
 
   @Test
-  public void testDeserialization() {
+  public void testDeserializeWithUnknownProperties() {
+    String json = "{\"error\":0," +
+            "\"master\":\"master\"," +
+            "\"master_identity\":null," +
+            "\"unknown_property\":null," +
+            "\"version\":1}";
+    ByteBuffer byteBuffer = ByteBuffer.wrap(json.getBytes());
     SchemaRegistryProtocol.Assignment assignment =
-            new SchemaRegistryProtocol.Assignment((short) 0, "master", null);
-    ByteBuffer bytes = assignment.toJsonBytes();
-    assert bytes != null;
+            SchemaRegistryProtocol.Assignment.fromJson(byteBuffer);
+    assertNotNull(assignment);
   }
 }


### PR DESCRIPTION
In order to allow for future expansion of the Kafka master election protocol messages, we need to discard unknown properties while deserializing SchemaRegistryProtocol.Assignment JSON objects. Without this, adding a new field in a newer SR version would cause old SR instances to crash.