### PR TITLE
ST-3988: update swagger-core to 1.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <json-schema.version>1.12.1</json-schema.version>
         <protobuf.version>3.11.4</protobuf.version>
         <wire.version>3.2.2</wire.version>
-        <swagger.version>1.6.0</swagger.version>
+        <swagger.version>1.6.2</swagger.version>
         <spotbugs.plugin.version>4.0.0</spotbugs.plugin.version>
     </properties>
 


### PR DESCRIPTION
swagger-core brings an outdated version of snakeyaml as a transitive dependency.