### PR TITLE
DG-951 Handle duplicate message names during deserialization

### DIFF
--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -905,7 +905,11 @@ public class ProtobufSchema implements ParsedSchema {
       sb.append(message.getName());
       types = message.getNestedTypes();
     }
-    return sb.toString();
+    String messageName = sb.toString();
+    String packageName = schemaObj.getPackageName();
+    return packageName != null && !packageName.isEmpty()
+        ? packageName + '.' + messageName
+        : messageName;
   }
 
   private MessageElement getMessageAtIndex(List<TypeElement> types, int index) {

--- a/protobuf-provider/src/test/resources/io/confluent/kafka/schemaregistry/protobuf/diff/SameMessageName.proto
+++ b/protobuf-provider/src/test/resources/io/confluent/kafka/schemaregistry/protobuf/diff/SameMessageName.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+import "TestProto.proto";
+import "TestProto2.proto";
+
+package test3;
+
+message TestMessage {
+    test1.TestMessage nested_message1 = 1;
+    test2.TestMessage nested_message2 = 2;
+}

--- a/protobuf-provider/src/test/resources/io/confluent/kafka/schemaregistry/protobuf/diff/TestProto.proto
+++ b/protobuf-provider/src/test/resources/io/confluent/kafka/schemaregistry/protobuf/diff/TestProto.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package test1;
+
 message TestMessage {
     string test_string = 1;
     int32 test_int = 2;

--- a/protobuf-provider/src/test/resources/io/confluent/kafka/schemaregistry/protobuf/diff/TestProto2.proto
+++ b/protobuf-provider/src/test/resources/io/confluent/kafka/schemaregistry/protobuf/diff/TestProto2.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+package test2;
+
 message TestMessage {
     string test_string = 1;
     string test_string2 = 2;

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufDeserializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufDeserializer.java
@@ -16,6 +16,7 @@
 
 package io.confluent.kafka.serializers.protobuf;
 
+import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.Message;
 import java.util.Objects;
@@ -138,7 +139,11 @@ public abstract class AbstractKafkaProtobufDeserializer<T extends Message>
       } else if (deriveType) {
         value = deriveType(buffer, schema);
       } else {
-        value = DynamicMessage.parseFrom(schema.toDescriptor(),
+        Descriptor descriptor = schema.toDescriptor();
+        if (descriptor == null) {
+          throw new SerializationException("Could not find descriptor with name " + schema.name());
+        }
+        value = DynamicMessage.parseFrom(descriptor,
             new ByteArrayInputStream(buffer.array(), start, length)
         );
       }


### PR DESCRIPTION
Handle duplicate message names during deserialization, by using the fully qualified name of the message