### PR TITLE
Fix issue where references with custom shared types returns redefine error

### DIFF
--- a/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/SchemasWithDependenciesTest.java
+++ b/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/SchemasWithDependenciesTest.java
@@ -18,7 +18,7 @@ public class SchemasWithDependenciesTest extends SchemaRegistryTest {
 
     private final String dependency = "{\n" +
             "  \"type\": \"record\",\n" +
-            "  \"namespace\": \"com.pizza\",\n" +
+            "  \"namespace\": \"com.shared\",\n" +
             "  \"name\": \"Amount\",\n" +
             "  \"fields\": [\n" +
             "    {\n" +
@@ -43,11 +43,72 @@ public class SchemasWithDependenciesTest extends SchemaRegistryTest {
             "    },\n" +
             "    {\n" +
             "      \"name\": \"cost\",\n" +
-            "      \"type\": \"com.pizza.Amount\"\n" +
+            "      \"type\": \"com.shared.Amount\"\n" +
             "    }\n" +
             "  ]\n" +
             "}";
 
+    private final String combinedSchema = "[\"com.pizza.Pizza\", \"com.soda.Soda\"]";
+
+    private final String inlineSchema1 = "{\n" +
+            "  \"type\": \"record\",\n" +
+            "  \"namespace\": \"com.pizza\",\n" +
+            "  \"name\": \"Pizza\",\n" +
+            "  \"fields\": [\n" +
+            "    {\n" +
+            "      \"name\": \"name\",\n" +
+            "      \"type\": \"string\"\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"name\": \"cost\",\n" +
+            "      \"type\": {\n" +
+            "  \"type\": \"record\",\n" +
+            "  \"namespace\": \"com.shared\",\n" +
+            "  \"name\": \"Amount\",\n" +
+            "  \"fields\": [\n" +
+            "    {\n" +
+            "      \"name\": \"amount\",\n" +
+            "      \"type\": \"string\"\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"name\": \"currency\",\n" +
+            "      \"type\": \"string\"\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}" +
+            "    }\n" +
+            "  ]\n" +
+            "}";
+
+    private final String inlineSchema2 = "{\n" +
+            "  \"type\": \"record\",\n" +
+            "  \"namespace\": \"com.soda\",\n" +
+            "  \"name\": \"Soda\",\n" +
+            "  \"fields\": [\n" +
+            "    {\n" +
+            "      \"name\": \"name\",\n" +
+            "      \"type\": \"string\"\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"name\": \"cost\",\n" +
+            "      \"type\": {\n" +
+            "  \"type\": \"record\",\n" +
+            "  \"namespace\": \"com.shared\",\n" +
+            "  \"name\": \"Amount\",\n" +
+            "  \"fields\": [\n" +
+            "    {\n" +
+            "      \"name\": \"amount\",\n" +
+            "      \"type\": \"string\"\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"name\": \"currency\",\n" +
+            "      \"type\": \"string\"\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}" +
+            "    }\n" +
+            "  ]\n" +
+            "}";
 
     @Test
     public void testSchemaWithDependencies() throws Exception {
@@ -58,7 +119,7 @@ public class SchemasWithDependenciesTest extends SchemaRegistryTest {
         File amountFile = new File(tempDirectory, "amount.avsc");
         try (
                 FileWriter pizzaWriter = new FileWriter(pizzaFile);
-                FileWriter amountWriter = new FileWriter(amountFile)
+                FileWriter amountWriter = new FileWriter(amountFile);
         ) {
             pizzaWriter.write(schema);
             amountWriter.write(dependency);
@@ -67,7 +128,7 @@ public class SchemasWithDependenciesTest extends SchemaRegistryTest {
         Map<String, List<Reference>> schemaRefs = new LinkedHashMap<>();
         List<Reference> subjectRefs = new ArrayList<>();
         Reference ref = new Reference();
-        ref.name = "com.pizza.Amount";
+        ref.name = "com.shared.Amount";
         ref.subject = "Amount";
         subjectRefs.add(ref);
         schemaRefs.put("Pizza", subjectRefs);
@@ -83,5 +144,51 @@ public class SchemasWithDependenciesTest extends SchemaRegistryTest {
 
         Assert.assertNotNull("The schema should've been generated", pizza);
         Assert.assertTrue("The schema should contain fields from the dependency", pizza.toString().contains("currency"));
+    }
+
+    @Test
+    public void testSchemasWithSharedInlineDependencies() throws Exception {
+        RegisterSchemaRegistryMojo schemaRegistryMojo = new RegisterSchemaRegistryMojo();
+        schemaRegistryMojo.client = new MockSchemaRegistryClient();
+
+        File pizzaFile = new File(tempDirectory, "pizza.avsc");
+        File sodaFile = new File(tempDirectory, "soda.avsc");
+        File comboFile = new File(tempDirectory, "combo.avsc");
+        try (
+                FileWriter pizzaWriter = new FileWriter(pizzaFile);
+                FileWriter sodaWriter = new FileWriter(sodaFile);
+                FileWriter comboWriter = new FileWriter(comboFile);
+        ) {
+            pizzaWriter.write(inlineSchema1);
+            sodaWriter.write(inlineSchema2);
+            comboWriter.write(combinedSchema);
+        }
+
+        Map<String, List<Reference>> schemaRefs = new LinkedHashMap<>();
+        List<Reference> subjectRefs = new ArrayList<>();
+        Reference ref1 = new Reference();
+        ref1.name = "com.pizza.Pizza";
+        ref1.subject = "Pizza";
+        subjectRefs.add(ref1);
+        Reference ref2 = new Reference();
+        ref2.name = "com.soda.Soda";
+        ref2.subject = "Soda";
+        subjectRefs.add(ref2);
+        schemaRefs.put("Combo", subjectRefs);
+        schemaRegistryMojo.references = schemaRefs;
+
+        Map<String, File> schemas = new LinkedHashMap<>();
+        schemas.put("Pizza", pizzaFile);
+        schemas.put("Soda", sodaFile);
+        schemas.put("Combo", comboFile);
+        schemaRegistryMojo.subjects = schemas;
+
+        schemaRegistryMojo.execute();
+
+        Schema pizza = ((AvroSchema) schemaRegistryMojo.schemas.get("Pizza")).rawSchema();
+        Schema soda = ((AvroSchema) schemaRegistryMojo.schemas.get("Soda")).rawSchema();
+
+        Assert.assertNotNull("The schema should've been generated", pizza);
+        Assert.assertNotNull("The schema should've been generated", soda);
     }
 }


### PR DESCRIPTION
Fixes #1793 (which was closed with a workaround, but is still an open issue).

When 2 or more schemas being used as references include the same schema as a type, the Avro parser throws an exception that the shared type can't be redefined.  This happens with schemas defined in IDL that use imports.  This scenario should not return the redefine error, because the type is not actually being redefined (just re-used).

What I changed:

- If a schema being used as a reference is identical to a schema that has already been parsed, don't add that duplicate schema to the AvroSchema parser.

- Use a new parser for each reference being parsed in canonicalString(), by moving the existing parser inside the for loop.

- Added a test to catch this error

