### PR TITLE
Increase timeout to 3 hrs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,4 +5,5 @@ common {
     "confluent-security-plugins", "kafka-connect-replicator",
     "ce-kafka-rest", "confluent-cloud-plugins", "schema-registry-plugins"]
   nanoVersion = true
+  timeoutHours = 3
 }


### PR DESCRIPTION
With new nanoVersioning, the build has to download thousands of pom files and causing downstream validation to timeout. Increase the timeout for downstream validation to pass. 