### PR TITLE
Skip plugin execution by configuration/CLI

### DIFF
--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/DownloadSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/DownloadSchemaRegistryMojo.java
@@ -88,6 +88,11 @@ public class DownloadSchemaRegistryMojo extends SchemaRegistryMojo {
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
+    if (skip) {
+      getLog().info("Plugin execution has been skipped");
+      return;
+    }
+
     try {
       getLog().debug(
           String.format("Checking if '%s' exists and is not a directory.", this.outputDirectory));

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
@@ -43,6 +43,9 @@ public abstract class SchemaRegistryMojo extends AbstractMojo {
   @Parameter
   String userInfoConfig;
 
+  @Parameter(property = "kafka-schema-registry.skip")
+  boolean skip;
+
   @Parameter(required = false)
   List<String> schemaProviders = new ArrayList<>();
 

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/UploadSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/UploadSchemaRegistryMojo.java
@@ -60,6 +60,11 @@ public abstract class UploadSchemaRegistryMojo extends SchemaRegistryMojo {
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
+    if (skip) {
+      getLog().info("Plugin execution has been skipped");
+      return;
+    }
+
     errors = 0;
     failures = 0;
 


### PR DESCRIPTION
Closes #1689

#### What does this PR do?

Sets both configuration and CLI option to skip the plugin execution both by Maven config:

```
<configuration>
    <skip>true|false</skip>
</configuration>
```
and CLI Option:

`mvn -Dkafka-schema-registry.skip`