### PR TITLE
DGS-1879 changed timeout parameter

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -98,8 +98,6 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
   public static final int MAX_VERSION = Integer.MAX_VALUE;
   private static final Logger log = LoggerFactory.getLogger(KafkaSchemaRegistry.class);
 
-  private static final long DESCRIBE_CLUSTER_TIMEOUT_MS = 10000L;
-
   private final SchemaRegistryConfig config;
   private final LookupCache<SchemaRegistryKey, SchemaRegistryValue> lookupCache;
   // visible for testing
@@ -978,7 +976,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, MasterAwareSchemaReg
       kafkaClusterId = adminClient
               .describeCluster()
               .clusterId()
-              .get(DESCRIBE_CLUSTER_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+              .get(initTimeout, TimeUnit.MILLISECONDS);
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       throw new SchemaRegistryException("Failed to get Kafka cluster ID", e);
     }


### PR DESCRIPTION
PR - DGS-1879 Fix 
[https://confluentinc.atlassian.net/browse/DGS-1879](url)

Changed hardcoded timeout parameter DESCRIBE_CLUSTER_TIMEOUT_MS that defaults to 10000 to initTimeout that takes the value of kafkastore.init.timeout.ms