### PR TITLE
MINOR: pass bootstrap servers to RestApp

### DIFF
--- a/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
@@ -181,7 +181,7 @@ public abstract class ClusterTestHarness {
   }
 
   protected void setupRestApp(Properties schemaRegistryProps) throws Exception {
-    restApp = new RestApp(schemaRegistryPort, zkConnect, null, KAFKASTORE_TOPIC,
+    restApp = new RestApp(schemaRegistryPort, zkConnect, bootstrapServers, KAFKASTORE_TOPIC,
                           compatibilityType, true, schemaRegistryProps);
     restApp.start();
   }


### PR DESCRIPTION
Pass bootstrap servers to RestApp for ClusterTestHarness tests, since ZooKeeper is deprecated and will be removed in the future.