### PR TITLE
DG-527 Omit defaults for proto 3 schemas (fixed in wire)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <json-schema.version>1.12.1</json-schema.version>
         <protobuf.version>3.11.4</protobuf.version>
-        <wire.version>3.1.0</wire.version>
+        <wire.version>3.2.2</wire.version>
         <swagger.version>1.6.0</swagger.version>
         <spotbugs.plugin.version>4.0.0</spotbugs.plugin.version>
     </properties>


### PR DESCRIPTION
Upgrade the wire library to get a fix so that defaults are omitted for proto 3.