### PR TITLE
#1515 - Cache Avro DatumReader and DatumWriter instances to increase performance

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -42,7 +42,7 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
   private final EncoderFactory encoderFactory = EncoderFactory.get();
   protected boolean autoRegisterSchema;
   protected boolean useLatestVersion;
-  private final Map<String, DatumWriter<Object>> datumWriterCache = new ConcurrentHashMap<>();
+  private final Map<Schema, DatumWriter<Object>> datumWriterCache = new ConcurrentHashMap<>();
 
   protected void configure(KafkaAvroSerializerConfig config) {
     configureClientProperties(config, new AvroSchemaProvider());
@@ -95,7 +95,7 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
             object instanceof NonRecordContainer ? ((NonRecordContainer) object).getValue()
                                                  : object;
         final Schema rawSchema = schema.rawSchema();
-        writer = datumWriterCache.computeIfAbsent(rawSchema.getFullName(), v -> {
+        writer = datumWriterCache.computeIfAbsent(rawSchema, v -> {
           if (value instanceof SpecificRecord) {
             return new SpecificDatumWriter<>(rawSchema);
           } else if (useSchemaReflection) {

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -30,6 +30,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
@@ -41,6 +42,7 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
   private final EncoderFactory encoderFactory = EncoderFactory.get();
   protected boolean autoRegisterSchema;
   protected boolean useLatestVersion;
+  private final Map<String, DatumWriter<Object>> datumWriterCache = new ConcurrentHashMap<>();
 
   protected void configure(KafkaAvroSerializerConfig config) {
     configureClientProperties(config, new AvroSchemaProvider());
@@ -92,14 +94,16 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
             value =
             object instanceof NonRecordContainer ? ((NonRecordContainer) object).getValue()
                                                  : object;
-        Schema rawSchema = schema.rawSchema();
-        if (value instanceof SpecificRecord) {
-          writer = new SpecificDatumWriter<>(rawSchema);
-        } else if (useSchemaReflection) {
-          writer = new ReflectDatumWriter<>(rawSchema);
-        } else {
-          writer = new GenericDatumWriter<>(rawSchema);
-        }
+        final Schema rawSchema = schema.rawSchema();
+        writer = datumWriterCache.computeIfAbsent(rawSchema.getFullName(), v -> {
+          if (value instanceof SpecificRecord) {
+            return new SpecificDatumWriter<>(rawSchema);
+          } else if (useSchemaReflection) {
+            return new ReflectDatumWriter<>(rawSchema);
+          } else {
+            return new GenericDatumWriter<>(rawSchema);
+          }
+        });
         writer.write(value, encoder);
         encoder.flush();
       }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/SchemaPair.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/SchemaPair.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.serializers;
+
+import org.apache.avro.Schema;
+
+import java.util.Objects;
+
+public class SchemaPair {
+  private final Schema writerSchema;
+  private final Schema readerSchema;
+
+  public SchemaPair(Schema writerSchema, Schema readerSchema) {
+    this.writerSchema = writerSchema;
+    this.readerSchema = readerSchema;
+  }
+
+  public Schema getWriterSchema() {
+    return writerSchema;
+  }
+
+  public Schema getReaderSchema() {
+    return readerSchema;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SchemaPair that = (SchemaPair) o;
+    return Objects.equals(writerSchema, that.writerSchema)
+        && Objects.equals(readerSchema, that.readerSchema);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(writerSchema, readerSchema);
+  }
+}


### PR DESCRIPTION
This is a PR fixing issue #1515 by caching the avro `DatumReader` and `DatumWriter` instances created when using instances of the `AbstractKafkaAvroDeserializer` and `AbstractKafkaAvroDeserializer` classes. Although the issue was only scoped to poor performance when serializing/deserializing `SpecificRecord` instances this PR applies the same caching logic when working with `GenericRecord` since JMH tests show improvements on deserialization there as well.

I have run benchmarks with the `io.confluent.schemaregistry.benchmark.SerdeBenchmark` JMH benchmark, which at the moment only benchmarks generic records. I have benchmarked using a single as well as 40 threads on my machine by running:
```bash
java -jar benchmark/target/benchmarks.jar -bm thrpt -tu s -f 1 -t 1 -wi 10 -i 10 -w 1 -r 1 -p serializationFormat=AVRO
java -jar benchmark/target/benchmarks.jar -bm thrpt -tu s -f 1 -t 40 -wi 10 -i 10 -w 1 -r 1 -p serializationFormat=AVRO
```

The results are: 
```
-------------------------- GenericRecord --------------------------

---- 1 thread ----
-- Stock
Benchmark                   (serializationFormat)   Mode  Cnt        Score        Error  Units
SerdeBenchmark.deserialize                   AVRO  thrpt   10  3964313,028 ±  84201,791  ops/s
SerdeBenchmark.serialize                     AVRO  thrpt   10  4878370,388 ± 100343,298  ops/s

-- Caching
Benchmark                   (serializationFormat)   Mode  Cnt        Score        Error  Units
SerdeBenchmark.deserialize                   AVRO  thrpt   10  6364262,919 ± 273945,502  ops/s
SerdeBenchmark.serialize                     AVRO  thrpt   10  5127353,620 ± 169815,194  ops/s

---- 40 threads ----
-- Stock
Benchmark                   (serializationFormat)   Mode  Cnt         Score         Error  Units
SerdeBenchmark.deserialize                   AVRO  thrpt   10  16769459,760 ±  233665,578  ops/s
SerdeBenchmark.serialize                     AVRO  thrpt   10  31693445,711 ± 1066292,286  ops/s

-- Caching
Benchmark                   (serializationFormat)   Mode  Cnt         Score         Error  Units
SerdeBenchmark.deserialize                   AVRO  thrpt   10  33163621,219 ± 1767851,714  ops/s
SerdeBenchmark.serialize                     AVRO  thrpt   10  31070235,686 ±  902265,617  ops/s
```

Single-threaded deserialization is 1.5x faster and multithreaded is 2x faster (on my machine). Serialization is roughly the same.

I have altered the above JMH benchmark to do specific avro serialization and deserialization to assess the converns raised in #1515. That code is not in a commitable state but can be viewed [here](https://github.com/TeletronicsDotAe/schema-registry/blob/issues/1515/master-specific-benchmark/benchmark/src/main/java/io/confluent/schemaregistry/benchmark/SerdeBenchmark.java). Results when running on my machine:

```
-------------------------- SpecificRecord --------------------------

---- 1 thread ----
-- Stock
Benchmark                   (serializationFormat)   Mode  Cnt       Score       Error  Units
SerdeBenchmark.deserialize                   AVRO  thrpt   10  358504,030 ± 13906,565  ops/s
SerdeBenchmark.serialize                     AVRO  thrpt   10  379361,650 ± 11641,322  ops/s

-- Caching
Benchmark                   (serializationFormat)   Mode  Cnt        Score       Error  Units
SerdeBenchmark.deserialize                   AVRO  thrpt   10  5995665,350 ± 87987,096  ops/s
SerdeBenchmark.serialize                     AVRO  thrpt   10  5107737,779 ± 99491,447  ops/s

---- 40 threads ----
-- Stock
Benchmark                   (serializationFormat)   Mode  Cnt        Score       Error  Units
SerdeBenchmark.deserialize                   AVRO  thrpt   10  1781519,126 ± 92044,391  ops/s
SerdeBenchmark.serialize                     AVRO  thrpt   10  1867259,722 ± 52876,002  ops/s

-- Caching
Benchmark                   (serializationFormat)   Mode  Cnt         Score         Error  Units
SerdeBenchmark.deserialize                   AVRO  thrpt   10  31863061,274 ±  969895,866  ops/s
SerdeBenchmark.serialize                     AVRO  thrpt   10  29982446,295 ± 1152760,094  ops/s
```

The results are an order of magnitude better, bringing specific avro serialization and deserialization on par with generic.