### PR TITLE
Add ability to use latest version during serialization

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
@@ -92,10 +92,11 @@ public class AvroMessageReader extends SchemaMessageReader<Object> {
       String topic,
       boolean parseKey,
       BufferedReader reader,
-      boolean autoRegister
+      boolean autoRegister,
+      boolean useLatest
   ) {
     super(schemaRegistryClient, new AvroSchema(keySchema), new AvroSchema(valueSchema), topic,
-        parseKey, reader, autoRegister);
+        parseKey, reader, autoRegister, useLatest);
   }
 
   @Override

--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
@@ -102,9 +102,10 @@ public class AvroMessageReader extends SchemaMessageReader<Object> {
   protected SchemaMessageSerializer<Object> createSerializer(
       SchemaRegistryClient schemaRegistryClient,
       boolean autoRegister,
+      boolean useLatest,
       Serializer keySerializer
   ) {
-    return new AvroMessageSerializer(schemaRegistryClient, autoRegister, keySerializer);
+    return new AvroMessageSerializer(schemaRegistryClient, autoRegister, useLatest, keySerializer);
   }
 
   @Override
@@ -136,10 +137,12 @@ public class AvroMessageReader extends SchemaMessageReader<Object> {
     protected final Serializer keySerializer;
 
     AvroMessageSerializer(
-        SchemaRegistryClient schemaRegistryClient, boolean autoRegister, Serializer keySerializer
+        SchemaRegistryClient schemaRegistryClient,
+        boolean autoRegister, boolean useLatest, Serializer keySerializer
     ) {
       this.schemaRegistry = schemaRegistryClient;
       this.autoRegisterSchema = autoRegister;
+      this.useLatestVersion = useLatest;
       this.keySerializer = keySerializer;
     }
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -40,10 +40,12 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
 
   private final EncoderFactory encoderFactory = EncoderFactory.get();
   protected boolean autoRegisterSchema;
+  protected boolean useLatestVersion;
 
   protected void configure(KafkaAvroSerializerConfig config) {
     configureClientProperties(config, new AvroSchemaProvider());
     autoRegisterSchema = config.autoRegisterSchema();
+    useLatestVersion = config.useLatestVersion();
   }
 
   protected KafkaAvroSerializerConfig serializerConfig(Map<String, ?> props) {
@@ -70,6 +72,10 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
       if (autoRegisterSchema) {
         restClientErrorMsg = "Error registering Avro schema: ";
         id = schemaRegistry.register(subject, schema);
+      } else if (useLatestVersion) {
+        restClientErrorMsg = "Error retrieving latest version: ";
+        schema = (AvroSchema) lookupLatestVersion(subject, schema);
+        id = schemaRegistry.getId(subject, schema);
       } else {
         restClientErrorMsg = "Error retrieving Avro schema: ";
         id = schemaRegistry.getId(subject, schema);

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageReader.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageReader.java
@@ -107,9 +107,11 @@ public class JsonSchemaMessageReader extends SchemaMessageReader<JsonNode>
   protected SchemaMessageSerializer<JsonNode> createSerializer(
       SchemaRegistryClient schemaRegistryClient,
       boolean autoRegister,
+      boolean useLatest,
       Serializer keySerializer
   ) {
-    return new JsonSchemaMessageSerializer(schemaRegistryClient, autoRegister, keySerializer);
+    return new JsonSchemaMessageSerializer(
+        schemaRegistryClient, autoRegister, useLatest, keySerializer);
   }
 
   @Override
@@ -132,10 +134,12 @@ public class JsonSchemaMessageReader extends SchemaMessageReader<JsonNode>
     protected final Serializer keySerializer;
 
     JsonSchemaMessageSerializer(
-        SchemaRegistryClient schemaRegistryClient, boolean autoRegister, Serializer keySerializer
+        SchemaRegistryClient schemaRegistryClient,
+        boolean autoRegister, boolean useLatest, Serializer keySerializer
     ) {
       this.schemaRegistry = schemaRegistryClient;
       this.autoRegisterSchema = autoRegister;
+      this.useLatestVersion = useLatest;
       this.keySerializer = keySerializer;
       this.validate = true;
     }

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageReader.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageReader.java
@@ -97,10 +97,11 @@ public class JsonSchemaMessageReader extends SchemaMessageReader<JsonNode>
       String topic,
       boolean parseKey,
       BufferedReader reader,
-      boolean autoRegister
+      boolean autoRegister,
+      boolean useLatest
   ) {
     super(schemaRegistryClient, keySchema, valueSchema, topic,
-        parseKey, reader, autoRegister);
+        parseKey, reader, autoRegister, useLatest);
   }
 
   @Override

--- a/json-schema-serializer/src/test/java/io/confluent/kafka/formatter/json/KafkaJsonSchemaFormatterTest.java
+++ b/json-schema-serializer/src/test/java/io/confluent/kafka/formatter/json/KafkaJsonSchemaFormatterTest.java
@@ -71,7 +71,7 @@ public class KafkaJsonSchemaFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     JsonSchemaMessageReader jsonSchemaReader =
         new JsonSchemaMessageReader(schemaRegistry, null, recordSchema, "topic1", false, reader,
-            true);
+            true, false);
     ProducerRecord<byte[], byte[]> message = jsonSchemaReader.readMessage();
 
     byte[] serializedValue = message.value();
@@ -98,7 +98,7 @@ public class KafkaJsonSchemaFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     JsonSchemaMessageReader jsonSchemaReader =
         new JsonSchemaMessageReader(schemaRegistry, keySchema, recordSchema, "topic1", true, reader,
-            true);
+            true, false);
     ProducerRecord<byte[], byte[]> message = jsonSchemaReader.readMessage();
 
     byte[] serializedKey = message.key();
@@ -123,7 +123,7 @@ public class KafkaJsonSchemaFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     JsonSchemaMessageReader jsonSchemaReader =
         new JsonSchemaMessageReader(schemaRegistry, null, recordSchema, "topic1", false, reader,
-            true);
+            true, false);
     try {
       jsonSchemaReader.readMessage();
       fail("Registering an invalid schema should fail");

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/formatter/protobuf/ProtobufMessageReader.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/formatter/protobuf/ProtobufMessageReader.java
@@ -78,9 +78,11 @@ public class ProtobufMessageReader extends SchemaMessageReader<Message> {
   protected SchemaMessageSerializer<Message> createSerializer(
       SchemaRegistryClient schemaRegistryClient,
       boolean autoRegister,
+      boolean useLatest,
       Serializer keySerializer
   ) {
-    return new ProtobufMessageSerializer(schemaRegistryClient, autoRegister, keySerializer);
+    return new ProtobufMessageSerializer(
+        schemaRegistryClient, autoRegister, useLatest, keySerializer);
   }
 
   @Override
@@ -107,10 +109,12 @@ public class ProtobufMessageReader extends SchemaMessageReader<Message> {
     protected final Serializer keySerializer;
 
     ProtobufMessageSerializer(
-        SchemaRegistryClient schemaRegistryClient, boolean autoRegister, Serializer keySerializer
+        SchemaRegistryClient schemaRegistryClient,
+        boolean autoRegister, boolean useLatest, Serializer keySerializer
     ) {
       this.schemaRegistry = schemaRegistryClient;
       this.autoRegisterSchema = autoRegister;
+      this.useLatestVersion = useLatest;
       this.keySerializer = keySerializer;
     }
 

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/formatter/protobuf/ProtobufMessageReader.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/formatter/protobuf/ProtobufMessageReader.java
@@ -68,10 +68,11 @@ public class ProtobufMessageReader extends SchemaMessageReader<Message> {
       String topic,
       boolean parseKey,
       BufferedReader reader,
-      boolean autoRegister
+      boolean autoRegister,
+      boolean useLatest
   ) {
     super(schemaRegistryClient, keySchema, valueSchema, topic,
-        parseKey, reader, autoRegister);
+        parseKey, reader, autoRegister, useLatest);
   }
 
   @Override

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufSerializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufSerializer.java
@@ -42,11 +42,13 @@ public abstract class AbstractKafkaProtobufSerializer<T extends Message>
     extends AbstractKafkaSchemaSerDe {
 
   protected boolean autoRegisterSchema;
+  protected boolean useLatestVersion;
   protected ReferenceSubjectNameStrategy referenceSubjectNameStrategy;
 
   protected void configure(KafkaProtobufSerializerConfig config) {
     configureClientProperties(config, new ProtobufSchemaProvider());
     this.autoRegisterSchema = config.autoRegisterSchema();
+    this.useLatestVersion = config.useLatestVersion();
     this.referenceSubjectNameStrategy = config.referenceSubjectNameStrategyInstance();
   }
 
@@ -77,6 +79,10 @@ public abstract class AbstractKafkaProtobufSerializer<T extends Message>
       if (autoRegisterSchema) {
         restClientErrorMsg = "Error registering Protobuf schema: ";
         id = schemaRegistry.register(subject, schema);
+      } else if (useLatestVersion) {
+        restClientErrorMsg = "Error retrieving latest version: ";
+        schema = (ProtobufSchema) lookupLatestVersion(subject, schema);
+        id = schemaRegistry.getId(subject, schema);
       } else {
         restClientErrorMsg = "Error retrieving Protobuf schema: ";
         id = schemaRegistry.getId(subject, schema);

--- a/protobuf-serializer/src/test/java/io/confluent/kafka/formatter/protobuf/KafkaProtobufFormatterTest.java
+++ b/protobuf-serializer/src/test/java/io/confluent/kafka/formatter/protobuf/KafkaProtobufFormatterTest.java
@@ -76,7 +76,7 @@ public class KafkaProtobufFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     ProtobufMessageReader protobufReader =
         new ProtobufMessageReader(schemaRegistry, null, recordSchema, "topic1", false, reader,
-            true);
+            true, false);
     ProducerRecord<byte[], byte[]> message = protobufReader.readMessage();
 
     byte[] serializedValue = message.value();
@@ -102,7 +102,7 @@ public class KafkaProtobufFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     ProtobufMessageReader protobufReader =
         new ProtobufMessageReader(schemaRegistry, null, enumSchema, "topic1", false, reader,
-            true);
+            true, false);
     ProducerRecord<byte[], byte[]> message = protobufReader.readMessage();
 
     byte[] serializedValue = message.value();
@@ -129,7 +129,7 @@ public class KafkaProtobufFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     ProtobufMessageReader protobufReader =
         new ProtobufMessageReader(schemaRegistry, keySchema, recordSchema, "topic1", true, reader,
-            true);
+            true, false);
     ProducerRecord<byte[], byte[]> message = protobufReader.readMessage();
 
     byte[] serializedKey = message.key();
@@ -154,7 +154,7 @@ public class KafkaProtobufFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     ProtobufMessageReader protobufReader =
         new ProtobufMessageReader(schemaRegistry, null, recordSchema, "topic1", false, reader,
-            true);
+            true, false);
     try {
       protobufReader.readMessage();
       fail("Registering an invalid schema should fail");

--- a/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageReader.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageReader.java
@@ -81,12 +81,13 @@ public abstract class SchemaMessageReader<T> implements MessageReader {
     this.valueSubject = topic + "-value";
     this.parseKey = parseKey;
     this.reader = reader;
-    this.serializer = createSerializer(schemaRegistryClient, autoRegister, null);
+    this.serializer = createSerializer(schemaRegistryClient, autoRegister, false, null);
   }
 
   protected abstract SchemaMessageSerializer<T> createSerializer(
       SchemaRegistryClient schemaRegistryClient,
       boolean autoRegister,
+      boolean useLatest,
       Serializer keySerializer
   );
 
@@ -126,9 +127,16 @@ public abstract class SchemaMessageReader<T> implements MessageReader {
     } else {
       autoRegisterSchema = true;
     }
+    boolean useLatest;
+    if (props.containsKey("use.latest.version")) {
+      useLatest = Boolean.parseBoolean(props.getProperty("use.latest.version").trim());
+    } else {
+      useLatest = false;
+    }
 
     if (this.serializer == null) {
-      this.serializer = createSerializer(schemaRegistry, autoRegisterSchema, keySerializer);
+      this.serializer = createSerializer(
+          schemaRegistry, autoRegisterSchema, useLatest, keySerializer);
     }
 
     valueSchema = getSchema(schemaRegistry, props, false);

--- a/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageReader.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageReader.java
@@ -72,7 +72,7 @@ public abstract class SchemaMessageReader<T> implements MessageReader {
    */
   public SchemaMessageReader(
       SchemaRegistryClient schemaRegistryClient, ParsedSchema keySchema, ParsedSchema valueSchema,
-      String topic, boolean parseKey, BufferedReader reader, boolean autoRegister
+      String topic, boolean parseKey, BufferedReader reader, boolean autoRegister, boolean useLatest
   ) {
     this.keySchema = keySchema;
     this.valueSchema = valueSchema;
@@ -81,7 +81,7 @@ public abstract class SchemaMessageReader<T> implements MessageReader {
     this.valueSubject = topic + "-value";
     this.parseKey = parseKey;
     this.reader = reader;
-    this.serializer = createSerializer(schemaRegistryClient, autoRegister, false, null);
+    this.serializer = createSerializer(schemaRegistryClient, autoRegister, useLatest, null);
   }
 
   protected abstract SchemaMessageSerializer<T> createSerializer(

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDeConfig.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDeConfig.java
@@ -64,6 +64,11 @@ public class AbstractKafkaSchemaSerDeConfig extends AbstractConfig {
   public static final String AUTO_REGISTER_SCHEMAS_DOC =
       "Specify if the Serializer should attempt to register the Schema with Schema Registry";
 
+  public static final String USE_LATEST_VERSION = "use.latest.version";
+  public static final boolean USE_LATEST_VERSION_DEFAULT = false;
+  public static final String USE_LATEST_VERSION_DOC =
+      "Specify if the Serializer should use the latest subject version for serialization";
+
   public static final String BASIC_AUTH_CREDENTIALS_SOURCE = SchemaRegistryClientConfig
       .BASIC_AUTH_CREDENTIALS_SOURCE;
   public static final String BASIC_AUTH_CREDENTIALS_SOURCE_DEFAULT = "URL";
@@ -133,8 +138,10 @@ public class AbstractKafkaSchemaSerDeConfig extends AbstractConfig {
                 Importance.LOW, MAX_SCHEMAS_PER_SUBJECT_DOC)
         .define(AUTO_REGISTER_SCHEMAS, Type.BOOLEAN, AUTO_REGISTER_SCHEMAS_DEFAULT,
                 Importance.MEDIUM, AUTO_REGISTER_SCHEMAS_DOC)
+        .define(USE_LATEST_VERSION, Type.BOOLEAN, USE_LATEST_VERSION_DEFAULT,
+                Importance.LOW, USE_LATEST_VERSION_DOC)
         .define(BASIC_AUTH_CREDENTIALS_SOURCE, Type.STRING, BASIC_AUTH_CREDENTIALS_SOURCE_DEFAULT,
-            Importance.MEDIUM, BASIC_AUTH_CREDENTIALS_SOURCE_DOC)
+                Importance.MEDIUM, BASIC_AUTH_CREDENTIALS_SOURCE_DOC)
         .define(BEARER_AUTH_CREDENTIALS_SOURCE, Type.STRING, BEARER_AUTH_CREDENTIALS_SOURCE_DEFAULT,
                 Importance.MEDIUM, BEARER_AUTH_CREDENTIALS_SOURCE_DOC)
         .define(SCHEMA_REGISTRY_USER_INFO_CONFIG, Type.PASSWORD, SCHEMA_REGISTRY_USER_INFO_DEFAULT,
@@ -169,6 +176,10 @@ public class AbstractKafkaSchemaSerDeConfig extends AbstractConfig {
 
   public boolean autoRegisterSchema() {
     return this.getBoolean(AUTO_REGISTER_SCHEMAS);
+  }
+
+  public boolean useLatestVersion() {
+    return this.getBoolean(USE_LATEST_VERSION);
   }
 
   public Object keySubjectNameStrategy() {


### PR DESCRIPTION
This helps to address issues where the object's schema
might have slightly different metadata than the latest
schema that is registered