### PR TITLE
DGS-1513 Store offset and timestamp with cached values

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ClearSubjectValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ClearSubjectValue.java
@@ -23,7 +23,7 @@ import javax.validation.constraints.NotEmpty;
 
 @JsonInclude(Include.NON_EMPTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ClearSubjectValue implements SchemaRegistryValue {
+public class ClearSubjectValue extends SchemaRegistryValue {
 
   @NotEmpty
   private String subject;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
@@ -24,7 +24,7 @@ import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 
 @JsonInclude(Include.NON_EMPTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ConfigValue implements SchemaRegistryValue {
+public class ConfigValue extends SchemaRegistryValue {
 
   private CompatibilityLevel compatibilityLevel;
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/DeleteSubjectValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/DeleteSubjectValue.java
@@ -26,7 +26,7 @@ import javax.validation.constraints.Min;
 
 @JsonInclude(Include.NON_EMPTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class DeleteSubjectValue implements SchemaRegistryValue {
+public class DeleteSubjectValue extends SchemaRegistryValue {
 
   @NotEmpty
   private String subject;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -47,6 +47,10 @@ public class KafkaStoreMessageHandler implements SchemaUpdateHandler {
    */
   public ValidationStatus validateUpdate(SchemaRegistryKey key, SchemaRegistryValue value,
                                          TopicPartition tp, long offset, long timestamp) {
+    // Store the offset and timestamp in the cached value
+    value.setOffset(offset);
+    value.setTimestamp(timestamp);
+
     if (key.getKeyType() == SchemaRegistryKeyType.SCHEMA) {
       SchemaValue schemaObj = (SchemaValue) value;
       if (schemaObj != null) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -47,9 +47,11 @@ public class KafkaStoreMessageHandler implements SchemaUpdateHandler {
    */
   public ValidationStatus validateUpdate(SchemaRegistryKey key, SchemaRegistryValue value,
                                          TopicPartition tp, long offset, long timestamp) {
-    // Store the offset and timestamp in the cached value
-    value.setOffset(offset);
-    value.setTimestamp(timestamp);
+    if (value != null) {
+      // Store the offset and timestamp in the cached value
+      value.setOffset(offset);
+      value.setTimestamp(timestamp);
+    }
 
     if (key.getKeyType() == SchemaRegistryKeyType.SCHEMA) {
       SchemaValue schemaObj = (SchemaValue) value;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ModeValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ModeValue.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonInclude(Include.NON_EMPTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ModeValue implements SchemaRegistryValue {
+public class ModeValue extends SchemaRegistryValue {
 
   private Mode mode;
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistryValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistryValue.java
@@ -15,6 +15,35 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
-public interface SchemaRegistryValue {
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonInclude(Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class SchemaRegistryValue {
+
+  protected Long offset;
+  protected Long timestamp;
+
+  @JsonProperty("offset")
+  public Long getOffset() {
+    return this.offset;
+  }
+
+  @JsonProperty("offset")
+  public void setOffset(Long offset) {
+    this.offset = offset;
+  }
+
+  @JsonProperty("ts")
+  public Long getTimestamp() {
+    return this.timestamp;
+  }
+
+  @JsonProperty("ts")
+  public void setTimestamp(Long timestamp) {
+    this.timestamp = timestamp;
+  }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaValue.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SchemaValue implements Comparable<SchemaValue>, SchemaRegistryValue {
+public class SchemaValue extends SchemaRegistryValue implements Comparable<SchemaValue> {
 
   @NotEmpty
   private String subject;

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/SchemaValuesTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/SchemaValuesTest.java
@@ -129,6 +129,29 @@ public class SchemaValuesTest {
 
   }
 
+  @Test
+  public void testSchemaValueDeserializeForOffsetTimestamp() throws SerializationException {
+    String subject = "test";
+    int version = 1;
+    SchemaKey key = new SchemaKey(subject, version);
+    key.setMagicByte(1);
+    Serializer<SchemaRegistryKey, SchemaRegistryValue> serializer = new SchemaRegistrySerializer();
+
+    String
+        schemaValueJson = "{\"subject\":\"test\",\"version\":1,\"id\":1,"
+        + "\"schema\":\"{\\\"type\\\":\\\"record\\\","
+        + "\\\"name\\\":\\\"myrecord\\\","
+        + "\\\"fields\\\":[{\\\"name\\\":\\\"f1067572235\\\","
+        + "\\\"type\\\":\\\"string\\\"}]}\",\"deleted\":true,\"offset\":1,\"ts\":123}";
+
+    SchemaValue schemaValue =
+        (SchemaValue) serializer.deserializeValue(key, schemaValueJson.getBytes());
+
+    assertEquals(1L, schemaValue.getOffset().longValue());
+    assertEquals(123L, schemaValue.getTimestamp().longValue());
+
+  }
+
   private void assertSchemaValue(String subject, int version, int schemaId,
                                  String schema, String type, boolean deleted,
                                  SchemaValue schemaValue) {


### PR DESCRIPTION
The offset and timestamp can be used to help with migrating schemas from one SR to another.

Added a unit test.