### PR TITLE
(work in progress) Add a way to disable host verification for clients of schema registry

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -34,6 +34,7 @@ import io.confluent.kafka.schemaregistry.client.security.bearerauth.BearerAuthCr
 
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.SslConfigs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -213,6 +214,10 @@ public class RestService implements Configurable {
 
     if (isValidProxyConfig(proxyHost, proxyPort)) {
       setProxy(proxyHost, proxyPort);
+    }
+    String endpointIdentificationAlgorithm = (String)configs.get(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG);
+    if (endpointIdentificationAlgorithm.trim().isEmpty()) {
+      setHostnameVerifier((hostname, session) -> true);
     }
   }
 


### PR DESCRIPTION
This PR add code to disable the Hostname verifier. While this is not clearly a fully fledged recommendation, it might become necessary in situations such as the ones described in #1504, to still get https and specially mTLS. 

This is focused on the clients of schema registry, so the serialisers used in the clients who talk to the main server when required.

*NOTE*: This pr is currently work in progress, is opened to gather early feedback.

fixed #1504 