### PR TITLE
DG-1162: Add verbose option to SR maven plugin test-compatibility goal

### DIFF
--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/TestCompatibilitySchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/TestCompatibilitySchemaRegistryMojo.java
@@ -19,14 +19,19 @@ package io.confluent.kafka.schemaregistry.maven;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Mojo(name = "test-compatibility", configurator = "custom-basic")
 public class TestCompatibilitySchemaRegistryMojo extends UploadSchemaRegistryMojo {
+
+  @Parameter(required = false)
+  boolean verbose = true;
 
   Map<String, Boolean> schemaCompatibility = new HashMap<>();
 
@@ -44,7 +49,8 @@ public class TestCompatibilitySchemaRegistryMojo extends UploadSchemaRegistryMoj
       );
     }
 
-    boolean compatible = this.client().testCompatibility(subject, schema);
+    List<String> errorMessages = this.client().testCompatibilityVerbose(subject, schema);
+    boolean compatible = errorMessages.isEmpty();
 
     if (compatible) {
       getLog().info(
@@ -55,13 +61,12 @@ public class TestCompatibilitySchemaRegistryMojo extends UploadSchemaRegistryMoj
           )
       );
     } else {
-      getLog().error(
-          String.format(
-              "Schema %s is not compatible with subject(%s)",
-              schemaPath,
-              subject
-          )
-      );
+      String errorLog = String.format(
+          "Schema %s is not compatible with subject(%s)", schemaPath, subject);
+      if (verbose) {
+        errorLog += " with error " + errorMessages.toString();
+      }
+      getLog().error(errorLog);
     }
 
     this.schemaCompatibility.put(subject, compatible);


### PR DESCRIPTION
Add the verbose option (default is `true`) to SR maven plugin test-compatibility goal, so the error log in compatibility checks will contains incompatible error details. 

An example error log message looks like the following

```
[error] Schema /var/folders/40/0fn6cc292_j051l5849vsgm00000gp/T/TestCompatibilitySchemaRegistryMojoTest5683166487534292171tmp/TestSubject000-Key.avsc is not compatible with subject(TestSubject000-Key) with error [Unable to read schema: 
"string"
using schema:
"int"]
```