### PR TITLE
Fixed JSON Schema compatibility check in case of CombinedSchema

### DIFF
--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiff.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiff.java
@@ -134,7 +134,15 @@ public class SchemaDiff {
           || combinedSchema.getCriterion() == CombinedSchema.ONE_CRITERION) {
         for (Schema subschema : combinedSchema.getSubschemas()) {
           final Context subctx = ctx.getSubcontext();
-          compare(subctx, original, subschema);
+
+          Schema referredSubschema;
+          if (subschema instanceof ReferenceSchema) {
+            referredSubschema = ((ReferenceSchema)subschema).getReferredSchema();
+          } else {
+            referredSubschema = subschema;
+          }
+
+          compare(subctx, original, referredSubschema);
           if (subctx.isCompatible()) {
             ctx.addDifferences(subctx.getDifferences());
             ctx.addDifference(Type.SUM_TYPE_EXTENDED);


### PR DESCRIPTION
It fixes schema comparsion when we use Combined Json Schema with oneOf as explained by the [link](https://docs.confluent.io/current/schema-registry/serdes-develop/serdes-json.html#multiple-event-types-in-the-same-topic)

![2 - what_should_be_compared_ObjectSchema_vs_ObjectSchema](https://user-images.githubusercontent.com/5605956/88387115-780dc180-cdba-11ea-88cf-6668fade1aad.png)
![01-what_you_compare_ObjectSchema_vs_RefferenceSchema](https://user-images.githubusercontent.com/5605956/88387117-79d78500-cdba-11ea-893e-2eb272ed0989.png)
