### PR TITLE
MINOR: API cleanup

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -81,16 +81,6 @@ public class ConfigResource {
       @Context HttpHeaders headers,
       @ApiParam(value = "Config Update Request", required = true)
       @NotNull ConfigUpdateRequest request) {
-    Set<String> subjects = null;
-    try {
-      subjects = schemaRegistry.listSubjects(false);
-    } catch (SchemaRegistryStoreException e) {
-      throw Errors.storeException("Failed to retrieve a list of all subjects"
-                                  + " from the registry", e);
-    } catch (SchemaRegistryException e) {
-      throw Errors.schemaRegistryException("Failed to retrieve a list of all subjects"
-                                           + " from the registry", e);
-    }
     CompatibilityLevel compatibilityLevel =
         CompatibilityLevel.forName(request.getCompatibilityLevel());
     if (compatibilityLevel == null) {
@@ -109,13 +99,6 @@ public class ConfigResource {
     } catch (SchemaRegistryRequestForwardingException e) {
       throw Errors.requestForwardingFailedException("Error while forwarding update config request"
                                                     + " to the leader", e);
-    }
-    if (!subjects.contains(subject)) {
-      log.debug("Updated compatibility level for unregistered subject " + subject + " to "
-                + request.getCompatibilityLevel());
-    } else {
-      log.debug("Updated compatibility level for subject " + subject + " to "
-                + request.getCompatibilityLevel());
     }
 
     return request;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/CloseableIterator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/CloseableIterator.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.storage;
+
+import java.io.Closeable;
+import java.util.Iterator;
+
+public interface CloseableIterator<T> extends Iterator<T>, Closeable {
+
+  @Override
+  void close();
+}

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
@@ -239,7 +239,7 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
     return subjects(matchingPredicate(subject), lookupDeletedSubjects);
   }
 
-  protected Set<String> subjects(Predicate<String> match, boolean lookupDeletedSubjects) {
+  public Set<String> subjects(Predicate<String> match, boolean lookupDeletedSubjects) {
     return store.entrySet().stream()
         .flatMap(e -> {
           K k = e.getKey();
@@ -261,7 +261,7 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
     return hasSubjects(matchingPredicate(subject), lookupDeletedSubjects);
   }
 
-  protected boolean hasSubjects(Predicate<String> match, boolean lookupDeletedSubjects) {
+  public boolean hasSubjects(Predicate<String> match, boolean lookupDeletedSubjects) {
     return store.entrySet().stream()
         .anyMatch(e -> {
           K k = e.getKey();

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
@@ -46,11 +46,7 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
   private final Map<SchemaKey, Set<Integer>> referencedBy;
 
   public InMemoryCache(Serializer<K, V> serializer) {
-    this(serializer, new ConcurrentSkipListMap<>());
-  }
-
-  public InMemoryCache(Serializer<K, V> serializer, ConcurrentNavigableMap<K, V> store) {
-    this.store = store;
+    this.store = new ConcurrentSkipListMap<>();
     this.guidToSubjectVersions = new ConcurrentHashMap<>();
     this.hashToGuid = new ConcurrentHashMap<>();
     this.referencedBy = new ConcurrentHashMap<>();

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
@@ -244,10 +244,10 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
 
   @Override
   public Set<String> subjects(String subject, boolean lookupDeletedSubjects) {
-    return subjects(matchingPredicate(subject), lookupDeletedSubjects);
+    return subjects(matchingSubjectPredicate(subject), lookupDeletedSubjects);
   }
 
-  protected Set<String> subjects(Predicate<String> match, boolean lookupDeletedSubjects) {
+  private Set<String> subjects(Predicate<String> match, boolean lookupDeletedSubjects) {
     return store.entrySet().stream()
         .flatMap(e -> {
           K k = e.getKey();
@@ -266,10 +266,10 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
 
   @Override
   public boolean hasSubjects(String subject, boolean lookupDeletedSubjects) {
-    return hasSubjects(matchingPredicate(subject), lookupDeletedSubjects);
+    return hasSubjects(matchingSubjectPredicate(subject), lookupDeletedSubjects);
   }
 
-  protected boolean hasSubjects(Predicate<String> match, boolean lookupDeletedSubjects) {
+  private boolean hasSubjects(Predicate<String> match, boolean lookupDeletedSubjects) {
     return store.entrySet().stream()
         .anyMatch(e -> {
           K k = e.getKey();
@@ -287,10 +287,10 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
 
   @Override
   public void clearSubjects(String subject) {
-    clearSubjects(matchingPredicate(subject));
+    clearSubjects(matchingSubjectPredicate(subject));
   }
 
-  protected void clearSubjects(Predicate<String> match) {
+  private void clearSubjects(Predicate<String> match) {
     BiPredicate<String, Integer> matchDeleted = matchDeleted(match);
 
     Map<Integer, Map<String, Integer>> guids =
@@ -315,7 +315,7 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
     });
   }
 
-  private Predicate<String> matchingPredicate(String subject) {
+  protected Predicate<String> matchingSubjectPredicate(String subject) {
     return s -> subject == null || subject.equals(s);
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
@@ -39,7 +39,6 @@ import java.util.stream.Stream;
  * In-memory store based on maps
  */
 public class InMemoryCache<K, V> implements LookupCache<K, V> {
-  // visible for subclasses
   private final ConcurrentNavigableMap<K, V> store;
   private final Map<String, Map<Integer, Map<String, Integer>>> guidToSubjectVersions;
   private final Map<String, Map<MD5, Integer>> hashToGuid;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -368,7 +367,7 @@ public class KafkaStore<K, V> implements Store<K, V> {
   }
 
   @Override
-  public Iterator<V> getAll(K key1, K key2) throws StoreException {
+  public CloseableIterator<V> getAll(K key1, K key2) throws StoreException {
     assertInitialized();
     return localStore.getAll(key1, key2);
   }
@@ -390,7 +389,7 @@ public class KafkaStore<K, V> implements Store<K, V> {
   }
 
   @Override
-  public Iterator<K> getAllKeys() throws StoreException {
+  public CloseableIterator<K> getAllKeys() throws StoreException {
     assertInitialized();
     return localStore.getAllKeys();
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -15,7 +15,6 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
-import java.io.IOException;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.Config;
@@ -410,7 +409,7 @@ public class KafkaStore<K, V> implements Store<K, V> {
         storeUpdateHandler.close();
       }
       log.debug("Kafka store shut down complete");
-    } catch (IOException e) {
+    } catch (Exception e) {
       throw new RuntimeException(e);
     }
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -28,11 +28,11 @@ public class KafkaStoreMessageHandler implements SchemaUpdateHandler {
 
   private static final Logger log = LoggerFactory.getLogger(KafkaStoreMessageHandler.class);
   private final KafkaSchemaRegistry schemaRegistry;
-  private final LookupCache<SchemaRegistryKey, SchemaRegistryValue> lookupCache;
+  private final LookupCache lookupCache;
   private IdGenerator idGenerator;
 
   public KafkaStoreMessageHandler(KafkaSchemaRegistry schemaRegistry,
-                                  LookupCache<SchemaRegistryKey, SchemaRegistryValue> lookupCache,
+                                  LookupCache lookupCache,
                                   IdGenerator idGenerator) {
     this.schemaRegistry = schemaRegistry;
     this.lookupCache = lookupCache;
@@ -50,21 +50,21 @@ public class KafkaStoreMessageHandler implements SchemaUpdateHandler {
     if (key.getKeyType() == SchemaRegistryKeyType.SCHEMA) {
       SchemaValue schemaObj = (SchemaValue) value;
       if (schemaObj != null) {
-        SchemaKey oldKey = lookupCache.schemaKeyById(schemaObj.getId());
-        if (oldKey != null) {
-          SchemaValue oldSchema;
-          try {
+        try {
+          SchemaKey oldKey = lookupCache.schemaKeyById(schemaObj.getId());
+          if (oldKey != null) {
+            SchemaValue oldSchema;
             oldSchema = (SchemaValue) lookupCache.get(oldKey);
-          } catch (StoreException e) {
-            log.error("Error while retrieving schema", e);
-            return false;
+            if (oldSchema != null && !oldSchema.getSchema().equals(schemaObj.getSchema())) {
+              log.error("Found a schema with duplicate ID {}.  This schema will not be "
+                      + "registered since a schema already exists with this ID.",
+                  schemaObj.getId());
+              return false;
+            }
           }
-          if (oldSchema != null && !oldSchema.getSchema().equals(schemaObj.getSchema())) {
-            log.error("Found a schema with duplicate ID {}.  This schema will not be "
-                    + "registered since a schema already exists with this ID.",
-                schemaObj.getId());
-            return false;
-          }
+        } catch (StoreException e) {
+          log.error("Error while retrieving schema", e);
+          return false;
         }
       }
     }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -28,11 +28,11 @@ public class KafkaStoreMessageHandler implements SchemaUpdateHandler {
 
   private static final Logger log = LoggerFactory.getLogger(KafkaStoreMessageHandler.class);
   private final KafkaSchemaRegistry schemaRegistry;
-  private final LookupCache lookupCache;
+  private final LookupCache<SchemaRegistryKey, SchemaRegistryValue> lookupCache;
   private IdGenerator idGenerator;
 
   public KafkaStoreMessageHandler(KafkaSchemaRegistry schemaRegistry,
-                                  LookupCache lookupCache,
+                                  LookupCache<SchemaRegistryKey, SchemaRegistryValue> lookupCache,
                                   IdGenerator idGenerator) {
     this.schemaRegistry = schemaRegistry;
     this.lookupCache = lookupCache;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThread.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThread.java
@@ -245,20 +245,24 @@ public class KafkaStoreReaderThread<K, V> extends ShutdownableThread {
 
   @Override
   public void shutdown() {
-    log.debug("Starting shutdown of KafkaStoreReaderThread.");
+    try {
+      log.debug("Starting shutdown of KafkaStoreReaderThread.");
 
-    super.initiateShutdown();
-    if (consumer != null) {
-      consumer.wakeup();
+      super.initiateShutdown();
+      if (consumer != null) {
+        consumer.wakeup();
+      }
+      if (localStore != null) {
+        localStore.close();
+      }
+      super.awaitShutdown();
+      if (consumer != null) {
+        consumer.close();
+      }
+      log.info("KafkaStoreReaderThread shutdown complete.");
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
-    if (localStore != null) {
-      localStore.close();
-    }
-    super.awaitShutdown();
-    if (consumer != null) {
-      consumer.close();
-    }
-    log.info("KafkaStoreReaderThread shutdown complete.");
   }
 
   public void waitUntilOffset(long offset, long timeout, TimeUnit timeUnit) throws StoreException {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupCache.java
@@ -15,6 +15,8 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
+import static io.confluent.kafka.schemaregistry.storage.SchemaRegistry.DEFAULT_TENANT;
+
 import java.util.Set;
 
 import io.confluent.kafka.schemaregistry.CompatibilityLevel;
@@ -139,4 +141,16 @@ public interface LookupCache<K,V> extends Store<K,V> {
    * @param subject the subject, or null for all subjects
    */
   void clearSubjects(String subject) throws StoreException;
+
+  default String tenant() {
+    return DEFAULT_TENANT;
+  }
+
+  /**
+   * Can be used by subclasses to implement multi-tenancy
+   *
+   * @param tenant the tenant
+   */
+  default void setTenant(String tenant) {
+  }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupCache.java
@@ -39,7 +39,7 @@ public interface LookupCache<K,V> extends Store<K,V> {
    * @param schema schema object; never {@code null}
    * @return the schema id and subjects associated with the schema, null otherwise.
    */
-  SchemaIdAndSubjects schemaIdAndSubjects(Schema schema);
+  SchemaIdAndSubjects schemaIdAndSubjects(Schema schema) throws StoreException;
 
   /**
    * Checks if a schema is registered in any subject.
@@ -47,7 +47,7 @@ public interface LookupCache<K,V> extends Store<K,V> {
    * @param schema schema object
    * @return true if the schema is already registered else false
    */
-  boolean containsSchema(Schema schema);
+  boolean containsSchema(Schema schema) throws StoreException;
 
   /**
    * Returns schemas that reference the given schema.
@@ -55,7 +55,7 @@ public interface LookupCache<K,V> extends Store<K,V> {
    * @param schema schema object
    * @return the ids of schemas that reference the given schema
    */
-  Set<Integer> referencesSchema(SchemaKey schema);
+  Set<Integer> referencesSchema(SchemaKey schema) throws StoreException;
 
   /**
    * Provides the {@link SchemaKey} for the provided schema id.
@@ -63,7 +63,7 @@ public interface LookupCache<K,V> extends Store<K,V> {
    * @param id the schema id; never {@code null}
    * @return the {@link SchemaKey} if found, otherwise null.
    */
-  SchemaKey schemaKeyById(Integer id);
+  SchemaKey schemaKeyById(Integer id) throws StoreException;
 
   /**
    * Callback that is invoked when a schema is registered.
@@ -103,7 +103,8 @@ public interface LookupCache<K,V> extends Store<K,V> {
    */
   CompatibilityLevel compatibilityLevel(String subject,
                                         boolean returnTopLevelIfNotFound,
-                                        CompatibilityLevel defaultForTopLevel);
+                                        CompatibilityLevel defaultForTopLevel)
+      throws StoreException;
 
   /**
    * Retrieves the mode for a subject.
@@ -113,7 +114,8 @@ public interface LookupCache<K,V> extends Store<K,V> {
    * @param defaultForTopLevel default value for the top level scope
    * @return the mode if found, otherwise null.
    */
-  Mode mode(String subject, boolean returnTopLevelIfNotFound, Mode defaultForTopLevel);
+  Mode mode(String subject, boolean returnTopLevelIfNotFound, Mode defaultForTopLevel)
+      throws StoreException;
 
   /**
    * Returns subjects that have schemas (that are not deleted) that match the given subject.

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/MD5.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/MD5.java
@@ -42,6 +42,10 @@ public class MD5 {
     this.md5 = md5;
   }
 
+  public byte[] bytes() {
+    return md5;
+  }
+
   /**
    * Factory method converts String into MD5 object.
    */

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
@@ -88,7 +88,11 @@ public interface SchemaRegistry extends SchemaVersionFetcher {
     return DEFAULT_TENANT;
   }
 
-  // Can be used by subclasses to implement multi-tenancy
+  /**
+   * Can be used by subclasses to implement multi-tenancy
+   *
+   * @param tenant the tenant
+   */
   default void setTenant(String tenant) {
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/Store.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/Store.java
@@ -44,5 +44,5 @@ public interface Store<K, V> {
 
   public CloseableIterator<K> getAllKeys() throws StoreException;
 
-  public void close();
+  public void close() throws StoreException;
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/Store.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/Store.java
@@ -15,7 +15,6 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
-import java.util.Iterator;
 import java.util.Map;
 
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
@@ -37,13 +36,13 @@ public interface Store<K, V> {
    * @return Iterator over keys in the half-open interval [key1, key2). If both keys are null,
    *     return an iterator over all keys in the database
    */
-  public Iterator<V> getAll(K key1, K key2) throws StoreException;
+  public CloseableIterator<V> getAll(K key1, K key2) throws StoreException;
 
   public void putAll(Map<K, V> entries) throws StoreException;
 
   public V delete(K key) throws StoreException;
 
-  public Iterator<K> getAllKeys() throws StoreException;
+  public CloseableIterator<K> getAllKeys() throws StoreException;
 
   public void close();
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/serialization/SchemaRegistrySerializer.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/serialization/SchemaRegistrySerializer.java
@@ -41,8 +41,9 @@ import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 public class SchemaRegistrySerializer
     implements Serializer<SchemaRegistryKey, SchemaRegistryValue> {
 
-  public SchemaRegistrySerializer() {
+  private static final long serialVersionUID = -2564877824075394626L;
 
+  public SchemaRegistrySerializer() {
   }
 
   /**

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/serialization/Serializer.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/serialization/Serializer.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafka.schemaregistry.storage.serialization;
 
+import java.io.Serializable;
 import org.apache.kafka.common.Configurable;
 
 import io.confluent.kafka.schemaregistry.storage.exceptions.SerializationException;
@@ -23,7 +24,7 @@ import io.confluent.kafka.schemaregistry.storage.exceptions.SerializationExcepti
  * @param <K> Key type to be serialized from. <p/> A class that implements this interface is
  *            expected to have a constructor with no parameter.
  */
-public interface Serializer<K, V> extends Configurable {
+public interface Serializer<K, V> extends Configurable, Serializable {
 
   /**
    * @param key Typed key

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
@@ -127,7 +127,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
 
   @Test
   public void testSimpleGetAfterFailure() throws Exception {
-    Store<String, String> inMemoryStore = new InMemoryCache<String, String>();
+    Store<String, String> inMemoryStore = new InMemoryCache<>(StringSerializer.INSTANCE);
     KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(
         bootstrapServers,
         inMemoryStore
@@ -202,7 +202,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
 
   @Test
   public void testDeleteAfterRestart() throws Exception {
-    Store<String, String> inMemoryStore = new InMemoryCache<String, String>();
+    Store<String, String> inMemoryStore = new InMemoryCache<>(StringSerializer.INSTANCE);
     KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(
         bootstrapServers,
         inMemoryStore
@@ -255,7 +255,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
 
   @Test
   public void testCustomGroupIdConfig() throws Exception {
-    Store<String, String> inMemoryStore = new InMemoryCache<String, String>();
+    Store<String, String> inMemoryStore = new InMemoryCache<>(StringSerializer.INSTANCE);
     String groupId = "test-group-id";
     Properties props = new Properties();
     props.put(SchemaRegistryConfig.KAFKASTORE_GROUP_ID_CONFIG, groupId);
@@ -267,7 +267,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
 
   @Test
   public void testDefaultGroupIdConfig() throws Exception {
-    Store<String, String> inMemoryStore = new InMemoryCache<String, String>();
+    Store<String, String> inMemoryStore = new InMemoryCache<>(StringSerializer.INSTANCE);
     Properties props = new Properties();
     KafkaStore kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(bootstrapServers, inMemoryStore, props);
 
@@ -289,7 +289,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
       admin.createTopics(Collections.singletonList(topic)).all().get(ADMIN_TIMEOUT_SEC, TimeUnit.SECONDS);
     }
 
-    Store<String, String> inMemoryStore = new InMemoryCache<String, String>();
+    Store<String, String> inMemoryStore = new InMemoryCache<>(StringSerializer.INSTANCE);
 
     KafkaStore kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(bootstrapServers, inMemoryStore, kafkaProps);
   }
@@ -309,7 +309,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
       admin.createTopics(Collections.singletonList(topic)).all().get(ADMIN_TIMEOUT_SEC, TimeUnit.SECONDS);
     }
 
-    Store<String, String> inMemoryStore = new InMemoryCache<String, String>();
+    Store<String, String> inMemoryStore = new InMemoryCache<>(StringSerializer.INSTANCE);
 
     StoreUtils.createAndInitKafkaStoreInstance(bootstrapServers, inMemoryStore, kafkaProps);
   }
@@ -319,7 +319,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
     Properties kafkaProps = new Properties();
     kafkaProps.put("kafkastore.topic.config.delete.retention.ms", "10000");
     kafkaProps.put("kafkastore.topic.config.segment.ms", "10000");
-    Store<String, String> inMemoryStore = new InMemoryCache<String, String>();
+    Store<String, String> inMemoryStore = new InMemoryCache<>(StringSerializer.INSTANCE);
     StoreUtils.createAndInitKafkaStoreInstance(bootstrapServers, inMemoryStore, kafkaProps);
 
     Properties props = new Properties();
@@ -427,9 +427,11 @@ public class KafkaStoreTest extends ClusterTestHarness {
         new SchemaValue("subject2", 1, id, "schemaString2", false)
     );
     int size = 0;
-    for (Iterator<SchemaRegistryKey> iter = kafkaStore.getAllKeys(); iter.hasNext(); ) {
-      size++;
-      iter.next();
+    try (CloseableIterator<SchemaRegistryKey> keys = kafkaStore.getAllKeys()) {
+      for (Iterator<SchemaRegistryKey> iter = keys; iter.hasNext(); ) {
+        size++;
+        iter.next();
+      }
     }
     assertEquals(1, size);
   }
@@ -456,9 +458,11 @@ public class KafkaStoreTest extends ClusterTestHarness {
         new SchemaValue("subject2", 1, id, "schemaString", false)
     );
     int size = 0;
-    for (Iterator<SchemaRegistryKey> iter = kafkaStore.getAllKeys(); iter.hasNext(); ) {
-      size++;
-      iter.next();
+    try (CloseableIterator<SchemaRegistryKey> keys = kafkaStore.getAllKeys()) {
+      for (Iterator<SchemaRegistryKey> iter = keys; iter.hasNext(); ) {
+        size++;
+        iter.next();
+      }
     }
     assertEquals(2, size);
   }
@@ -488,9 +492,11 @@ public class KafkaStoreTest extends ClusterTestHarness {
         new SchemaValue("subject2", 1, id, "schemaString2", false)
     );
     int size = 0;
-    for (Iterator<SchemaRegistryKey> iter = kafkaStore.getAllKeys(); iter.hasNext(); ) {
-      size++;
-      iter.next();
+    try (CloseableIterator<SchemaRegistryKey> keys = kafkaStore.getAllKeys()) {
+      for (Iterator<SchemaRegistryKey> iter = keys; iter.hasNext(); ) {
+        size++;
+        iter.next();
+      }
     }
     assertEquals(1, size);
   }
@@ -520,9 +526,11 @@ public class KafkaStoreTest extends ClusterTestHarness {
         new SchemaValue("subject2", 1, id, "schemaString", false)
     );
     int size = 0;
-    for (Iterator<SchemaRegistryKey> iter = kafkaStore.getAllKeys(); iter.hasNext(); ) {
-      size++;
-      iter.next();
+    try (CloseableIterator<SchemaRegistryKey> keys = kafkaStore.getAllKeys()) {
+      for (Iterator<SchemaRegistryKey> iter = keys; iter.hasNext(); ) {
+        size++;
+        iter.next();
+      }
     }
     assertEquals(2, size);
   }
@@ -540,8 +548,10 @@ public class KafkaStoreTest extends ClusterTestHarness {
             new SchemaRegistrySerializer()
     );
 
+    InMemoryCache<String, String> store = new InMemoryCache<>(StringSerializer.INSTANCE);
+    store.init();
     KafkaStoreMessageHandler storeMessageHandler = new KafkaStoreMessageHandler(schemaRegistry,
-            new InMemoryCache<>(), new IncrementalIdGenerator());
+            store, new IncrementalIdGenerator());
 
     storeMessageHandler.handleUpdate(new DeleteSubjectKey("test"), null, null, null, 0L, 0L);
   }
@@ -559,8 +569,10 @@ public class KafkaStoreTest extends ClusterTestHarness {
             new SchemaRegistrySerializer()
     );
 
+    InMemoryCache<String, String> store = new InMemoryCache<>(StringSerializer.INSTANCE);
+    store.init();
     KafkaStoreMessageHandler storeMessageHandler = new KafkaStoreMessageHandler(schemaRegistry,
-            new InMemoryCache<>(), new IncrementalIdGenerator());
+          store, new IncrementalIdGenerator());
 
     storeMessageHandler.handleUpdate(new ClearSubjectKey("test"), null, null, null, 0L, 0L);
   }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
@@ -548,7 +548,8 @@ public class KafkaStoreTest extends ClusterTestHarness {
             new SchemaRegistrySerializer()
     );
 
-    InMemoryCache<String, String> store = new InMemoryCache<>(StringSerializer.INSTANCE);
+    InMemoryCache<SchemaRegistryKey, SchemaRegistryValue> store =
+            new InMemoryCache<>(new SchemaRegistrySerializer());
     store.init();
     KafkaStoreMessageHandler storeMessageHandler = new KafkaStoreMessageHandler(schemaRegistry,
             store, new IncrementalIdGenerator());
@@ -569,7 +570,8 @@ public class KafkaStoreTest extends ClusterTestHarness {
             new SchemaRegistrySerializer()
     );
 
-    InMemoryCache<String, String> store = new InMemoryCache<>(StringSerializer.INSTANCE);
+    InMemoryCache<SchemaRegistryKey, SchemaRegistryValue> store =
+            new InMemoryCache<>(new SchemaRegistrySerializer());
     store.init();
     KafkaStoreMessageHandler storeMessageHandler = new KafkaStoreMessageHandler(schemaRegistry,
           store, new IncrementalIdGenerator());

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/StoreUtils.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/StoreUtils.java
@@ -14,6 +14,8 @@
  */
 package io.confluent.kafka.schemaregistry.storage;
 
+import io.confluent.kafka.schemaregistry.storage.exceptions.SerializationException;
+import io.confluent.kafka.schemaregistry.storage.serialization.Serializer;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.types.Password;
 
@@ -37,7 +39,7 @@ public class StoreUtils {
    */
   public static KafkaStore<String, String> createAndInitKafkaStoreInstance(String bootstrapServers)
       throws RestConfigException, StoreInitializationException, SchemaRegistryException {
-    Store<String, String> inMemoryStore = new InMemoryCache<String, String>();
+    Store<String, String> inMemoryStore = new InMemoryCache<>(StringSerializer.INSTANCE);
     return createAndInitKafkaStoreInstance(bootstrapServers, inMemoryStore);
   }
   /**
@@ -66,7 +68,7 @@ public class StoreUtils {
 
     props.put(SchemaRegistryConfig.ZOOKEEPER_SET_ACL_CONFIG, false);
 
-    Store<String, String> inMemoryStore = new InMemoryCache<String, String>();
+    Store<String, String> inMemoryStore = new InMemoryCache<>(StringSerializer.INSTANCE);
     return createAndInitKafkaStoreInstance(bootstrapServers, inMemoryStore, props);
   }
 
@@ -93,7 +95,7 @@ public class StoreUtils {
               ((Password) sslConfigs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG)).value());
     }
 
-    Store<String, String> inMemoryStore = new InMemoryCache<String, String>();
+    Store<String, String> inMemoryStore = new InMemoryCache<>(StringSerializer.INSTANCE);
     return createAndInitKafkaStoreInstance(bootstrapServers, inMemoryStore, props);
   }
 
@@ -117,5 +119,4 @@ public class StoreUtils {
     kafkaStore.init();
     return kafkaStore;
   }
-
 }

--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -67,6 +67,16 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
     </Match>
 
     <Match>
+        <Class name="io.confluent.kafka.schemaregistry.storage.InMemoryCache"/>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
+    </Match>
+
+    <Match>
+        <Class name="io.confluent.kafka.schemaregistry.storage.MD5"/>
+        <Bug pattern="EI_EXPOSE_REP"/>
+    </Match>
+
+    <Match>
         <Class name="io.confluent.kafka.schemaregistry.storage.MD5"/>
         <Bug pattern="EI_EXPOSE_REP2"/>
     </Match>


### PR DESCRIPTION
Some API cleanup to enable future extensibility
- Ensure LookupCache APIs throw StoreException
- Use CloseableIterator
- Pass serializer to InMemoryCache constructor
- Use thread-safe structures
- Minor optimization for updating subject config