### PR TITLE
Upgrade maven-plugin dependencies to 3.6 in 5.4.x (#1517)

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -24,14 +24,19 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.0</version>
+            <version>3.6.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.2</version>
+            <version>3.6.0</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
@@ -49,7 +54,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.6.0</version>
                 <configuration>
                     <goalPrefix>schema-registry</goalPrefix>
                 </configuration>

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/RegisterSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/RegisterSchemaRegistryMojo.java
@@ -16,10 +16,8 @@
 
 package io.confluent.kafka.schemaregistry.maven;
 
-import com.google.inject.internal.util.Preconditions;
-
+import com.google.common.base.Preconditions;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-
 import org.apache.avro.Schema;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/TestCompatibilitySchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/TestCompatibilitySchemaRegistryMojo.java
@@ -16,10 +16,8 @@
 
 package io.confluent.kafka.schemaregistry.maven;
 
-import com.google.inject.internal.util.Preconditions;
-
+import com.google.common.base.Preconditions;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-
 import org.apache.avro.Schema;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;


### PR DESCRIPTION
Backport of https://github.com/confluentinc/schema-registry/pull/1517


Conflicts: Use `com.google.common.base`

	maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/RegisterSchemaRegistryMojo.java
	maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/TestCompatibilitySchemaRegistryMojo.java