### PR TITLE
Add failing compatibility reason in rest response 

### DIFF
--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
@@ -361,7 +361,7 @@ public class KafkaAvroSerializerTest {
 
     AvroSchema avroSchemaV1 = new AvroSchema(schemaV1);
     AvroSchema avroSchemaV2 = new AvroSchema(schemaV2);
-    assertTrue("Schema V2 should be backwards compatible", avroSchemaV2.isBackwardCompatible(avroSchemaV1));
+    assertTrue("Schema V2 should be backwards compatible", avroSchemaV2.isBackwardCompatible(avroSchemaV1).isEmpty());
 
     GenericRecord recordV1 = new GenericData.Record(avroSchemaV1.rawSchema());
     recordV1.put(fieldToDelete, "present");

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/CompatibilityChecker.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/CompatibilityChecker.java
@@ -64,7 +64,8 @@ public class CompatibilityChecker {
       FULL_TRANSITIVE_VALIDATOR);
 
   private static final SchemaValidator NO_OP_VALIDATOR =
-      (schema, schemas) -> Collections.emptyList();
+          (schema, schemas) -> Collections.emptyList();
+
   public static final CompatibilityChecker NO_OP_CHECKER =
       new CompatibilityChecker(NO_OP_VALIDATOR);
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/CompatibilityChecker.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/CompatibilityChecker.java
@@ -64,7 +64,7 @@ public class CompatibilityChecker {
       FULL_TRANSITIVE_VALIDATOR);
 
   private static final SchemaValidator NO_OP_VALIDATOR =
-          (schema, schemas) -> Collections.emptyList();
+      (schema, schemas) -> Collections.emptyList();
   public static final CompatibilityChecker NO_OP_CHECKER =
       new CompatibilityChecker(NO_OP_VALIDATOR);
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/CompatibilityChecker.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/CompatibilityChecker.java
@@ -64,7 +64,7 @@ public class CompatibilityChecker {
       FULL_TRANSITIVE_VALIDATOR);
 
   private static final SchemaValidator NO_OP_VALIDATOR =
-          (schema, schemas) -> Collections.emptyList();
+      (schema, schemas) -> Collections.emptyList();
 
   public static final CompatibilityChecker NO_OP_CHECKER =
       new CompatibilityChecker(NO_OP_VALIDATOR);

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/CompatibilityChecker.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/CompatibilityChecker.java
@@ -63,7 +63,8 @@ public class CompatibilityChecker {
   public static final CompatibilityChecker FULL_TRANSITIVE_CHECKER = new CompatibilityChecker(
       FULL_TRANSITIVE_VALIDATOR);
 
-  private static final SchemaValidator NO_OP_VALIDATOR = (schema, schemas) -> true;
+  private static final SchemaValidator NO_OP_VALIDATOR =
+          (schema, schemas) -> Collections.emptyList();
   public static final CompatibilityChecker NO_OP_CHECKER =
       new CompatibilityChecker(NO_OP_VALIDATOR);
 
@@ -74,7 +75,7 @@ public class CompatibilityChecker {
   }
 
   // visible for testing
-  public boolean isCompatible(
+  public List<String> isCompatible(
       ParsedSchema newSchema, List<? extends ParsedSchema> previousSchemas
   ) {
     List<? extends ParsedSchema> previousSchemasCopy = new ArrayList<>(previousSchemas);

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
@@ -16,9 +16,10 @@
 
 package io.confluent.kafka.schemaregistry;
 
+import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
-
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 
 /**
@@ -83,9 +84,10 @@ public interface ParsedSchema {
    * to ensure that it is compatible with the specified schema.
    *
    * @param previousSchema previous schema
-   * @return whether this schema is backward compatible with the previous schema
+   * @return an empty list if this schema is backward compatible with the previous schema,
+   *         otherwise the list of error messages
    */
-  boolean isBackwardCompatible(ParsedSchema previousSchema);
+  List<String> isBackwardCompatible(ParsedSchema previousSchema);
 
   /**
    * Checks the compatibility between this schema and the specified schemas.
@@ -95,13 +97,14 @@ public interface ParsedSchema {
    *
    * @param level the compatibility level
    * @param previousSchemas full schema history in chronological order
-   * @return whether this schema is compatible with the previous schemas
+   * @return an empty list if this schema is backward compatible with the previous schema, otherwise
+   *         the list of error messages
    */
-  default boolean isCompatible(CompatibilityLevel level,
-                               List<? extends ParsedSchema> previousSchemas) {
+  default List<String> isCompatible(
+      CompatibilityLevel level, List<? extends ParsedSchema> previousSchemas) {
     for (ParsedSchema previousSchema : previousSchemas) {
       if (!schemaType().equals(previousSchema.schemaType())) {
-        return false;
+        return new LinkedList<>(Arrays.asList("Incompatible because of different schema type"));
       }
     }
     return CompatibilityChecker.checker(level).isCompatible(this, previousSchemas);

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
@@ -16,8 +16,7 @@
 
 package io.confluent.kafka.schemaregistry;
 
-import java.util.Arrays;
-import java.util.LinkedList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
@@ -104,7 +103,7 @@ public interface ParsedSchema {
       CompatibilityLevel level, List<? extends ParsedSchema> previousSchemas) {
     for (ParsedSchema previousSchema : previousSchemas) {
       if (!schemaType().equals(previousSchema.schemaType())) {
-        return new LinkedList<>(Arrays.asList("Incompatible because of different schema type"));
+        return Collections.singletonList("Incompatible because of different schema type");
       }
     }
     return CompatibilityChecker.checker(level).isCompatible(this, previousSchemas);

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidationStrategy.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidationStrategy.java
@@ -20,6 +20,8 @@
 
 package io.confluent.kafka.schemaregistry;
 
+import java.util.List;
+
 /**
  * An interface for validating the compatibility of a single schema against
  * another.
@@ -34,6 +36,7 @@ public interface SchemaValidationStrategy {
    *
    * @param toValidate The schema to validate
    * @param existing The schema to validate against
+   * @return List of error message, other wise empty list
    */
-  boolean validate(ParsedSchema toValidate, ParsedSchema existing);
+  List<String> validate(ParsedSchema toValidate, ParsedSchema existing);
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidationStrategy.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidationStrategy.java
@@ -36,7 +36,7 @@ public interface SchemaValidationStrategy {
    *
    * @param toValidate The schema to validate
    * @param existing The schema to validate against
-   * @return List of error message, other wise empty list
+   * @return List of error message, otherwise empty list
    */
   List<String> validate(ParsedSchema toValidate, ParsedSchema existing);
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidator.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidator.java
@@ -20,6 +20,8 @@
 
 package io.confluent.kafka.schemaregistry;
 
+import java.util.List;
+
 /**
  * <p>
  * A SchemaValidator has one method, which validates that a {@link ParsedSchema} is
@@ -42,6 +44,8 @@ public interface SchemaValidator {
    * @param toValidate The schema to validate
    * @param existing The schemas to validate against, in order from most recent to latest if
    *     applicable
+   * @return empty list if the schema is compatible with the provided schema, other wise the list
+   *        of error messages
    */
-  boolean validate(ParsedSchema toValidate, Iterable<? extends ParsedSchema> existing);
+  List<String> validate(ParsedSchema toValidate, Iterable<? extends ParsedSchema> existing);
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidator.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidator.java
@@ -44,8 +44,7 @@ public interface SchemaValidator {
    * @param toValidate The schema to validate
    * @param existing The schemas to validate against, in order from most recent to latest if
    *     applicable
-   * @return empty list if the schema is compatible with the provided schema, other wise the list
-   *        of error messages
+   * @return List of error message, otherwise empty list
    */
   List<String> validate(ParsedSchema toValidate, Iterable<? extends ParsedSchema> existing);
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidatorBuilder.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidatorBuilder.java
@@ -23,6 +23,7 @@ package io.confluent.kafka.schemaregistry;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.ArrayList;
 
 /**
  * <p>
@@ -57,18 +58,10 @@ public final class SchemaValidatorBuilder {
   public SchemaValidatorBuilder mutualReadStrategy() {
 
     this.strategy = (toValidate, existing) -> {
-      List<String> backward = existing.isBackwardCompatible(toValidate);
-      List<String> forward = toValidate.isBackwardCompatible(existing);
-      if (!backward.isEmpty() && !forward.isEmpty()) {
-        backward.addAll(forward);
-        return backward;
-      } else if (!backward.isEmpty()) {
-        return backward;
-      } else if (!forward.isEmpty())  {
-        return forward;
-      } else {
-        return Collections.emptyList();
-      }
+      List<String> result = new ArrayList<>();
+      result.addAll(existing.isBackwardCompatible(toValidate));
+      result.addAll(toValidate.isBackwardCompatible(existing));
+      return result;
     };
     return this;
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidatorBuilder.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidatorBuilder.java
@@ -20,6 +20,7 @@
 
 package io.confluent.kafka.schemaregistry;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -58,15 +59,15 @@ public final class SchemaValidatorBuilder {
     this.strategy = (toValidate, existing) -> {
       List<String> backward = existing.isBackwardCompatible(toValidate);
       List<String> forward = toValidate.isBackwardCompatible(existing);
-      if (backward != null && forward != null) {
+      if (!backward.isEmpty() && !forward.isEmpty()) {
         backward.addAll(forward);
         return backward;
-      } else if (backward != null) {
+      } else if (!backward.isEmpty()) {
         return backward;
-      } else if (forward != null)  {
+      } else if (!forward.isEmpty())  {
         return forward;
       } else {
-        return null;
+        return Collections.emptyList();
       }
     };
     return this;
@@ -80,7 +81,7 @@ public final class SchemaValidatorBuilder {
         ParsedSchema existing = schemas.next();
         return strategy.validate(toValidate, existing);
       }
-      return null;
+      return Collections.emptyList();
     };
   }
 
@@ -89,11 +90,11 @@ public final class SchemaValidatorBuilder {
     return (toValidate, schemasInOrder) -> {
       for (ParsedSchema existing : schemasInOrder) {
         List<String> errorMessages = strategy.validate(toValidate, existing);
-        if (errorMessages != null) {
+        if (!errorMessages.isEmpty()) {
           return errorMessages;
         }
       }
-      return null;
+      return Collections.emptyList();
     };
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
@@ -30,8 +30,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.LinkedList;
-import java.util.Arrays;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -161,18 +159,18 @@ public class AvroSchema implements ParsedSchema {
   @Override
   public List<String> isBackwardCompatible(ParsedSchema previousSchema) {
     if (!schemaType().equals(previousSchema.schemaType())) {
-      return new LinkedList<>(Arrays.asList("Incompatible because of different schema type"));
+      return Collections.singletonList("Incompatible because of different schema type");
     }
     try {
       BACKWARD_VALIDATOR.validate(this.schemaObj,
           Collections.singleton(((AvroSchema) previousSchema).schemaObj));
       return Collections.emptyList();
     } catch (SchemaValidationException e) {
-      return new LinkedList<>(Arrays.asList(e.toString()));
+      return Collections.singletonList(e.toString());
     } catch (Exception e) {
       log.error("Unexpected exception during compatibility check", e);
-      return new LinkedList<>(Arrays.asList(
-              String.format("Unexpected exception during compatibility check", e)));
+      return Collections.singletonList(
+              "Unexpected exception during compatibility check: " + e.getMessage());
     }
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
@@ -30,6 +30,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.LinkedList;
+import java.util.Arrays;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -156,19 +159,20 @@ public class AvroSchema implements ParsedSchema {
   }
 
   @Override
-  public boolean isBackwardCompatible(ParsedSchema previousSchema) {
+  public List<String> isBackwardCompatible(ParsedSchema previousSchema) {
     if (!schemaType().equals(previousSchema.schemaType())) {
-      return false;
+      return new LinkedList<>(Arrays.asList("Incompatible because of different schema type"));
     }
     try {
       BACKWARD_VALIDATOR.validate(this.schemaObj,
           Collections.singleton(((AvroSchema) previousSchema).schemaObj));
-      return true;
+      return Collections.emptyList();
     } catch (SchemaValidationException e) {
-      return false;
+      return new LinkedList<>(Arrays.asList(e.toString()));
     } catch (Exception e) {
       log.error("Unexpected exception during compatibility check", e);
-      return false;
+      return new LinkedList<>(Arrays.asList(
+              String.format("Unexpected exception during compatibility check", e)));
     }
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
@@ -166,7 +166,7 @@ public class AvroSchema implements ParsedSchema {
           Collections.singleton(((AvroSchema) previousSchema).schemaObj));
       return Collections.emptyList();
     } catch (SchemaValidationException e) {
-      return Collections.singletonList(e.toString());
+      return Collections.singletonList(e.getMessage());
     } catch (Exception e) {
       log.error("Unexpected exception during compatibility check", e);
       return Collections.singletonList(

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -426,14 +426,14 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   public boolean testCompatibility(String subject, ParsedSchema schema)
       throws IOException, RestClientException {
     return restService.testCompatibility(schema.canonicalString(), schema.schemaType(),
-        schema.references(), subject, "latest");
+        schema.references(), subject, "latest", false).isEmpty();
   }
 
   @Override
   public List<String> testCompatibilityVerbose(String subject, ParsedSchema schema)
           throws IOException, RestClientException {
-    return restService.testCompatibilityVerbose(schema.canonicalString(), schema.schemaType(),
-            schema.references(), subject, "latest");
+    return restService.testCompatibility(schema.canonicalString(), schema.schemaType(),
+            schema.references(), subject, "latest", true);
   }
 
   @Override

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -430,6 +430,13 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
+  public List<String> testCompatibilityVerbose(String subject, ParsedSchema schema)
+          throws IOException, RestClientException {
+    return restService.testCompatibilityVerbose(schema.canonicalString(), schema.schemaType(),
+            schema.references(), subject, "latest");
+  }
+
+  @Override
   public String updateCompatibility(String subject, String compatibility)
       throws IOException, RestClientException {
     ConfigUpdateRequest response = restService.updateCompatibility(compatibility, subject);

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -378,7 +378,7 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
 
     CompatibilityLevel compatibilityLevel = CompatibilityLevel.forName(compatibility);
     if (compatibilityLevel == null) {
-      return new LinkedList<>(Arrays.asList("Compatibility level not specify."));
+      return new LinkedList<>(Arrays.asList("Compatibility level not specified."));
     }
 
     List<ParsedSchema> schemaHistory = new ArrayList<>();

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import java.util.LinkedList;
 
 /**
  * Mock implementation of SchemaRegistryClient that can be used for tests. This version is NOT
@@ -355,6 +356,29 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
     CompatibilityLevel compatibilityLevel = CompatibilityLevel.forName(compatibility);
     if (compatibilityLevel == null) {
       return false;
+    }
+
+    List<ParsedSchema> schemaHistory = new ArrayList<>();
+    for (int version : allVersions(subject)) {
+      SchemaMetadata schemaMetadata = getSchemaMetadata(subject, version);
+      schemaHistory.add(getSchemaBySubjectAndIdFromRegistry(subject,
+          schemaMetadata.getId()));
+    }
+
+    return newSchema.isCompatible(compatibilityLevel, schemaHistory).isEmpty();
+  }
+
+  @Override
+  public List<String> testCompatibilityVerbose(String subject, ParsedSchema newSchema)
+          throws IOException, RestClientException {
+    String compatibility = compatibilityCache.get(subject);
+    if (compatibility == null) {
+      compatibility = defaultCompatibility;
+    }
+
+    CompatibilityLevel compatibilityLevel = CompatibilityLevel.forName(compatibility);
+    if (compatibilityLevel == null) {
+      return new LinkedList<>(Arrays.asList("Compatibility level not specify."));
     }
 
     List<ParsedSchema> schemaHistory = new ArrayList<>();

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -121,8 +121,10 @@ public interface SchemaRegistryClient extends SchemaVersionFetcher {
   public boolean testCompatibility(String subject, ParsedSchema schema)
       throws IOException, RestClientException;
 
-  public List<String> testCompatibilityVerbose(String subject, ParsedSchema schema)
-          throws IOException, RestClientException;
+  default List<String> testCompatibilityVerbose(String subject, ParsedSchema schema)
+          throws IOException, RestClientException {
+    throw new UnsupportedOperationException();
+  }
 
   public String updateCompatibility(String subject, String compatibility)
       throws IOException, RestClientException;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -121,6 +121,9 @@ public interface SchemaRegistryClient extends SchemaVersionFetcher {
   public boolean testCompatibility(String subject, ParsedSchema schema)
       throws IOException, RestClientException;
 
+  public List<String> testCompatibilityVerbose(String subject, ParsedSchema schema)
+          throws IOException, RestClientException;
+
   public String updateCompatibility(String subject, String compatibility)
       throws IOException, RestClientException;
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -505,89 +505,57 @@ public class RestService implements Configurable {
   }
 
   // Visible for testing
-  public boolean testCompatibility(String schemaString, String subject, String version)
+  public List<String> testCompatibility(String schemaString, String subject, String version)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
-    return testCompatibility(request, subject, version);
+    return testCompatibility(request, subject, version, false);
   }
 
-  public boolean testCompatibility(String schemaString,
-                                   String schemaType,
-                                   List<SchemaReference> references,
-                                   String subject,
-                                   String version)
+  public List<String> testCompatibility(String schemaString,
+                                        String schemaType,
+                                        List<SchemaReference> references,
+                                        String subject,
+                                        String version,
+                                        boolean verbose)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
     request.setSchemaType(schemaType);
     request.setReferences(references);
-    return testCompatibility(request, subject, version);
+    return testCompatibility(request, subject, version, verbose);
   }
 
-  public boolean testCompatibility(RegisterSchemaRequest registerSchemaRequest,
-                                   String subject,
-                                   String version)
+  public List<String> testCompatibility(RegisterSchemaRequest registerSchemaRequest,
+                                        String subject,
+                                        String version,
+                                        boolean verbose)
       throws IOException, RestClientException {
     return testCompatibility(DEFAULT_REQUEST_PROPERTIES, registerSchemaRequest,
-                             subject, version);
+                             subject, version, verbose);
   }
 
-  public boolean testCompatibility(Map<String, String> requestProperties,
-                                   RegisterSchemaRequest registerSchemaRequest,
-                                   String subject,
-                                   String version)
+  public List<String> testCompatibility(Map<String, String> requestProperties,
+                                        RegisterSchemaRequest registerSchemaRequest,
+                                        String subject,
+                                        String version,
+                                        boolean verbose)
       throws IOException, RestClientException {
     UriBuilder builder = UriBuilder.fromPath(
         "/compatibility/subjects/{subject}/versions/{version}");
+    builder.queryParam("verbose", verbose);
     String path = builder.build(subject, version).toString();
 
     CompatibilityCheckResponse response =
         httpRequest(path, "POST",
                     registerSchemaRequest.toJson().getBytes(StandardCharsets.UTF_8),
                     requestProperties, COMPATIBILITY_CHECK_RESPONSE_TYPE_REFERENCE);
-    return response.getIsCompatible();
-  }
-
-  public List<String> testCompatibilityVerbose(String schemaString,
-                                               String schemaType,
-                                               List<SchemaReference> references,
-                                               String subject,
-                                               String version)
-      throws IOException, RestClientException {
-    RegisterSchemaRequest request = new RegisterSchemaRequest();
-    request.setSchema(schemaString);
-    request.setSchemaType(schemaType);
-    request.setReferences(references);
-    return testCompatibilityVerbose(request, subject, version);
-  }
-
-  public List<String> testCompatibilityVerbose(RegisterSchemaRequest registerSchemaRequest,
-                                               String subject,
-                                               String version)
-      throws IOException, RestClientException {
-    return testCompatibilityVerbose(
-        DEFAULT_REQUEST_PROPERTIES, registerSchemaRequest, subject, version);
-  }
-
-  public List<String> testCompatibilityVerbose(Map<String, String> requestProperties,
-                                               RegisterSchemaRequest registerSchemaRequest,
-                                               String subject,
-                                               String version)
-      throws IOException, RestClientException {
-    UriBuilder builder =
-        UriBuilder.fromPath("/compatibility/subjects/{subject}/versions/{version}");
-    builder.queryParam("verbose", true);
-    String path = builder.build(subject, version).toString();
-
-    CompatibilityCheckResponse response =
-        httpRequest(
-            path,
-            "POST",
-            registerSchemaRequest.toJson().getBytes(StandardCharsets.UTF_8),
-            requestProperties,
-            COMPATIBILITY_CHECK_RESPONSE_TYPE_REFERENCE);
-    return response.getErrorMessages();
+    if (verbose) {
+      return response.getMessages();
+    } else {
+      return response.getIsCompatible()
+              ? Collections.emptyList() : Collections.singletonList("Schemas are incompatible");
+    }
   }
 
   public ConfigUpdateRequest updateCompatibility(String compatibility, String subject)

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -576,7 +576,7 @@ public class RestService implements Configurable {
                                                String version)
       throws IOException, RestClientException {
     UriBuilder builder =
-        UriBuilder.fromPath("/compatibility/subjects/{subject}/versions/{version}");
+        UriBuilder.fromPath("/compatibility/subjects/{subject}/versions/{version}?verbose=true");
     String path = builder.build(subject, version).toString();
 
     CompatibilityCheckResponse response =

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -576,7 +576,8 @@ public class RestService implements Configurable {
                                                String version)
       throws IOException, RestClientException {
     UriBuilder builder =
-        UriBuilder.fromPath("/compatibility/subjects/{subject}/versions/{version}?verbose=true");
+        UriBuilder.fromPath("/compatibility/subjects/{subject}/versions/{version}");
+    builder.queryParam("verbose", true);
     String path = builder.build(subject, version).toString();
 
     CompatibilityCheckResponse response =

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -578,6 +578,7 @@ public class RestService implements Configurable {
     UriBuilder builder =
         UriBuilder.fromPath("/compatibility/subjects/{subject}/versions/{version}");
     builder.queryParam("verbose", true);
+
     String path = builder.build(subject, version).toString();
 
     CompatibilityCheckResponse response =

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -578,7 +578,6 @@ public class RestService implements Configurable {
     UriBuilder builder =
         UriBuilder.fromPath("/compatibility/subjects/{subject}/versions/{version}");
     builder.queryParam("verbose", true);
-
     String path = builder.build(subject, version).toString();
 
     CompatibilityCheckResponse response =

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -549,6 +549,46 @@ public class RestService implements Configurable {
     return response.getIsCompatible();
   }
 
+  public List<String> testCompatibilityVerbose(String schemaString,
+                                               String schemaType,
+                                               List<SchemaReference> references,
+                                               String subject,
+                                               String version)
+      throws IOException, RestClientException {
+    RegisterSchemaRequest request = new RegisterSchemaRequest();
+    request.setSchema(schemaString);
+    request.setSchemaType(schemaType);
+    request.setReferences(references);
+    return testCompatibilityVerbose(request, subject, version);
+  }
+
+  public List<String> testCompatibilityVerbose(RegisterSchemaRequest registerSchemaRequest,
+                                               String subject,
+                                               String version)
+      throws IOException, RestClientException {
+    return testCompatibilityVerbose(
+        DEFAULT_REQUEST_PROPERTIES, registerSchemaRequest, subject, version);
+  }
+
+  public List<String> testCompatibilityVerbose(Map<String, String> requestProperties,
+                                               RegisterSchemaRequest registerSchemaRequest,
+                                               String subject,
+                                               String version)
+      throws IOException, RestClientException {
+    UriBuilder builder =
+        UriBuilder.fromPath("/compatibility/subjects/{subject}/versions/{version}");
+    String path = builder.build(subject, version).toString();
+
+    CompatibilityCheckResponse response =
+        httpRequest(
+            path,
+            "POST",
+            registerSchemaRequest.toJson().getBytes(StandardCharsets.UTF_8),
+            requestProperties,
+            COMPATIBILITY_CHECK_RESPONSE_TYPE_REFERENCE);
+    return response.getErrorMessages();
+  }
+
   public ConfigUpdateRequest updateCompatibility(String compatibility, String subject)
       throws IOException, RestClientException {
     ConfigUpdateRequest request = new ConfigUpdateRequest();

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/CompatibilityCheckResponse.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/CompatibilityCheckResponse.java
@@ -16,16 +16,21 @@
 
 package io.confluent.kafka.schemaregistry.client.rest.entities.requests;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.IOException;
 
 import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
+
+import java.util.List;
 import java.util.Objects;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class CompatibilityCheckResponse {
 
   private boolean isCompatible;
+  private List<String> errorMessages = null;
 
   public static CompatibilityCheckResponse fromJson(String json) throws IOException {
     return JacksonMapper.INSTANCE.readValue(json, CompatibilityCheckResponse.class);
@@ -43,6 +48,16 @@ public class CompatibilityCheckResponse {
 
   public String toJson() throws IOException {
     return JacksonMapper.INSTANCE.writeValueAsString(this);
+  }
+
+  @JsonProperty("error_messages")
+  public List<String> getErrorMessages() {
+    return errorMessages;
+  }
+
+  @JsonProperty("error_messages")
+  public void setErrorMessages(List<String> errorMessages) {
+    this.errorMessages = errorMessages;
   }
 
   @Override

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/CompatibilityCheckResponse.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/CompatibilityCheckResponse.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 public class CompatibilityCheckResponse {
 
   private boolean isCompatible;
-  private List<String> errorMessages = null;
+  private List<String> messages = null;
 
   public static CompatibilityCheckResponse fromJson(String json) throws IOException {
     return JacksonMapper.INSTANCE.readValue(json, CompatibilityCheckResponse.class);
@@ -50,14 +50,14 @@ public class CompatibilityCheckResponse {
     return JacksonMapper.INSTANCE.writeValueAsString(this);
   }
 
-  @JsonProperty("error_messages")
-  public List<String> getErrorMessages() {
-    return errorMessages;
+  @JsonProperty("messages")
+  public List<String> getMessages() {
+    return messages;
   }
 
-  @JsonProperty("error_messages")
-  public void setErrorMessages(List<String> errorMessages) {
-    this.errorMessages = errorMessages;
+  @JsonProperty("messages")
+  public void setMessages(List<String> messages) {
+    this.messages = messages;
   }
 
   @Override

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -95,6 +95,10 @@ paths:
         required: true
         schema:
           $ref: "#/definitions/RegisterSchemaRequest"
+      - name: "verbose"
+        in: "query"
+        required: false
+        type: "boolean"
       responses:
         200:
           description: "successful operation"

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -916,7 +916,7 @@ definitions:
     properties:
       is_compatible:
         type: "boolean"
-      error_messages:
+      messages:
         type: "array"
         items:
           type: "string"

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -912,6 +912,10 @@ definitions:
     properties:
       is_compatible:
         type: "boolean"
+      error_messages:
+        type: "array"
+        items:
+          type: "string"
   Config:
     type: "object"
     properties:

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -133,7 +133,11 @@ public class CompatibilityResource {
               : Collections.emptyList()
       );
     } catch (InvalidSchemaException e) {
-      throw Errors.invalidSchemaException(e);
+      if (verbose) {
+        errorMessages = Collections.singletonList(e.getMessage());
+      } else {
+        throw Errors.invalidSchemaException(e);
+      }
     } catch (SchemaRegistryStoreException e) {
       throw Errors.storeException(
           "Error while getting compatibility level for subject " + subject, e);
@@ -153,7 +157,7 @@ public class CompatibilityResource {
     CompatibilityCheckResponse compatibilityCheckResponse = new CompatibilityCheckResponse();
     compatibilityCheckResponse.setIsCompatible(errorMessages.isEmpty());
     if (verbose) {
-      compatibilityCheckResponse.setErrorMessages(errorMessages);
+      compatibilityCheckResponse.setMessages(errorMessages);
     }
     return compatibilityCheckResponse;
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -21,6 +21,8 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import java.util.Collections;
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,7 +99,7 @@ public class CompatibilityResource {
              subject, version, request.getVersion(), request.getId(), request.getSchemaType());
     // returns true if posted schema is compatible with the specified version. "latest" is 
     // a special version
-    boolean isCompatible = false;
+    List<String> errorMessages;
     VersionId versionId = parseVersionId(version);
     Schema schemaForSpecifiedVersion = null;
     try {
@@ -122,7 +124,7 @@ public class CompatibilityResource {
         request.getSchema()
     );
     try {
-      isCompatible = schemaRegistry.isCompatible(
+      errorMessages = schemaRegistry.isCompatible(
           subject, schema,
           schemaForSpecifiedVersion != null
               ? Collections.singletonList(schemaForSpecifiedVersion)
@@ -138,7 +140,8 @@ public class CompatibilityResource {
           "Error while getting compatibility level for subject " + subject, e);
     }
     CompatibilityCheckResponse compatibilityCheckResponse = new CompatibilityCheckResponse();
-    compatibilityCheckResponse.setIsCompatible(isCompatible);
+    compatibilityCheckResponse.setIsCompatible(errorMessages.isEmpty());
+    compatibilityCheckResponse.setErrorMessages(errorMessages);
     asyncResponse.resume(compatibilityCheckResponse);
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -141,6 +141,7 @@ public class CompatibilityResource {
       throw Errors.schemaRegistryException(
           "Error while getting compatibility level for subject " + subject, e);
     }
+
     CompatibilityCheckResponse compatibilityCheckResponse =
             createCompatiblityCheckResponse(errorMessages, verbose);
     asyncResponse.resume(compatibilityCheckResponse);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -1283,8 +1283,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
 
   @Override
   public List<String> isCompatible(String subject,
-                              Schema newSchema,
-                              Schema latestSchema)
+                                   Schema newSchema,
+                                   Schema latestSchema)
       throws SchemaRegistryException {
     if (latestSchema == null) {
       log.error("Lastest schema not provided");
@@ -1298,8 +1298,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
    */
   @Override
   public List<String> isCompatible(String subject,
-                              Schema newSchema,
-                              List<Schema> previousSchemas)
+                                   Schema newSchema,
+                                   List<Schema> previousSchemas)
       throws SchemaRegistryException {
 
     if (previousSchemas == null) {
@@ -1318,8 +1318,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   }
 
   private List<String> isCompatibleWithPrevious(String subject,
-                                           ParsedSchema parsedSchema,
-                                           List<ParsedSchema> previousSchemas)
+                                                ParsedSchema parsedSchema,
+                                                List<ParsedSchema> previousSchemas)
       throws SchemaRegistryException {
 
     CompatibilityLevel compatibility = getCompatibilityLevelInScope(subject);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -467,7 +467,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       }
       Collections.reverse(undeletedVersions);
 
-      boolean isCompatible = isCompatibleWithPrevious(subject, parsedSchema, undeletedVersions);
+      boolean isCompatible =
+              isCompatibleWithPrevious(subject, parsedSchema, undeletedVersions).isEmpty();
       // Allow schema providers to modify the schema during compatibility checks
       schema.setSchema(parsedSchema.canonicalString());
       schema.setReferences(parsedSchema.references());
@@ -1281,7 +1282,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   }
 
   @Override
-  public boolean isCompatible(String subject,
+  public List<String> isCompatible(String subject,
                               Schema newSchema,
                               Schema latestSchema)
       throws SchemaRegistryException {
@@ -1296,7 +1297,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
    * @param previousSchemas Full schema history in chronological order
    */
   @Override
-  public boolean isCompatible(String subject,
+  public List<String> isCompatible(String subject,
                               Schema newSchema,
                               List<Schema> previousSchemas)
       throws SchemaRegistryException {
@@ -1316,7 +1317,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     return isCompatibleWithPrevious(subject, parsedSchema, prevParsedSchemas);
   }
 
-  private boolean isCompatibleWithPrevious(String subject,
+  private List<String> isCompatibleWithPrevious(String subject,
                                            ParsedSchema parsedSchema,
                                            List<ParsedSchema> previousSchemas)
       throws SchemaRegistryException {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
@@ -72,12 +72,12 @@ public interface SchemaRegistry extends SchemaVersionFetcher {
       throws SchemaRegistryException;
 
   List<String> isCompatible(String subject,
-                       Schema newSchema,
-                       Schema targetSchema) throws SchemaRegistryException;
+                            Schema newSchema,
+                            Schema targetSchema) throws SchemaRegistryException;
 
   List<String> isCompatible(String subject,
-                       Schema newSchema,
-                       List<Schema> previousSchemas) throws SchemaRegistryException;
+                            Schema newSchema,
+                            List<Schema> previousSchemas) throws SchemaRegistryException;
 
   void close();
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
@@ -71,11 +71,11 @@ public interface SchemaRegistry extends SchemaVersionFetcher {
   Schema lookUpSchemaUnderSubject(String subject, Schema schema, boolean lookupDeletedSchema)
       throws SchemaRegistryException;
 
-  boolean isCompatible(String subject,
+  List<String> isCompatible(String subject,
                        Schema newSchema,
                        Schema targetSchema) throws SchemaRegistryException;
 
-  boolean isCompatible(String subject,
+  List<String> isCompatible(String subject,
                        Schema newSchema,
                        List<Schema> previousSchemas) throws SchemaRegistryException;
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/avro/AvroCompatibilityTest.java
@@ -97,23 +97,23 @@ public class AvroCompatibilityTest {
   public void testBasicBackwardsCompatibility() {
     CompatibilityChecker checker = CompatibilityChecker.BACKWARD_CHECKER;
     assertTrue("adding a field with default is a backward compatible change",
-               checker.isCompatible(schema2, Collections.singletonList(schema1)));
+               checker.isCompatible(schema2, Collections.singletonList(schema1)).isEmpty());
     assertFalse("adding a field w/o default is not a backward compatible change",
-                checker.isCompatible(schema3, Collections.singletonList(schema1)));
+                checker.isCompatible(schema3, Collections.singletonList(schema1)).isEmpty());
     assertTrue("changing field name with alias is a backward compatible change",
-                checker.isCompatible(schema4, Collections.singletonList(schema1)));
+                checker.isCompatible(schema4, Collections.singletonList(schema1)).isEmpty());
     assertTrue("evolving a field type to a union is a backward compatible change",
-               checker.isCompatible(schema6, Collections.singletonList(schema1)));
+               checker.isCompatible(schema6, Collections.singletonList(schema1)).isEmpty());
     assertFalse("removing a type from a union is not a backward compatible change",
-                checker.isCompatible(schema1, Collections.singletonList(schema6)));
+                checker.isCompatible(schema1, Collections.singletonList(schema6)).isEmpty());
     assertTrue("adding a new type in union is a backward compatible change",
-               checker.isCompatible(schema7, Collections.singletonList(schema6)));
+               checker.isCompatible(schema7, Collections.singletonList(schema6)).isEmpty());
     assertFalse("removing a type from a union is not a backward compatible change",
-                checker.isCompatible(schema6, Collections.singletonList(schema7)));
+                checker.isCompatible(schema6, Collections.singletonList(schema7)).isEmpty());
     
     // Only schema 2 is checked
     assertTrue("removing a default is not a transitively compatible change",
-        checker.isCompatible(schema3, Arrays.asList(schema1, schema2)));
+        checker.isCompatible(schema3, Arrays.asList(schema1, schema2)).isEmpty());
   }
   
   /*
@@ -125,15 +125,15 @@ public class AvroCompatibilityTest {
     CompatibilityChecker checker = CompatibilityChecker.BACKWARD_TRANSITIVE_CHECKER;
     // All compatible
     assertTrue("iteratively adding fields with defaults is a compatible change",
-        checker.isCompatible(schema8, Arrays.asList(schema1, schema2)));
+        checker.isCompatible(schema8, Arrays.asList(schema1, schema2)).isEmpty());
     
     // 1 == 2, 2 == 3, 3 != 1
     assertTrue("adding a field with default is a backward compatible change",
-        checker.isCompatible(schema2, Collections.singletonList(schema1)));
+        checker.isCompatible(schema2, Collections.singletonList(schema1)).isEmpty());
     assertTrue("removing a default is a compatible change, but not transitively",
-        checker.isCompatible(schema3, Arrays.asList(schema2)));
+        checker.isCompatible(schema3, Arrays.asList(schema2)).isEmpty());
     assertFalse("removing a default is not a transitively compatible change",
-        checker.isCompatible(schema3, Arrays.asList(schema2, schema1)));
+        checker.isCompatible(schema3, Arrays.asList(schema2, schema1)).isEmpty());
   }
   
   /*
@@ -144,17 +144,17 @@ public class AvroCompatibilityTest {
   public void testBasicForwardsCompatibility() {
     CompatibilityChecker checker = CompatibilityChecker.FORWARD_CHECKER;
     assertTrue("adding a field is a forward compatible change",
-        checker.isCompatible(schema2, Collections.singletonList(schema1)));
+        checker.isCompatible(schema2, Collections.singletonList(schema1)).isEmpty());
     assertTrue("adding a field is a forward compatible change",
-        checker.isCompatible(schema3, Collections.singletonList(schema1)));
+        checker.isCompatible(schema3, Collections.singletonList(schema1)).isEmpty());
     assertTrue("adding a field is a forward compatible change",
-        checker.isCompatible(schema3, Collections.singletonList(schema2)));
+        checker.isCompatible(schema3, Collections.singletonList(schema2)).isEmpty());
     assertTrue("adding a field is a forward compatible change",
-        checker.isCompatible(schema2, Collections.singletonList(schema3)));
+        checker.isCompatible(schema2, Collections.singletonList(schema3)).isEmpty());
     
     // Only schema 2 is checked
     assertTrue("removing a default is not a transitively compatible change",
-        checker.isCompatible(schema1, Arrays.asList(schema3, schema2)));
+        checker.isCompatible(schema1, Arrays.asList(schema3, schema2)).isEmpty());
   }
   
   /*
@@ -166,15 +166,15 @@ public class AvroCompatibilityTest {
     CompatibilityChecker checker = CompatibilityChecker.FORWARD_TRANSITIVE_CHECKER;
     // All compatible
     assertTrue("iteratively removing fields with defaults is a compatible change",
-        checker.isCompatible(schema1, Arrays.asList(schema8, schema2)));
+        checker.isCompatible(schema1, Arrays.asList(schema8, schema2)).isEmpty());
     
     // 1 == 2, 2 == 3, 3 != 1
     assertTrue("adding default to a field is a compatible change",
-        checker.isCompatible(schema2, Collections.singletonList(schema3)));
+        checker.isCompatible(schema2, Collections.singletonList(schema3)).isEmpty());
     assertTrue("removing a field with a default is a compatible change",
-        checker.isCompatible(schema1, Arrays.asList(schema2)));
+        checker.isCompatible(schema1, Arrays.asList(schema2)).isEmpty());
     assertFalse("removing a default is not a transitively compatible change",
-        checker.isCompatible(schema1, Arrays.asList(schema2, schema3)));
+        checker.isCompatible(schema1, Arrays.asList(schema2, schema3)).isEmpty());
   }
   
   /*
@@ -184,14 +184,14 @@ public class AvroCompatibilityTest {
   public void testBasicFullCompatibility() {
     CompatibilityChecker checker = CompatibilityChecker.FULL_CHECKER;
     assertTrue("adding a field with default is a backward and a forward compatible change",
-        checker.isCompatible(schema2, Collections.singletonList(schema1)));
+        checker.isCompatible(schema2, Collections.singletonList(schema1)).isEmpty());
     
     // Only schema 2 is checked!
     assertTrue("transitively adding a field without a default is not a compatible change",
-        checker.isCompatible(schema3, Arrays.asList(schema1, schema2)));
+        checker.isCompatible(schema3, Arrays.asList(schema1, schema2)).isEmpty());
     // Only schema 2 is checked!
     assertTrue("transitively removing a field without a default is not a compatible change",
-        checker.isCompatible(schema1, Arrays.asList(schema3, schema2)));
+        checker.isCompatible(schema1, Arrays.asList(schema3, schema2)).isEmpty());
   }
   
   /*
@@ -204,24 +204,24 @@ public class AvroCompatibilityTest {
     
     // Simple check
     assertTrue("iteratively adding fields with defaults is a compatible change",
-        checker.isCompatible(schema8, Arrays.asList(schema1, schema2)));
+        checker.isCompatible(schema8, Arrays.asList(schema1, schema2)).isEmpty());
     assertTrue("iteratively removing fields with defaults is a compatible change",
-        checker.isCompatible(schema1, Arrays.asList(schema8, schema2)));
+        checker.isCompatible(schema1, Arrays.asList(schema8, schema2)).isEmpty());
     
     assertTrue("adding default to a field is a compatible change",
-        checker.isCompatible(schema2, Collections.singletonList(schema3)));
+        checker.isCompatible(schema2, Collections.singletonList(schema3)).isEmpty());
     assertTrue("removing a field with a default is a compatible change",
-        checker.isCompatible(schema1, Arrays.asList(schema2)));
+        checker.isCompatible(schema1, Arrays.asList(schema2)).isEmpty());
     
     assertTrue("adding a field with default is a compatible change",
-        checker.isCompatible(schema2, Collections.singletonList(schema1)));
+        checker.isCompatible(schema2, Collections.singletonList(schema1)).isEmpty());
     assertTrue("removing a default from a field compatible change",
-        checker.isCompatible(schema3, Arrays.asList(schema2)));
+        checker.isCompatible(schema3, Arrays.asList(schema2)).isEmpty());
 
     assertFalse("transitively adding a field without a default is not a compatible change",
-        checker.isCompatible(schema3, Arrays.asList(schema2, schema1)));
+        checker.isCompatible(schema3, Arrays.asList(schema2, schema1)).isEmpty());
     assertFalse("transitively removing a field without a default is not a compatible change",
-        checker.isCompatible(schema1, Arrays.asList(schema2, schema3)));
+        checker.isCompatible(schema1, Arrays.asList(schema2, schema3)).isEmpty());
   }
   
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -158,13 +158,13 @@ public class RestApiTest extends ClusterTestHarness {
     // test compatibility of this schema against the latest version under the subject
     String schema1 = allSchemas.get(0);
     boolean isCompatible =
-        restApp.restClient.testCompatibility(schema1, subject, "latest");
+        restApp.restClient.testCompatibility(schema1, subject, "latest").isEmpty();
     assertTrue("First schema registered should be compatible", isCompatible);
 
     for (int i = 0; i < numSchemas; i++) {
       // Test that compatibility check doesn't change the number of versions
       String schema = allSchemas.get(i);
-      isCompatible = restApp.restClient.testCompatibility(schema, subject, "latest");
+      isCompatible = restApp.restClient.testCompatibility(schema, subject, "latest").isEmpty();
       TestUtils.checkNumberOfVersions(restApp.restClient, numRegisteredSchemas, subject);
     }
   }
@@ -199,7 +199,8 @@ public class RestApiTest extends ClusterTestHarness {
         restApp.restClient.lookUpSubjectVersion(schema1, subject).getVersion();
     boolean isCompatible = restApp.restClient.testCompatibility(schema2, subject,
                                                                 String.valueOf(
-                                                                    versionOfRegisteredSchema));
+                                                                    versionOfRegisteredSchema))
+                                              .isEmpty();
     assertFalse("Schema should be incompatible with specified version", isCompatible);
   }
 
@@ -659,7 +660,8 @@ public class RestApiTest extends ClusterTestHarness {
   @Test
   public void testCompatibilityNonExistentSubject() throws Exception {
     String schema = TestUtils.getRandomCanonicalAvroString(1).get(0);
-    boolean result = restApp.restClient.testCompatibility(schema, "non-existent-subject", "latest");
+    boolean result = restApp.restClient.testCompatibility(schema, "non-existent-subject", "latest")
+                                       .isEmpty();
     assertTrue("Compatibility succeeds", result);
   }
 
@@ -1038,13 +1040,13 @@ public class RestApiTest extends ClusterTestHarness {
     restApp.restClient.registerSchema(schema1, subject);
 
     boolean isCompatible = restApp.restClient.testCompatibility(wrongSchema2, subject,
-                                                                "latest");
+                                                                "latest").isEmpty();
     assertTrue("Schema should be compatible with specified version", isCompatible);
 
     restApp.restClient.registerSchema(wrongSchema2, subject);
 
     isCompatible = restApp.restClient.testCompatibility(correctSchema2, subject,
-                                                        "latest");
+                                                        "latest").isEmpty();
     assertFalse("Schema should be incompatible with specified version", isCompatible);
     try {
       restApp.restClient.registerSchema(correctSchema2, subject);
@@ -1057,7 +1059,7 @@ public class RestApiTest extends ClusterTestHarness {
 
     restApp.restClient.deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject, "latest");
     isCompatible = restApp.restClient.testCompatibility(correctSchema2, subject,
-                                                        "latest");
+                                                        "latest").isEmpty();
     assertTrue("Schema should be compatible with specified version", isCompatible);
 
     restApp.restClient.registerSchema(correctSchema2, subject);

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -42,6 +42,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.LinkedList;
+import java.util.Arrays;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
@@ -300,9 +302,9 @@ public class JsonSchema implements ParsedSchema {
   }
 
   @Override
-  public boolean isBackwardCompatible(ParsedSchema previousSchema) {
+  public List<String> isBackwardCompatible(ParsedSchema previousSchema) {
     if (!schemaType().equals(previousSchema.schemaType())) {
-      return false;
+      return new LinkedList<>(Arrays.asList("Incompatible because of different schema type"));
     }
     final List<Difference> differences = SchemaDiff.compare(
         ((JsonSchema) previousSchema).rawSchema(),
@@ -314,17 +316,22 @@ public class JsonSchema implements ParsedSchema {
     boolean isCompatible = incompatibleDiffs.isEmpty();
     if (!isCompatible) {
       boolean first = true;
+      List<String> errorMessages = new LinkedList<>();
       for (Difference incompatibleDiff : incompatibleDiffs) {
         if (first) {
           // Log first incompatible change as warning
           log.warn("Found incompatible change: {}", incompatibleDiff);
+          errorMessages.add(String.format("Found incompatible change: {}", incompatibleDiff));
           first = false;
         } else {
           log.debug("Found incompatible change: {}", incompatibleDiff);
+          errorMessages.add(String.format("Found incompatible change: {}", incompatibleDiff));
         }
       }
+      return errorMessages;
+    } else {
+      return Collections.emptyList();
     }
-    return isCompatible;
   }
 
   @Override

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -42,8 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import java.util.LinkedList;
-import java.util.Arrays;
+import java.util.ArrayList;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
@@ -304,7 +303,7 @@ public class JsonSchema implements ParsedSchema {
   @Override
   public List<String> isBackwardCompatible(ParsedSchema previousSchema) {
     if (!schemaType().equals(previousSchema.schemaType())) {
-      return new LinkedList<>(Arrays.asList("Incompatible because of different schema type"));
+      return Collections.singletonList("Incompatible because of different schema type");
     }
     final List<Difference> differences = SchemaDiff.compare(
         ((JsonSchema) previousSchema).rawSchema(),
@@ -316,7 +315,7 @@ public class JsonSchema implements ParsedSchema {
     boolean isCompatible = incompatibleDiffs.isEmpty();
     if (!isCompatible) {
       boolean first = true;
-      List<String> errorMessages = new LinkedList<>();
+      List<String> errorMessages = new ArrayList<>();
       for (Difference incompatibleDiff : incompatibleDiffs) {
         if (first) {
           // Log first incompatible change as warning

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/TestSchemaValidation.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/TestSchemaValidation.java
@@ -226,11 +226,11 @@ public class TestSchemaValidation {
       Schema reader = tc.getReader();
       Schema writer = tc.getWriter();
       SchemaValidator validator = builder.canReadStrategy().validateAll();
-      boolean valid = validator.validate(
+      List<String> valid = validator.validate(
           new JsonSchema(reader),
           Collections.singleton(new JsonSchema(writer))
       );
-      Assert.assertFalse(valid);
+      Assert.assertFalse(valid.isEmpty());
     }
   }
 
@@ -247,7 +247,7 @@ public class TestSchemaValidation {
     for (int i = prev.length - 1; i >= 0; i--) {
       prior.add(new JsonSchema(prev[i]));
     }
-    boolean valid = validator.validate(new JsonSchema(schemaFails), prior);
-    Assert.assertFalse(valid);
+    List<String> valid = validator.validate(new JsonSchema(schemaFails), prior);
+    Assert.assertFalse(valid.isEmpty());
   }
 }

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -61,8 +61,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.LinkedList;
-import java.util.Arrays;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
@@ -789,7 +787,7 @@ public class ProtobufSchema implements ParsedSchema {
   @Override
   public List<String> isBackwardCompatible(ParsedSchema previousSchema) {
     if (!schemaType().equals(previousSchema.schemaType())) {
-      return new LinkedList<>(Arrays.asList("Incompatible because of different schema type"));
+      return Collections.singletonList("Incompatible because of different schema type");
     }
     final List<Difference> differences = SchemaDiff.compare(
         (ProtobufSchema) previousSchema, this
@@ -800,7 +798,7 @@ public class ProtobufSchema implements ParsedSchema {
     boolean isCompatible = incompatibleDiffs.isEmpty();
     if (!isCompatible) {
       boolean first = true;
-      List<String> errorMessages = new LinkedList<>();
+      List<String> errorMessages = new ArrayList<>();
       for (Difference incompatibleDiff : incompatibleDiffs) {
         if (first) {
           // Log first incompatible change as warning

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -377,11 +377,11 @@ public class ProtobufSchemaTest {
     String fileProto = schema.formattedString(ProtobufSchema.SERIALIZED_FORMAT);
     ProtobufSchema schema2 = new ProtobufSchema(fileProto);
     assertTrue(schema.isCompatible(
-        CompatibilityLevel.BACKWARD, Collections.singletonList(schema2)));
+        CompatibilityLevel.BACKWARD, Collections.singletonList(schema2)).isEmpty());
     fileProto = schema2.formattedString(ProtobufSchema.SERIALIZED_FORMAT);
     ProtobufSchema schema3 = new ProtobufSchema(fileProto);
     assertTrue(schema2.isCompatible(
-        CompatibilityLevel.BACKWARD, Collections.singletonList(schema3)));
+        CompatibilityLevel.BACKWARD, Collections.singletonList(schema3)).isEmpty());
     assertEquals(schema2, schema3);
 
     original = resourceLoader.readObj("NestedTestProto.proto");
@@ -389,11 +389,11 @@ public class ProtobufSchemaTest {
     fileProto = schema.formattedString(ProtobufSchema.SERIALIZED_FORMAT);
     schema2 = new ProtobufSchema(fileProto);
     assertTrue(schema.isCompatible(
-        CompatibilityLevel.BACKWARD, Collections.singletonList(schema2)));
+        CompatibilityLevel.BACKWARD, Collections.singletonList(schema2)).isEmpty());
     fileProto = schema2.formattedString(ProtobufSchema.SERIALIZED_FORMAT);
     schema3 = new ProtobufSchema(fileProto);
     assertTrue(schema2.isCompatible(
-        CompatibilityLevel.BACKWARD, Collections.singletonList(schema3)));
+        CompatibilityLevel.BACKWARD, Collections.singletonList(schema3)).isEmpty());
     assertEquals(schema2, schema3);
   }
 

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -204,7 +204,7 @@ public abstract class AbstractKafkaSchemaSerDe {
               + " of type " + schemaMetadata.getSchemaType()));
       // Sanity check by testing latest is backward compatibility with schema
       // Don't test for forward compatibility so unions can be handled properly
-      if (!latestVersion.isBackwardCompatible(schema)) {
+      if (!latestVersion.isBackwardCompatible(schema).isEmpty()) {
         throw new IOException("Incompatible schema " + schemaMetadata.getSchema()
             + " with refs " + schemaMetadata.getReferences()
             + " of type " + schemaMetadata.getSchemaType()


### PR DESCRIPTION
- add testCompatibilityVerbose for client and server, update related class methods to return List<String> instead of boolean

Related issue: https://github.com/confluentinc/schema-registry/issues/1551