### PR TITLE
DG-436 Pass existing Avro schema instead of regenerating

### DIFF
--- a/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -333,6 +333,10 @@ public class AvroData {
    */
   public Object fromConnectData(Schema schema, Object value) {
     org.apache.avro.Schema avroSchema = fromConnectSchema(schema);
+    return fromConnectData(schema, avroSchema, value);
+  }
+
+  protected Object fromConnectData(Schema schema, org.apache.avro.Schema avroSchema, Object value) {
     return fromConnectData(schema, avroSchema, value, true, false, enhancedSchemaSupport);
   }
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
@@ -161,7 +161,7 @@ public class AvroMessageReader extends SchemaMessageReader<Object> {
         Object object,
         ParsedSchema schema
     ) {
-      return super.serializeImpl(subject, object);
+      return super.serializeImpl(subject, object, (AvroSchema) schema);
     }
   }
 }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
@@ -55,10 +55,9 @@ public class KafkaAvroSerializer extends AbstractKafkaAvroSerializer implements 
     if (record == null) {
       return null;
     }
-    return serializeImpl(
-        getSubjectName(topic, isKey, record,
-            new AvroSchema(AvroSchemaUtils.getSchema(record, useSchemaReflection))),
-            record);
+    AvroSchema schema = new AvroSchema(AvroSchemaUtils.getSchema(record, useSchemaReflection));
+    return serializeImpl(getSubjectName(topic, isKey, record, schema),
+        record, schema);
   }
 
   @Override

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -13,7 +13,7 @@
               files="SchemaRegistryCoordinator.java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(AbstractKafkaAvroDeserializer|AbstractKafkaAvroSerializer|RestService|Errors|SchemaRegistryRestApplication|KafkaSchemaRegistry|KafkaStore|AvroData|KafkaGroupMasterElector|ProtobufSchema|ProtobufData|JsonSchemaData|InMemoryCache|SchemaMessageReader|JsonSchemaConverter).java"/>
+              files="(AbstractKafkaAvroDeserializer|AbstractKafkaAvroSerializer|RestService|Errors|SchemaRegistryRestApplication|KafkaSchemaRegistry|KafkaStore|AvroConverter|AvroData|KafkaGroupMasterElector|ProtobufSchema|ProtobufData|JsonSchemaData|InMemoryCache|SchemaMessageReader|JsonSchemaConverter).java"/>
 
     <suppress checks="ClassFanOutComplexity"
               files="(RestService|KafkaSchemaRegistry|KafkaStore|KafkaStoreReaderThread|AvroData|KafkaGroupMasterElector).java"/>


### PR DESCRIPTION
During serialization, pass an existing Avro schema instead
of regenerating it from the payload.  This is more efficient,
and also fixes a bug in unions where the schema generated
from the payload no longer reflects the original union.