### PR TITLE
Backport #1733 to 5.4.x

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -74,6 +74,12 @@ public class SchemaRegistryConfig extends RestConfig {
   public static final String KAFKASTORE_TOPIC_CONFIG = "kafkastore.topic";
   public static final String DEFAULT_KAFKASTORE_TOPIC = "_schemas";
   /**
+   * <code>kafkastore.topic.skip.validation</code>
+   */
+  public static final String KAFKASTORE_TOPIC_SKIP_VALIDATION_CONFIG =
+      "kafkastore.topic.skip.validation";
+  public static final boolean DEFAULT_KAFKASTORE_TOPIC_SKIP_VALIDATION = false;
+  /**
    * <code>kafkastore.topic.replication.factor</code>
    */
   public static final String KAFKASTORE_TOPIC_REPLICATION_FACTOR_CONFIG =
@@ -220,6 +226,8 @@ public class SchemaRegistryConfig extends RestConfig {
   protected static final String KAFKASTORE_TOPIC_DOC =
       "The durable single partition topic that acts"
       + "as the durable log for the data";
+  protected static final String KAFKASTORE_TOPIC_SKIP_VALIDATION_DOC =
+      "Whether schema registry should skip validation & creation of topics on boot.";
   protected static final String KAFKASTORE_TOPIC_REPLICATION_FACTOR_DOC =
       "The desired replication factor of the schema topic. The actual replication factor "
       + "will be the smaller of this value and the number of live Kafka brokers.";
@@ -376,6 +384,10 @@ public class SchemaRegistryConfig extends RestConfig {
     )
     .define(KAFKASTORE_TOPIC_CONFIG, ConfigDef.Type.STRING, DEFAULT_KAFKASTORE_TOPIC,
         ConfigDef.Importance.HIGH, KAFKASTORE_TOPIC_DOC
+    )
+    .define(KAFKASTORE_TOPIC_SKIP_VALIDATION_CONFIG, ConfigDef.Type.BOOLEAN,
+        DEFAULT_KAFKASTORE_TOPIC_SKIP_VALIDATION,
+        ConfigDef.Importance.MEDIUM, KAFKASTORE_TOPIC_SKIP_VALIDATION_CONFIG
     )
     .define(KAFKASTORE_TOPIC_REPLICATION_FACTOR_CONFIG, ConfigDef.Type.INT,
         DEFAULT_KAFKASTORE_TOPIC_REPLICATION_FACTOR,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -70,6 +70,7 @@ public class KafkaStore<K, V> implements Store<K, V> {
   private final int initTimeout;
   private final int timeout;
   private final String bootstrapBrokers;
+  private final boolean skipSchemaTopicValidation;
   private KafkaProducer<byte[], byte[]> producer;
   private KafkaStoreReaderThread<K, V> kafkaTopicReader;
   // Noop key is only used to help reliably determine last offset; reader thread ignores
@@ -104,6 +105,8 @@ public class KafkaStore<K, V> implements Store<K, V> {
     this.noopKey = noopKey;
     this.config = config;
     this.bootstrapBrokers = config.bootstrapBrokers();
+    this.skipSchemaTopicValidation =
+        config.getBoolean(SchemaRegistryConfig.KAFKASTORE_TOPIC_SKIP_VALIDATION_CONFIG);
 
     log.info("Initializing KafkaStore with broker endpoints: " + this.bootstrapBrokers);
   }
@@ -161,6 +164,11 @@ public class KafkaStore<K, V> implements Store<K, V> {
 
 
   private void createOrVerifySchemaTopic() throws StoreInitializationException {
+    if (this.skipSchemaTopicValidation) {
+      log.info("Skipping auto topic creation and verification");
+      return;
+    }
+
     Properties props = new Properties();
     addSchemaRegistryConfigsToClientProperties(this.config, props);
     props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapBrokers);


### PR DESCRIPTION
I'm not sure what the policy is for backporting is, but it would be useful to have this feature on the `5.4.x` release series.

Related: #1733 