### PR TITLE
Fix default value for array of records

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -1927,8 +1927,12 @@ public class AvroData {
         }
         List<Object> result = new ArrayList<>(jsonValue.size());
         for (JsonNode elem : jsonValue) {
-          result.add(
-              defaultValueFromAvro(schema, avroSchema.getElementType(), elem, toConnectContext));
+          result.add(defaultValueFromAvro(
+              schema.valueSchema(),
+              avroSchema.getElementType(),
+              elem,
+              toConnectContext
+          ));
         }
         return result;
       }

--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -1927,12 +1927,9 @@ public class AvroData {
         }
         List<Object> result = new ArrayList<>(jsonValue.size());
         for (JsonNode elem : jsonValue) {
-          result.add(defaultValueFromAvro(
-              schema.valueSchema(),
-              avroSchema.getElementType(),
-              elem,
-              toConnectContext
-          ));
+          Object converted = defaultValueFromAvro(
+              schema.valueSchema(), avroSchema.getElementType(), elem, toConnectContext);
+          result.add(converted);
         }
         return result;
       }

--- a/avro-converter/src/test/avro/ArrayOfRecordsWithDefault.avsc
+++ b/avro-converter/src/test/avro/ArrayOfRecordsWithDefault.avsc
@@ -1,0 +1,35 @@
+{
+  "type": "record",
+  "name": "ArrayOfRecordsWithDefault",
+  "namespace": "com.connect.avro",
+  "fields": [
+    {
+      "name": "records",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "ArrayItem",
+          "namespace": "com.connect.avro",
+          "fields": [
+            {
+              "name": "itemName",
+              "type": "string"
+            }, {
+              "name": "itemValue",
+              "type": "string"
+            }, {
+              "name": "itemValueNullable",
+              "type": ["null", "string"],
+              "default": null
+            }
+          ]
+        }
+      },
+      "default": [
+        {"itemName": "item1", "itemValue": "value1"},
+        {"itemName": "item2", "itemValue": "value2"}
+      ]
+    }
+  ]
+}

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AdditionalAvroDataTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AdditionalAvroDataTest.java
@@ -10,6 +10,7 @@ import io.test.avro.union.FirstOption;
 import io.test.avro.union.MultiTypeUnionMessage;
 import io.test.avro.union.SecondOption;
 
+import java.util.List;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Parser;
 import org.apache.avro.generic.GenericData;
@@ -18,6 +19,7 @@ import org.apache.avro.reflect.ReflectData;
 import org.apache.avro.reflect.Union;
 import org.apache.avro.specific.SpecificData;
 import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -164,6 +166,30 @@ public class AdditionalAvroDataTest
         Object o = avroData.fromConnectData(schemaAndValue.schema(), schemaAndValue.value());
         Assert.assertEquals(obj ,o);
         avroData.fromConnectSchema(connectSchema);
+    }
+
+    @Test
+    public void testArrayOfRecordsWithDefaultValue() throws IOException
+    {
+        Schema avroSchema =
+            new Parser().parse(new File("src/test/avro/ArrayOfRecordsWithDefault.avsc"));
+
+        org.apache.kafka.connect.data.Schema connectSchema = avroData.toConnectSchema(avroSchema);
+
+        Object object = connectSchema.field("records").schema().defaultValue();
+
+        Assert.assertTrue(object instanceof List);
+
+        List arrayList = (List) object;
+        Assert.assertEquals(arrayList.size(), 2);
+
+        Struct item1 = (Struct) arrayList.get(0);
+        Assert.assertEquals(item1.get("itemName"), "item1");
+        Assert.assertEquals(item1.get("itemValue"), "value1");
+
+        Struct item2 = (Struct) arrayList.get(1);
+        Assert.assertEquals(item2.get("itemName"), "item2");
+        Assert.assertEquals(item2.get("itemValue"), "value2");
     }
 
     @Union({MyImpl1.class, MyImpl2.class})


### PR DESCRIPTION
I found this issue when testing the sink connector with an avro schema that has an array as one of its fields with default value.

This array field contains a list of RECORD type, I discovered that when setting default value for array item, it was passing the ARRAY as schema type for each array item. This will cause the next recursive call to fail at creating array item as RECORD type using Struct.

The fix is simple, just use valueSchema() instead.

In our company we are still using 5.1.4 release version of this lib, it'd be great to release the fix if this PR is approved.

I've added an issue with more details: https://github.com/confluentinc/schema-registry/issues/2037