### PR TITLE
Use protobuf.version from common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <kotlin.version>1.4.21</kotlin.version>
         <json-schema.version>1.12.2</json-schema.version>
-        <protobuf.version>3.17.3</protobuf.version>
         <proto-google-common-protos.version>2.3.2</proto-google-common-protos.version>
         <protoc.jar.maven.plugin.version>3.11.4</protoc.jar.maven.plugin.version>
         <wire.version>3.6.0</wire.version>


### PR DESCRIPTION
`protobuf.version` is now defined in the `common` repo