### PR TITLE
DGS-1734: MockSchemaRegistryClient need to perform a correct deleteSchemaVersion

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -500,8 +500,19 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
       boolean isPermanent)
       throws IOException, RestClientException {
     if (versionCache.containsKey(subject)) {
-      versionCache.get(subject).values().remove(Integer.valueOf(version));
-      return 0;
+      Map<ParsedSchema, Integer> schemaVersionMap = versionCache.get(subject);
+      for (Map.Entry<ParsedSchema, Integer> entry : schemaVersionMap.entrySet()) {
+        if (entry.getValue().equals(Integer.valueOf(version))) {
+          if (schemaVersionMap.containsValue(Integer.valueOf(version))) {
+            schemaVersionMap.values().remove(entry.getValue());
+          }
+
+          if (isPermanent) {
+            idCache.get(subject).remove(entry.getValue());
+          }
+          return Integer.valueOf(version);
+        }
+      }
     }
     return -1;
   }


### PR DESCRIPTION
See github issue here: #1643
JIRA ticket: https://confluentinc.atlassian.net/browse/DGS-1734

Fixing deleteSchemaVersion in MockSchemaRegistryClient in order to mimic correct deletion behavior.