### PR TITLE
DG-789 Fix for CVE-2020-15824

### DIFF
--- a/json-schema-provider/pom.xml
+++ b/json-schema-provider/pom.xml
@@ -59,6 +59,10 @@
             <artifactId>mbknor-jackson-jsonschema_${kafka.scala.version}</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
         <podam.version>6.0.2.RELEASE</podam.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
+        <kotlin.version>1.4.0-rc</kotlin.version>
         <json-schema.version>1.12.1</json-schema.version>
         <protobuf.version>3.11.4</protobuf.version>
         <wire.version>3.2.2</wire.version>
@@ -121,6 +122,12 @@
                 <groupId>com.squareup.wire</groupId>
                 <artifactId>wire-schema</artifactId>
                 <version>${wire.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-stdlib</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.datatype</groupId>
@@ -156,6 +163,17 @@
                 <groupId>com.kjetland</groupId>
                 <artifactId>mbknor-jackson-jsonschema_${kafka.scala.version}</artifactId>
                 <version>${mbknor-jackson-jsonschema.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-stdlib</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib</artifactId>
+                <version>${kotlin.version}</version>
             </dependency>
             <dependency>
                 <groupId>uk.co.jemos.podam</groupId>

--- a/protobuf-converter/pom.xml
+++ b/protobuf-converter/pom.xml
@@ -46,6 +46,10 @@
             <artifactId>wire-schema</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-serializer</artifactId>
         </dependency>

--- a/protobuf-provider/pom.xml
+++ b/protobuf-provider/pom.xml
@@ -32,6 +32,10 @@
             <artifactId>wire-schema</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
         </dependency>


### PR DESCRIPTION
Upgrade kotlin-stdlib to 1.4.x due to CVE https://nvd.nist.gov/vuln/detail/CVE-2020-15824