### PR TITLE
Change subject-level mode DELETE response type from String to ModeGet…

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -80,9 +80,6 @@ public class RestService implements Configurable {
   private static final TypeReference<Config> GET_CONFIG_RESPONSE_TYPE =
       new TypeReference<Config>() {
       };
-  private static final TypeReference<List<ModeGetResponse>> GET_MODES_RESPONSE_TYPE =
-      new TypeReference<List<ModeGetResponse>>() {
-      };
   private static final TypeReference<ModeGetResponse> GET_MODE_RESPONSE_TYPE =
       new TypeReference<ModeGetResponse>() {
       };
@@ -135,8 +132,8 @@ public class RestService implements Configurable {
   private static final TypeReference<? extends List<Integer>> DELETE_SUBJECT_RESPONSE_TYPE =
       new TypeReference<List<Integer>>() {
       };
-  private static final TypeReference<String> DELETE_SUBJECT_MODE_RESPONSE_TYPE =
-      new TypeReference<String>() {
+  private static final TypeReference<ModeGetResponse> DELETE_SUBJECT_MODE_RESPONSE_TYPE =
+      new TypeReference<ModeGetResponse>() {
       };
   private static final TypeReference<Config> DELETE_SUBJECT_CONFIG_RESPONSE_TYPE =
       new TypeReference<Config>() {
@@ -692,17 +689,17 @@ public class RestService implements Configurable {
     return mode;
   }
 
-  public String deleteSubjectMode(String subject)
+  public ModeGetResponse deleteSubjectMode(String subject)
       throws IOException, RestClientException {
     return deleteSubjectMode(DEFAULT_REQUEST_PROPERTIES, subject);
   }
 
-  public String deleteSubjectMode(Map<String, String> requestProperties, String subject)
+  public ModeGetResponse deleteSubjectMode(Map<String, String> requestProperties, String subject)
       throws IOException, RestClientException {
     UriBuilder builder = UriBuilder.fromPath("/mode/{subject}");
     String path = builder.build(subject).toString();
 
-    String response = httpRequest(path, "DELETE", null, requestProperties,
+    ModeGetResponse response = httpRequest(path, "DELETE", null, requestProperties,
         DELETE_SUBJECT_MODE_RESPONSE_TYPE);
     return response;
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
@@ -170,6 +170,7 @@ public class ModeResource {
       @PathParam("subject") String subject) {
     log.info("Deleting mode for subject {}", subject);
     Mode deletedMode;
+    ModeGetResponse deleteModeResponse;
     try {
       deletedMode = schemaRegistry.getMode(subject);
       if (deletedMode == null) {
@@ -179,6 +180,7 @@ public class ModeResource {
       Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
           headers, schemaRegistry.config().whitelistHeaders());
       schemaRegistry.deleteSubjectModeOrForward(subject, headerProperties);
+      deleteModeResponse = new ModeGetResponse(deletedMode.name());
     } catch (OperationNotPermittedException e) {
       throw Errors.operationNotPermittedException(e.getMessage());
     } catch (SchemaRegistryStoreException e) {
@@ -189,6 +191,6 @@ public class ModeResource {
       throw Errors.requestForwardingFailedException("Error while forwarding delete mode request"
           + " to the leader", e);
     }
-    asyncResponse.resume(deletedMode);
+    asyncResponse.resume(deleteModeResponse);
   }
 }


### PR DESCRIPTION
…Response

**What?**
Change the subject-level Mode DELETE API reponse type, added in https://github.com/confluentinc/schema-registry/pull/1780 

**Test**
Done manual test. The resource is also covered by existing unit tests.
```
 % curl -X PUT -H "Content-Type: application/vnd.schemaregistry.v1+json" \   
    --data '{"mode": "READONLY"}' \     
    http://localhost:8081/mode/Kafka-value
{"mode":"READONLY"}%                                                                                                                                                                           
 % curl -X DELETE -H "Content-Type: application/vnd.schemaregistry.v1+json" \
    http://localhost:8081/mode/Kafka-value
{"mode":"READONLY"}%   
```