### PR TITLE
DG-800 Cache ProtobufSchema using name in Converter

### DIFF
--- a/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufData.java
+++ b/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufData.java
@@ -84,7 +84,7 @@ public class ProtobufData {
   private int defaultSchemaNameIndex = 0;
 
   private final Cache<Schema, ProtobufSchema> fromConnectSchemaCache;
-  private final Cache<ProtobufSchema, Schema> toConnectSchemaCache;
+  private final Cache<Pair<String, ProtobufSchema>, Schema> toConnectSchemaCache;
   private boolean enhancedSchemaSupport;
 
   public ProtobufData() {
@@ -857,7 +857,8 @@ public class ProtobufData {
     if (schema == null) {
       return null;
     }
-    Schema cachedSchema = toConnectSchemaCache.get(schema);
+    Pair<String, ProtobufSchema> cacheKey = new Pair<>(schema.name(), schema);
+    Schema cachedSchema = toConnectSchemaCache.get(cacheKey);
     if (cachedSchema != null) {
       return cachedSchema;
     }
@@ -866,7 +867,7 @@ public class ProtobufData {
     ToConnectContext ctx = new ToConnectContext();
     ctx.put(descriptor.getFullName(), builder);
     Schema resultSchema = toConnectSchema(ctx, builder, descriptor, schema.version()).build();
-    toConnectSchemaCache.put(schema, resultSchema);
+    toConnectSchemaCache.put(cacheKey, resultSchema);
     return resultSchema;
   }
 

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufConverterTest.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufConverterTest.java
@@ -350,7 +350,7 @@ public class ProtobufConverterTest {
   }
 
   @Test
-  public void testToConnectDataForValueBothMessages() throws Exception {
+  public void testToConnectDataForValueWithBothMessages() throws Exception {
     converter.configure(SR_CONFIG, false);
     // extra byte for message index
     byte[] input = concat(new byte[]{0, 0, 0, 0, 1, 0}, HELLO_WORLD_MESSAGE.toByteArray());

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufConverterTest.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufConverterTest.java
@@ -350,6 +350,41 @@ public class ProtobufConverterTest {
   }
 
   @Test
+  public void testToConnectDataForValueBothMessages() throws Exception {
+    converter.configure(SR_CONFIG, false);
+    // extra byte for message index
+    byte[] input = concat(new byte[]{0, 0, 0, 0, 1, 0}, HELLO_WORLD_MESSAGE.toByteArray());
+    schemaRegistry.register("my-topic-value", getSchema(TestMessage.getDescriptor()));
+    SchemaAndValue result = converter.toConnectData("my-topic", input);
+
+    SchemaAndValue expected = new SchemaAndValue(getTestMessageSchema(),
+            getTestMessageStruct(TEST_MSG_STRING, 123)
+    );
+
+    assertEquals(expected, result);
+
+    // extra bytes for message index
+    input = concat(new byte[]{0, 0, 0, 0, 1, 2, 2}, HELLO_WORLD_MESSAGE2.toByteArray());
+    schemaRegistry.register("my-topic-value", getSchema(TestMessage2.getDescriptor()));
+    result = converter.toConnectData("my-topic", input);
+
+    SchemaBuilder builder = getTestMessageSchemaBuilder("TestMessage2");
+    builder.field(
+            "test_message",
+            getTestMessageSchemaBuilder("TestMessage")
+                    .optional()
+                    .parameter(PROTOBUF_TYPE_TAG, String.valueOf(16))
+                    .build()
+    );
+    Schema schema = builder.version(1).build();
+    Struct struct = getTestMessageStruct(schema, TEST_MSG_STRING, 123);
+    struct.put("test_message", null);
+    expected = new SchemaAndValue(schema, struct);
+
+    assertEquals(expected, result);
+  }
+
+  @Test
   public void testToConnectDataForValueWithNamespace() throws Exception {
     Map<String, Object> configs = new HashMap<>();
     configs.put(KafkaProtobufSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "bogus");


### PR DESCRIPTION
Cache ProtobufSchema using name in Converter.

This fixes https://github.com/confluentinc/schema-registry/issues/1584