### PR TITLE
UIF-302: Add Guava declaration in dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,11 @@
                 <version>${avro.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>uk.co.jemos.podam</groupId>
                 <artifactId>podam</artifactId>
                 <version>${podam.version}</version>


### PR DESCRIPTION
This makes sure subprojects use the same version of Guava. 5.5.x has been fixed. This will be applied to [5.0.x to 5.4.x].