### PR TITLE
Add node information to SchemaRegistryProtocol

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java
@@ -148,7 +148,7 @@ final class SchemaRegistryCoordinator extends AbstractCoordinator implements Clo
   ) {
     assignmentSnapshot = SchemaRegistryProtocol.deserializeAssignment(memberAssignment);
     listener.onAssigned(assignmentSnapshot, generation);
-    if (nodeCountMetric != null) {
+    if (nodeCountMetric != null && assignmentSnapshot.nodes() != null) {
       nodeCountMetric.set(assignmentSnapshot.nodes().size());
     }
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -147,6 +148,9 @@ final class SchemaRegistryCoordinator extends AbstractCoordinator implements Clo
   ) {
     assignmentSnapshot = SchemaRegistryProtocol.deserializeAssignment(memberAssignment);
     listener.onAssigned(assignmentSnapshot, generation);
+    if (nodeCountMetric != null) {
+      nodeCountMetric.set(assignmentSnapshot.nodes().size());
+    }
   }
 
   @Override
@@ -157,11 +161,14 @@ final class SchemaRegistryCoordinator extends AbstractCoordinator implements Clo
   ) {
     log.debug("Performing assignment");
 
+    List<SchemaRegistryIdentity> nodes = new ArrayList<>();
+
     Map<String, SchemaRegistryIdentity> memberConfigs = new HashMap<>();
     for (JoinGroupResponseData.JoinGroupResponseMember entry : allMemberMetadata) {
       SchemaRegistryIdentity identity
           = SchemaRegistryProtocol.deserializeMetadata(ByteBuffer.wrap(entry.metadata()));
       memberConfigs.put(entry.memberId(), identity);
+      nodes.add(identity);
     }
 
     log.debug("Member information: {}", memberConfigs);
@@ -202,7 +209,7 @@ final class SchemaRegistryCoordinator extends AbstractCoordinator implements Clo
     // All members currently receive the same assignment information since it is just the leader ID
     Map<String, ByteBuffer> groupAssignment = new HashMap<>();
     SchemaRegistryProtocol.Assignment assignment
-        = new SchemaRegistryProtocol.Assignment(error, leaderKafkaId, leaderIdentity);
+        = new SchemaRegistryProtocol.Assignment(error, leaderKafkaId, leaderIdentity, nodes);
     log.debug("Assignment: {}", assignment);
     for (String member : memberConfigs.keySet()) {
       groupAssignment.put(member, SchemaRegistryProtocol.serializeAssignment(assignment));

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryProtocol.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryProtocol.java
@@ -130,6 +130,7 @@ class SchemaRegistryProtocol {
              + ", error=" + error
              + ", leader='" + leader + '\''
              + ", leaderIdentity=" + leaderIdentity
+             + ", nodes=" + nodes
              + '}';
     }
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryProtocol.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryProtocol.java
@@ -22,6 +22,7 @@ import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.List;
 
 
 /**
@@ -62,14 +63,17 @@ class SchemaRegistryProtocol {
     private final short error;
     private final String leader;
     private final SchemaRegistryIdentity leaderIdentity;
+    private final List<SchemaRegistryIdentity> nodes;
 
     public Assignment(@JsonProperty("error") short error,
                       @JsonProperty("master") String leader,
-                      @JsonProperty("master_identity") SchemaRegistryIdentity leaderIdentity) {
+                      @JsonProperty("master_identity") SchemaRegistryIdentity leaderIdentity,
+                      @JsonProperty("nodes") List<SchemaRegistryIdentity> nodes) {
       this.version = CURRENT_VERSION;
       this.error = error;
       this.leader = leader;
       this.leaderIdentity = leaderIdentity;
+      this.nodes = nodes;
     }
 
     public static Assignment fromJson(ByteBuffer json) {
@@ -100,6 +104,11 @@ class SchemaRegistryProtocol {
     @JsonProperty("master_identity")
     public SchemaRegistryIdentity leaderIdentity() {
       return leaderIdentity;
+    }
+
+    @JsonProperty("nodes")
+    public List<SchemaRegistryIdentity> nodes() {
+      return nodes;
     }
 
     public boolean failed() {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistryIdentity.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistryIdentity.java
@@ -17,12 +17,11 @@ package io.confluent.kafka.schemaregistry.storage;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-
-import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
-import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 
 /**
  * The identity of a schema registry instance. The leader will store the json representation of its
@@ -161,11 +160,13 @@ public class SchemaRegistryIdentity {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
+    sb.append("SchemaRegistryIdentity{");
     sb.append("version=" + this.version + ",");
     sb.append("host=" + this.host + ",");
     sb.append("port=" + this.port + ",");
     sb.append("scheme=" + this.scheme + ",");
     sb.append("leaderEligibility=" + this.leaderEligibility);
+    sb.append("}");
     return sb.toString();
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/LeaderElectorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/LeaderElectorTest.java
@@ -785,8 +785,8 @@ public class LeaderElectorTest extends ClusterTestHarness {
       TestUtils.waitUntilTrue(() -> {
         for (Collection<RestApp> collection : apps) {
           for (RestApp app : collection) {
-            if (count != app.restApp.schemaRegistry().getMetricsContainer().getNodeCountMetric()
-                    .get()) {
+            if (app.restApp.schemaRegistry().getMetricsContainer().getNodeCountMetric().get()
+                    != count) {
               return false;
             }
           }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/LeaderElectorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/LeaderElectorTest.java
@@ -710,5 +710,4 @@ public class LeaderElectorTest extends ClusterTestHarness {
 
     assertEquals(errMsg, expectedSchemaString, schemaString);
   }
-
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinatorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinatorTest.java
@@ -346,10 +346,8 @@ public class SchemaRegistryCoordinatorTest {
       SchemaRegistryIdentity leaderIdentity,
       Errors error
   ) {
-    List<SchemaRegistryIdentity> nodes = new ArrayList<>();
-    nodes.add(leaderIdentity);
     SchemaRegistryProtocol.Assignment assignment = new SchemaRegistryProtocol.Assignment(
-        assignmentError, leader, leaderIdentity, nodes
+        assignmentError, leader, leaderIdentity, null
     );
     ByteBuffer buf = SchemaRegistryProtocol.serializeAssignment(assignment);
     return new SyncGroupResponse(new SyncGroupResponseData()

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinatorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinatorTest.java
@@ -346,8 +346,10 @@ public class SchemaRegistryCoordinatorTest {
       SchemaRegistryIdentity leaderIdentity,
       Errors error
   ) {
+    List<SchemaRegistryIdentity> nodes = new ArrayList<>();
+    nodes.add(leaderIdentity);
     SchemaRegistryProtocol.Assignment assignment = new SchemaRegistryProtocol.Assignment(
-        assignmentError, leader, leaderIdentity
+        assignmentError, leader, leaderIdentity, nodes
     );
     ByteBuffer buf = SchemaRegistryProtocol.serializeAssignment(assignment);
     return new SyncGroupResponse(new SyncGroupResponseData()

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/metrics/NodeCountMetricTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/metrics/NodeCountMetricTest.java
@@ -41,7 +41,7 @@ public class NodeCountMetricTest extends ClusterTestHarness {
       follower.start();
     }
 
-    // Make a leader-eligible 'cluster'
+    // Make a leader-eligible cluster, wait for reelection and verify metric
     Set<RestApp> leaderApps = new HashSet<>();
     for (int i = 0; i < numLeaders; i++) {
       RestApp leader = new RestApp(choosePort(),
@@ -53,7 +53,7 @@ public class NodeCountMetricTest extends ClusterTestHarness {
       checkNodeCountMetric(leaderApps, followerApps);
     }
 
-    // Kill the current leader and wait for reelection until no leaders are left
+    // Kill the current leader, wait for reelection and verify metric until no leaders are left
     while (!leaderApps.isEmpty()) {
       RestApp reportedLeader = TestUtils.checkOneLeader(leaderApps);
       leaderApps.remove(reportedLeader);

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/metrics/NodeCountMetricTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/metrics/NodeCountMetricTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.metrics;
+
+import io.confluent.kafka.schemaregistry.ClusterTestHarness;
+import io.confluent.kafka.schemaregistry.CompatibilityLevel;
+import io.confluent.kafka.schemaregistry.RestApp;
+import io.confluent.kafka.schemaregistry.utils.TestUtils;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+public class NodeCountMetricTest extends ClusterTestHarness {
+
+  @Test
+  public void testNodeCountMetric() throws Exception {
+    int numFollowers = 2;
+    int numLeaders = 2;
+
+    Set<RestApp> followerApps = new HashSet<>();
+    for (int i = 0; i < numFollowers; i++) {
+      RestApp follower = new RestApp(choosePort(), null, bootstrapServers, KAFKASTORE_TOPIC,
+              CompatibilityLevel.NONE.name, false, null);
+      followerApps.add(follower);
+      follower.start();
+    }
+
+    // Make a leader-eligible 'cluster'
+    Set<RestApp> leaderApps = new HashSet<>();
+    for (int i = 0; i < numLeaders; i++) {
+      RestApp leader = new RestApp(choosePort(),
+              null, bootstrapServers, KAFKASTORE_TOPIC,
+              CompatibilityLevel.NONE.name, true, null);
+      leaderApps.add(leader);
+      leader.start();
+      TestUtils.waitUntilLeaderElectionCompletes(leaderApps);
+      checkNodeCountMetric(leaderApps, followerApps);
+    }
+
+    // Kill the current leader and wait for reelection until no leaders are left
+    while (!leaderApps.isEmpty()) {
+      RestApp reportedLeader = TestUtils.checkOneLeader(leaderApps);
+      leaderApps.remove(reportedLeader);
+
+      reportedLeader.stop();
+      TestUtils.waitUntilLeaderElectionCompletes(leaderApps);
+      checkNodeCountMetric(leaderApps, followerApps);
+    }
+
+    for (RestApp follower : followerApps) {
+      follower.stop();
+    }
+  }
+
+  private void checkNodeCountMetric(final Collection<RestApp>... apps) {
+    final long count = Arrays.stream(apps).map(x -> x.size()).reduce(0, Integer::sum);
+    TestUtils.waitUntilTrue(() -> {
+      for (Collection<RestApp> collection : apps) {
+        for (RestApp app : collection) {
+          if (app.restApp.schemaRegistry().getMetricsContainer().getNodeCountMetric().get()
+                  != count) {
+            return false;
+          }
+        }
+      }
+      return true;
+    }, 3000, "Metrics should have been updated by now");
+  }
+}


### PR DESCRIPTION
As of right now, we cannot compute the number of nodes in an SR cluster because the nodes do not fully know about each other. This PR adds this information to the SchemaRegistryProtocol, used when Kafka election is enabled on the SR.