### PR TITLE
#1914 - register all files in outputDirectory if no subjects provided

### DIFF
--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/UploadSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/UploadSchemaRegistryMojo.java
@@ -19,6 +19,8 @@ package io.confluent.kafka.schemaregistry.maven;
 import com.google.common.base.Preconditions;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+
+import org.apache.commons.compress.utils.FileNameUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -29,6 +31,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -36,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
@@ -45,6 +49,9 @@ import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientExcept
 public abstract class UploadSchemaRegistryMojo extends SchemaRegistryMojo {
 
   public static final String PERCENT_REPLACEMENT = "_x";
+
+  @Parameter(required = false)
+  File outputDirectory;
 
   @Parameter(required = true)
   Map<String, File> subjects = new HashMap<>();
@@ -74,6 +81,10 @@ public abstract class UploadSchemaRegistryMojo extends SchemaRegistryMojo {
 
     errors = 0;
     failures = 0;
+
+    if (subjects.size() == 0 && outputDirectory != null) {
+      subjects = Arrays.stream(outputDirectory.listFiles()).collect(Collectors.toMap(f -> FileNameUtils.getBaseName(f.getName()), f -> f));
+    }
 
     for (String subject : subjects.keySet()) {
       processSubject(subject, false);

--- a/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/RegisterSchemaRegistryMojoTest.java
+++ b/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/RegisterSchemaRegistryMojoTest.java
@@ -179,4 +179,31 @@ public class RegisterSchemaRegistryMojoTest extends SchemaRegistryTest {
     this.mojo.subjects = subjectToFile;
     this.mojo.execute();
   }
+
+  @Test
+  public void shouldTakeSchemasFromOutputDirectoryIfNoSubjectsProvided() throws IOException, MojoFailureException, MojoExecutionException {
+    Map<String, Integer> expectedVersions = new LinkedHashMap<>();
+
+    Map<String, File> subjectToFile = new LinkedHashMap<>();
+    int version = 1;
+    for (int i = 0; i < 2; i++) {
+      String keySubject = String.format("TestSubject%03d-key", i);
+      String valueSubject = String.format("TestSubject%03d-value", i);
+      Schema keySchema = Schema.create(Schema.Type.STRING);
+      Schema valueSchema = Schema.createUnion(Arrays.asList(Schema.create(Schema.Type.STRING), Schema.create(Schema.Type.NULL)));
+      File keySchemaFile = new File(this.tempDirectory, keySubject + ".avsc");
+      File valueSchemaFile = new File(this.tempDirectory, valueSubject + ".avsc");
+      writeSchema(keySchemaFile, keySchema);
+      writeSchema(valueSchemaFile, valueSchema);
+      subjectToFile.put(keySubject, keySchemaFile);
+      expectedVersions.put(keySubject, version);
+      subjectToFile.put(valueSubject, valueSchemaFile);
+      expectedVersions.put(valueSubject, version);
+    }
+
+    this.mojo.outputDirectory = this.tempDirectory;
+    this.mojo.execute();
+
+    Assert.assertThat(this.mojo.schemaVersions, IsEqual.equalTo(expectedVersions));
+  }
 }


### PR DESCRIPTION
fixes #1914 

for downloading schemas there is a "download them all" way by providing output directory and regex for schema names

but for registering them we need to type each and every to plugin configuration as subjects

will be so nice if there will be a way to register all schemas in output directory the same way as download works