### PR TITLE
Deserialization does not work correctly in case of refference schema …

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -22,7 +22,7 @@
               files="(Errors|AvroMessageReader).java"/>
 
     <suppress checks="CyclomaticComplexity"
-              files="(AbstractKafkaAvroDeserializer|AvroSchemaUtils|CompatibilityResource|KafkaSchemaRegistry|KafkaStoreReaderThread|AvroData|DownloadSchemaRegistryMojo|MockSchemaRegistryClient|SchemaRegistrySerializer|SchemaValue|SubjectVersionsResource|ProtobufSchema|SchemaDiff|FieldSchemaDiff|MessageSchemaDiff|DynamicSchema|SchemaMessageFormatter|ProtobufData|JsonSchema|JSON.*|JsonSchemaData|SchemaMessageReader).java"/>
+              files="(AbstractKafkaJsonSchemaDeserializer|AAbstractKafkaAvroDeserializer|AvroSchemaUtils|CompatibilityResource|KafkaSchemaRegistry|KafkaStoreReaderThread|AvroData|DownloadSchemaRegistryMojo|MockSchemaRegistryClient|SchemaRegistrySerializer|SchemaValue|SubjectVersionsResource|ProtobufSchema|SchemaDiff|FieldSchemaDiff|MessageSchemaDiff|DynamicSchema|SchemaMessageFormatter|ProtobufData|JsonSchema|JSON.*|JsonSchemaData|SchemaMessageReader).java"/>
 
     <suppress checks="NPathComplexity"
               files="(AvroData|DownloadSchemaRegistryMojo|KafkaSchemaRegistry|Schema|SchemaValue|SchemaDiff|MessageSchemaDiff|ProtobufData|JsonSchemaData|SchemaMessageFormatter|SchemaMessageReader).java"/>


### PR DESCRIPTION
[schemas.zip](https://github.com/confluentinc/schema-registry/files/4984592/schemas.zip)
[pojos.zip](https://github.com/confluentinc/schema-registry/files/4984596/pojos.zip)


The standard implementation of deserialization fails on this "complex" case:

- K-Streams use KafkaJsonSchemaSerde[T](schemaRegistryClient)
- class hierarchy for messages within topic
Event<-TaskEvent
TaskEvent<-TaskCreated
TaskEvent<-TaskFinished
TaskEvent<-TaskFailed

- Schema in schema registry (CombinedSchema, oneOf + refs) + type.property for child schemas showing which class to use on deserialization

The patch make the code below just working, it will correctly deserialise messages "derived" from TaskEvent

```
  val taskEvents: KStream[String, TaskEvent] = builder.stream[String, TaskEvent]("tasks")
  taskEvents.peek((k, v) => println(s"${v}\n\n "))
```