### PR TITLE
DG-767 Use passed in defaults for client ssl configs

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClientConfig.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClientConfig.java
@@ -43,7 +43,7 @@ public class SchemaRegistryClientConfig {
         : sslConfigDef.configKeys().values()) {
       configDef.define(namespace + configKey.name,
           typeFor(configKey.type),
-          configKey.defaultValue != null ? configKey.defaultValue : "",
+          configKey.defaultValue,
           importanceFor(configKey.importance),
           configKey.documentation);
     }


### PR DESCRIPTION
KIP-519 / KAFKA-8890 for 2.6 added an additional
SSL config of Type.CLASS,
which fails when SR clients pass a default of "" when dynamically 
defining SSL configs in the client config.
Instead, use the passed in defaults.

Note:  using a default of null for Type.STRING only works for 6.0
due to changes to the underlying ConfigDef class.
