### PR TITLE
Add getSchemas functionality to the SchemaRegistryClient.

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -302,6 +302,27 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
+  public synchronized List<ParsedSchema> getSchemas(
+          String subjectPrefix,
+          boolean lookupDeletedSchema,
+          boolean latestOnly)
+          throws IOException, RestClientException {
+    List<Schema> restSchemas = restService.getSchemas(
+            subjectPrefix,
+            lookupDeletedSchema,
+            latestOnly);
+    return restSchemas.stream()
+        .map(restSchema -> parseSchema(
+                  restSchema.getSchemaType(),
+                  restSchema.getSchema(),
+                  restSchema.getReferences())
+        )
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .collect(Collectors.toList());
+  }
+
+  @Override
   public Collection<String> getAllSubjectsById(int id) throws IOException, RestClientException {
     return restService.getAllSubjectsById(id);
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -83,7 +83,7 @@ public interface SchemaRegistryClient extends SchemaVersionFetcher {
   public ParsedSchema getSchemaBySubjectAndId(String subject, int id)
       throws IOException, RestClientException;
 
-  default public List<ParsedSchema> getSchemas(
+  public default List<ParsedSchema> getSchemas(
       String subjectPrefix,
       boolean lookupDeletedSchema,
       boolean latestOnly)

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -83,11 +83,13 @@ public interface SchemaRegistryClient extends SchemaVersionFetcher {
   public ParsedSchema getSchemaBySubjectAndId(String subject, int id)
       throws IOException, RestClientException;
 
-  public List<ParsedSchema> getSchemas(
+  default public List<ParsedSchema> getSchemas(
       String subjectPrefix,
       boolean lookupDeletedSchema,
       boolean latestOnly)
-      throws IOException, RestClientException;
+      throws IOException, RestClientException {
+    throw new UnsupportedOperationException();
+  }
 
   public Collection<String> getAllSubjectsById(int id) throws IOException, RestClientException;
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -83,6 +83,12 @@ public interface SchemaRegistryClient extends SchemaVersionFetcher {
   public ParsedSchema getSchemaBySubjectAndId(String subject, int id)
       throws IOException, RestClientException;
 
+  public List<ParsedSchema> getSchemas(
+      String subjectPrefix,
+      boolean lookupDeletedSchema,
+      boolean latestOnly)
+      throws IOException, RestClientException;
+
   public Collection<String> getAllSubjectsById(int id) throws IOException, RestClientException;
 
   default Collection<SubjectVersion> getAllVersionsById(int id) throws IOException,


### PR DESCRIPTION
Hello! I work with Riot Games and we have a use case where we need to poll the schema registry for all the latest schemas.  I found the /schemas route in the API would support this but the functionality didn't exist in the SchemaRegistryClient (or CachedSchemaRegistryClient).

I believe this is the lightest change I could make to surface this functionality.

I went with a functional/streams style where it made sense but if that doesn't fit I'm happy to back out to an imperative style.