### PR TITLE
DG-424: prevent import different schema with same id

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -410,7 +410,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
 
         SchemaKey schemaKey = new SchemaKey(subject, schema.getVersion());
         if (schemaId >= 0) {
-          checkIfSchemaWithIdExist(schemaId, parsedSchema);
+          checkIfSchemaWithIdExist(schemaId, schema);
           schema.setId(schemaId);
           kafkaStore.put(schemaKey, new SchemaValue(schema));
         } else {
@@ -632,14 +632,14 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     }
   }
 
-  public void checkIfSchemaWithIdExist(int id, ParsedSchema parsedSchema)
+  public void checkIfSchemaWithIdExist(int id, Schema schema)
       throws SchemaRegistryException, StoreException {
     SchemaKey existingKey = this.lookupCache.schemaKeyById(id);
     if (existingKey != null) {
       SchemaRegistryValue existingValue = this.lookupCache.get(existingKey);
       if (existingValue != null
           && existingValue instanceof SchemaValue
-          && !((SchemaValue) existingValue).getSchema().equals(parsedSchema.canonicalString())) {
+          && !((SchemaValue) existingValue).getSchema().equals(schema.getSchema())) {
         throw new OperationNotPermittedException(
             String.format("Overwrite new schema with id %s is not permitted.", id)
         );

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -410,17 +410,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
 
         SchemaKey schemaKey = new SchemaKey(subject, schema.getVersion());
         if (schemaId >= 0) {
-          SchemaKey existingKey = this.lookupCache.schemaKeyById(schemaId);
-          if (existingKey != null) {
-            SchemaRegistryValue existingValue = kafkaStore.get(existingKey);
-            if (existingValue != null
-                && existingValue instanceof SchemaValue
-                && !((SchemaValue) existingValue).getSchema().equals(schema.getSchema())) {
-              throw new OperationNotPermittedException(
-                  String.format("Overwrite new schema with id %s is not permitted.", schemaId)
-              );
-            }
-          }
+          checkIfSchemaWithIdExist(schemaId, parsedSchema);
           schema.setId(schemaId);
           kafkaStore.put(schemaKey, new SchemaValue(schema));
         } else {
@@ -639,6 +629,21 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
     } else {
       // this schema was never registered in the registry under any subject
       return null;
+    }
+  }
+
+  public void checkIfSchemaWithIdExist(int id, ParsedSchema parsedSchema)
+      throws SchemaRegistryException, StoreException {
+    SchemaKey existingKey = this.lookupCache.schemaKeyById(id);
+    if (existingKey != null) {
+      SchemaRegistryValue existingValue = this.lookupCache.get(existingKey);
+      if (existingValue != null
+          && existingValue instanceof SchemaValue
+          && !((SchemaValue) existingValue).getSchema().equals(parsedSchema.canonicalString())) {
+        throw new OperationNotPermittedException(
+            String.format("Overwrite new schema with id %s is not permitted.", id)
+        );
+      }
     }
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -410,6 +410,17 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
 
         SchemaKey schemaKey = new SchemaKey(subject, schema.getVersion());
         if (schemaId >= 0) {
+          SchemaKey existingKey = this.lookupCache.schemaKeyById(schemaId);
+          if (existingKey != null) {
+            SchemaRegistryValue existingValue = kafkaStore.get(existingKey);
+            if (existingValue != null
+                && existingValue instanceof SchemaValue
+                && !((SchemaValue) existingValue).getSchema().equals(schema.getSchema())) {
+              throw new OperationNotPermittedException(
+                  String.format("Overwrite new schema with id %s is not permitted.", schemaId)
+              );
+            }
+          }
           schema.setId(schemaId);
           kafkaStore.put(schemaKey, new SchemaValue(schema));
         } else {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -22,7 +22,6 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.ServerClusterId;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-import io.confluent.kafka.schemaregistry.exceptions.OperationNotPermittedException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidVersionException;
 import io.confluent.kafka.schemaregistry.utils.TestUtils;


### PR DESCRIPTION
As mentioned in the ticket, currently in IMPORT mode, user can import compatible but different schema to the same id, and saw a fake success message because the schema is actually not overwrote.  
```
[2021-01-20 14:48:44,145] INFO Registering new schema: subject Kafka-key, version 1, id 100002, type null (io.confluent.kafka.schemaregistry.rest.resources.SubjectVersionsResource:250)
[2021-01-20 14:48:44,146] INFO Wait to catch up until the offset at 4 (io.confluent.kafka.schemaregistry.storage.KafkaStore:305)
[2021-01-20 14:48:44,191] INFO Wait to catch up until the offset at 5 (io.confluent.kafka.schemaregistry.storage.KafkaStore:305)
[2021-01-20 14:48:44,192] ERROR Found a schema with duplicate ID 100002.  This schema will not be registered since a schema already exists with this ID. (io.confluent.kafka.schemaregistry.storage.KafkaStoreMessageHandler:63)
[2021-01-20 14:48:44,194] WARN Ignore invalid update to key {magic=1,keytype=SCHEMA,subject=Kafka-key,version=1} (io.confluent.kafka.schemaregistry.storage.KafkaStoreReaderThread:212)
[2021-01-20 14:48:44,195] INFO [0:0:0:0:0:0:0:1] - - [20/Jan/2021:22:48:44 +0000] "POST /subjects/Kafka-key/versions HTTP/1.1" 200 13  52 (io.confluent.rest-utils.requests:62)
```

This PR attempt to fix this bug, by checking if a schema with the given id exists. If it does, and the existing schema is different than the one supplied, we throw an Exception to forbid this operation.  