### PR TITLE
To add dependencies it's enough to use the same Schema.Parser() to parse dependencies and subjects. (#855)

### DIFF
--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/DownloadSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/DownloadSchemaRegistryMojo.java
@@ -51,6 +51,7 @@ public class DownloadSchemaRegistryMojo extends SchemaRegistryMojo {
   @Parameter(required = true)
   File outputDirectory;
 
+
   @Parameter(required = false, defaultValue = "true")
   boolean prettyPrintSchemas;
 

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/RegisterSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/RegisterSchemaRegistryMojo.java
@@ -17,9 +17,7 @@
 package io.confluent.kafka.schemaregistry.maven;
 
 import com.google.inject.internal.util.Preconditions;
-
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-
 import org.apache.avro.Schema;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -30,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 @Mojo(name = "register")
@@ -37,7 +36,11 @@ public class RegisterSchemaRegistryMojo extends SchemaRegistryMojo {
 
   @Parameter(required = true)
   Map<String, File> subjects = new HashMap<>();
+
   Map<String, Integer> schemaVersions;
+
+  @Parameter(required = false)
+  List<String> imports;
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
@@ -76,5 +79,13 @@ public class RegisterSchemaRegistryMojo extends SchemaRegistryMojo {
     Preconditions.checkState(errors == 0,
                              "One or more exceptions were encountered while registering the "
                              + "schemas.");
+  }
+
+  @Override
+  protected Schema.Parser newParser() {
+    if (imports == null || imports.isEmpty()) {
+      return super.newParser();
+    }
+    return parserWithDependencies(imports);
   }
 }

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
@@ -64,7 +64,7 @@ public abstract class SchemaRegistryMojo extends AbstractMojo {
     Map<String, Schema> results = new LinkedHashMap<>();
 
     for (Map.Entry<String, File> kvp : subjects.entrySet()) {
-      Schema.Parser parser = new Schema.Parser();
+      Schema.Parser parser = newParser();
       getLog().debug(
           String.format(
               "Loading schema for subject(%s) from %s.",
@@ -91,4 +91,28 @@ public abstract class SchemaRegistryMojo extends AbstractMojo {
 
     return results;
   }
+
+  protected Schema.Parser newParser() {
+    return new Schema.Parser();
+  }
+
+  Schema.Parser parserWithDependencies(List<String> dependencies) {
+    Schema.Parser parserWithDepencies = new Schema.Parser();
+
+    for (String dependency : dependencies) {
+      try (FileInputStream inputStream = new FileInputStream(dependency)) {
+        parserWithDepencies.parse(inputStream);
+        getLog().debug(String.format("Parsing imports:%s", dependency));
+      } catch (IOException ex) {
+        getLog().error("Exception thrown while loading dependency " + dependency, ex);
+      } catch (SchemaParseException ex) {
+        getLog().error("Exception thrown while parsing dependency " + dependency, ex);
+      }
+    }
+
+    return parserWithDepencies;
+  }
+
+
+
 }

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/TestCompatibilitySchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/TestCompatibilitySchemaRegistryMojo.java
@@ -17,9 +17,7 @@
 package io.confluent.kafka.schemaregistry.maven;
 
 import com.google.inject.internal.util.Preconditions;
-
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-
 import org.apache.avro.Schema;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -30,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 @Mojo(name = "test-compatibility")
@@ -39,6 +38,9 @@ public class TestCompatibilitySchemaRegistryMojo extends SchemaRegistryMojo {
   Map<String, File> subjects = new HashMap<>();
 
   Map<String, Boolean> schemaCompatibility;
+
+  @Parameter(required = false)
+  List<String> imports;
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
@@ -91,5 +93,13 @@ public class TestCompatibilitySchemaRegistryMojo extends SchemaRegistryMojo {
     Preconditions.checkState(errorCount == 0,
                              "One or more schema was found to be incompatible with the current "
                              + "version.");
+  }
+
+  @Override
+  protected Schema.Parser newParser() {
+    if (imports == null || imports.isEmpty()) {
+      return super.newParser();
+    }
+    return parserWithDependencies(imports);
   }
 }

--- a/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/SchemasWithDependenciesTest.java
+++ b/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/SchemasWithDependenciesTest.java
@@ -1,0 +1,119 @@
+package io.confluent.kafka.schemaregistry.maven;
+
+import org.apache.avro.Schema;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SchemasWithDependenciesTest extends SchemaRegistryTest {
+
+    private final String dependency = "{\n" +
+            "  \"type\": \"record\",\n" +
+            "  \"namespace\": \"com.pizza\",\n" +
+            "  \"name\": \"Amount\",\n" +
+            "  \"fields\": [\n" +
+            "    {\n" +
+            "      \"name\": \"amount\",\n" +
+            "      \"type\": \"string\"\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"name\": \"currency\",\n" +
+            "      \"type\": \"string\"\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}";
+
+    private final String schema = "{\n" +
+            "  \"type\": \"record\",\n" +
+            "  \"namespace\": \"com.pizza\",\n" +
+            "  \"name\": \"Pizza\",\n" +
+            "  \"fields\": [\n" +
+            "    {\n" +
+            "      \"name\": \"name\",\n" +
+            "      \"type\": \"string\"\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"name\": \"cost\",\n" +
+            "      \"type\": \"com.pizza.Amount\"\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}";
+
+
+    @Test
+    public void testSchemaWithDependenciesRegister() throws IOException {
+        RegisterSchemaRegistryMojo schemaRegistryMojo = new RegisterSchemaRegistryMojo() {
+            @Override
+            public void execute() throws MojoExecutionException, MojoFailureException {
+
+            }
+        };
+
+        File pizzaFile = new File(tempDirectory, "pizza.avsc");
+        File amountFile = new File(tempDirectory, "amount.avsc");
+        try (
+                FileWriter pizzaWriter = new FileWriter(pizzaFile);
+                FileWriter amountWriter = new FileWriter(amountFile)
+        ) {
+            pizzaWriter.write(schema);
+            amountWriter.write(dependency);
+        }
+
+        ArrayList<String> imports = new ArrayList<>();
+        imports.add(amountFile.getAbsolutePath());
+        schemaRegistryMojo.imports = imports;
+
+        Map<String,File> schemas = new HashMap<>();
+        schemas.put("Pizza", pizzaFile);
+
+        Map<String, Schema> parsedSchemas = schemaRegistryMojo.loadSchemas(schemas);
+        Schema pizza = parsedSchemas.get("Pizza");
+
+        Assert.assertNotNull("The schema should've been generated", pizza);
+        Assert.assertTrue("The schema should contain fields from the dependency", pizza.toString().contains("currency"));
+    }
+
+    @Test
+    public void testSchemaWithDependencies() throws IOException {
+        TestCompatibilitySchemaRegistryMojo schemaRegistryMojo = new TestCompatibilitySchemaRegistryMojo() {
+            @Override
+            public void execute() throws MojoExecutionException, MojoFailureException {
+
+            }
+
+
+        };
+
+        File pizzaFile = new File(tempDirectory, "pizza.avsc");
+        File amountFile = new File(tempDirectory, "amount.avsc");
+        try (
+                FileWriter pizzaWriter = new FileWriter(pizzaFile);
+                FileWriter amountWriter = new FileWriter(amountFile)
+        ) {
+            pizzaWriter.write(schema);
+            amountWriter.write(dependency);
+        }
+
+        ArrayList<String> imports = new ArrayList<>();
+        imports.add(amountFile.getAbsolutePath());
+        schemaRegistryMojo.imports = imports;
+
+        Map<String,File> schemas = new HashMap<>();
+        schemas.put("Pizza", pizzaFile);
+
+        Map<String, Schema> parsedSchemas = schemaRegistryMojo.loadSchemas(schemas);
+        Schema pizza = parsedSchemas.get("Pizza");
+
+        Assert.assertNotNull("The schema should've been generated", pizza);
+        Assert.assertTrue("The schema should contain fields from the dependency", pizza.toString().contains("currency"));
+    }
+}


### PR DESCRIPTION


This code wraps the creation of a new Schema.Parser and if dependencies are specified it creates a new parser with dependencies.

I decided to create a new parser for each subject both for simplicity and to don't allow to have dependencies across subjects