### PR TITLE
DG-27 Use leader/follower terminology

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -13,10 +13,10 @@
               files="SchemaRegistryCoordinator.java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(AbstractKafkaAvroDeserializer|AbstractKafkaAvroSerializer|RestService|Errors|SchemaRegistryRestApplication|KafkaSchemaRegistry|KafkaStore|AvroConverter|AvroData|KafkaGroupMasterElector|ProtobufSchema|ProtobufData|JsonSchemaData|InMemoryCache|SchemaMessageReader|JsonSchemaConverter).java"/>
+              files="(AbstractKafkaAvroDeserializer|AbstractKafkaAvroSerializer|RestService|Errors|SchemaRegistryRestApplication|KafkaSchemaRegistry|KafkaStore|AvroConverter|AvroData|KafkaGroupLeaderElector|ProtobufSchema|ProtobufData|JsonSchemaData|InMemoryCache|SchemaMessageReader|JsonSchemaConverter).java"/>
 
     <suppress checks="ClassFanOutComplexity"
-              files="(RestService|KafkaSchemaRegistry|KafkaStore|KafkaStoreReaderThread|AvroData|KafkaGroupMasterElector).java"/>
+              files="(RestService|KafkaSchemaRegistry|KafkaStore|KafkaStoreReaderThread|AvroData|KafkaGroupLeaderElector).java"/>
 
     <suppress checks="LineLength"
               files="(Errors|AvroMessageReader).java"/>

--- a/config/schema-registry.properties
+++ b/config/schema-registry.properties
@@ -30,7 +30,7 @@ listeners=http://0.0.0.0:8081
 
 # Alternatively, Schema Registry can now operate without Zookeeper, handling all coordination via
 # Kafka brokers. Use this setting to specify the bootstrap servers for your Kafka cluster and it
-# will be used both for selecting the master schema registry instance and for storing the data for
+# will be used both for selecting the leader schema registry instance and for storing the data for
 # registered schemas.
 # (Note that you cannot mix the two modes; use this mode only on new deployments or by shutting down
 # all instances, switching to the new configuration, and then starting the schema registry

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/exceptions/SchemaRegistryRequestForwardingException.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/exceptions/SchemaRegistryRequestForwardingException.java
@@ -16,7 +16,7 @@
 package io.confluent.kafka.schemaregistry.exceptions;
 
 /**
- * Indicates an error while forwarding a write request to the master node in a schema
+ * Indicates an error while forwarding a write request to the leader node in a schema
  * registry cluster
  */
 public class SchemaRegistryRequestForwardingException extends SchemaRegistryException {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/exceptions/UnknownLeaderException.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/exceptions/UnknownLeaderException.java
@@ -13,20 +13,27 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.kafka.schemaregistry.masterelector.kafka;
+package io.confluent.kafka.schemaregistry.exceptions;
 
 /**
- * Listener for rebalance events in the Kafka group.
+ * Indicates that the node that is asked to serve the request is not the current leader and
+ * is not aware of the leader node to forward the request to
  */
-interface SchemaRegistryRebalanceListener {
-  /**
-   * Invoked when a new assignment is created by joining the schema registry group. This is
-   * invoked for both successful and unsuccessful assignments.
-   */
-  void onAssigned(SchemaRegistryProtocol.Assignment assignment, int generation);
+public class UnknownLeaderException extends SchemaRegistryException {
 
-  /**
-   * Invoked when a rebalance operation starts, revoking leadership
-   */
-  void onRevoked();
+  public UnknownLeaderException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public UnknownLeaderException(String message) {
+    super(message);
+  }
+
+  public UnknownLeaderException(Throwable cause) {
+    super(cause);
+  }
+
+  public UnknownLeaderException() {
+    super();
+  }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/ClientConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/ClientConfig.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.kafka.schemaregistry.masterelector.kafka;
+package io.confluent.kafka.schemaregistry.leaderelector.kafka;
 
 import org.apache.kafka.clients.ClientDnsLookup;
 import org.apache.kafka.clients.CommonClientConfigs;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryProtocol.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryProtocol.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.kafka.schemaregistry.masterelector.kafka;
+package io.confluent.kafka.schemaregistry.leaderelector.kafka;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -60,16 +60,16 @@ class SchemaRegistryProtocol {
 
     private final int version;
     private final short error;
-    private final String master;
-    private final SchemaRegistryIdentity masterIdentity;
+    private final String leader;
+    private final SchemaRegistryIdentity leaderIdentity;
 
     public Assignment(@JsonProperty("error") short error,
-                      @JsonProperty("master") String master,
-                      @JsonProperty("master_identity") SchemaRegistryIdentity masterIdentity) {
+                      @JsonProperty("master") String leader,
+                      @JsonProperty("master_identity") SchemaRegistryIdentity leaderIdentity) {
       this.version = CURRENT_VERSION;
       this.error = error;
-      this.master = master;
-      this.masterIdentity = masterIdentity;
+      this.leader = leader;
+      this.leaderIdentity = leaderIdentity;
     }
 
     public static Assignment fromJson(ByteBuffer json) {
@@ -93,13 +93,13 @@ class SchemaRegistryProtocol {
     }
 
     @JsonProperty("master")
-    public String master() {
-      return master;
+    public String leader() {
+      return leader;
     }
 
     @JsonProperty("master_identity")
-    public SchemaRegistryIdentity masterIdentity() {
-      return masterIdentity;
+    public SchemaRegistryIdentity leaderIdentity() {
+      return leaderIdentity;
     }
 
     public boolean failed() {
@@ -119,8 +119,8 @@ class SchemaRegistryProtocol {
       return "Assignment{"
              + "version=" + version
              + ", error=" + error
-             + ", master='" + master + '\''
-             + ", masterIdentity=" + masterIdentity
+             + ", leader='" + leader + '\''
+             + ", leaderIdentity=" + leaderIdentity
              + '}';
     }
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryRebalanceListener.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryRebalanceListener.java
@@ -13,27 +13,20 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.kafka.schemaregistry.exceptions;
+package io.confluent.kafka.schemaregistry.leaderelector.kafka;
 
 /**
- * Indicates that the node that is asked to serve the request is not the current master and
- * is not aware of the master node to forward the request to
+ * Listener for rebalance events in the Kafka group.
  */
-public class UnknownMasterException extends SchemaRegistryException {
+interface SchemaRegistryRebalanceListener {
+  /**
+   * Invoked when a new assignment is created by joining the schema registry group. This is
+   * invoked for both successful and unsuccessful assignments.
+   */
+  void onAssigned(SchemaRegistryProtocol.Assignment assignment, int generation);
 
-  public UnknownMasterException(String message, Throwable cause) {
-    super(message, cause);
-  }
-
-  public UnknownMasterException(String message) {
-    super(message);
-  }
-
-  public UnknownMasterException(Throwable cause) {
-    super(cause);
-  }
-
-  public UnknownMasterException() {
-    super();
-  }
+  /**
+   * Invoked when a rebalance operation starts, revoking leadership
+   */
+  void onRevoked();
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/metrics/MetricsContainer.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/metrics/MetricsContainer.java
@@ -48,7 +48,7 @@ public class MetricsContainer {
   private final Map<String, String> configuredTags;
   private final String commitId;
 
-  private final SchemaRegistryMetric isMasterNode;
+  private final SchemaRegistryMetric isLeaderNode;
   private final SchemaRegistryMetric nodeCount;
 
   private final SchemaRegistryMetric schemasCreated;
@@ -81,8 +81,8 @@ public class MetricsContainer {
 
     this.metrics = new Metrics(metricConfig, reporters, new SystemTime());
 
-    this.isMasterNode = createMetric("master-slave-role",
-            "1.0 indicates the node is the active master in the cluster and is the"
+    this.isLeaderNode = createMetric("master-slave-role",
+            "1.0 indicates the node is the active leader in the cluster and is the"
             + " node where all register schema and config update requests are "
             + "served.");
     this.nodeCount = createMetric("node-count", "Number of Schema Registry nodes in the cluster");
@@ -129,8 +129,8 @@ public class MetricsContainer {
     return nodeCount;
   }
 
-  public SchemaRegistryMetric isMaster() {
-    return isMasterNode;
+  public SchemaRegistryMetric isLeader() {
+    return isLeaderNode;
   }
 
   public SchemaRegistryMetric getApiCallsSuccess() {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -101,10 +101,12 @@ public class SchemaRegistryConfig extends RestConfig {
   public static final String KAFKASTORE_UPDATE_HANDLERS_CONFIG = "kafkastore.update.handlers";
 
   /**
-   * <code>master.eligibility</code>*
+   * <code>leader.eligibility</code>*
    */
+  @Deprecated
   public static final String MASTER_ELIGIBILITY = "master.eligibility";
-  public static final boolean DEFAULT_MASTER_ELIGIBILITY = true;
+  public static final String LEADER_ELIGIBILITY = "leader.eligibility";
+  public static final boolean DEFAULT_LEADER_ELIGIBILITY = true;
   /**
    * <code>mode.mutability</code>*
    */
@@ -189,7 +191,7 @@ public class SchemaRegistryConfig extends RestConfig {
 
   protected static final String SCHEMAREGISTRY_GROUP_ID_DOC =
       "Use this setting to override the group.id for the Kafka group used when Kafka is used for "
-      + "master election.\n"
+      + "leader election.\n"
       + "Without this configuration, group.id will be \"schema-registry\". If you want to run "
       + "more than one schema registry cluster against a single Kafka cluster you should make "
       + "this setting unique for each cluster.";
@@ -203,7 +205,7 @@ public class SchemaRegistryConfig extends RestConfig {
       + "The effect of this setting depends on whether you specify `kafkastore.connection.url`."
       + "\n"
       + "If `kafkastore.connection.url` is not specified, then the Kafka cluster containing these "
-      + "bootstrap servers will be used both to coordinate schema registry instances (master "
+      + "bootstrap servers will be used both to coordinate schema registry instances (leader "
       + "election) and store schema data."
       + "\n"
       + "If `kafkastore.connection.url` is specified, then this setting is used to control how "
@@ -267,11 +269,11 @@ public class SchemaRegistryConfig extends RestConfig {
       + "forward_transitive (new schema is forward compatible with all previous versions), "
       + "full_transitive (new schema is backward and forward compatible with all previous "
       + "versions)";
-  protected static final String MASTER_ELIGIBILITY_DOC =
-      "If true, this node can participate in master election. In a multi-colo setup, turn this off "
-      + "for clusters in the slave data center.";
+  protected static final String LEADER_ELIGIBILITY_DOC =
+      "If true, this node can participate in leader election. In a multi-colo setup, turn this off "
+      + "for clusters in the follower data center.";
   protected static final String MODE_MUTABILITY_DOC =
-      "If true, this node will allow mode changes if it is the master.";
+      "If true, this node will allow mode changes if it is the leader.";
   protected static final String KAFKASTORE_SECURITY_PROTOCOL_DOC =
       "The security protocol to use when connecting with Kafka, the underlying persistent storage. "
       + "Values can be `PLAINTEXT`, `SSL`, `SASL_PLAINTEXT`, or `SASL_SSL`.";
@@ -333,14 +335,14 @@ public class SchemaRegistryConfig extends RestConfig {
       "  A list of classpath resources containing static resources to serve using the default "
           + "servlet.";
   protected static final String SCHEMAREGISTRY_INTER_INSTANCE_PROTOCOL_DOC =
-      "The protocol used while making calls between the instances of schema registry. The slave "
-      + "to master node calls for writes and deletes will use the specified protocol. The default "
+      "The protocol used while making calls between the instances of schema registry. The follower "
+      + "to leader node calls for writes and deletes will use the specified protocol. The default "
       + "value would be `http`. When `https` is set, `ssl.keystore.` and "
       + "`ssl.truststore.` configs are used while making the call. The "
       + "schema.registry.inter.instance.protocol name is deprecated; prefer using "
       + "inter.instance.protocol instead.";
   private static final String INTER_INSTANCE_HEADERS_WHITELIST_DOC
-      = "A list of ``http`` headers to forward from slave to master, "
+      = "A list of ``http`` headers to forward from follower to leader, "
       + "in addition to ``Content-Type``, ``Accept``, ``Authorization``.";
 
   private static final boolean ZOOKEEPER_SET_ACL_DEFAULT = false;
@@ -426,8 +428,11 @@ public class SchemaRegistryConfig extends RestConfig {
     .define(ZOOKEEPER_SET_ACL_CONFIG, ConfigDef.Type.BOOLEAN, ZOOKEEPER_SET_ACL_DEFAULT,
         ConfigDef.Importance.HIGH, ZOOKEEPER_SET_ACL_DOC
     )
-    .define(MASTER_ELIGIBILITY, ConfigDef.Type.BOOLEAN, DEFAULT_MASTER_ELIGIBILITY,
-        ConfigDef.Importance.MEDIUM, MASTER_ELIGIBILITY_DOC
+    .define(MASTER_ELIGIBILITY, ConfigDef.Type.BOOLEAN, null,
+        ConfigDef.Importance.MEDIUM, LEADER_ELIGIBILITY_DOC
+    )
+    .define(LEADER_ELIGIBILITY, ConfigDef.Type.BOOLEAN, DEFAULT_LEADER_ELIGIBILITY,
+        ConfigDef.Importance.MEDIUM, LEADER_ELIGIBILITY_DOC
     )
     .define(MODE_MUTABILITY, ConfigDef.Type.BOOLEAN, DEFAULT_MODE_MUTABILITY,
         ConfigDef.Importance.LOW, MODE_MUTABILITY_DOC

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/Errors.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/Errors.java
@@ -60,7 +60,7 @@ public class Errors {
   public static final int STORE_ERROR_CODE = 50001;
   public static final int OPERATION_TIMEOUT_ERROR_CODE = 50002;
   public static final int REQUEST_FORWARDING_FAILED_ERROR_CODE = 50003;
-  public static final int UNKNOWN_MASTER_ERROR_CODE = 50004;
+  public static final int UNKNOWN_LEADER_ERROR_CODE = 50004;
   // 50005 is used by the RestService to indicate a JSON Parse Error
 
   public static RestException subjectNotFoundException(String subject) {
@@ -144,7 +144,7 @@ public class Errors {
     return new RestRequestForwardingException(message, cause);
   }
 
-  public static RestException unknownMasterException(String message, Throwable cause) {
-    return new RestUnknownMasterException(message, cause);
+  public static RestException unknownLeaderException(String message, Throwable cause) {
+    return new RestUnknownLeaderException(message, cause);
   }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/RestOperationNotPermittedException.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/RestOperationNotPermittedException.java
@@ -16,8 +16,8 @@
 package io.confluent.kafka.schemaregistry.rest.exceptions;
 
 /**
- * Indicates that the node that is asked to serve the request is not the current master and
- * is not aware of the master node to forward the request to
+ * Indicates that the node that is asked to serve the request is not the current leader and
+ * is not aware of the leader node to forward the request to
  */
 
 import io.confluent.rest.exceptions.RestConstraintViolationException;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/RestRequestForwardingException.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/RestRequestForwardingException.java
@@ -18,7 +18,7 @@ package io.confluent.kafka.schemaregistry.rest.exceptions;
 import io.confluent.rest.exceptions.RestServerErrorException;
 
 /**
- * Indicates a problem while forwarding the request to the master node in a schema
+ * Indicates a problem while forwarding the request to the leader node in a schema
  * registry cluster
  */
 public class RestRequestForwardingException extends RestServerErrorException {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/RestUnknownLeaderException.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/RestUnknownLeaderException.java
@@ -16,21 +16,21 @@
 package io.confluent.kafka.schemaregistry.rest.exceptions;
 
 /**
- * Indicates that the node that is asked to serve the request is not the current master and
- * is not aware of the master node to forward the request to
+ * Indicates that the node that is asked to serve the request is not the current leader and
+ * is not aware of the leader node to forward the request to
  */
 
 import io.confluent.rest.exceptions.RestServerErrorException;
 
-public class RestUnknownMasterException extends RestServerErrorException {
+public class RestUnknownLeaderException extends RestServerErrorException {
 
-  private static final int ERROR_CODE = Errors.UNKNOWN_MASTER_ERROR_CODE;
+  private static final int ERROR_CODE = Errors.UNKNOWN_LEADER_ERROR_CODE;
 
-  public RestUnknownMasterException(String message) {
+  public RestUnknownLeaderException(String message) {
     super(message, ERROR_CODE);
   }
 
-  public RestUnknownMasterException(String message, Throwable cause) {
+  public RestUnknownLeaderException(String message, Throwable cause) {
     super(message, ERROR_CODE, cause);
   }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -44,7 +44,7 @@ import io.confluent.kafka.schemaregistry.exceptions.OperationNotPermittedExcepti
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryRequestForwardingException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException;
-import io.confluent.kafka.schemaregistry.exceptions.UnknownMasterException;
+import io.confluent.kafka.schemaregistry.exceptions.UnknownLeaderException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidCompatibilityException;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
@@ -104,11 +104,11 @@ public class ConfigResource {
       throw Errors.operationNotPermittedException(e.getMessage());
     } catch (SchemaRegistryStoreException e) {
       throw Errors.storeException("Failed to update compatibility level", e);
-    } catch (UnknownMasterException e) {
-      throw Errors.unknownMasterException("Failed to update compatibility level", e);
+    } catch (UnknownLeaderException e) {
+      throw Errors.unknownLeaderException("Failed to update compatibility level", e);
     } catch (SchemaRegistryRequestForwardingException e) {
       throw Errors.requestForwardingFailedException("Error while forwarding update config request"
-                                                    + " to the master", e);
+                                                    + " to the leader", e);
     }
     if (!subjects.contains(subject)) {
       log.debug("Updated compatibility level for unregistered subject " + subject + " to "
@@ -172,11 +172,11 @@ public class ConfigResource {
       throw Errors.operationNotPermittedException(e.getMessage());
     } catch (SchemaRegistryStoreException e) {
       throw Errors.storeException("Failed to update compatibility level", e);
-    } catch (UnknownMasterException e) {
-      throw Errors.unknownMasterException("Failed to update compatibility level", e);
+    } catch (UnknownLeaderException e) {
+      throw Errors.unknownLeaderException("Failed to update compatibility level", e);
     } catch (SchemaRegistryRequestForwardingException e) {
       throw Errors.requestForwardingFailedException("Error while forwarding update config request"
-                                                    + " to the master", e);
+                                                    + " to the leader", e);
     }
 
     return request;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
@@ -38,7 +38,7 @@ import io.confluent.kafka.schemaregistry.exceptions.OperationNotPermittedExcepti
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryRequestForwardingException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException;
-import io.confluent.kafka.schemaregistry.exceptions.UnknownMasterException;
+import io.confluent.kafka.schemaregistry.exceptions.UnknownLeaderException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidModeException;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
@@ -83,11 +83,11 @@ public class ModeResource {
       throw Errors.operationNotPermittedException(e.getMessage());
     } catch (SchemaRegistryStoreException e) {
       throw Errors.storeException("Failed to update mode", e);
-    } catch (UnknownMasterException e) {
-      throw Errors.unknownMasterException("Failed to update mode", e);
+    } catch (UnknownLeaderException e) {
+      throw Errors.unknownLeaderException("Failed to update mode", e);
     } catch (SchemaRegistryRequestForwardingException e) {
       throw Errors.requestForwardingFailedException("Error while forwarding update mode request"
-                                                    + " to the master", e);
+                                                    + " to the leader", e);
     }
 
     return request;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -56,7 +56,7 @@ import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryRequestForwardingException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryTimeoutException;
-import io.confluent.kafka.schemaregistry.exceptions.UnknownMasterException;
+import io.confluent.kafka.schemaregistry.exceptions.UnknownLeaderException;
 import io.confluent.kafka.schemaregistry.rest.VersionId;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
@@ -275,13 +275,13 @@ public class SubjectVersionsResource {
                                   + " to the Kafka store", e);
     } catch (SchemaRegistryRequestForwardingException e) {
       throw Errors.requestForwardingFailedException("Error while forwarding register schema request"
-                                                    + " to the master", e);
+                                                    + " to the leader", e);
     } catch (IncompatibleSchemaException e) {
       throw Errors.incompatibleSchemaException("Schema being registered is incompatible with an"
                                                + " earlier schema for subject "
                                                + "\"" + subjectName + "\"", e);
-    } catch (UnknownMasterException e) {
-      throw Errors.unknownMasterException("Master not known.", e);
+    } catch (UnknownLeaderException e) {
+      throw Errors.unknownLeaderException("Leader not known.", e);
     } catch (SchemaRegistryException e) {
       throw Errors.schemaRegistryException("Error while registering schema", e);
     }
@@ -360,11 +360,11 @@ public class SubjectVersionsResource {
     } catch (SchemaRegistryRequestForwardingException e) {
       throw Errors
           .requestForwardingFailedException("Error while forwarding delete schema version request"
-                                            + " to the master", e);
+                                            + " to the leader", e);
     } catch (ReferenceExistsException e) {
       throw Errors.referenceExistsException(e.getMessage());
-    } catch (UnknownMasterException e) {
-      throw Errors.unknownMasterException("Master not known.", e);
+    } catch (UnknownLeaderException e) {
+      throw Errors.unknownLeaderException("Leader not known.", e);
     } catch (SchemaRegistryException e) {
       throw Errors.schemaRegistryException("Error while deleting Schema Version", e);
     }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -43,13 +43,13 @@ import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryTimeoutException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaVersionNotSoftDeletedException;
 import io.confluent.kafka.schemaregistry.exceptions.SubjectNotSoftDeletedException;
-import io.confluent.kafka.schemaregistry.exceptions.UnknownMasterException;
+import io.confluent.kafka.schemaregistry.exceptions.UnknownLeaderException;
 import io.confluent.kafka.schemaregistry.id.IdGenerator;
 import io.confluent.kafka.schemaregistry.id.IncrementalIdGenerator;
 import io.confluent.kafka.schemaregistry.id.ZookeeperIdGenerator;
 import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
-import io.confluent.kafka.schemaregistry.masterelector.kafka.KafkaGroupMasterElector;
-import io.confluent.kafka.schemaregistry.masterelector.zookeeper.ZookeeperMasterElector;
+import io.confluent.kafka.schemaregistry.leaderelector.kafka.KafkaGroupLeaderElector;
+import io.confluent.kafka.schemaregistry.leaderelector.zookeeper.ZookeeperLeaderElector;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.rest.VersionId;
@@ -87,7 +87,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
-public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaRegistry {
+public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaRegistry {
 
   /**
    * Schema versions under a particular subject are indexed from MIN_VERSION.
@@ -110,13 +110,13 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
   private final int kafkaStoreTimeoutMs;
   private final int initTimeout;
   private final int kafkaStoreMaxRetries;
-  private final boolean isEligibleForMasterElector;
+  private final boolean isEligibleForLeaderElector;
   private final boolean allowModeChanges;
-  private SchemaRegistryIdentity masterIdentity;
-  private RestService masterRestService;
+  private SchemaRegistryIdentity leaderIdentity;
+  private RestService leaderRestService;
   private SslFactory sslFactory;
   private IdGenerator idGenerator = null;
-  private MasterElector masterElector = null;
+  private LeaderElector leaderElector = null;
   private final MetricsContainer metricsContainer;
   private final Map<String, SchemaProvider> providers;
 
@@ -128,16 +128,20 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     }
     this.config = config;
     this.props = new HashMap<>();
+    Boolean leaderEligibility = config.getBoolean(SchemaRegistryConfig.MASTER_ELIGIBILITY);
+    if (leaderEligibility == null) {
+      leaderEligibility = config.getBoolean(SchemaRegistryConfig.LEADER_ELIGIBILITY);
+    }
+    this.isEligibleForLeaderElector = leaderEligibility;
     String host = config.getString(SchemaRegistryConfig.HOST_NAME_CONFIG);
     SchemeAndPort schemeAndPort = getSchemeAndPortForIdentity(
         config.getInt(SchemaRegistryConfig.PORT_CONFIG),
         config.getList(RestConfig.LISTENERS_CONFIG),
         config.interInstanceProtocol()
     );
-    this.isEligibleForMasterElector = config.getBoolean(SchemaRegistryConfig.MASTER_ELIGIBILITY);
     this.allowModeChanges = config.getBoolean(SchemaRegistryConfig.MODE_MUTABILITY);
     this.myIdentity = new SchemaRegistryIdentity(host, schemeAndPort.port,
-        isEligibleForMasterElector, schemeAndPort.scheme);
+        isEligibleForLeaderElector, schemeAndPort.scheme);
     this.sslFactory =
         new SslFactory(ConfigDef.convertToStringMapWithPasswordValues(config.values()));
     this.kafkaStoreTimeoutMs =
@@ -284,7 +288,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     try {
       if (config.useKafkaCoordination()) {
         log.info("Joining schema registry with Kafka-based coordination");
-        masterElector = new KafkaGroupMasterElector(config, myIdentity, this);
+        leaderElector = new KafkaGroupLeaderElector(config, myIdentity, this);
       } else {
         log.info("Joining schema registry with Zookeeper-based coordination");
         log.warn("*****************************************************************************");
@@ -292,12 +296,12 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
         log.warn("Please switch to Kafka-based coordination with "
             + "\"kafkastore.bootstrap.servers\".");
         log.warn("*****************************************************************************");
-        masterElector = new ZookeeperMasterElector(config, myIdentity, this);
+        leaderElector = new ZookeeperLeaderElector(config, myIdentity, this);
       }
-      masterElector.init();
+      leaderElector.init();
     } catch (SchemaRegistryStoreException e) {
       throw new SchemaRegistryInitializationException(
-          "Error electing master while initializing schema registry", e);
+          "Error electing leader while initializing schema registry", e);
     } catch (SchemaRegistryTimeoutException e) {
       throw new SchemaRegistryInitializationException(e);
     }
@@ -307,58 +311,58 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     return kafkaStore.initialized();
   }
 
-  public boolean isMaster() {
-    kafkaStore.masterLock().lock();
+  public boolean isLeader() {
+    kafkaStore.leaderLock().lock();
     try {
-      if (masterIdentity != null && masterIdentity.equals(myIdentity)) {
+      if (leaderIdentity != null && leaderIdentity.equals(myIdentity)) {
         return true;
       } else {
         return false;
       }
     } finally {
-      kafkaStore.masterLock().unlock();
+      kafkaStore.leaderLock().unlock();
     }
   }
 
   /**
-   * 'Inform' this SchemaRegistry instance which SchemaRegistry is the current master.
-   * If this instance is set as the new master, ensure it is up-to-date with data in
+   * 'Inform' this SchemaRegistry instance which SchemaRegistry is the current leader.
+   * If this instance is set as the new leader, ensure it is up-to-date with data in
    * the kafka store, and tell Zookeeper to allocate the next batch of schema IDs.
    *
-   * @param newMaster Identity of the current master. null means no master is alive.
+   * @param newLeader Identity of the current leader. null means no leader is alive.
    */
   @Override
-  public void setMaster(@Nullable SchemaRegistryIdentity newMaster)
+  public void setLeader(@Nullable SchemaRegistryIdentity newLeader)
       throws SchemaRegistryTimeoutException, SchemaRegistryStoreException, IdGenerationException {
-    log.debug("Setting the master to " + newMaster);
+    log.debug("Setting the leader to " + newLeader);
 
-    // Only schema registry instances eligible for master can be set to master
-    if (newMaster != null && !newMaster.getMasterEligibility()) {
+    // Only schema registry instances eligible for leader can be set to leader
+    if (newLeader != null && !newLeader.getLeaderEligibility()) {
       throw new IllegalStateException(
-          "Tried to set an ineligible node to master: " + newMaster);
+          "Tried to set an ineligible node to leader: " + newLeader);
     }
 
-    kafkaStore.masterLock().lock();
+    kafkaStore.leaderLock().lock();
     try {
-      SchemaRegistryIdentity previousMaster = masterIdentity;
-      masterIdentity = newMaster;
+      SchemaRegistryIdentity previousLeader = leaderIdentity;
+      leaderIdentity = newLeader;
 
-      if (masterIdentity == null) {
-        masterRestService = null;
+      if (leaderIdentity == null) {
+        leaderRestService = null;
       } else {
-        masterRestService = new RestService(masterIdentity.getUrl());
+        leaderRestService = new RestService(leaderIdentity.getUrl());
         if (sslFactory != null && sslFactory.sslContext() != null) {
-          masterRestService.setSslSocketFactory(sslFactory.sslContext().getSocketFactory());
-          masterRestService.setHostnameVerifier(getHostnameVerifier());
+          leaderRestService.setSslSocketFactory(sslFactory.sslContext().getSocketFactory());
+          leaderRestService.setHostnameVerifier(getHostnameVerifier());
         }
       }
 
-      if (masterIdentity != null && !masterIdentity.equals(previousMaster) && isMaster()) {
-        // The new master may not know the exact last offset in the Kafka log. So, mark the
+      if (leaderIdentity != null && !leaderIdentity.equals(previousLeader) && isLeader()) {
+        // The new leader may not know the exact last offset in the Kafka log. So, mark the
         // last offset invalid here
         kafkaStore.markLastWrittenOffsetInvalid();
-        //ensure the new master catches up with the offsets before it gets nextid and assigns
-        // master
+        //ensure the new leader catches up with the offsets before it gets nextid and assigns
+        // leader
         try {
           kafkaStore.waitUntilKafkaReaderReachesLastOffset(initTimeout);
         } catch (StoreException e) {
@@ -366,9 +370,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
         }
         idGenerator.init();
       }
-      metricsContainer.isMaster().set(isMaster() ? 1 : 0);
+      metricsContainer.isLeader().set(isLeader() ? 1 : 0);
     } finally {
-      kafkaStore.masterLock().unlock();
+      kafkaStore.leaderLock().unlock();
     }
   }
 
@@ -381,15 +385,15 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
   }
 
   /**
-   * Return the identity of the SchemaRegistry that this instance thinks is current master.
-   * Any request that requires writing new data gets forwarded to the master.
+   * Return the identity of the SchemaRegistry that this instance thinks is current leader.
+   * Any request that requires writing new data gets forwarded to the leader.
    */
-  public SchemaRegistryIdentity masterIdentity() {
-    kafkaStore.masterLock().lock();
+  public SchemaRegistryIdentity leaderIdentity() {
+    kafkaStore.leaderLock().lock();
     try {
-      return masterIdentity;
+      return leaderIdentity;
     } finally {
-      kafkaStore.masterLock().unlock();
+      kafkaStore.leaderLock().unlock();
     }
   }
 
@@ -541,14 +545,14 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
 
     kafkaStore.lockFor(subject).lock();
     try {
-      if (isMaster()) {
+      if (isLeader()) {
         return register(subject, schema);
       } else {
-        // forward registering request to the master
-        if (masterIdentity != null) {
-          return forwardRegisterRequestToMaster(subject, schema, headerProperties);
+        // forward registering request to the leader
+        if (leaderIdentity != null) {
+          return forwardRegisterRequestToLeader(subject, schema, headerProperties);
         } else {
-          throw new UnknownMasterException("Register schema request failed since master is "
+          throw new UnknownLeaderException("Register schema request failed since leader is "
                                            + "unknown");
         }
       }
@@ -606,15 +610,15 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
 
     kafkaStore.lockFor(subject).lock();
     try {
-      if (isMaster()) {
+      if (isLeader()) {
         deleteSchemaVersion(subject, schema, permanentDelete);
       } else {
-        // forward registering request to the master
-        if (masterIdentity != null) {
-          forwardDeleteSchemaVersionRequestToMaster(headerProperties, subject,
+        // forward registering request to the leader
+        if (leaderIdentity != null) {
+          forwardDeleteSchemaVersionRequestToLeader(headerProperties, subject,
                   schema.getVersion(), permanentDelete);
         } else {
-          throw new UnknownMasterException("Register schema request failed since master is "
+          throw new UnknownLeaderException("Register schema request failed since leader is "
                                            + "unknown");
         }
       }
@@ -681,16 +685,16 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
       boolean permanentDelete) throws SchemaRegistryException {
     kafkaStore.lockFor(subject).lock();
     try {
-      if (isMaster()) {
+      if (isLeader()) {
         return deleteSubject(subject, permanentDelete);
       } else {
-        // forward registering request to the master
-        if (masterIdentity != null) {
-          return forwardDeleteSubjectRequestToMaster(requestProperties,
+        // forward registering request to the leader
+        if (leaderIdentity != null) {
+          return forwardDeleteSubjectRequestToLeader(requestProperties,
                   subject,
                   permanentDelete);
         } else {
-          throw new UnknownMasterException("Register schema request failed since master is "
+          throw new UnknownLeaderException("Register schema request failed since leader is "
                                            + "unknown");
         }
       }
@@ -741,10 +745,10 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     return null;
   }
 
-  private int forwardRegisterRequestToMaster(String subject, Schema schema,
+  private int forwardRegisterRequestToLeader(String subject, Schema schema,
                                              Map<String, String> headerProperties)
       throws SchemaRegistryRequestForwardingException {
-    final UrlList baseUrl = masterRestService.getBaseUrls();
+    final UrlList baseUrl = leaderRestService.getBaseUrls();
 
     RegisterSchemaRequest registerSchemaRequest = new RegisterSchemaRequest();
     registerSchemaRequest.setSchema(schema.getSchema());
@@ -754,7 +758,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     log.debug(String.format("Forwarding registering schema request %s to %s",
                             registerSchemaRequest, baseUrl));
     try {
-      int id = masterRestService.registerSchema(headerProperties, registerSchemaRequest, subject);
+      int id = leaderRestService.registerSchema(headerProperties, registerSchemaRequest, subject);
       return id;
     } catch (IOException e) {
       throw new SchemaRegistryRequestForwardingException(
@@ -766,18 +770,18 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     }
   }
 
-  private void forwardUpdateCompatibilityLevelRequestToMaster(
+  private void forwardUpdateCompatibilityLevelRequestToLeader(
       String subject, CompatibilityLevel compatibilityLevel,
       Map<String, String> headerProperties)
       throws SchemaRegistryRequestForwardingException {
-    UrlList baseUrl = masterRestService.getBaseUrls();
+    UrlList baseUrl = leaderRestService.getBaseUrls();
 
     ConfigUpdateRequest configUpdateRequest = new ConfigUpdateRequest();
     configUpdateRequest.setCompatibilityLevel(compatibilityLevel.name);
     log.debug(String.format("Forwarding update config request %s to %s",
                             configUpdateRequest, baseUrl));
     try {
-      masterRestService.updateConfig(headerProperties, configUpdateRequest, subject);
+      leaderRestService.updateConfig(headerProperties, configUpdateRequest, subject);
     } catch (IOException e) {
       throw new SchemaRegistryRequestForwardingException(
           String.format("Unexpected error while forwarding the update config request %s to %s",
@@ -788,17 +792,17 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     }
   }
 
-  private void forwardDeleteSchemaVersionRequestToMaster(
+  private void forwardDeleteSchemaVersionRequestToLeader(
       Map<String, String> headerProperties,
       String subject,
       Integer version,
       boolean permanentDelete) throws SchemaRegistryRequestForwardingException {
-    UrlList baseUrl = masterRestService.getBaseUrls();
+    UrlList baseUrl = leaderRestService.getBaseUrls();
 
     log.debug(String.format("Forwarding deleteSchemaVersion schema version request %s-%s to %s",
                             subject, version, baseUrl));
     try {
-      masterRestService.deleteSchemaVersion(headerProperties, subject,
+      leaderRestService.deleteSchemaVersion(headerProperties, subject,
               String.valueOf(version), permanentDelete);
     } catch (IOException e) {
       throw new SchemaRegistryRequestForwardingException(
@@ -810,16 +814,16 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     }
   }
 
-  private List<Integer> forwardDeleteSubjectRequestToMaster(
+  private List<Integer> forwardDeleteSubjectRequestToLeader(
       Map<String, String> requestProperties,
       String subject,
       boolean permanentDelete) throws SchemaRegistryRequestForwardingException {
-    UrlList baseUrl = masterRestService.getBaseUrls();
+    UrlList baseUrl = leaderRestService.getBaseUrls();
 
     log.debug(String.format("Forwarding delete subject request for  %s to %s",
                             subject, baseUrl));
     try {
-      return masterRestService.deleteSubject(requestProperties, subject, permanentDelete);
+      return leaderRestService.deleteSubject(requestProperties, subject, permanentDelete);
     } catch (IOException e) {
       throw new SchemaRegistryRequestForwardingException(
           String.format(
@@ -830,18 +834,18 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     }
   }
 
-  private void forwardSetModeRequestToMaster(
+  private void forwardSetModeRequestToLeader(
       String subject, Mode mode,
       Map<String, String> headerProperties)
       throws SchemaRegistryRequestForwardingException {
-    UrlList baseUrl = masterRestService.getBaseUrls();
+    UrlList baseUrl = leaderRestService.getBaseUrls();
 
     ModeUpdateRequest modeUpdateRequest = new ModeUpdateRequest();
     modeUpdateRequest.setMode(mode.name());
     log.debug(String.format("Forwarding update mode request %s to %s",
         modeUpdateRequest, baseUrl));
     try {
-      masterRestService.setMode(headerProperties, modeUpdateRequest, subject);
+      leaderRestService.setMode(headerProperties, modeUpdateRequest, subject);
     } catch (IOException e) {
       throw new SchemaRegistryRequestForwardingException(
           String.format("Unexpected error while forwarding the update mode request %s to %s",
@@ -1146,13 +1150,13 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
   public void close() {
     log.info("Shutting down schema registry");
     kafkaStore.close();
-    if (masterElector != null) {
-      masterElector.close();
+    if (leaderElector != null) {
+      leaderElector.close();
     }
   }
 
   public void updateCompatibilityLevel(String subject, CompatibilityLevel newCompatibilityLevel)
-      throws SchemaRegistryStoreException, OperationNotPermittedException, UnknownMasterException {
+      throws SchemaRegistryStoreException, OperationNotPermittedException, UnknownLeaderException {
     if (getModeInScope(subject) == Mode.READONLY) {
       throw new OperationNotPermittedException("Subject " + subject + " is in read-only mode");
     }
@@ -1171,18 +1175,18 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
   public void updateConfigOrForward(String subject, CompatibilityLevel newCompatibilityLevel,
                                     Map<String, String> headerProperties)
       throws SchemaRegistryStoreException, SchemaRegistryRequestForwardingException,
-             UnknownMasterException, OperationNotPermittedException {
+      UnknownLeaderException, OperationNotPermittedException {
     kafkaStore.lockFor(subject).lock();
     try {
-      if (isMaster()) {
+      if (isLeader()) {
         updateCompatibilityLevel(subject, newCompatibilityLevel);
       } else {
-        // forward update config request to the master
-        if (masterIdentity != null) {
-          forwardUpdateCompatibilityLevelRequestToMaster(subject, newCompatibilityLevel,
+        // forward update config request to the leader
+        if (leaderIdentity != null) {
+          forwardUpdateCompatibilityLevelRequestToLeader(subject, newCompatibilityLevel,
                                                          headerProperties);
         } else {
-          throw new UnknownMasterException("Update config request failed since master is "
+          throw new UnknownLeaderException("Update config request failed since leader is "
                                            + "unknown");
         }
       }
@@ -1308,17 +1312,17 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
 
   public void setModeOrForward(String subject, Mode mode, Map<String, String> headerProperties)
       throws SchemaRegistryStoreException, SchemaRegistryRequestForwardingException,
-      OperationNotPermittedException, UnknownMasterException {
+      OperationNotPermittedException, UnknownLeaderException {
     kafkaStore.lockFor(subject).lock();
     try {
-      if (isMaster()) {
+      if (isLeader()) {
         setMode(subject, mode);
       } else {
-        // forward update mode request to the master
-        if (masterIdentity != null) {
-          forwardSetModeRequestToMaster(subject, mode, headerProperties);
+        // forward update mode request to the leader
+        if (leaderIdentity != null) {
+          forwardSetModeRequestToLeader(subject, mode, headerProperties);
         } else {
-          throw new UnknownMasterException("Update mode request failed since master is "
+          throw new UnknownLeaderException("Update mode request failed since leader is "
               + "unknown");
         }
       }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -483,7 +483,7 @@ public class KafkaStore<K, V> implements Store<K, V> {
     this.lastWrittenOffset = lastOffset;
   }
 
-  public Lock masterLock() {
+  public Lock leaderLock() {
     return lock;
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LeaderAwareSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LeaderAwareSchemaRegistry.java
@@ -21,10 +21,10 @@ import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryTimeoutExcepti
 
 /**
  * Internal interface for schema registry implementations. Used as a restricted interface for
- * MasterElectors to interact with.
+ * LeaderElectors to interact with.
  */
-public interface MasterAwareSchemaRegistry {
-  void setMaster(SchemaRegistryIdentity newMaster) throws SchemaRegistryTimeoutException,
+public interface LeaderAwareSchemaRegistry {
+  void setLeader(SchemaRegistryIdentity newLeader) throws SchemaRegistryTimeoutException,
       SchemaRegistryStoreException, IdGenerationException;
 
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LeaderElector.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LeaderElector.java
@@ -20,7 +20,7 @@ import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryInitialization
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryTimeoutException;
 
-public interface MasterElector {
+public interface LeaderElector {
 
   void init() throws SchemaRegistryTimeoutException, SchemaRegistryStoreException,
       SchemaRegistryInitializationException, IdGenerationException;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistryIdentity.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistryIdentity.java
@@ -25,7 +25,7 @@ import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 
 /**
- * The identity of a schema registry instance. The master will store the json representation of its
+ * The identity of a schema registry instance. The leader will store the json representation of its
  * identity in Zookeeper.
  */
 public class SchemaRegistryIdentity {
@@ -35,19 +35,19 @@ public class SchemaRegistryIdentity {
   private Integer version;
   private String host;
   private Integer port;
-  private Boolean masterEligibility;
+  private Boolean leaderEligibility;
   private String scheme;
 
   public SchemaRegistryIdentity(
       @JsonProperty("host") String host,
       @JsonProperty("port") Integer port,
-      @JsonProperty("master_eligibility") Boolean masterEligibility,
+      @JsonProperty("master_eligibility") Boolean leaderEligibility,
       @JsonProperty(value = "scheme", defaultValue = SchemaRegistryConfig.HTTP) String scheme
   ) {
     this.version = CURRENT_VERSION;
     this.host = host;
     this.port = port;
-    this.masterEligibility = masterEligibility;
+    this.leaderEligibility = leaderEligibility;
     this.scheme = scheme;
   }
 
@@ -96,13 +96,13 @@ public class SchemaRegistryIdentity {
   }
 
   @JsonProperty("master_eligibility")
-  public boolean getMasterEligibility() {
-    return this.masterEligibility;
+  public boolean getLeaderEligibility() {
+    return this.leaderEligibility;
   }
 
   @JsonProperty("master_eligibility")
-  public void setMasterEligibility(Boolean eligibility) {
-    this.masterEligibility = eligibility;
+  public void setLeaderEligibility(Boolean eligibility) {
+    this.leaderEligibility = eligibility;
   }
 
   @JsonProperty(value = "scheme", defaultValue = SchemaRegistryConfig.HTTP)
@@ -139,7 +139,7 @@ public class SchemaRegistryIdentity {
     if (!this.port.equals(that.port)) {
       return false;
     }
-    if (!this.masterEligibility.equals(that.masterEligibility)) {
+    if (!this.leaderEligibility.equals(that.leaderEligibility)) {
       return false;
     }
     if (!this.scheme.equals(that.scheme)) {
@@ -153,7 +153,7 @@ public class SchemaRegistryIdentity {
     int result = port;
     result = 31 * result + host.hashCode();
     result = 31 * result + version;
-    result = 31 * result + masterEligibility.hashCode();
+    result = 31 * result + leaderEligibility.hashCode();
     result = 31 * result + scheme.hashCode();
     return result;
   }
@@ -165,7 +165,7 @@ public class SchemaRegistryIdentity {
     sb.append("host=" + this.host + ",");
     sb.append("port=" + this.port + ",");
     sb.append("scheme=" + this.scheme + ",");
-    sb.append("masterEligibility=" + this.masterEligibility);
+    sb.append("leaderEligibility=" + this.leaderEligibility);
     return sb.toString();
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
@@ -44,14 +44,14 @@ public class RestApp {
 
   public RestApp(int port,
                  String zkConnect, String kafkaTopic,
-                 String compatibilityType, boolean masterEligibility, Properties schemaRegistryProps) {
+                 String compatibilityType, boolean leaderEligibility, Properties schemaRegistryProps) {
     this(port, zkConnect, null, kafkaTopic, compatibilityType,
-         masterEligibility, schemaRegistryProps);
+        leaderEligibility, schemaRegistryProps);
   }
 
   public RestApp(int port,
                  String zkConnect, String bootstrapBrokers,
-                 String kafkaTopic, String compatibilityType, boolean masterEligibility,
+                 String kafkaTopic, String compatibilityType, boolean leaderEligibility,
                  Properties schemaRegistryProps) {
     prop = new Properties();
     if (schemaRegistryProps != null) {
@@ -66,7 +66,7 @@ public class RestApp {
     }
     prop.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG, kafkaTopic);
     prop.put(SchemaRegistryConfig.SCHEMA_COMPATIBILITY_CONFIG, compatibilityType);
-    prop.put(SchemaRegistryConfig.MASTER_ELIGIBILITY, masterEligibility);
+    prop.put(SchemaRegistryConfig.LEADER_ELIGIBILITY, leaderEligibility);
   }
 
   public void start() throws Exception {
@@ -97,21 +97,21 @@ public class RestApp {
     prop.putAll(props);
   }
 
-  public boolean isMaster() {
-    return restApp.schemaRegistry().isMaster();
+  public boolean isLeader() {
+    return restApp.schemaRegistry().isLeader();
   }
 
-  public void setMaster(SchemaRegistryIdentity schemaRegistryIdentity)
+  public void setLeader(SchemaRegistryIdentity schemaRegistryIdentity)
       throws SchemaRegistryException {
-    restApp.schemaRegistry().setMaster(schemaRegistryIdentity);
+    restApp.schemaRegistry().setLeader(schemaRegistryIdentity);
   }
 
   public SchemaRegistryIdentity myIdentity() {
     return restApp.schemaRegistry().myIdentity();
   }
 
-  public SchemaRegistryIdentity masterIdentity() {
-    return restApp.schemaRegistry().masterIdentity();
+  public SchemaRegistryIdentity leaderIdentity() {
+    return restApp.schemaRegistry().leaderIdentity();
   }
   
   public SchemaRegistry schemaRegistry() {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinatorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinatorTest.java
@@ -13,7 +13,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.kafka.schemaregistry.masterelector.kafka;
+package io.confluent.kafka.schemaregistry.leaderelector.kafka;
 
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.storage.SchemaRegistryIdentity;
@@ -182,8 +182,8 @@ public class SchemaRegistryCoordinatorTest {
     assertEquals(0, rebalanceListener.revokedCount);
     assertEquals(1, rebalanceListener.assignedCount);
     assertFalse(rebalanceListener.assignments.get(0).failed());
-    assertEquals(consumerId, rebalanceListener.assignments.get(0).master());
-    assertEquals(LEADER_INFO, rebalanceListener.assignments.get(0).masterIdentity());
+    assertEquals(consumerId, rebalanceListener.assignments.get(0).leader());
+    assertEquals(LEADER_INFO, rebalanceListener.assignments.get(0).leaderIdentity());
   }
 
   @Test
@@ -221,8 +221,8 @@ public class SchemaRegistryCoordinatorTest {
     assertEquals(1, rebalanceListener.assignedCount);
     // No leader isn't considered a failure
     assertFalse(rebalanceListener.assignments.get(0).failed());
-    assertNull(rebalanceListener.assignments.get(0).master());
-    assertNull(rebalanceListener.assignments.get(0).masterIdentity());
+    assertNull(rebalanceListener.assignments.get(0).leader());
+    assertNull(rebalanceListener.assignments.get(0).leaderIdentity());
   }
 
   @Test
@@ -259,8 +259,8 @@ public class SchemaRegistryCoordinatorTest {
     assertEquals(0, rebalanceListener.revokedCount);
     assertEquals(1, rebalanceListener.assignedCount);
     assertTrue(rebalanceListener.assignments.get(0).failed());
-    assertNull(rebalanceListener.assignments.get(0).master());
-    assertNull(rebalanceListener.assignments.get(0).masterIdentity());
+    assertNull(rebalanceListener.assignments.get(0).leader());
+    assertNull(rebalanceListener.assignments.get(0).leaderIdentity());
   }
 
   @Test
@@ -293,8 +293,8 @@ public class SchemaRegistryCoordinatorTest {
     assertEquals(0, rebalanceListener.revokedCount);
     assertEquals(1, rebalanceListener.assignedCount);
     assertFalse(rebalanceListener.assignments.get(0).failed());
-    assertEquals(LEADER_ID, rebalanceListener.assignments.get(0).master());
-    assertEquals(LEADER_INFO, rebalanceListener.assignments.get(0).masterIdentity());
+    assertEquals(LEADER_ID, rebalanceListener.assignments.get(0).leader());
+    assertEquals(LEADER_INFO, rebalanceListener.assignments.get(0).leaderIdentity());
   }
 
   private FindCoordinatorResponse groupCoordinatorResponse(Node node, Errors error) {
@@ -304,11 +304,11 @@ public class SchemaRegistryCoordinatorTest {
   private JoinGroupResponse joinGroupLeaderResponse(
       int generationId,
       String memberId,
-      Map<String, SchemaRegistryIdentity> memberMasterEligibility,
+      Map<String, SchemaRegistryIdentity> memberLeaderEligibility,
       Errors error
   ) {
     List<JoinGroupResponseData.JoinGroupResponseMember> metadata = new ArrayList<>();
-    for (Map.Entry<String, SchemaRegistryIdentity> configStateEntry : memberMasterEligibility.entrySet()) {
+    for (Map.Entry<String, SchemaRegistryIdentity> configStateEntry : memberLeaderEligibility.entrySet()) {
       SchemaRegistryIdentity memberIdentity = configStateEntry.getValue();
       ByteBuffer buf = SchemaRegistryProtocol.serializeMetadata(memberIdentity);
       metadata.add(new JoinGroupResponseData.JoinGroupResponseMember()
@@ -342,12 +342,12 @@ public class SchemaRegistryCoordinatorTest {
 
   private SyncGroupResponse syncGroupResponse(
       short assignmentError,
-      String master,
-      SchemaRegistryIdentity masterIdentity,
+      String leader,
+      SchemaRegistryIdentity leaderIdentity,
       Errors error
   ) {
     SchemaRegistryProtocol.Assignment assignment = new SchemaRegistryProtocol.Assignment(
-        assignmentError, master, masterIdentity
+        assignmentError, leader, leaderIdentity
     );
     ByteBuffer buf = SchemaRegistryProtocol.serializeAssignment(assignment);
     return new SyncGroupResponse(new SyncGroupResponseData()

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryProtocolTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryProtocolTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.kafka.schemaregistry.masterelector.kafka;
+package io.confluent.kafka.schemaregistry.leaderelector.kafka;
 
 import org.junit.Test;
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/leaderelector/zookeeper/ZookeeperLeaderElectorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/leaderelector/zookeeper/ZookeeperLeaderElectorTest.java
@@ -12,7 +12,7 @@
  * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package io.confluent.kafka.schemaregistry.masterelector.zookeeper;
+package io.confluent.kafka.schemaregistry.leaderelector.zookeeper;
 
 import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.RestApp;
@@ -31,9 +31,9 @@ import java.util.concurrent.Callable;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-// Tests that are specific to the ZookeeperMasterElector. See MasterElectorTest for general tests
-// covering all MasterElectors
-public class ZookeeperMasterElectorTest extends ClusterTestHarness {
+// Tests that are specific to the ZookeeperLeaderElector. See LeaderElectorTest for general tests
+// covering all LeaderElectors
+public class ZookeeperLeaderElectorTest extends ClusterTestHarness {
   private static final int ID_BATCH_SIZE =
       ZookeeperIdGenerator.ZOOKEEPER_SCHEMA_ID_COUNTER_BATCH_SIZE;
   private static final String ZK_ID_COUNTER_PATH =
@@ -83,11 +83,11 @@ public class ZookeeperMasterElectorTest extends ClusterTestHarness {
     Callable<Boolean> electionComplete = new Callable<Boolean>() {
       @Override
       public Boolean call() throws Exception {
-        return restApp2.isMaster();
+        return restApp2.isLeader();
       }
     };
     TestUtils.waitUntilTrue(electionComplete, 15000,
-                            "Schema registry instance 2 should become the master");
+                            "Schema registry instance 2 should become the leader");
     // Reelection should have triggered zk id to update to the next batch
     assertEquals("Zk counter is not the expected value.",
                  2 * ID_BATCH_SIZE, getZkIdCounter(zkUtils));

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -457,7 +457,7 @@ public class RestApiTest extends ClusterTestHarness {
     assertEquals("Registering a new schema should succeed", 2, registeredId);
 
     SchemaString schemaString = restApp.restClient.getId(2);
-    // the newly registered schema should be immediately readable on the master
+    // the newly registered schema should be immediately readable on the leader
     assertEquals("Registered schema should be found",
         schemas.get(1),
         schemaString.getSchemaString());

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/json/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/json/RestApiTest.java
@@ -151,7 +151,7 @@ public class RestApiTest extends ClusterTestHarness {
     assertEquals("Registering a new schema should succeed", 2, registeredId);
 
     SchemaString schemaString = restApp.restClient.getId(2);
-    // the newly registered schema should be immediately readable on the master
+    // the newly registered schema should be immediately readable on the leader
     assertEquals("Registered schema should be found",
         MAPPER.readTree(schemas.get("main.json")),
         MAPPER.readTree(schemaString.getSchemaString())

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/protobuf/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/protobuf/RestApiTest.java
@@ -153,7 +153,7 @@ public class RestApiTest extends ClusterTestHarness {
     assertEquals("Registering a new schema should succeed", 2, registeredId);
 
     SchemaString schemaString = restApp.restClient.getId(2);
-    // the newly registered schema should be immediately readable on the master
+    // the newly registered schema should be immediately readable on the leader
     assertEquals("Registered schema should be found",
         schemas.get("root.proto"),
         schemaString.getSchemaString()

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/utils/TestUtils.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/utils/TestUtils.java
@@ -118,7 +118,7 @@ public class TestUtils {
     int registeredId = restService.registerSchema(schemaString, subject);
     assertEquals("Registering a new schema should succeed", expectedId, registeredId);
 
-    // the newly registered schema should be immediately readable on the master
+    // the newly registered schema should be immediately readable on the leader
     assertEquals("Registered schema should be found",
             schemaString,
             restService.getId(expectedId).getSchemaString());
@@ -135,7 +135,7 @@ public class TestUtils {
     );
     assertEquals("Registering a new schema should succeed", expectedId, registeredId);
 
-    // the newly registered schema should be immediately readable on the master
+    // the newly registered schema should be immediately readable on the leader
     assertEquals("Registered schema should be found",
         schemaString,
         restService.getId(expectedId).getSchemaString());


### PR DESCRIPTION
- Deprecate `master.eligibility`
- Add `leader.eligibility`
- Deprecate `schema_registry_master` (which is in already deprecated `ZookeeperLeaderElector`)
- Changed other places to use leader/follower