### PR TITLE
DGS-1469 Add server-side schema cache

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -129,6 +129,17 @@ public class SchemaRegistryConfig extends RestConfig {
   public static final String COMPATIBILITY_CONFIG = "avro.compatibility.level";
   public static final String SCHEMA_COMPATIBILITY_CONFIG = "schema.compatibility.level";
 
+  /**
+   * <code>schema.cache.size</code>
+   */
+  public static final String SCHEMA_CACHE_SIZE_CONFIG = "schema.cache.size";
+  public static final int SCHEMA_CACHE_SIZE_DEFAULT = 1000;
+  /**
+   * <code>schema.cache.size</code>
+   */
+  public static final String SCHEMA_CACHE_EXPIRY_SECS_CONFIG = "schema.cache.expiry.secs";
+  public static final int SCHEMA_CACHE_EXPIRY_SECS_DEFAULT = 300;
+
   public static final String ZOOKEEPER_SET_ACL_CONFIG = "zookeeper.set.acl";
   public static final String KAFKASTORE_SECURITY_PROTOCOL_CONFIG =
       "kafkastore.security.protocol";
@@ -266,6 +277,10 @@ public class SchemaRegistryConfig extends RestConfig {
       + "forward_transitive (new schema is forward compatible with all previous versions), "
       + "full_transitive (new schema is backward and forward compatible with all previous "
       + "versions)";
+  protected static final String SCHEMA_CACHE_SIZE_DOC =
+      "The maximum size of the schema cache.";
+  protected static final String SCHEMA_CACHE_EXPIRY_SECS_DOC =
+      "The expiration in seconds for entries accessed in the cache.";
   protected static final String MASTER_ELIGIBILITY_DOC =
       "If true, this node can participate in master election. In a multi-colo setup, turn this off "
       + "for clusters in the slave data center.";
@@ -422,6 +437,12 @@ public class SchemaRegistryConfig extends RestConfig {
     )
     .define(SCHEMA_COMPATIBILITY_CONFIG, ConfigDef.Type.STRING, COMPATIBILITY_DEFAULT,
         ConfigDef.Importance.HIGH, COMPATIBILITY_DOC
+    )
+    .define(SCHEMA_CACHE_SIZE_CONFIG, ConfigDef.Type.INT, SCHEMA_CACHE_SIZE_DEFAULT,
+        ConfigDef.Importance.LOW, SCHEMA_CACHE_SIZE_DOC
+    )
+    .define(SCHEMA_CACHE_EXPIRY_SECS_CONFIG, ConfigDef.Type.INT, SCHEMA_CACHE_EXPIRY_SECS_DEFAULT,
+        ConfigDef.Importance.LOW, SCHEMA_CACHE_EXPIRY_SECS_DOC
     )
     .define(ZOOKEEPER_SET_ACL_CONFIG, ConfigDef.Type.BOOLEAN, ZOOKEEPER_SET_ACL_DEFAULT,
         ConfigDef.Importance.HIGH, ZOOKEEPER_SET_ACL_DOC

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -135,7 +135,7 @@ public class SchemaRegistryConfig extends RestConfig {
   public static final String SCHEMA_CACHE_SIZE_CONFIG = "schema.cache.size";
   public static final int SCHEMA_CACHE_SIZE_DEFAULT = 1000;
   /**
-   * <code>schema.cache.size</code>
+   * <code>schema.cache.expiry.secs</code>
    */
   public static final String SCHEMA_CACHE_EXPIRY_SECS_CONFIG = "schema.cache.expiry.secs";
   public static final int SCHEMA_CACHE_EXPIRY_SECS_DEFAULT = 300;


### PR DESCRIPTION
Add a server-side cache to cache the parsed version of input schema strings.  All existing tests of schema registration and schema lookup go through this cache.