### PR TITLE
Fix String.format in compatibility errorMessages

### DIFF
--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -320,11 +320,11 @@ public class JsonSchema implements ParsedSchema {
         if (first) {
           // Log first incompatible change as warning
           log.warn("Found incompatible change: {}", incompatibleDiff);
-          errorMessages.add(String.format("Found incompatible change: {}", incompatibleDiff));
+          errorMessages.add(String.format("Found incompatible change: %s", incompatibleDiff));
           first = false;
         } else {
           log.debug("Found incompatible change: {}", incompatibleDiff);
-          errorMessages.add(String.format("Found incompatible change: {}", incompatibleDiff));
+          errorMessages.add(String.format("Found incompatible change: %s", incompatibleDiff));
         }
       }
       return errorMessages;

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -975,11 +975,11 @@ public class ProtobufSchema implements ParsedSchema {
         if (first) {
           // Log first incompatible change as warning
           log.warn("Found incompatible change: {}", incompatibleDiff);
-          errorMessages.add(String.format("Found incompatible change: {}", incompatibleDiff));
+          errorMessages.add(String.format("Found incompatible change: %s", incompatibleDiff));
           first = false;
         } else {
           log.debug("Found incompatible change: {}", incompatibleDiff);
-          errorMessages.add(String.format("Found incompatible change: {}", incompatibleDiff));
+          errorMessages.add(String.format("Found incompatible change: %s", incompatibleDiff));
         }
       }
       return errorMessages;


### PR DESCRIPTION
The verbose parameter on the schema registry compatibility API returned bad error messages because of a mistake when using String.format.
This should fix the issue.