### PR TITLE
Removed property ${confluent.maven.repo}

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
     <properties>
         <apache.directory.server.version>2.0.0-M22</apache.directory.server.version>
         <apache.directory.api.version>1.0.0-M33</apache.directory.api.version>
-        <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <exec-maven-plugin.version>1.2.1</exec-maven-plugin.version>
         <podam.version>6.0.2.RELEASE</podam.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
@@ -71,7 +70,7 @@
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>${confluent.maven.repo}</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
This property was used in repository/url definition.  This causes a problem with resolution of the parent project/pom, since
property-evaluation occurs in Maven after the parent project is resolved.

Same change for `kafka-connect-jdbc`: https://github.com/confluentinc/kafka-connect-jdbc/pull/942

To test, run this isolating Maven build before on `6.0.0-post` branch (fails) then for PR branch (passes):

```
docker run -it --rm --name isolated-build -v "$(pwd):/usr/src/mymaven" -w /usr/src/mymaven maven:3-jdk-8 mvn clean install
```