### PR TITLE
DGS-1737: MockSchemaRegistryClient doesn't generate new schema id with protobuf

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -52,8 +53,8 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
   private static final String WILDCARD = "*";
 
   private String defaultCompatibility = "BACKWARD";
-  private final Map<String, Map<ParsedSchema, Integer>> schemaCache;
-  private final Map<ParsedSchema, Integer> schemaIdCache;
+  private final Map<String, Map<WrappedParsedSchema, Integer>> schemaCache;
+  private final Map<WrappedParsedSchema, Integer> schemaIdCache;
   private final Map<String, Map<Integer, ParsedSchema>> idCache;
   private final Map<String, Map<ParsedSchema, Integer>> versionCache;
   private final Map<String, String> compatibilityCache;
@@ -66,7 +67,7 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   public MockSchemaRegistryClient(List<SchemaProvider> providers) {
-    schemaCache = new HashMap<String, Map<ParsedSchema, Integer>>();
+    schemaCache = new HashMap<String, Map<WrappedParsedSchema, Integer>>();
     schemaIdCache = new HashMap<>();
     idCache = new HashMap<String, Map<Integer, ParsedSchema>>();
     versionCache = new HashMap<String, Map<ParsedSchema, Integer>>();
@@ -84,6 +85,39 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
       provider.configure(schemaProviderConfigs);
     }
   }
+
+  private static class WrappedParsedSchema {
+    ParsedSchema parsedSchema;
+
+    public WrappedParsedSchema(ParsedSchema schema) {
+      this.parsedSchema = schema;
+    }
+
+    public ParsedSchema getParsedSchema() {
+      return this.parsedSchema;
+    }
+
+    @Override
+    public int hashCode() {
+      return parsedSchema.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+
+      WrappedParsedSchema that = (WrappedParsedSchema) o;
+      return Objects.equals(parsedSchema, that.parsedSchema)
+              && Objects.equals(parsedSchema.name(), that.parsedSchema.name());
+    }
+  }
+
 
   @Override
   public Optional<ParsedSchema> parseSchema(
@@ -123,10 +157,10 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
       idSchemaMap = new HashMap<Integer, ParsedSchema>();
     }
     if (registerRequest) {
-      Integer schemaId = schemaIdCache.get(schema);
+      Integer schemaId = schemaIdCache.get(new WrappedParsedSchema(schema));
       if (schemaId == null) {
         schemaId = id >= 0 ? id : ids.incrementAndGet();
-        schemaIdCache.put(schema, schemaId);
+        schemaIdCache.put(new WrappedParsedSchema(schema), schemaId);
       } else if (id >= 0 && id != schemaId) {
         throw new IllegalStateException("Schema already registered with id "
             + schemaId + " instead of input id " + id);
@@ -185,16 +219,16 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
   @Override
   public synchronized int register(String subject, ParsedSchema schema, int version, int id)
       throws IOException, RestClientException {
-    Map<ParsedSchema, Integer> schemaIdMap;
+    Map<WrappedParsedSchema, Integer> schemaIdMap;
     if (schemaCache.containsKey(subject)) {
       schemaIdMap = schemaCache.get(subject);
     } else {
-      schemaIdMap = new HashMap<ParsedSchema, Integer>();
+      schemaIdMap = new HashMap<WrappedParsedSchema, Integer>();
       schemaCache.put(subject, schemaIdMap);
     }
 
-    if (schemaIdMap.containsKey(schema)) {
-      int schemaId = schemaIdMap.get(schema);
+    if (schemaIdMap.containsKey(new WrappedParsedSchema(schema))) {
+      int schemaId = schemaIdMap.get(new WrappedParsedSchema(schema));
       if (id >= 0 && id != schemaId) {
         throw new IllegalStateException("Schema already registered with id "
             + schemaId + " instead of input id " + id);
@@ -202,7 +236,7 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
       return schemaId;
     } else {
       id = getIdFromRegistry(subject, schema, true, id);
-      schemaIdMap.put(schema, id);
+      schemaIdMap.put(new WrappedParsedSchema(schema), id);
       if (!idCache.get(null).containsKey(id)) {
         idCache.get(null).put(id, schema);
       }


### PR DESCRIPTION
Addressing the issue mentioned here: #1910
JIRA ticket here: https://confluentinc.atlassian.net/browse/DGS-1737

When two message types within one proto file are registered with MockSchemaRegistryClient, since the client only compares schema strings, the second register will be considered existing in the registry, while it is not (with different descriptors and names). So we're wrapping the ParsedSchema so that when we decide whether the schema exists in the registry, we compare both schema string and the name (in the example of https://github.com/khaelys/spring-kafka-protobuf-issue, the two schemas could be differentiated with name Message1 and Message2).

We're not adding name comparison to ProtobufSchema.equals() because many existing tests still require only comparing schema strings when looking up from versionCache.

Testing: locally tested with the use case from https://github.com/khaelys/spring-kafka-protobuf-issue to make it pass.