### PR TITLE
Fix documentation on the built package path

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,16 +159,20 @@ To create a packaged version, optionally skipping the tests:
 mvn package [-DskipTests]
 ```
 
-This produces a version ready for production in `package/target/kafka-schema-registry-package-$VERSION-package` containing a
-directory layout similar to the packaged binary versions.
+It produces:
 
-You can also produce a standalone fat JAR using the `standalone` profile:
+- Schema registry in `package-schema-registry/target/kafka-schema-registry-package-$VERSION-package`
+- Serde tools for avro/json/protobuf in `package-kafka-serde-tools/target/kafka-serde-tools-package-$VERSION-package`
+
+Each of the produced contains a directory layout similar to the packaged binary versions.
+
+You can also produce a standalone fat JAR of schema registry using the `standalone` profile:
 
 ```bash
 mvn package -P standalone [-DskipTests]
 ```
 
-This generates `package/target/kafka-schema-registry-package-$VERSION-standalone.jar`, which includes all the dependencies as well.
+This generates `package-schema-registry/target/kafka-schema-registry-package-$VERSION-standalone.jar`, which includes all the dependencies as well.
 
 OpenAPI Spec
 ------------


### PR DESCRIPTION
I found this problem while building the Schema Registry package.

Schema Registry is built in `package-schema-registry/target`, not `package` anymore. Plus, Serde tools is built in `package-kafka-serde-tools/target`.