### PR TITLE
DGS-1664 Allow URL encoded subject names in maven plugin

### DIFF
--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -230,6 +230,8 @@ paths:
             \ code 50003 -- Error while forwarding the request to the primary"
   /mode:
     get:
+      summary: "Get global mode."
+      description: ""
       operationId: "getTopLevelMode"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
@@ -246,7 +248,11 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/ModeGetResponse"
+        500:
+          description: "Error code 50001 -- Error in the backend data store"
     put:
+      summary: "Update global mode."
+      description: ""
       operationId: "updateTopLevelMode"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
@@ -269,8 +275,17 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/ModeUpdateRequest"
+        422:
+          description: "Error code 42204 -- Invalid mode\nError code 42205 -- Operation\
+            \ not permitted"
+        500:
+          description: "Error code 50001 -- Error in the backend data store\nError\
+            \ code 50003 -- Error while forwarding the request to the primary\nError\
+            \ code 50004 -- Unknown leader"
   /mode/{subject}:
     get:
+      summary: "Get mode for a subject."
+      description: ""
       operationId: "getMode"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
@@ -284,6 +299,7 @@ paths:
       parameters:
       - name: "subject"
         in: "path"
+        description: "Name of the Subject"
         required: true
         type: "string"
       responses:
@@ -291,7 +307,13 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/ModeGetResponse"
+        404:
+          description: "Subject not found"
+        500:
+          description: "Error code 50001 -- Error in the backend data store"
     put:
+      summary: "Update mode for the specified subject."
+      description: ""
       operationId: "updateMode"
       consumes:
       - "application/vnd.schemaregistry.v1+json"
@@ -305,6 +327,7 @@ paths:
       parameters:
       - name: "subject"
         in: "path"
+        description: "Name of the Subject"
         required: true
         type: "string"
       - in: "body"
@@ -318,6 +341,13 @@ paths:
           description: "successful operation"
           schema:
             $ref: "#/definitions/ModeUpdateRequest"
+        422:
+          description: "Error code 42204 -- Invalid mode\nError code 42205 -- Operation\
+            \ not permitted"
+        500:
+          description: "Error code 50001 -- Error in the backend data store\nError\
+            \ code 50003 -- Error while forwarding the request to the primary\nError\
+            \ code 50004 -- Unknown leader"
   /schemas/ids/{id}:
     get:
       summary: "Get the schema string identified by the input ID."

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/RegisterSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/RegisterSchemaRegistryMojo.java
@@ -19,6 +19,7 @@ package io.confluent.kafka.schemaregistry.maven;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 
+import java.io.File;
 import org.apache.maven.plugins.annotations.Mojo;
 
 import java.io.IOException;
@@ -29,6 +30,7 @@ public class RegisterSchemaRegistryMojo extends UploadSchemaRegistryMojo {
 
   @Override
   protected boolean processSchema(String subject,
+                                  File schemaPath,
                                   ParsedSchema schema,
                                   Map<String, Integer> schemaVersions)
       throws IOException, RestClientException {

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/TestCompatibilitySchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/TestCompatibilitySchemaRegistryMojo.java
@@ -32,11 +32,10 @@ public class TestCompatibilitySchemaRegistryMojo extends UploadSchemaRegistryMoj
 
   @Override
   protected boolean processSchema(String subject,
+                                  File schemaPath,
                                   ParsedSchema schema,
                                   Map<String, Integer> schemaVersions)
       throws IOException, RestClientException {
-
-    File schemaPath = this.subjects.get(subject);
 
     if (getLog().isDebugEnabled()) {
       getLog().debug(

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/UploadSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/UploadSchemaRegistryMojo.java
@@ -56,7 +56,7 @@ public abstract class UploadSchemaRegistryMojo extends SchemaRegistryMojo {
   Map<String, List<Reference>> references = new HashMap<>();
 
   @Parameter(required = false)
-  boolean decodeUrl = true;
+  boolean decodeSubject = true;
 
   Map<String, ParsedSchema> schemas = new HashMap<>();
   Map<String, Integer> schemaVersions = new HashMap<>();
@@ -108,7 +108,7 @@ public abstract class UploadSchemaRegistryMojo extends SchemaRegistryMojo {
       }
 
       String subject = key;
-      if (decodeUrl && subject.contains(PERCENT_REPLACEMENT)) {
+      if (decodeSubject && subject.contains(PERCENT_REPLACEMENT)) {
         subject = decode(subject);
       }
       boolean success = processSchema(subject, file, schema.get(), schemaVersions);

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/UploadSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/UploadSchemaRegistryMojo.java
@@ -108,7 +108,7 @@ public abstract class UploadSchemaRegistryMojo extends SchemaRegistryMojo {
       }
 
       String subject = key;
-      if (decodeUrl) {
+      if (decodeUrl && subject.contains(PERCENT_REPLACEMENT)) {
         subject = decode(subject);
       }
       boolean success = processSchema(subject, file, schema.get(), schemaVersions);

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/UploadSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/UploadSchemaRegistryMojo.java
@@ -44,7 +44,7 @@ import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientExcept
 
 public abstract class UploadSchemaRegistryMojo extends SchemaRegistryMojo {
 
-  public static final String PERCENT_REPLACEMENT = "_:";
+  public static final String PERCENT_REPLACEMENT = "_x";
 
   @Parameter(required = true)
   Map<String, File> subjects = new HashMap<>();
@@ -54,6 +54,9 @@ public abstract class UploadSchemaRegistryMojo extends SchemaRegistryMojo {
 
   @Parameter(required = false)
   Map<String, List<Reference>> references = new HashMap<>();
+
+  @Parameter(required = false)
+  boolean decodeUrl = true;
 
   Map<String, ParsedSchema> schemas = new HashMap<>();
   Map<String, Integer> schemaVersions = new HashMap<>();
@@ -105,7 +108,7 @@ public abstract class UploadSchemaRegistryMojo extends SchemaRegistryMojo {
       }
 
       String subject = key;
-      if (subject.contains(PERCENT_REPLACEMENT)) {
+      if (decodeUrl) {
         subject = decode(subject);
       }
       boolean success = processSchema(subject, file, schema.get(), schemaVersions);
@@ -121,7 +124,7 @@ public abstract class UploadSchemaRegistryMojo extends SchemaRegistryMojo {
   }
 
   protected static String decode(String subject) throws UnsupportedEncodingException {
-    // Replace underscore-colon with percent sign, since percent is not allowed in XML name
+    // Replace _x colon with percent sign, since percent is not allowed in XML name
     subject = subject.replaceAll(PERCENT_REPLACEMENT, "%");
     return URLDecoder.decode(subject, "UTF-8");
   }

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/UploadSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/UploadSchemaRegistryMojo.java
@@ -17,6 +17,8 @@
 package io.confluent.kafka.schemaregistry.maven;
 
 import com.google.common.base.Preconditions;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -41,6 +43,8 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 
 public abstract class UploadSchemaRegistryMojo extends SchemaRegistryMojo {
+
+  public static final String PERCENT_REPLACEMENT = "_:";
 
   @Parameter(required = true)
   Map<String, File> subjects = new HashMap<>();
@@ -100,7 +104,11 @@ public abstract class UploadSchemaRegistryMojo extends SchemaRegistryMojo {
         return;
       }
 
-      boolean success = processSchema(key, schema.get(), schemaVersions);
+      String subject = key;
+      if (subject.contains(PERCENT_REPLACEMENT)) {
+        subject = decode(subject);
+      }
+      boolean success = processSchema(subject, file, schema.get(), schemaVersions);
       if (!success) {
         failures++;
       }
@@ -112,7 +120,14 @@ public abstract class UploadSchemaRegistryMojo extends SchemaRegistryMojo {
     }
   }
 
+  protected static String decode(String subject) throws UnsupportedEncodingException {
+    // Replace underscore-colon with percent sign, since percent is not allowed in XML name
+    subject = subject.replaceAll(PERCENT_REPLACEMENT, "%");
+    return URLDecoder.decode(subject, "UTF-8");
+  }
+
   protected abstract boolean processSchema(String subject,
+                                           File schemaPath,
                                            ParsedSchema schema,
                                            Map<String, Integer> schemaVersions)
       throws IOException, RestClientException;

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/ValidateSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/ValidateSchemaRegistryMojo.java
@@ -18,6 +18,7 @@ package io.confluent.kafka.schemaregistry.maven;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -27,6 +28,7 @@ public class ValidateSchemaRegistryMojo extends UploadSchemaRegistryMojo {
 
   @Override
   protected boolean processSchema(String subject,
+                                  File schemaPath,
                                   ParsedSchema schema,
                                   Map<String, Integer> schemaVersions)
       throws IOException, RestClientException {

--- a/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/RegisterSchemaRegistryMojoTest.java
+++ b/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/RegisterSchemaRegistryMojoTest.java
@@ -15,21 +15,16 @@
  */
 package io.confluent.kafka.schemaregistry.maven;
 
-import static io.confluent.kafka.schemaregistry.maven.UploadSchemaRegistryMojo.PERCENT_REPLACEMENT;
-
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
-import java.net.URLDecoder;
 import org.apache.avro.Schema;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.hamcrest.core.IsEqual;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -122,7 +117,7 @@ public class RegisterSchemaRegistryMojoTest extends SchemaRegistryTest {
     }
 
     this.mojo.subjects = subjectToFile;
-    this.mojo.decodeUrl = false;
+    this.mojo.decodeSubject = false;
     this.mojo.execute();
 
     Assert.assertThat(this.mojo.schemaVersions, IsEqual.equalTo(expectedVersions));


### PR DESCRIPTION
We allow URL encoded names in XML tags that represent subject names.  However, since `%` is not allowed, we replace it with `_x`.  There is also a new flag to not attempt a URL decoding.

Fixes #1876 