### PR TITLE
Force non-required fields to be optional in JsonSchemaData

### DIFF
--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
@@ -935,7 +935,9 @@ public class JsonSchemaData {
         for (Map.Entry<String, org.everit.json.schema.Schema> property : sortedMap.values()) {
           String subFieldName = property.getKey();
           org.everit.json.schema.Schema subSchema = property.getValue();
-          builder.field(subFieldName, toConnectSchema(subSchema));
+          builder.field(subFieldName,
+                  toConnectSchema(subSchema, null, !objectSchema.getRequiredProperties().contains(subFieldName))
+          );
         }
       }
     } else if (jsonSchema instanceof ReferenceSchema) {


### PR DESCRIPTION
Fields can be "optional" in two ways:
- nullable
- not required

So a field in a Struct can be required and nullable, meaning the field
must exist in the struct but might not have a value. Non-required fields
in the schema were made nullable in the Connect schema but were still
required. This commit fixes that.