### PR TITLE
ST-3988: update swagger-core to 1.6.2

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-core</artifactId>
-            <version>1.5.3</version>
+            <version>1.6.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>javax.validation</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -215,7 +215,7 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-core</artifactId>
-            <version>1.5.3</version>
+            <version>1.6.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
swagger-core brings an outdated version of snakeyaml as a transitive dependency.