### PR TITLE
Allow disabling hostname verification

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClientConfig.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClientConfig.java
@@ -34,6 +34,8 @@ public class SchemaRegistryClientConfig {
   public static final String PROXY_HOST = "proxy.host";
   public static final String PROXY_PORT = "proxy.port";
 
+  public static final String SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG = "ssl.endpoint.identification.algorithm";
+
   public static void withClientSslSupport(ConfigDef configDef, String namespace) {
     org.apache.kafka.common.config.ConfigDef sslConfigDef = new org.apache.kafka.common.config
         .ConfigDef();


### PR DESCRIPTION
Meant to complete the work by @purbon in #1505 and resolves #1504.

Feedback in #1505 was to provide a similar way to disable hostname verification to how it is done server side.
[KafkaSchemaRegistry](https://github.com/confluentinc/schema-registry/blob/cbbc2125b287f1b8be3bfe6fdbd6a2a496733db9/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java#L1520) uses [RestConfig](https://github.com/confluentinc/rest-utils/blob/2699be7140cf2f081c7cc9a12079fe2dc01ab1b8/core/src/main/java/io/confluent/rest/RestConfig.java#L218) which sets a default value of `null` to the property.

In order to avoid introducing another dependency on the client, we add the configuration in `SchemaRegistryClientConfig` and check for it when configuring. Similar logic to server side was used.