### PR TITLE
Add kafkastore.topic.skip.validation configurations option

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -77,7 +77,8 @@ public class SchemaRegistryConfig extends RestConfig {
   /**
    * <code>kafkastore.topic.skip.validation</code>
    */
-  public static final String KAFKASTORE_TOPIC_SKIP_VALIDATION_CONFIG = "kafkastore.topic.skip.validation";
+  public static final String KAFKASTORE_TOPIC_SKIP_VALIDATION_CONFIG =
+      "kafkastore.topic.skip.validation";
   public static final boolean DEFAULT_KAFKASTORE_TOPIC_SKIP_VALIDATION = false;
   /**
    * <code>kafkastore.topic.replication.factor</code>
@@ -402,7 +403,8 @@ public class SchemaRegistryConfig extends RestConfig {
     .define(KAFKASTORE_TOPIC_CONFIG, ConfigDef.Type.STRING, DEFAULT_KAFKASTORE_TOPIC,
         ConfigDef.Importance.HIGH, KAFKASTORE_TOPIC_DOC
     )
-    .define(KAFKASTORE_TOPIC_SKIP_VALIDATION_CONFIG, ConfigDef.Type.BOOLEAN, DEFAULT_KAFKASTORE_TOPIC_SKIP_VALIDATION,
+    .define(KAFKASTORE_TOPIC_SKIP_VALIDATION_CONFIG, ConfigDef.Type.BOOLEAN,
+        DEFAULT_KAFKASTORE_TOPIC_SKIP_VALIDATION,
         ConfigDef.Importance.MEDIUM, KAFKASTORE_TOPIC_SKIP_VALIDATION_CONFIG
     )
     .define(KAFKASTORE_TOPIC_REPLICATION_FACTOR_CONFIG, ConfigDef.Type.INT,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -75,10 +75,10 @@ public class SchemaRegistryConfig extends RestConfig {
   public static final String KAFKASTORE_TOPIC_CONFIG = "kafkastore.topic";
   public static final String DEFAULT_KAFKASTORE_TOPIC = "_schemas";
   /**
-   * <code>kafkastore.topic.verify</code>
+   * <code>kafkastore.topic.skip.validation</code>
    */
-  public static final String KAFKASTORE_TOPIC_VERIFY_CONFIG = "kafkastore.topic.verify";
-  public static final boolean DEFAULT_KAFKASTORE_TOPIC_VERIFY = true;
+  public static final String KAFKASTORE_TOPIC_SKIP_VALIDATION_CONFIG = "kafkastore.topic.skip.validation";
+  public static final boolean DEFAULT_KAFKASTORE_TOPIC_SKIP_VALIDATION = false;
   /**
    * <code>kafkastore.topic.replication.factor</code>
    */
@@ -237,8 +237,8 @@ public class SchemaRegistryConfig extends RestConfig {
   protected static final String KAFKASTORE_TOPIC_DOC =
       "The durable single partition topic that acts"
       + "as the durable log for the data";
-  protected static final String KAFKASTORE_TOPIC_VERIFY_DOC =
-      "Whether schema registry should verify & attempt to create topics on boot.";
+  protected static final String KAFKASTORE_TOPIC_SKIP_VALIDATION_DOC =
+      "Whether schema registry should skip validation & creation of topics on boot.";
   protected static final String KAFKASTORE_TOPIC_REPLICATION_FACTOR_DOC =
       "The desired replication factor of the schema topic. The actual replication factor "
       + "will be the smaller of this value and the number of live Kafka brokers.";
@@ -402,8 +402,8 @@ public class SchemaRegistryConfig extends RestConfig {
     .define(KAFKASTORE_TOPIC_CONFIG, ConfigDef.Type.STRING, DEFAULT_KAFKASTORE_TOPIC,
         ConfigDef.Importance.HIGH, KAFKASTORE_TOPIC_DOC
     )
-    .define(KAFKASTORE_TOPIC_VERIFY_CONFIG, ConfigDef.Type.BOOLEAN, DEFAULT_KAFKASTORE_TOPIC_VERIFY,
-        ConfigDef.Importance.HIGH, KAFKASTORE_TOPIC_VERIFY_CONFIG
+    .define(KAFKASTORE_TOPIC_SKIP_VALIDATION_CONFIG, ConfigDef.Type.BOOLEAN, DEFAULT_KAFKASTORE_TOPIC_SKIP_VALIDATION,
+        ConfigDef.Importance.MEDIUM, KAFKASTORE_TOPIC_SKIP_VALIDATION_CONFIG
     )
     .define(KAFKASTORE_TOPIC_REPLICATION_FACTOR_CONFIG, ConfigDef.Type.INT,
         DEFAULT_KAFKASTORE_TOPIC_REPLICATION_FACTOR,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -75,6 +75,11 @@ public class SchemaRegistryConfig extends RestConfig {
   public static final String KAFKASTORE_TOPIC_CONFIG = "kafkastore.topic";
   public static final String DEFAULT_KAFKASTORE_TOPIC = "_schemas";
   /**
+   * <code>kafkastore.topic.verify</code>
+   */
+  public static final String KAFKASTORE_TOPIC_VERIFY_CONFIG = "kafkastore.topic.verify";
+  public static final boolean DEFAULT_KAFKASTORE_TOPIC_VERIFY = true;
+  /**
    * <code>kafkastore.topic.replication.factor</code>
    */
   public static final String KAFKASTORE_TOPIC_REPLICATION_FACTOR_CONFIG =
@@ -232,6 +237,8 @@ public class SchemaRegistryConfig extends RestConfig {
   protected static final String KAFKASTORE_TOPIC_DOC =
       "The durable single partition topic that acts"
       + "as the durable log for the data";
+  protected static final String KAFKASTORE_TOPIC_VERIFY_DOC =
+      "Whether schema registry should verify & attempt to create topics on boot.";
   protected static final String KAFKASTORE_TOPIC_REPLICATION_FACTOR_DOC =
       "The desired replication factor of the schema topic. The actual replication factor "
       + "will be the smaller of this value and the number of live Kafka brokers.";
@@ -394,6 +401,9 @@ public class SchemaRegistryConfig extends RestConfig {
     )
     .define(KAFKASTORE_TOPIC_CONFIG, ConfigDef.Type.STRING, DEFAULT_KAFKASTORE_TOPIC,
         ConfigDef.Importance.HIGH, KAFKASTORE_TOPIC_DOC
+    )
+    .define(KAFKASTORE_TOPIC_VERIFY_CONFIG, ConfigDef.Type.BOOLEAN, DEFAULT_KAFKASTORE_TOPIC_VERIFY,
+        ConfigDef.Importance.HIGH, KAFKASTORE_TOPIC_VERIFY_CONFIG
     )
     .define(KAFKASTORE_TOPIC_REPLICATION_FACTOR_CONFIG, ConfigDef.Type.INT,
         DEFAULT_KAFKASTORE_TOPIC_REPLICATION_FACTOR,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -104,7 +104,8 @@ public class KafkaStore<K, V> implements Store<K, V> {
     this.noopKey = noopKey;
     this.config = config;
     this.bootstrapBrokers = config.bootstrapBrokers();
-    this.skipSchemaTopicValidation = config.getBoolean(SchemaRegistryConfig.KAFKASTORE_TOPIC_SKIP_VALIDATION_CONFIG);
+    this.skipSchemaTopicValidation =
+        config.getBoolean(SchemaRegistryConfig.KAFKASTORE_TOPIC_SKIP_VALIDATION_CONFIG);
 
     log.info("Initializing KafkaStore with broker endpoints: " + this.bootstrapBrokers);
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -69,7 +69,7 @@ public class KafkaStore<K, V> implements Store<K, V> {
   private final int initTimeout;
   private final int timeout;
   private final String bootstrapBrokers;
-  private final boolean verifySchemaTopic;
+  private final boolean skipSchemaTopicValidation;
   private KafkaProducer<byte[], byte[]> producer;
   private KafkaStoreReaderThread<K, V> kafkaTopicReader;
   // Noop key is only used to help reliably determine last offset; reader thread ignores
@@ -104,7 +104,7 @@ public class KafkaStore<K, V> implements Store<K, V> {
     this.noopKey = noopKey;
     this.config = config;
     this.bootstrapBrokers = config.bootstrapBrokers();
-    this.verifySchemaTopic = config.getBoolean(SchemaRegistryConfig.KAFKASTORE_TOPIC_VERIFY_CONFIG);
+    this.skipSchemaTopicValidation = config.getBoolean(SchemaRegistryConfig.KAFKASTORE_TOPIC_SKIP_VALIDATION_CONFIG);
 
     log.info("Initializing KafkaStore with broker endpoints: " + this.bootstrapBrokers);
   }
@@ -162,7 +162,7 @@ public class KafkaStore<K, V> implements Store<K, V> {
 
 
   private void createOrVerifySchemaTopic() throws StoreInitializationException {
-    if (!this.verifySchemaTopic) {
+    if (this.skipSchemaTopicValidation) {
       log.info("Skipping auto topic creation and verification");
       return;
     }


### PR DESCRIPTION
Adds the `kafkastore.topic.skip.validation` option (defaulting to `false` to
preserve current behaviour). This options controls whether
schema-registry performs validation and auto-creation of the schema
topics on boot.

Enabling this option is required in environments where clients do not
have the `DescribeConfigs` or where topic auto creation is not
supported.

For example, this is required in order to run the schema-registry with
Heroku's managed Apache Kafka service (See [Kafka on Heroku ACLs]).

[Kafka on Heroku ACLs]:
https://devcenter.heroku.com/articles/kafka-on-heroku#understanding-acls

Signed-off-by: Christian Gregg <christian@bissy.io>