### PR TITLE
DG-628 Allow changes to id during json schema compat checks

### DIFF
--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiff.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiff.java
@@ -40,6 +40,7 @@ public class SchemaDiff {
   static {
     Set<Difference.Type> changes = new HashSet<>();
 
+    changes.add(Type.ID_CHANGED);
     changes.add(Type.DESCRIPTION_CHANGED);
     changes.add(Type.TITLE_CHANGED);
     changes.add(Type.DEFAULT_CHANGED);

--- a/json-schema-provider/src/test/resources/diff-schema-examples.json
+++ b/json-schema-provider/src/test/resources/diff-schema-examples.json
@@ -10,7 +10,7 @@
     "changes": [
       "ID_CHANGED #/"
     ],
-    "compatible": false
+    "compatible": true
   },
   {
     "description": "Detect changes to title",


### PR DESCRIPTION
Allow changes to id during json schema compat checks.

The initial implementation did not allow such changes, which is overly strict.