### PR TITLE
DGS-1557: Upgrade io.netty_netty-codec

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -74,6 +74,17 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-codec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>com.101tec</groupId>


### PR DESCRIPTION
Upgrade the io.netty_netty-codec to `4.1.62.Final`, which is specified in https://github.com/confluentinc/rest-utils/blob/6.2.x/pom.xml#L60