### PR TITLE
DGS-1328 Add DELETE API for subject config and subject mode

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -135,7 +135,7 @@ public class RestService implements Configurable {
   private static final TypeReference<? extends List<Integer>> DELETE_SUBJECT_RESPONSE_TYPE =
       new TypeReference<List<Integer>>() {
       };
-  private static final TypeReference<String> DELETE_MODE_RESPONSE_TYPE =
+  private static final TypeReference<String> DELETE_SUBJECT_MODE_RESPONSE_TYPE =
       new TypeReference<String>() {
       };
   private static final TypeReference<Config> DELETE_SUBJECT_CONFIG_RESPONSE_TYPE =
@@ -690,6 +690,21 @@ public class RestService implements Configurable {
     ModeGetResponse mode =
         httpRequest(path, "GET", null, DEFAULT_REQUEST_PROPERTIES, GET_MODE_RESPONSE_TYPE);
     return mode;
+  }
+
+  public String deleteSubjectMode(String subject)
+      throws IOException, RestClientException {
+    return deleteSubjectMode(DEFAULT_REQUEST_PROPERTIES, subject);
+  }
+
+  public String deleteSubjectMode(Map<String, String> requestProperties, String subject)
+      throws IOException, RestClientException {
+    UriBuilder builder = UriBuilder.fromPath("/mode/{subject}");
+    String path = builder.build(subject).toString();
+
+    String response = httpRequest(path, "DELETE", null, requestProperties,
+        DELETE_SUBJECT_MODE_RESPONSE_TYPE);
+    return response;
   }
 
   public List<Schema> getSchemas(

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -138,6 +138,9 @@ public class RestService implements Configurable {
   private static final TypeReference<String> DELETE_MODE_RESPONSE_TYPE =
       new TypeReference<String>() {
       };
+  private static final TypeReference<Config> DELETE_SUBJECT_CONFIG_RESPONSE_TYPE =
+      new TypeReference<Config>() {
+      };
   private static final TypeReference<ServerClusterId> GET_CLUSTER_ID_RESPONSE_TYPE =
       new TypeReference<ServerClusterId>() {
       };
@@ -600,19 +603,42 @@ public class RestService implements Configurable {
 
   public Config getConfig(String subject)
       throws IOException, RestClientException {
-    return getConfig(DEFAULT_REQUEST_PROPERTIES, subject);
+    return getConfig(DEFAULT_REQUEST_PROPERTIES, subject, false);
   }
 
   public Config getConfig(Map<String, String> requestProperties,
                           String subject)
       throws IOException, RestClientException {
+    return getConfig(requestProperties, subject, false);
+  }
+
+  public Config getConfig(Map<String, String> requestProperties,
+                          String subject,
+                          boolean defaultToGlobal)
+      throws IOException, RestClientException {
     String path = subject != null
-                  ? UriBuilder.fromPath("/config/{subject}").build(subject).toString()
-                  : "/config";
+        ? UriBuilder.fromPath("/config/{subject}")
+        .queryParam("defaultToGlobal", defaultToGlobal).build(subject).toString()
+        : "/config";
 
     Config config =
         httpRequest(path, "GET", null, requestProperties, GET_CONFIG_RESPONSE_TYPE);
     return config;
+  }
+
+  public Config deleteSubjectConfig(String subject)
+      throws IOException, RestClientException {
+    return deleteSubjectConfig(DEFAULT_REQUEST_PROPERTIES, subject);
+  }
+
+  public Config deleteSubjectConfig(Map<String, String> requestProperties, String subject)
+      throws IOException, RestClientException {
+    UriBuilder builder = UriBuilder.fromPath("/config/{subject}");
+    String path = builder.build(subject).toString();
+
+    Config response = httpRequest(path, "DELETE", null, requestProperties,
+        DELETE_SUBJECT_CONFIG_RESPONSE_TYPE);
+    return response;
   }
 
   public ModeUpdateRequest setMode(String mode)

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -232,6 +232,43 @@ paths:
         500:
           description: "Error code 50001 -- Error in the backend data store\nError\
             \ code 50003 -- Error while forwarding the request to the primary"
+    delete:
+      summary: "Deletes the specified subject-level compatibility level config and\
+        \ revert to the global default."
+      description: ""
+      operationId: "deleteSubjectConfig"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters:
+      - name: "subject"
+        in: "path"
+        description: "the name of the subject"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "string"
+            enum:
+            - "NONE"
+            - "BACKWARD"
+            - "BACKWARD_TRANSITIVE"
+            - "FORWARD"
+            - "FORWARD_TRANSITIVE"
+            - "FULL"
+            - "FULL_TRANSITIVE"
+        404:
+          description: "Error code 40401 -- Subject not found"
+        500:
+          description: "Error code 50001 -- Error in the backend datastore"
   /mode:
     get:
       summary: "Get global mode."

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -393,6 +393,40 @@ paths:
           description: "Error code 50001 -- Error in the backend data store\nError\
             \ code 50003 -- Error while forwarding the request to the primary\nError\
             \ code 50004 -- Unknown leader"
+    delete:
+      summary: "Deletes the specified subject-level mode and revert to the global\
+        \ default."
+      description: ""
+      operationId: "deleteSubjectMode"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters:
+      - name: "subject"
+        in: "path"
+        description: "the name of the subject"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "string"
+            enum:
+            - "READWRITE"
+            - "READONLY"
+            - "READONLY_OVERRIDE"
+            - "IMPORT"
+        404:
+          description: "Error code 40401 -- Subject not found"
+        500:
+          description: "Error code 50001 -- Error in the backend datastore"
   /schemas:
     get:
       summary: "Get the schemas."

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -26,12 +26,15 @@ import java.util.Map;
 
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 
@@ -177,5 +180,43 @@ public class ConfigResource {
       throw Errors.storeException("Failed to get compatibility level", e);
     }
     return config;
+  }
+
+  @DELETE
+  @Path("/{subject}")
+  @ApiOperation(value = "Deletes the specified subject-level compatibility level config and "
+      + "revert to the global default.", response = CompatibilityLevel.class)
+  @ApiResponses(value = {
+      @ApiResponse(code = 404, message = "Error code 40401 -- Subject not found"),
+      @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend datastore")
+  })
+  public void deleteSubjectConfig(
+      final @Suspended AsyncResponse asyncResponse,
+      @Context HttpHeaders headers,
+      @ApiParam(value = "the name of the subject", required = true)
+      @PathParam("subject") String subject) {
+    log.info("Deleting compatibility setting for subject {}", subject);
+    Config deletedConfig;
+    try {
+      CompatibilityLevel currentCompatibility = schemaRegistry.getCompatibilityLevel(subject);
+      if (currentCompatibility == null) {
+        throw Errors.subjectNotFoundException(subject);
+      }
+
+      Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
+          headers, schemaRegistry.config().whitelistHeaders());
+      schemaRegistry.deleteSubjectCompatibilityConfigOrForward(subject, headerProperties);
+      deletedConfig = new Config(currentCompatibility.name);
+    } catch (OperationNotPermittedException e) {
+      throw Errors.operationNotPermittedException(e.getMessage());
+    } catch (SchemaRegistryStoreException e) {
+      throw Errors.storeException("Failed to update compatibility level", e);
+    } catch (UnknownLeaderException e) {
+      throw Errors.unknownLeaderException("Failed to update compatibility level", e);
+    } catch (SchemaRegistryRequestForwardingException e) {
+      throw Errors.requestForwardingFailedException("Error while forwarding update config request"
+          + " to the leader", e);
+    }
+    asyncResponse.resume(deletedConfig);
   }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -210,11 +210,11 @@ public class ConfigResource {
     } catch (OperationNotPermittedException e) {
       throw Errors.operationNotPermittedException(e.getMessage());
     } catch (SchemaRegistryStoreException e) {
-      throw Errors.storeException("Failed to update compatibility level", e);
+      throw Errors.storeException("Failed to delete compatibility level", e);
     } catch (UnknownLeaderException e) {
-      throw Errors.unknownLeaderException("Failed to update compatibility level", e);
+      throw Errors.unknownLeaderException("Failed to delete compatibility level", e);
     } catch (SchemaRegistryRequestForwardingException e) {
-      throw Errors.requestForwardingFailedException("Error while forwarding update config request"
+      throw Errors.requestForwardingFailedException("Error while forwarding delete config request"
           + " to the leader", e);
     }
     asyncResponse.resume(deletedConfig);

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -1446,6 +1446,10 @@ public class RestApiTest extends ClusterTestHarness {
     restApp.restClient.setMode("READWRITE", subject);
     assertEquals("READWRITE", restApp.restClient.getMode(subject).getMode());
 
+    //test delete subject mode
+    restApp.restClient.deleteSubjectMode(subject);
+    assertEquals("READONLY", restApp.restClient.getMode(subject, true).getMode());
+
     //test READONLY_OVERRIDE globalMode override subjectMode
     restApp.restClient.setMode("READONLY_OVERRIDE", null);
     assertEquals("READONLY_OVERRIDE", restApp.restClient.getMode(subject).getMode());

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -371,6 +371,14 @@ public class RestApiTest extends ClusterTestHarness {
                  FORWARD.name,
                  restApp.restClient.getConfig(subject).getCompatibilityLevel());
 
+    // delete subject compatibility
+    restApp.restClient.deleteSubjectConfig(subject);
+
+    assertEquals("Compatibility level for this subject should be reverted to none",
+        NONE.name,
+        restApp.restClient
+            .getConfig(RestService.DEFAULT_REQUEST_PROPERTIES, subject, true)
+            .getCompatibilityLevel());
   }
 
   @Test


### PR DESCRIPTION
Done manual test, will update system tests later. 

Example usage:
```
 % curl -X GET http://localhost:8081/config
{"compatibilityLevel":"BACKWARD"}%  
 % curl -X PUT -H "Content-Type: application/vnd.schemaregistry.v1+json" --data '{"compatibility": "FORWARD"}' http://localhost:8081/config/Kafka-key 
{"compatibility":"FORWARD"}%                                                                                                                                                                  
 % curl -X GET http://localhost:8081/config/Kafka-key                                                                                                
{"compatibilityLevel":"FORWARD"}%                                                                                                                                                              
 % curl -X DELETE -H "Content-Type: application/vnd.schemaregistry.v1+json" http://localhost:8081/config/Kafka-key
{"compatibilityLevel":"FORWARD"}%                                                                                                                                                              
 % curl -X GET http://localhost:8081/config/Kafka-key                                                             
{"error_code":40401,"message":"Subject 'Kafka-key' not found."}%                                                                                                                               
 % curl -X GET "http://localhost:8081/config/Kafka-key?defaultToGlobal=true"
{"compatibilityLevel":"BACKWARD"}%         
```