### PR TITLE
Avro Console producer should support subject name strategy option

### DIFF
--- a/avro-serializer/pom.xml
+++ b/avro-serializer/pom.xml
@@ -61,6 +61,16 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -73,14 +73,14 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
     try {
       int id;
       if (autoRegisterSchema) {
-        restClientErrorMsg = "Error registering Avro schema: ";
+        restClientErrorMsg = "Error registering Avro schema";
         id = schemaRegistry.register(subject, schema);
       } else if (useLatestVersion) {
-        restClientErrorMsg = "Error retrieving latest version: ";
+        restClientErrorMsg = "Error retrieving latest version of Avro schema";
         schema = (AvroSchema) lookupLatestVersion(subject, schema);
         id = schemaRegistry.getId(subject, schema);
       } else {
-        restClientErrorMsg = "Error retrieving Avro schema: ";
+        restClientErrorMsg = "Error retrieving Avro schema";
         id = schemaRegistry.getId(subject, schema);
       }
       ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -122,7 +122,8 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
       // ClassCastException, etc
       throw new SerializationException("Error serializing Avro message", e);
     } catch (RestClientException e) {
-      throw new SerializationException(restClientErrorMsg + schema, e);
+      throw new SerializationException(restClientErrorMsg + " for subject " + subject
+              + " and schema: " + schema, e);
     }
   }
 }

--- a/avro-serializer/src/test/java/io/confluent/kafka/formatter/KafkaAvroFormatterTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/formatter/KafkaAvroFormatterTest.java
@@ -16,6 +16,9 @@
 package io.confluent.kafka.formatter;
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.testutil.MockSchemaRegistry;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import io.confluent.kafka.serializers.subject.TopicRecordNameStrategy;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -29,9 +32,12 @@ import org.junit.Test;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -44,6 +50,10 @@ import static org.junit.Assert.fail;
 
 public class KafkaAvroFormatterTest {
 
+  private static final String RECORD_SCHEMA_STRING = "{\"namespace\": \"example.avro\"," +
+          "\"type\": \"record\"," +
+          "\"name\": \"User\"," +
+          "\"fields\": [{\"name\": \"name\", \"type\": \"string\"}]}";
   private Properties props;
   private AvroMessageFormatter formatter;
   private Schema recordSchema = null;
@@ -55,12 +65,8 @@ public class KafkaAvroFormatterTest {
     props = new Properties();
     props.put(KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "bogus");
 
-    String userSchema = "{\"namespace\": \"example.avro\"," +
-                        "\"type\": \"record\"," +
-                        "\"name\": \"User\"," +
-                        "\"fields\": [{\"name\": \"name\", \"type\": \"string\"}]}";
     Schema.Parser parser = new Schema.Parser();
-    recordSchema = parser.parse(userSchema);
+    recordSchema = parser.parse(RECORD_SCHEMA_STRING);
     intSchema = parser.parse("{\"type\" : \"int\"}");
     schemaRegistry = new MockSchemaRegistryClient();
     formatter = new AvroMessageFormatter(schemaRegistry, null);
@@ -247,6 +253,58 @@ public class KafkaAvroFormatterTest {
     formatter.writeTo(crecord, ps);
     String outputJson = baos.toString();
 
+    assertEquals("Input value json should match output value json", inputJson, outputJson);
+  }
+
+  @Test
+  public void testUsingSubjectNameStrategy() throws Exception {
+    final Map<String, String> propertyMap = new HashMap<>();
+    final String topicName = "mytopic";
+    propertyMap.put("topic", topicName);
+    propertyMap.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "mock://foo");
+    propertyMap.put(AbstractKafkaSchemaSerDeConfig.VALUE_SUBJECT_NAME_STRATEGY, TopicRecordNameStrategy.class.getName());
+    propertyMap.put(AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, "false");
+    propertyMap.put(SchemaMessageReader.VALUE_SCHEMA, RECORD_SCHEMA_STRING);
+
+    final AvroMessageFormatter avroMessageFormatter = new AvroMessageFormatter();
+    avroMessageFormatter.configure(propertyMap);
+
+    final SchemaRegistryClient schemaRegistryClient = MockSchemaRegistry.getClientForScope("foo");
+
+    schemaRegistryClient.register(topicName + "-value", new AvroSchema(recordSchema));
+
+    String inputJson = "{\"name\":\"myname\"}\n";
+    final InputStream is = new ByteArrayInputStream(inputJson.getBytes());
+    AvroMessageReader avroReader = new AvroMessageReader();
+    // Initialize AvroMessageReader using the same approach that ConsoleProducer uses so we exercise that code
+    final Properties properties = new Properties();
+    properties.putAll(propertyMap);
+    avroReader.init(is, properties);
+
+    try {
+      ProducerRecord<byte[], byte[]> message = avroReader.readMessage();
+      fail("Expected exception was not thrown. Exception should have been thrown due to schema not present in the " +
+              "mock schema registry with the TopicRecordNameStrategy, and auto-register disabled.");
+    } catch (SerializationException e) {
+      assertTrue(e.getMessage().contains("Error retrieving Avro schema"));
+    }
+
+    // Now register the schema with the proper name and try again
+    schemaRegistryClient.register(topicName + "-" + recordSchema.getFullName(), new AvroSchema(recordSchema));
+
+    is.reset();
+    ProducerRecord<byte[], byte[]> message = avroReader.readMessage();
+
+    byte[] serializedValue = message.value();
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    PrintStream ps = new PrintStream(baos);
+    ConsumerRecord<byte[], byte[]> crecord = new ConsumerRecord<>(
+            "topic1", 0, 200, 1000, TimestampType.LOG_APPEND_TIME, 0, 0, serializedValue.length,
+            null, serializedValue);
+
+    avroMessageFormatter.writeTo(crecord, ps);
+
+    String outputJson = baos.toString();
     assertEquals("Input value json should match output value json", inputJson, outputJson);
   }
 }

--- a/avro-serializer/src/test/resources/log4j.properties
+++ b/avro-serializer/src/test/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n

--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,7 @@
                 <plugin>
                     <groupId>com.github.os72</groupId>
                     <artifactId>protoc-jar-maven-plugin</artifactId>
-                    <version>3.11.1</version>
+                    <version>3.11.4</version>
                     <executions>
                         <execution>
                             <phase>generate-test-sources</phase>

--- a/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageFormatter.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageFormatter.java
@@ -16,6 +16,7 @@
 
 package io.confluent.kafka.formatter;
 
+import io.confluent.kafka.schemaregistry.testutil.MockSchemaRegistry;
 import kafka.common.MessageFormatter;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.config.ConfigException;
@@ -29,6 +30,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -203,12 +205,19 @@ public abstract class SchemaMessageFormatter<T> implements MessageFormatter {
       String schemaRegistryUrl,
       Map<String, Object> originals
   ) {
-    return new CachedSchemaRegistryClient(
-        Collections.singletonList(schemaRegistryUrl),
-        AbstractKafkaSchemaSerDeConfig.MAX_SCHEMAS_PER_SUBJECT_DEFAULT,
-        Collections.singletonList(getProvider()),
-        originals
-    );
+    final String maybeMockScope = MockSchemaRegistry.validateAndMaybeGetMockScope(
+            Collections.singletonList(schemaRegistryUrl));
+    final List<SchemaProvider> providers = Collections.singletonList(getProvider());
+    if (maybeMockScope == null) {
+      return new CachedSchemaRegistryClient(
+              Collections.singletonList(schemaRegistryUrl),
+              AbstractKafkaSchemaSerDeConfig.MAX_SCHEMAS_PER_SUBJECT_DEFAULT,
+              providers,
+              originals
+      );
+    } else {
+      return MockSchemaRegistry.getClientForScope(maybeMockScope, providers);
+    }
   }
 
   protected abstract SchemaProvider getProvider();

--- a/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageReader.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageReader.java
@@ -17,6 +17,9 @@
 package io.confluent.kafka.formatter;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import io.confluent.kafka.schemaregistry.testutil.MockSchemaRegistry;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDe;
+import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
 import kafka.common.KafkaException;
 import kafka.common.MessageReader;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -49,6 +52,9 @@ import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 
 public abstract class SchemaMessageReader<T> implements MessageReader {
+
+  public static final String VALUE_SCHEMA = "value.schema";
+  public static final String KEY_SCHEMA = "key.schema";
 
   private String topic = null;
   private BufferedReader reader = null;
@@ -94,6 +100,9 @@ public abstract class SchemaMessageReader<T> implements MessageReader {
   @Override
   public void init(java.io.InputStream inputStream, Properties props) {
     topic = props.getProperty("topic");
+    if (topic == null) {
+      throw new ConfigException("Missing topic!");
+    }
     if (props.containsKey("parse.key")) {
       parseKey = props.getProperty("parse.key").trim().toLowerCase().equals("true");
     }
@@ -109,18 +118,10 @@ public abstract class SchemaMessageReader<T> implements MessageReader {
       throw new ConfigException("Missing schema registry url!");
     }
 
-    Map<String, Object> originals = getPropertiesMap(props);
+    SchemaRegistryClient schemaRegistry = getSchemaRegistryClient(props, url);
 
-    SchemaRegistryClient schemaRegistry = new CachedSchemaRegistryClient(
-        Collections.singletonList(url),
-        AbstractKafkaSchemaSerDeConfig.MAX_SCHEMAS_PER_SUBJECT_DEFAULT,
-        Collections.singletonList(getProvider()),
-        originals
-    );
     Serializer keySerializer = getKeySerializer(props);
 
-    keySubject = topic + "-key";
-    valueSubject = topic + "-value";
     boolean autoRegisterSchema;
     if (props.containsKey("auto.register")) {
       autoRegisterSchema = Boolean.parseBoolean(props.getProperty("auto.register").trim());
@@ -141,9 +142,60 @@ public abstract class SchemaMessageReader<T> implements MessageReader {
           schemaRegistry, autoRegisterSchema, useLatest, keySerializer);
     }
 
+    // This class is only used in a scenario where a single schema is used. It does not support
+    // writing data which has a different schema for each record. Therefore, we can calculate the
+    // subject names and schemas once rather than per-message in
+    // AbstractKafkaSchemaSerDe#getSubjectName(...) as would otherwise happen.
+    final AbstractKafkaSchemaSerDeConfig config =
+            new AbstractKafkaSchemaSerDeConfig(AbstractKafkaSchemaSerDeConfig.baseConfigDef(),
+                    props, false);
+
     valueSchema = getSchema(schemaRegistry, props, false);
+    final Object valueSubjectNameStrategy = config.valueSubjectNameStrategy();
+    valueSubject = getSubjectName(valueSubjectNameStrategy, topic, true, valueSchema);
+
     if (needsKeySchema()) {
       keySchema = getSchema(schemaRegistry, props, true);
+      final Object keySubjectNameStrategy = config.keySubjectNameStrategy();
+      keySubject = getSubjectName(keySubjectNameStrategy, topic, true, keySchema);
+    }
+  }
+
+  private SchemaRegistryClient getSchemaRegistryClient(Properties props, String url) {
+    Map<String, Object> originals = getPropertiesMap(props);
+
+    final List<String> schemaRegistryUrls = Collections.singletonList(url);
+    final List<SchemaProvider> schemaProviders = Collections.singletonList(getProvider());
+    final String maybeMockScope =
+            MockSchemaRegistry.validateAndMaybeGetMockScope(schemaRegistryUrls);
+    SchemaRegistryClient schemaRegistry;
+    if (maybeMockScope == null) {
+      schemaRegistry = new CachedSchemaRegistryClient(
+              schemaRegistryUrls,
+              AbstractKafkaSchemaSerDeConfig.MAX_SCHEMAS_PER_SUBJECT_DEFAULT,
+              schemaProviders,
+              originals
+      );
+    } else {
+      schemaRegistry = MockSchemaRegistry.getClientForScope(maybeMockScope, schemaProviders);
+    }
+    return schemaRegistry;
+  }
+
+  /**
+   * @see AbstractKafkaSchemaSerDe#getSubjectName(String, boolean, Object, ParsedSchema)
+   */
+  private String getSubjectName(Object subjectNameStrategy, String topic, boolean isKey,
+                                ParsedSchema schema) {
+    if (subjectNameStrategy instanceof SubjectNameStrategy) {
+      return ((SubjectNameStrategy) subjectNameStrategy).subjectName(topic, isKey, schema);
+    } else {
+      // We don't have an instance of an object, only a schema, so we can't provide the necessary
+      // params to the deprecated strategy.
+      throw new RuntimeException("Classes extending deprecated "
+              + io.confluent.kafka.serializers.subject.SubjectNameStrategy.class.getCanonicalName()
+              + " are not supported. Use classes extending "
+              + SubjectNameStrategy.class.getCanonicalName() + " instead.");
     }
   }
 
@@ -172,6 +224,9 @@ public abstract class SchemaMessageReader<T> implements MessageReader {
     return parseSchema(schemaRegistry, schemaString, refs);
   }
 
+  /**
+   * @return schema, if props identifies one by ID, otherwise null
+   */
   private ParsedSchema getSchemaById(SchemaRegistryClient schemaRegistry,
                                      Properties props,
                                      boolean isKey) {
@@ -193,7 +248,7 @@ public abstract class SchemaMessageReader<T> implements MessageReader {
   }
 
   private String getSchemaString(Properties props, boolean isKey) {
-    String propKeyRaw = isKey ? "key.schema" : "value.schema";
+    String propKeyRaw = isKey ? KEY_SCHEMA : VALUE_SCHEMA;
     String propKeyFile = isKey ? "key.schema.file" : "value.schema.file";
     if (props.containsKey(propKeyRaw)) {
       return props.getProperty(propKeyRaw);

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -24,13 +24,11 @@ import org.apache.avro.generic.GenericContainer;
 import org.apache.kafka.common.cache.Cache;
 import org.apache.kafka.common.cache.LRUCache;
 import org.apache.kafka.common.cache.SynchronizedCache;
-import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.SerializationException;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -51,7 +49,6 @@ public abstract class AbstractKafkaSchemaSerDe {
   protected static final byte MAGIC_BYTE = 0x0;
   protected static final int idSize = 4;
   private static int DEFAULT_CACHE_CAPACITY = 1000;
-  private static final String MOCK_URL_PREFIX = "mock://";
 
   protected SchemaRegistryClient schemaRegistry;
   protected Object keySubjectNameStrategy = new TopicNameStrategy();
@@ -68,7 +65,7 @@ public abstract class AbstractKafkaSchemaSerDe {
     int maxSchemaObject = config.getMaxSchemasPerSubject();
     Map<String, Object> originals = config.originalsWithPrefix("");
     if (null == schemaRegistry) {
-      String mockScope = validateAndMaybeGetMockScope(urls);
+      String mockScope = MockSchemaRegistry.validateAndMaybeGetMockScope(urls);
       List<SchemaProvider> providers = Collections.singletonList(provider);
       if (mockScope != null) {
         schemaRegistry = MockSchemaRegistry.getClientForScope(mockScope, providers);
@@ -85,29 +82,6 @@ public abstract class AbstractKafkaSchemaSerDe {
     keySubjectNameStrategy = config.keySubjectNameStrategy();
     valueSubjectNameStrategy = config.valueSubjectNameStrategy();
     useSchemaReflection = config.useSchemaReflection();
-  }
-
-  private static String validateAndMaybeGetMockScope(final List<String> urls) {
-    final List<String> mockScopes = new LinkedList<>();
-    for (final String url : urls) {
-      if (url.startsWith(MOCK_URL_PREFIX)) {
-        mockScopes.add(url.substring(MOCK_URL_PREFIX.length()));
-      }
-    }
-
-    if (mockScopes.isEmpty()) {
-      return null;
-    } else if (mockScopes.size() > 1) {
-      throw new ConfigException(
-              "Only one mock scope is permitted for 'schema.registry.url'. Got: " + urls
-      );
-    } else if (urls.size() > mockScopes.size()) {
-      throw new ConfigException(
-              "Cannot mix mock and real urls for 'schema.registry.url'. Got: " + urls
-      );
-    } else {
-      return mockScopes.get(0);
-    }
   }
 
   /**

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDeConfig.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDeConfig.java
@@ -169,6 +169,10 @@ public class AbstractKafkaSchemaSerDeConfig extends AbstractConfig {
     super(config, props);
   }
 
+  public AbstractKafkaSchemaSerDeConfig(ConfigDef definition, Map<?, ?> originals, boolean doLog) {
+    super(definition, originals, doLog);
+  }
+
   public int getMaxSchemasPerSubject() {
     return this.getInt(MAX_SCHEMAS_PER_SUBJECT_CONFIG);
   }


### PR DESCRIPTION
- Fixes #898 SchemaMessageReader (used by classes like
AvroMessageFormatter) no longer hard-codes the subject name format.
Instead, it leverages AbstractKafkaSchemaSerDeConfig's existing logic to
use the configuration properties to determine the subject name strategy
for the value and, if needed, the key. This allows use of the
"kafka-avro-console-producer" tool with  non-default subject name
strategies.
- Added unit test to exercise the logic from AvroMessageReader#init()
which was previously not covered.
- Spread MockSchemaRegistry functionality so it's not just in
AbstractKafkaSchemaSerDe, but can be used in other classes such as
SchemaMessageFormatter for more testability.
- Improved error message when schema not found to include the subject
name that was used.
- Fixed "Unsupported platform: protoc-3.11.4-osx-x86_64.exe" due to
using incorrect version of protoc-jar-maven-plugin.