### PR TITLE
DGS-1869 Reduce synchronization in CachedSchemaRegistryClient

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -301,6 +301,9 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   @Override
   public ParsedSchema getSchemaBySubjectAndId(String subject, int id)
       throws IOException, RestClientException {
+    if (subject == null) {
+      subject = NO_SUBJECT;
+    }
 
     final Map<Integer, ParsedSchema> idSchemaMap = idCache
         .computeIfAbsent(subject, k -> new ConcurrentHashMap<>());


### PR DESCRIPTION
Use the double-checked locking pattern with ConcurrentHashMap to reduce synchronization blocks.