### PR TITLE
Corrected Typo in ProtobufConverter and JsonSchemaConverter

### DIFF
--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverter.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverter.java
@@ -96,7 +96,8 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
       );
     } catch (InvalidConfigurationException e) {
       throw new ConfigException(
-          String.format("Failed to access Avro data from topic %s : %s", topic, e.getMessage())
+          String.format("Failed to access JSON Schema data from "
+                  + "topic %s : %s", topic, e.getMessage())
       );
     }
   }
@@ -122,7 +123,8 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
       );
     } catch (InvalidConfigurationException e) {
       throw new ConfigException(
-          String.format("Failed to access Avro data from topic %s : %s", topic, e.getMessage())
+          String.format("Failed to access JSON Schema data from "
+                  + "topic %s : %s", topic, e.getMessage())
       );
     }
   }

--- a/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufConverter.java
+++ b/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufConverter.java
@@ -102,7 +102,7 @@ public class ProtobufConverter implements Converter {
       ), e);
     } catch (InvalidConfigurationException e) {
       throw new ConfigException(
-          String.format("Failed to access Avro data from topic %s : %s", topic, e.getMessage())
+          String.format("Failed to access Protobuf data from topic %s : %s", topic, e.getMessage())
       );
     }
   }
@@ -133,7 +133,7 @@ public class ProtobufConverter implements Converter {
       ), e);
     } catch (InvalidConfigurationException e) {
       throw new ConfigException(
-          String.format("Failed to access Avro data from topic %s : %s", topic, e.getMessage())
+          String.format("Failed to access Protobuf data from topic %s : %s", topic, e.getMessage())
       );
     }
   }


### PR DESCRIPTION
- InvalidConfigurationException error message in ProtobufConverter and JsonSchemaConverter said "Failed to access Avro data"
- Corrected it to "Failed to access Protobuf data" and  "Failed to access JSON Schema data" respectively.


