### PR TITLE
DG-935 Treat removing Protobuf message types as incompatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,7 @@
                 <plugin>
                     <groupId>com.github.os72</groupId>
                     <artifactId>protoc-jar-maven-plugin</artifactId>
-                    <version>3.11.1</version>
+                    <version>3.11.4</version>
                     <executions>
                         <execution>
                             <phase>generate-test-sources</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,7 @@
                 <plugin>
                     <groupId>com.github.os72</groupId>
                     <artifactId>protoc-jar-maven-plugin</artifactId>
-                    <version>3.11.4</version>
+                    <version>${protobuf.version}</version>
                     <executions>
                         <execution>
                             <phase>generate-test-sources</phase>

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/diff/FieldSchemaDiff.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/diff/FieldSchemaDiff.java
@@ -45,7 +45,7 @@ public class FieldSchemaDiff {
     if (originalType != null && originalType.isMap()) {
       original = originalType.getMapType();
     }
-    TypeElementInfo updateType = ctx.getType(update.toString(), true);
+    TypeElementInfo updateType = ctx.getType(update.toString(), false);
     if (updateType != null && updateType.isMap()) {
       update = updateType.getMapType();
     }

--- a/protobuf-provider/src/test/resources/diff-schema-examples.json
+++ b/protobuf-provider/src/test/resources/diff-schema-examples.json
@@ -257,7 +257,7 @@
     "changes": [
       "MESSAGE_REMOVED #/GoogleHome"
     ],
-    "compatible": true
+    "compatible": false
   },
   {
     "description": "Detect moving from import",


### PR DESCRIPTION
Treat removing Protobuf message types as incompatible, since old records may rely on the message that is being removed.