### PR TITLE
DGS-1653: Add configs properties for SR Maven Plugin

### DIFF
--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
@@ -49,6 +49,9 @@ public abstract class SchemaRegistryMojo extends AbstractMojo {
   @Parameter(required = false)
   List<String> schemaProviders = new ArrayList<>();
 
+  @Parameter
+  Map<String, String> sslConfigs = new HashMap<>();
+
   protected SchemaRegistryClient client;
 
   void client(SchemaRegistryClient client) {
@@ -63,6 +66,9 @@ public abstract class SchemaRegistryMojo extends AbstractMojo {
         // a single schema registry URL, so there is no additional utility of the URL source.
         config.put(SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO");
         config.put(SchemaRegistryClientConfig.USER_INFO_CONFIG, userInfoConfig);
+      }
+      if (sslConfigs != null && !sslConfigs.isEmpty()) {
+        config.putAll(sslConfigs);
       }
       List<SchemaProvider> providers = schemaProviders != null && !schemaProviders.isEmpty()
                                        ? schemaProviders()

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
@@ -50,7 +50,7 @@ public abstract class SchemaRegistryMojo extends AbstractMojo {
   List<String> schemaProviders = new ArrayList<>();
 
   @Parameter
-  Map<String, String> sslConfigs = new HashMap<>();
+  Map<String, String> configs = new HashMap<>();
 
   protected SchemaRegistryClient client;
 
@@ -67,8 +67,8 @@ public abstract class SchemaRegistryMojo extends AbstractMojo {
         config.put(SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO");
         config.put(SchemaRegistryClientConfig.USER_INFO_CONFIG, userInfoConfig);
       }
-      if (sslConfigs != null && !sslConfigs.isEmpty()) {
-        config.putAll(sslConfigs);
+      if (configs != null && !configs.isEmpty()) {
+        config.putAll(configs);
       }
       List<SchemaProvider> providers = schemaProviders != null && !schemaProviders.isEmpty()
                                        ? schemaProviders()

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
@@ -61,14 +61,14 @@ public abstract class SchemaRegistryMojo extends AbstractMojo {
   protected SchemaRegistryClient client() {
     if (null == this.client) {
       Map<String, String> config = new HashMap<>();
+      if (configs != null && !configs.isEmpty()) {
+        config.putAll(configs);
+      }
       if (userInfoConfig != null) {
         // Note that BASIC_AUTH_CREDENTIALS_SOURCE is not configurable as the plugin only supports
         // a single schema registry URL, so there is no additional utility of the URL source.
         config.put(SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO");
         config.put(SchemaRegistryClientConfig.USER_INFO_CONFIG, userInfoConfig);
-      }
-      if (configs != null && !configs.isEmpty()) {
-        config.putAll(configs);
       }
       List<SchemaProvider> providers = schemaProviders != null && !schemaProviders.isEmpty()
                                        ? schemaProviders()


### PR DESCRIPTION
The new added `configs` parameter can be used to specify any valid config for the `CachedSchemaRegistryClient`.

**Example usage**
To set up SSL, one can specify the keystore/truststore location by adding the following configuration to the maven plugin
```
<configuration>
  <configs>
    <schema.registry.ssl.keystore.location>path-to-keystore.jks</schema.registry.ssl.keystore.location>
    <schema.registry.ssl.keystore.password>password</schema.registry.ssl.keystore.password>
    <schema.registry.ssl.truststore.location>path-to-truststore.jks</schema.registry.ssl.truststore.location> 
    <schema.registry.ssl.truststore.password>password</schema.registry.ssl.truststore.password>
   </configs>
</configuration>
```


**Testing**
Done manual test