### PR TITLE
METRICS-1988: add confluent-telemetry directory to schema-registry-run-class

### DIFF
--- a/bin/schema-registry-run-class
+++ b/bin/schema-registry-run-class
@@ -36,7 +36,7 @@ for dir in $base_dir/package-schema-registry/target/kafka-schema-registry-packag
 done
 
 # Production jars, including kafka, rest-utils, and schema-registry
-for library in "confluent-security/schema-registry" "confluent-common" "rest-utils" "schema-registry"; do
+for library in "confluent-security/schema-registry" "confluent-common" "confluent-telemetry" "rest-utils" "schema-registry"; do
   CLASSPATH=$CLASSPATH:$base_dir/share/java/$library/*      
 done
 


### PR DESCRIPTION
### what
Add `share/java/confluent-telemetry` to SR's classpath.

### why
This is where we'll install the confluent-metrics jar (as part of packaging) and we need this jar for telemetry to work.