### PR TITLE
DGS-1657 Add converter flag to enable scrubbing invalid names

### DIFF
--- a/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -21,6 +21,9 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.regex.Pattern;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericEnumSymbol;
@@ -108,6 +111,9 @@ public class AvroData {
   public static final String AVRO_TYPE_ANYTHING = NAMESPACE + ".Anything";
 
   private static final Map<String, Schema.Type> NON_AVRO_TYPES_BY_TYPE_CODE = new HashMap<>();
+
+  private static Pattern NAME_START_CHAR = Pattern.compile("^[A-Za-z_]");
+  private static Pattern NAME_INVALID_CHARS = Pattern.compile("[^A-Za-z0-9_]");
 
   static {
     NON_AVRO_TYPES_BY_TYPE_CODE.put(CONNECT_TYPE_INT8, Schema.Type.INT8);
@@ -314,6 +320,7 @@ public class AvroData {
   private Cache<AvroSchema, Schema> toConnectSchemaCache;
   private boolean connectMetaData;
   private boolean enhancedSchemaSupport;
+  private boolean scrubInvalidNames;
 
   public AvroData(int cacheSize) {
     this(new AvroDataConfig.Builder()
@@ -330,6 +337,7 @@ public class AvroData {
             avroDataConfig.getSchemasCacheSize()));
     this.connectMetaData = avroDataConfig.isConnectMetaData();
     this.enhancedSchemaSupport = avroDataConfig.isEnhancedAvroSchemaSupport();
+    this.scrubInvalidNames = avroDataConfig.isScrubInvalidNames();
   }
 
   /**
@@ -743,7 +751,7 @@ public class AvroData {
     if (schema.name() != null) {
       String[] split = splitName(schema.name());
       namespace = split[0];
-      name = split[1];
+      name = scrubName(split[1]);
     }
 
     // Extra type annotation information for otherwise lossy conversions
@@ -880,11 +888,12 @@ public class AvroData {
           }
           List<org.apache.avro.Schema.Field> fields = new ArrayList<>();
           for (Field field : schema.fields()) {
+            String fieldName = scrubName(field.name());
             String fieldDoc = schema.parameters() != null
                 ? schema.parameters()
                   .get(AVRO_FIELD_DOC_PREFIX_PROP + field.name())
                 : null;
-            addAvroRecordField(fields, field.name(), field.schema(), fieldDoc, fromConnectContext);
+            addAvroRecordField(fields, fieldName, field.schema(), fieldDoc, fromConnectContext);
           }
           baseSchema.setFields(fields);
         }
@@ -1022,6 +1031,27 @@ public class AvroData {
     }
     fromConnectSchemaCache.put(schema, finalSchema);
     return finalSchema;
+  }
+
+  private String scrubName(String name) {
+    return scrubInvalidNames ? doScrubName(name) : name;
+  }
+
+  // Visible for testing
+  protected static String doScrubName(String name) {
+    try {
+      if (name == null) {
+        return name;
+      }
+      String encoded = URLEncoder.encode(name, "UTF-8");
+      if (!NAME_START_CHAR.matcher(encoded).lookingAt()) {
+        encoded = "x" + encoded;  // use an arbitrary valid prefix
+      }
+      encoded = NAME_INVALID_CHARS.matcher(encoded).replaceAll("_");
+      return encoded;
+    } catch (UnsupportedEncodingException e) {
+      return name;
+    }
   }
 
   public org.apache.avro.Schema fromConnectSchemaWithCycle(

--- a/avro-data/src/main/java/io/confluent/connect/avro/AvroDataConfig.java
+++ b/avro-data/src/main/java/io/confluent/connect/avro/AvroDataConfig.java
@@ -31,6 +31,11 @@ public class AvroDataConfig extends AbstractConfig {
       "Toggle for enabling/disabling enhanced avro schema support: Enum symbol preservation and "
       + "Package Name awareness";
 
+  public static final String SCRUB_INVALID_NAMES_CONFIG = "scrub.invalid.names";
+  public static final boolean SCRUB_INVALID_NAMES_DEFAULT = false;
+  public static final String SCRUB_INVALID_NAMES_DOC =
+      "Whether to scrub invalid names by replacing invalid characters with valid ones";
+
   public static final String CONNECT_META_DATA_CONFIG = "connect.meta.data";
   public static final boolean CONNECT_META_DATA_DEFAULT = true;
   public static final String CONNECT_META_DATA_DOC =
@@ -49,6 +54,8 @@ public class AvroDataConfig extends AbstractConfig {
                 ENHANCED_AVRO_SCHEMA_SUPPORT_DEFAULT,
                 ConfigDef.Importance.MEDIUM,
                 ENHANCED_AVRO_SCHEMA_SUPPORT_DOC)
+        .define(SCRUB_INVALID_NAMES_CONFIG, ConfigDef.Type.BOOLEAN, SCRUB_INVALID_NAMES_DEFAULT,
+                ConfigDef.Importance.MEDIUM, SCRUB_INVALID_NAMES_DOC)
         .define(CONNECT_META_DATA_CONFIG, ConfigDef.Type.BOOLEAN, CONNECT_META_DATA_DEFAULT,
                 ConfigDef.Importance.LOW, CONNECT_META_DATA_DOC)
         .define(SCHEMAS_CACHE_SIZE_CONFIG, ConfigDef.Type.INT, SCHEMAS_CACHE_SIZE_DEFAULT,
@@ -65,6 +72,10 @@ public class AvroDataConfig extends AbstractConfig {
 
   public boolean isConnectMetaData() {
     return this.getBoolean(CONNECT_META_DATA_CONFIG);
+  }
+
+  public boolean isScrubInvalidNames() {
+    return this.getBoolean(SCRUB_INVALID_NAMES_CONFIG);
   }
 
   public int getSchemasCacheSize() {

--- a/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufDataConfig.java
+++ b/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufDataConfig.java
@@ -31,6 +31,11 @@ public class ProtobufDataConfig extends AbstractConfig {
       "Toggle for enabling/disabling enhanced protobuf schema support: "
           + "package name preservation";
 
+  public static final String SCRUB_INVALID_NAMES_CONFIG = "scrub.invalid.names";
+  public static final boolean SCRUB_INVALID_NAMES_DEFAULT = false;
+  public static final String SCRUB_INVALID_NAMES_DOC =
+      "Whether to scrub invalid names by replacing invalid characters with valid ones";
+
   public static final String SCHEMAS_CACHE_SIZE_CONFIG = "schemas.cache.config";
   public static final int SCHEMAS_CACHE_SIZE_DEFAULT = 1000;
   public static final String SCHEMAS_CACHE_SIZE_DOC = "Size of the converted schemas cache";
@@ -42,6 +47,8 @@ public class ProtobufDataConfig extends AbstractConfig {
             ENHANCED_PROTOBUF_SCHEMA_SUPPORT_DEFAULT,
             ConfigDef.Importance.MEDIUM,
             ENHANCED_PROTOBUF_SCHEMA_SUPPORT_DOC)
+        .define(SCRUB_INVALID_NAMES_CONFIG, ConfigDef.Type.BOOLEAN, SCRUB_INVALID_NAMES_DEFAULT,
+            ConfigDef.Importance.MEDIUM, SCRUB_INVALID_NAMES_DOC)
         .define(SCHEMAS_CACHE_SIZE_CONFIG,
             ConfigDef.Type.INT,
             SCHEMAS_CACHE_SIZE_DEFAULT,
@@ -56,6 +63,10 @@ public class ProtobufDataConfig extends AbstractConfig {
 
   public boolean isEnhancedProtobufSchemaSupport() {
     return this.getBoolean(ENHANCED_PROTOBUF_SCHEMA_SUPPORT_CONFIG);
+  }
+
+  public boolean isScrubInvalidNames() {
+    return this.getBoolean(SCRUB_INVALID_NAMES_CONFIG);
   }
 
   public int schemaCacheSize() {

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
@@ -1013,6 +1013,33 @@ public class ProtobufDataTest {
   }
 
   @Test
+  public void testFromConnectWithInvalidName() {
+    ProtobufDataConfig protobufDataConfig = new ProtobufDataConfig.Builder()
+        .with(ProtobufDataConfig.SCRUB_INVALID_NAMES_CONFIG, true)
+        .build();
+    ProtobufData protobufData = new ProtobufData(protobufDataConfig);
+    Schema schema = SchemaBuilder.struct()
+        .name("org.acme.invalid record-name")
+        .field("invalid field-name", Schema.STRING_SCHEMA)
+        .build();
+    ProtobufSchema protobufSchema = protobufData.fromConnectSchema(schema);
+    Descriptor descriptor = protobufSchema.toDescriptor();
+    assertEquals("invalid_record_name", descriptor.getName());
+    assertEquals("invalid_field_name", descriptor.getFields().get(0).getName());
+  }
+
+  @Test
+  public void testNameScrubbing() {
+    assertEquals("abc_2B____", ProtobufData.doScrubName("abc+-.*_"));
+    assertEquals("abc_def", ProtobufData.doScrubName("abc-def"));
+    assertEquals("abc_2Bdef", ProtobufData.doScrubName("abc+def"));
+    assertEquals("abc__def", ProtobufData.doScrubName("abc  def"));
+    assertEquals("abc_def", ProtobufData.doScrubName("abc.def"));
+    assertEquals("x0abc_def", ProtobufData.doScrubName("0abc.def"));
+    assertEquals("x_abc_def", ProtobufData.doScrubName("_abc.def"));
+  }
+
+  @Test
   public void testToConnectRecursiveSchema() {
     ProtobufSchema protobufSchema = new ProtobufSchema(
         RecursiveKeyValue.RecursiveKeyValueMessage.getDescriptor());


### PR DESCRIPTION
Add converter flag to enable scrubbing invalid names, for both Avro and Protobuf converters.

Add unit tests.

Fixes #1861