### PR TITLE
small fix in deleteSchemaVersion for MockSchemaRegistryClient

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -503,12 +503,11 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
       Map<ParsedSchema, Integer> schemaVersionMap = versionCache.get(subject);
       for (Map.Entry<ParsedSchema, Integer> entry : schemaVersionMap.entrySet()) {
         if (entry.getValue().equals(Integer.valueOf(version))) {
-          if (schemaVersionMap.containsValue(Integer.valueOf(version))) {
-            schemaVersionMap.values().remove(entry.getValue());
-          }
+          schemaVersionMap.values().remove(entry.getValue());
 
           if (isPermanent) {
             idCache.get(subject).remove(entry.getValue());
+            schemaCache.get(subject).remove(entry.getKey());
           }
           return Integer.valueOf(version);
         }


### PR DESCRIPTION
removing redundant check, and delete from schemaCache.