### PR TITLE
DGS-1820 Pass ObjectMapper to JSON Schema generator

### DIFF
--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaUtils.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaUtils.java
@@ -111,6 +111,15 @@ public class JsonSchemaUtils {
       SpecificationVersion specVersion,
       boolean useOneofForNullables,
       SchemaRegistryClient client) throws IOException {
+    return getSchema(object, specVersion, useOneofForNullables, jsonMapper, client);
+  }
+
+  public static JsonSchema getSchema(
+      Object object,
+      SpecificationVersion specVersion,
+      boolean useOneofForNullables,
+      ObjectMapper objectMapper,
+      SchemaRegistryClient client) throws IOException {
     if (object == null) {
       return null;
     }
@@ -158,7 +167,7 @@ public class JsonSchemaUtils {
         break;
     }
     config = config.withJsonSchemaDraft(draft);
-    JsonSchemaGenerator jsonSchemaGenerator = new JsonSchemaGenerator(jsonMapper, config);
+    JsonSchemaGenerator jsonSchemaGenerator = new JsonSchemaGenerator(objectMapper, config);
     JsonNode jsonSchema = jsonSchemaGenerator.generateJsonSchema(cls);
     return new JsonSchema(jsonSchema);
   }

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializer.java
@@ -87,7 +87,8 @@ public class KafkaJsonSchemaSerializer<T> extends AbstractKafkaJsonSchemaSeriali
 
   private JsonSchema getSchema(T record) {
     try {
-      return JsonSchemaUtils.getSchema(record, specVersion, oneofForNullables, schemaRegistry);
+      return JsonSchemaUtils.getSchema(
+          record, specVersion, oneofForNullables, objectMapper, schemaRegistry);
     } catch (IOException e) {
       throw new SerializationException(e);
     }

--- a/json-schema-serializer/src/test/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializerTest.java
+++ b/json-schema-serializer/src/test/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializerTest.java
@@ -144,11 +144,6 @@ public class KafkaJsonSchemaSerializerTest {
     @JsonProperty
     public Optional<String> nickName;
     @JsonProperty
-    @JsonSchemaInject(
-        // Ensure type of LocalDate is string
-        strings = {@JsonSchemaString(path = "type", value = "string")},
-        merge = false
-    )
     public LocalDate birthdate;
 
     public User() {}


### PR DESCRIPTION
This is to avoid having to use @SchemaInject to change
the types for date/datetime types.