### PR TITLE
DGS-1658: Preserve field names when rendering Protobuf objects as JSON

### DIFF
--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaUtils.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaUtils.java
@@ -74,6 +74,7 @@ public class ProtobufSchemaUtils {
       return null;
     }
     String jsonString = JsonFormat.printer()
+        .preservingProtoFieldNames()
         .includingDefaultValueFields()
         .omittingInsignificantWhitespace()
         .print(message);

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/formatter/protobuf/ProtobufMessageFormatter.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/formatter/protobuf/ProtobufMessageFormatter.java
@@ -88,6 +88,7 @@ public class ProtobufMessageFormatter extends SchemaMessageFormatter<Message> {
     Message object = deserializer.deserialize(data);
     try {
       output.print(object == null ? null : JsonFormat.printer()
+          .preservingProtoFieldNames()
           .includingDefaultValueFields()
           .omittingInsignificantWhitespace()
           .print(object));


### PR DESCRIPTION
Preserving the field names that are in snake_case (currently it's automatically converted to camelCase which is confusing to users). This change only impacts kafka-protobuf-console-consumer.