### PR TITLE
DG-607 Add lenient processing for numbers in oneof

### DIFF
--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
@@ -202,7 +202,7 @@ public class JsonSchemaData {
         return value.isIntegralNumber();
       case FLOAT32:
       case FLOAT64:
-        return value.isFloatingPointNumber();
+        return value.isNumber();
       case BOOLEAN:
         return value.isBoolean();
       case STRING:

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
@@ -197,15 +197,12 @@ public class JsonSchemaData {
     switch (fieldSchema.type()) {
       case INT8:
       case INT16:
-        return value.isShort();
       case INT32:
-        return value.isInt();
       case INT64:
-        return value.isLong();
+        return value.isIntegralNumber();
       case FLOAT32:
-        return value.isFloat();
       case FLOAT64:
-        return value.isDouble();
+        return value.isFloatingPointNumber();
       case BOOLEAN:
         return value.isBoolean();
       case STRING:

--- a/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
+++ b/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
@@ -905,6 +905,25 @@ public class JsonSchemaDataTest {
   }
 
   @Test
+  public void testToConnectUnionDifferentNumericType() {
+    StringSchema firstSchema = StringSchema.builder()
+        .build();
+    NumberSchema secondSchema = NumberSchema.builder()
+        .requiresNumber(true)
+        .build();
+    CombinedSchema schema = CombinedSchema.oneOf(ImmutableList.of(firstSchema, secondSchema))
+        .build();
+    SchemaBuilder builder = SchemaBuilder.struct().name(JSON_TYPE_ONE_OF);
+    builder.field(JSON_TYPE_ONE_OF + ".field.0", Schema.OPTIONAL_STRING_SCHEMA);
+    builder.field(JSON_TYPE_ONE_OF + ".field.1", Schema.OPTIONAL_FLOAT64_SCHEMA);
+    Schema expectedSchema = builder.build();
+
+    Struct expected = new Struct(expectedSchema).put(JSON_TYPE_ONE_OF + ".field.1", (double) 123);
+    // Pass an IntNode instead of a DoubleNode
+    checkNonObjectConversion(expectedSchema, expected, schema, IntNode.valueOf(123));
+  }
+
+  @Test
   public void testToConnectMapOptionalValue() {
     testToConnectMapOptional("some value");
   }

--- a/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
+++ b/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
@@ -886,6 +886,25 @@ public class JsonSchemaDataTest {
   }
 
   @Test
+  public void testToConnectUnionDifferentIntegralType() {
+    StringSchema firstSchema = StringSchema.builder()
+        .build();
+    NumberSchema secondSchema = NumberSchema.builder()
+        .requiresInteger(true)
+        .build();
+    CombinedSchema schema = CombinedSchema.oneOf(ImmutableList.of(firstSchema, secondSchema))
+        .build();
+    SchemaBuilder builder = SchemaBuilder.struct().name(JSON_TYPE_ONE_OF);
+    builder.field(JSON_TYPE_ONE_OF + ".field.0", Schema.OPTIONAL_STRING_SCHEMA);
+    builder.field(JSON_TYPE_ONE_OF + ".field.1", Schema.OPTIONAL_INT64_SCHEMA);
+    Schema expectedSchema = builder.build();
+
+    Struct expected = new Struct(expectedSchema).put(JSON_TYPE_ONE_OF + ".field.1", 123L);
+    // Pass an IntNode instead of a LongNode
+    checkNonObjectConversion(expectedSchema, expected, schema, IntNode.valueOf(123));
+  }
+
+  @Test
   public void testToConnectMapOptionalValue() {
     testToConnectMapOptional("some value");
   }

--- a/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
+++ b/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
@@ -868,8 +868,7 @@ public class JsonSchemaDataTest {
 
   @Test
   public void testToConnectUnionSecondField() {
-    NumberSchema firstSchema = NumberSchema.builder()
-        .unprocessedProperties(Collections.singletonMap("connect.type", "int8"))
+    StringSchema firstSchema = StringSchema.builder()
         .build();
     NumberSchema secondSchema = NumberSchema.builder()
         .unprocessedProperties(Collections.singletonMap("connect.type", "int32"))
@@ -877,7 +876,7 @@ public class JsonSchemaDataTest {
     CombinedSchema schema = CombinedSchema.oneOf(ImmutableList.of(firstSchema, secondSchema))
         .build();
     SchemaBuilder builder = SchemaBuilder.struct().name(JSON_TYPE_ONE_OF);
-    builder.field(JSON_TYPE_ONE_OF + ".field.0", Schema.OPTIONAL_INT8_SCHEMA);
+    builder.field(JSON_TYPE_ONE_OF + ".field.0", Schema.OPTIONAL_STRING_SCHEMA);
     builder.field(JSON_TYPE_ONE_OF + ".field.1", Schema.OPTIONAL_INT32_SCHEMA);
     Schema expectedSchema = builder.build();
 


### PR DESCRIPTION
Add lenient processing for numbers in oneof.  

This allows all integral types to be convertible to each other in a oneof, as well as all floating numeric types.