### PR TITLE
Changes to log version and commitId when the schema registry service comes up in CP

### DIFF
--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -1,53 +1,144 @@
----
-swagger: "2.0"
+openapi: 3.0.1
 info:
-  version: "v1"
-  title: "Confluent Schema Registry"
-schemes:
-- "http"
-- "https"
+  title: Confluent Schema Registry
+  version: v1
 paths:
+  /compatibility/subjects/{subject}/versions/{version}:
+    post:
+      summary: Test input schema against a particular version of a subject's schema
+        for compatibility.
+      description: "the compatibility level applied for the check is the configured\
+        \ compatibility level for the subject (http:get:: /config/(string: subject)).\
+        \ If this subject's compatibility level was never changed, then the global\
+        \ compatibility level applies (http:get:: /config)."
+      operationId: testCompatibilityBySubjectName
+      parameters:
+      - name: Content-Type
+        in: header
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        schema:
+          type: string
+      - name: subject
+        in: path
+        description: Subject of the schema version against which compatibility is
+          to be tested
+        required: true
+        schema:
+          type: string
+      - name: version
+        in: path
+        description: "Version of the subject's schema against which compatibility\
+          \ is to be tested. Valid values for versionId are between [1,2^31-1] or\
+          \ the string \"latest\".\"latest\" checks compatibility of the input schema\
+          \ with the last registered schema under the specified subject"
+        required: true
+        schema:
+          type: string
+      - name: verbose
+        in: query
+        schema:
+          type: boolean
+      requestBody:
+        description: Schema
+        content:
+          application/vnd.schemaregistry.v1+json:
+            schema:
+              $ref: '#/components/schemas/RegisterSchemaRequest'
+          application/vnd.schemaregistry+json:
+            schema:
+              $ref: '#/components/schemas/RegisterSchemaRequest'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterSchemaRequest'
+          application/octet-stream:
+            schema:
+              $ref: '#/components/schemas/RegisterSchemaRequest'
+        required: true
+      responses:
+        default:
+          content:
+            application/vnd.schemaregistry.v1+json:
+              schema:
+                $ref: '#/components/schemas/CompatibilityCheckResponse'
+            application/vnd.schemaregistry+json; qs=0.9:
+              schema:
+                $ref: '#/components/schemas/CompatibilityCheckResponse'
+            application/json; qs=0.5:
+              schema:
+                $ref: '#/components/schemas/CompatibilityCheckResponse'
+        "404":
+          description: |-
+            Error code 40401 -- Subject not found
+            Error code 40402 -- Version not found
+        "422":
+          description: |-
+            Error code 42201 -- Invalid schema or schema type
+            Error code 42202 -- Invalid version
+        "500":
+          description: Error code 50001 -- Error in the backend data store
   /:
     get:
-      summary: "Schema Registry Root Resource"
-      description: "The Root resource is a no-op."
-      operationId: "get"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
-      parameters: []
+      summary: Schema Registry Root Resource
+      description: The Root resource is a no-op.
+      operationId: get
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "object"
-            additionalProperties:
-              type: "object"
+        default:
+          content:
+            application/vnd.schemaregistry.v1+json:
+              schema:
+                type: string
+            application/vnd.schemaregistry+json; qs=0.9:
+              schema:
+                type: string
+            application/json; qs=0.5:
+              schema:
+                type: string
     post:
-      operationId: "post"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
-      parameters: []
+      operationId: post
+      requestBody:
+        content:
+          application/vnd.schemaregistry.v1+json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+          application/vnd.schemaregistry+json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+          application/octet-stream:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "object"
-            additionalProperties:
-              type: "string"
+        default:
+          description: default response
+          content:
+            application/vnd.schemaregistry.v1+json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+            application/vnd.schemaregistry+json; qs=0.9:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+            application/json; qs=0.5:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
   /compatibility/subjects/{subject}/versions:
     post:
       summary: "Test input schema against a subject's schemas for compatibility, based\
@@ -57,807 +148,608 @@ paths:
         \ compatibility level for the subject (http:get:: /config/(string: subject)).\
         \ If this subject's compatibility level was never changed, then the global\
         \ compatibility level applies (http:get:: /config)."
-      operationId: "testCompatibilityForSubject"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
+      operationId: testCompatibilityForSubject
       parameters:
-      - name: "Content-Type"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "Accept"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "subject"
-        in: "path"
-        description: "Subject of the schema version against which compatibility is\
-          \ to be tested"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "body"
-        description: "Schema"
+      - name: Content-Type
+        in: header
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        schema:
+          type: string
+      - name: subject
+        in: path
+        description: Subject of the schema version against which compatibility is
+          to be tested
         required: true
         schema:
-          $ref: "#/definitions/RegisterSchemaRequest"
-      - name: "verbose"
-        in: "query"
-        required: false
-        type: "boolean"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/CompatibilityCheckResponse"
-        422:
-          description: "Error code 42201 -- Invalid schema or schema type\nError code\
-            \ 42202 -- Invalid version"
-        500:
-          description: "Error code 50001 -- Error in the backend data store"
-  /compatibility/subjects/{subject}/versions/{version}:
-    post:
-      summary: "Test input schema against a particular version of a subject's schema\
-        \ for compatibility."
-      description: "the compatibility level applied for the check is the configured\
-        \ compatibility level for the subject (http:get:: /config/(string: subject)).\
-        \ If this subject's compatibility level was never changed, then the global\
-        \ compatibility level applies (http:get:: /config)."
-      operationId: "testCompatibilityBySubjectName"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
-      parameters:
-      - name: "Content-Type"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "Accept"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "subject"
-        in: "path"
-        description: "Subject of the schema version against which compatibility is\
-          \ to be tested"
-        required: true
-        type: "string"
-      - name: "version"
-        in: "path"
-        description: "Version of the subject's schema against which compatibility\
-          \ is to be tested. Valid values for versionId are between [1,2^31-1] or\
-          \ the string \"latest\".\"latest\" checks compatibility of the input schema\
-          \ with the last registered schema under the specified subject"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "body"
-        description: "Schema"
-        required: true
+          type: string
+      - name: verbose
+        in: query
         schema:
-          $ref: "#/definitions/RegisterSchemaRequest"
-      - name: "verbose"
-        in: "query"
-        required: false
-        type: "boolean"
+          type: boolean
+      requestBody:
+        description: Schema
+        content:
+          application/vnd.schemaregistry.v1+json:
+            schema:
+              $ref: '#/components/schemas/RegisterSchemaRequest'
+          application/vnd.schemaregistry+json:
+            schema:
+              $ref: '#/components/schemas/RegisterSchemaRequest'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterSchemaRequest'
+          application/octet-stream:
+            schema:
+              $ref: '#/components/schemas/RegisterSchemaRequest'
+        required: true
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/CompatibilityCheckResponse"
-        404:
-          description: "Error code 40401 -- Subject not found\nError code 40402 --\
-            \ Version not found"
-        422:
-          description: "Error code 42201 -- Invalid schema or schema type\nError code\
-            \ 42202 -- Invalid version"
-        500:
-          description: "Error code 50001 -- Error in the backend data store"
+        default:
+          content:
+            application/vnd.schemaregistry.v1+json:
+              schema:
+                $ref: '#/components/schemas/CompatibilityCheckResponse'
+            application/vnd.schemaregistry+json; qs=0.9:
+              schema:
+                $ref: '#/components/schemas/CompatibilityCheckResponse'
+            application/json; qs=0.5:
+              schema:
+                $ref: '#/components/schemas/CompatibilityCheckResponse'
+        "422":
+          description: |-
+            Error code 42201 -- Invalid schema or schema type
+            Error code 42202 -- Invalid version
+        "500":
+          description: Error code 50001 -- Error in the backend data store
   /config:
     get:
-      summary: "Get global compatibility level."
-      description: ""
-      operationId: "getTopLevelConfig"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
-      parameters: []
+      summary: Get global compatibility level.
+      operationId: getTopLevelConfig
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Config"
-        500:
-          description: "Error code 50001 -- Error in the backend data store"
+        "500":
+          description: Error code 50001 -- Error in the backend data store
     put:
-      summary: "Update global compatibility level."
-      description: ""
-      operationId: "updateTopLevelConfig"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
-      parameters:
-      - in: "body"
-        name: "body"
-        description: "Config Update Request"
+      summary: Update global compatibility level.
+      operationId: updateTopLevelConfig
+      requestBody:
+        description: Config Update Request
+        content:
+          application/vnd.schemaregistry.v1+json:
+            schema:
+              $ref: '#/components/schemas/ConfigUpdateRequest'
+          application/vnd.schemaregistry+json:
+            schema:
+              $ref: '#/components/schemas/ConfigUpdateRequest'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConfigUpdateRequest'
+          application/octet-stream:
+            schema:
+              $ref: '#/components/schemas/ConfigUpdateRequest'
         required: true
-        schema:
-          $ref: "#/definitions/ConfigUpdateRequest"
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/ConfigUpdateRequest"
-        422:
-          description: "Error code 42203 -- Invalid compatibility level"
-        500:
-          description: "Error code 50001 -- Error in the backend data store\nError\
-            \ code 50003 -- Error while forwarding the request to the primary\n"
+        "422":
+          description: Error code 42203 -- Invalid compatibility level
+        "500":
+          description: |
+            Error code 50001 -- Error in the backend data store
+            Error code 50003 -- Error while forwarding the request to the primary
   /config/{subject}:
     get:
-      summary: "Get compatibility level for a subject."
-      description: ""
-      operationId: "getSubjectLevelConfig"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
+      summary: Get compatibility level for a subject.
+      operationId: getSubjectLevelConfig
       parameters:
-      - name: "subject"
-        in: "path"
-        required: true
-        type: "string"
-      - name: "defaultToGlobal"
-        in: "query"
-        required: false
-        type: "boolean"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Config"
-        404:
-          description: "Subject not found"
-        500:
-          description: "Error code 50001 -- Error in the backend data store"
-    put:
-      summary: "Update compatibility level for the specified subject."
-      description: ""
-      operationId: "updateSubjectLevelConfig"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
-      parameters:
-      - name: "subject"
-        in: "path"
-        description: "Name of the Subject"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "body"
-        description: "Config Update Request"
+      - name: subject
+        in: path
         required: true
         schema:
-          $ref: "#/definitions/ConfigUpdateRequest"
+          type: string
+      - name: defaultToGlobal
+        in: query
+        schema:
+          type: boolean
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/ConfigUpdateRequest"
-        422:
-          description: "Error code 42203 -- Invalid compatibility level\nError code\
-            \ 40402 -- Version not found"
-        500:
-          description: "Error code 50001 -- Error in the backend data store\nError\
-            \ code 50003 -- Error while forwarding the request to the primary"
-    delete:
-      summary: "Deletes the specified subject-level compatibility level config and\
-        \ revert to the global default."
-      description: ""
-      operationId: "deleteSubjectConfig"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
+        "404":
+          description: Subject not found
+        "500":
+          description: Error code 50001 -- Error in the backend data store
+    put:
+      summary: Update compatibility level for the specified subject.
+      operationId: updateSubjectLevelConfig
       parameters:
-      - name: "subject"
-        in: "path"
-        description: "the name of the subject"
+      - name: subject
+        in: path
+        description: Name of the Subject
         required: true
-        type: "string"
+        schema:
+          type: string
+      requestBody:
+        description: Config Update Request
+        content:
+          application/vnd.schemaregistry.v1+json:
+            schema:
+              $ref: '#/components/schemas/ConfigUpdateRequest'
+          application/vnd.schemaregistry+json:
+            schema:
+              $ref: '#/components/schemas/ConfigUpdateRequest'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConfigUpdateRequest'
+          application/octet-stream:
+            schema:
+              $ref: '#/components/schemas/ConfigUpdateRequest'
+        required: true
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "string"
-            enum:
-            - "NONE"
-            - "BACKWARD"
-            - "BACKWARD_TRANSITIVE"
-            - "FORWARD"
-            - "FORWARD_TRANSITIVE"
-            - "FULL"
-            - "FULL_TRANSITIVE"
-        404:
-          description: "Error code 40401 -- Subject not found"
-        500:
-          description: "Error code 50001 -- Error in the backend datastore"
+        "422":
+          description: |-
+            Error code 42203 -- Invalid compatibility level
+            Error code 40402 -- Version not found
+        "500":
+          description: |-
+            Error code 50001 -- Error in the backend data store
+            Error code 50003 -- Error while forwarding the request to the primary
+    delete:
+      summary: Deletes the specified subject-level compatibility level config and
+        revert to the global default.
+      operationId: deleteSubjectConfig
+      parameters:
+      - name: subject
+        in: path
+        description: the name of the subject
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/vnd.schemaregistry.v1+json:
+              schema:
+                type: string
+                enum:
+                - NONE
+                - BACKWARD
+                - BACKWARD_TRANSITIVE
+                - FORWARD
+                - FORWARD_TRANSITIVE
+                - FULL
+                - FULL_TRANSITIVE
+            application/vnd.schemaregistry+json; qs=0.9:
+              schema:
+                type: string
+                enum:
+                - NONE
+                - BACKWARD
+                - BACKWARD_TRANSITIVE
+                - FORWARD
+                - FORWARD_TRANSITIVE
+                - FULL
+                - FULL_TRANSITIVE
+            application/json; qs=0.5:
+              schema:
+                type: string
+                enum:
+                - NONE
+                - BACKWARD
+                - BACKWARD_TRANSITIVE
+                - FORWARD
+                - FORWARD_TRANSITIVE
+                - FULL
+                - FULL_TRANSITIVE
+        "404":
+          description: Error code 40401 -- Subject not found
+        "500":
+          description: Error code 50001 -- Error in the backend datastore
   /contexts:
     get:
-      summary: "Get a list of contexts."
-      description: ""
-      operationId: "listContexts"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
-      parameters: []
+      summary: Get a list of contexts.
+      operationId: listContexts
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              type: "string"
-        500:
-          description: "Error code 50001 -- Error in the backend datastore"
+        "500":
+          description: Error code 50001 -- Error in the backend datastore
   /mode:
     get:
-      summary: "Get global mode."
-      description: ""
-      operationId: "getTopLevelMode"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
-      parameters: []
+      summary: Get global mode.
+      operationId: getTopLevelMode
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Mode"
-        500:
-          description: "Error code 50001 -- Error in the backend data store"
+        "500":
+          description: Error code 50001 -- Error in the backend data store
     put:
-      summary: "Update global mode."
-      description: ""
-      operationId: "updateTopLevelMode"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
+      summary: Update global mode.
+      operationId: updateTopLevelMode
       parameters:
-      - in: "body"
-        name: "body"
-        description: "Update Request"
-        required: true
+      - name: force
+        in: query
         schema:
-          $ref: "#/definitions/ModeUpdateRequest"
-      - name: "force"
-        in: "query"
-        required: false
-        type: "boolean"
+          type: boolean
+      requestBody:
+        description: Update Request
+        content:
+          application/vnd.schemaregistry.v1+json:
+            schema:
+              $ref: '#/components/schemas/ModeUpdateRequest'
+          application/vnd.schemaregistry+json:
+            schema:
+              $ref: '#/components/schemas/ModeUpdateRequest'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ModeUpdateRequest'
+          application/octet-stream:
+            schema:
+              $ref: '#/components/schemas/ModeUpdateRequest'
+        required: true
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/ModeUpdateRequest"
-        422:
-          description: "Error code 42204 -- Invalid mode\nError code 42205 -- Operation\
-            \ not permitted"
-        500:
-          description: "Error code 50001 -- Error in the backend data store\nError\
-            \ code 50003 -- Error while forwarding the request to the primary\nError\
-            \ code 50004 -- Unknown leader"
+        "422":
+          description: |-
+            Error code 42204 -- Invalid mode
+            Error code 42205 -- Operation not permitted
+        "500":
+          description: |-
+            Error code 50001 -- Error in the backend data store
+            Error code 50003 -- Error while forwarding the request to the primary
+            Error code 50004 -- Unknown leader
   /mode/{subject}:
     get:
-      summary: "Get mode for a subject."
-      description: ""
-      operationId: "getMode"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
+      summary: Get mode for a subject.
+      operationId: getMode
       parameters:
-      - name: "subject"
-        in: "path"
-        description: "Name of the Subject"
-        required: true
-        type: "string"
-      - name: "defaultToGlobal"
-        in: "query"
-        required: false
-        type: "boolean"
-      responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Mode"
-        404:
-          description: "Subject not found"
-        500:
-          description: "Error code 50001 -- Error in the backend data store"
-    put:
-      summary: "Update mode for the specified subject."
-      description: ""
-      operationId: "updateMode"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
-      parameters:
-      - name: "subject"
-        in: "path"
-        description: "Name of the Subject"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "body"
-        description: "Update Request"
+      - name: subject
+        in: path
+        description: Name of the Subject
         required: true
         schema:
-          $ref: "#/definitions/ModeUpdateRequest"
-      - name: "force"
-        in: "query"
-        required: false
-        type: "boolean"
+          type: string
+      - name: defaultToGlobal
+        in: query
+        schema:
+          type: boolean
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/ModeUpdateRequest"
-        422:
-          description: "Error code 42204 -- Invalid mode\nError code 42205 -- Operation\
-            \ not permitted"
-        500:
-          description: "Error code 50001 -- Error in the backend data store\nError\
-            \ code 50003 -- Error while forwarding the request to the primary\nError\
-            \ code 50004 -- Unknown leader"
-    delete:
-      summary: "Deletes the specified subject-level mode and revert to the global\
-        \ default."
-      description: ""
-      operationId: "deleteSubjectMode"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
+        "404":
+          description: Subject not found
+        "500":
+          description: Error code 50001 -- Error in the backend data store
+    put:
+      summary: Update mode for the specified subject.
+      operationId: updateMode
       parameters:
-      - name: "subject"
-        in: "path"
-        description: "the name of the subject"
+      - name: subject
+        in: path
+        description: Name of the Subject
         required: true
-        type: "string"
+        schema:
+          type: string
+      - name: force
+        in: query
+        schema:
+          type: boolean
+      requestBody:
+        description: Update Request
+        content:
+          application/vnd.schemaregistry.v1+json:
+            schema:
+              $ref: '#/components/schemas/ModeUpdateRequest'
+          application/vnd.schemaregistry+json:
+            schema:
+              $ref: '#/components/schemas/ModeUpdateRequest'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ModeUpdateRequest'
+          application/octet-stream:
+            schema:
+              $ref: '#/components/schemas/ModeUpdateRequest'
+        required: true
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "string"
-            enum:
-            - "READWRITE"
-            - "READONLY"
-            - "READONLY_OVERRIDE"
-            - "IMPORT"
-        404:
-          description: "Error code 40401 -- Subject not found"
-        500:
-          description: "Error code 50001 -- Error in the backend datastore"
+        "422":
+          description: |-
+            Error code 42204 -- Invalid mode
+            Error code 42205 -- Operation not permitted
+        "500":
+          description: |-
+            Error code 50001 -- Error in the backend data store
+            Error code 50003 -- Error while forwarding the request to the primary
+            Error code 50004 -- Unknown leader
+    delete:
+      summary: Deletes the specified subject-level mode and revert to the global default.
+      operationId: deleteSubjectMode
+      parameters:
+      - name: subject
+        in: path
+        description: the name of the subject
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/vnd.schemaregistry.v1+json:
+              schema:
+                type: string
+                enum:
+                - READWRITE
+                - READONLY
+                - READONLY_OVERRIDE
+                - IMPORT
+            application/vnd.schemaregistry+json; qs=0.9:
+              schema:
+                type: string
+                enum:
+                - READWRITE
+                - READONLY
+                - READONLY_OVERRIDE
+                - IMPORT
+            application/json; qs=0.5:
+              schema:
+                type: string
+                enum:
+                - READWRITE
+                - READONLY
+                - READONLY_OVERRIDE
+                - IMPORT
+        "404":
+          description: Error code 40401 -- Subject not found
+        "500":
+          description: Error code 50001 -- Error in the backend datastore
   /schemas:
     get:
-      summary: "Get the schemas."
-      description: ""
-      operationId: "getSchemas"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
+      summary: Get the schemas.
+      operationId: getSchemas
       parameters:
-      - name: "subjectPrefix"
-        in: "query"
-        required: false
-        type: "string"
-      - name: "deleted"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "latestOnly"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
-      - name: "offset"
-        in: "query"
-        required: false
-        type: "integer"
-        default: 0
-        format: "int32"
-      - name: "limit"
-        in: "query"
-        required: false
-        type: "integer"
-        default: -1
-        format: "int32"
+      - name: subjectPrefix
+        in: query
+        schema:
+          type: string
+          default: ""
+      - name: deleted
+        in: query
+        schema:
+          type: boolean
+          default: false
+      - name: latestOnly
+        in: query
+        schema:
+          type: boolean
+          default: false
+      - name: offset
+        in: query
+        schema:
+          type: integer
+          format: int32
+          default: 0
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          format: int32
+          default: -1
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/Schema"
-        500:
-          description: "Error code 50001 -- Error in the backend data store\n"
+        "500":
+          description: |
+            Error code 50001 -- Error in the backend data store
   /schemas/ids/{id}:
     get:
-      summary: "Get the schema string identified by the input ID."
-      description: ""
-      operationId: "getSchema"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
+      summary: Get the schema string identified by the input ID.
+      operationId: getSchema
       parameters:
-      - name: "id"
-        in: "path"
-        description: "Globally unique identifier of the schema"
+      - name: id
+        in: path
+        description: Globally unique identifier of the schema
         required: true
-        type: "integer"
-        format: "int32"
-      - name: "subject"
-        in: "query"
-        required: false
-        type: "string"
-      - name: "format"
-        in: "query"
-        required: false
-        type: "string"
-      - name: "fetchMaxId"
-        in: "query"
-        required: false
-        type: "boolean"
-        default: false
+        schema:
+          type: integer
+          format: int32
+      - name: subject
+        in: query
+        schema:
+          type: string
+      - name: format
+        in: query
+        schema:
+          type: string
+          default: ""
+      - name: fetchMaxId
+        in: query
+        schema:
+          type: boolean
+          default: false
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/SchemaString"
-        404:
-          description: "Error code 40403 -- Schema not found\n"
-        500:
-          description: "Error code 50001 -- Error in the backend data store\n"
+        "404":
+          description: |
+            Error code 40403 -- Schema not found
+        "500":
+          description: |
+            Error code 50001 -- Error in the backend data store
   /schemas/ids/{id}/subjects:
     get:
-      summary: "Get all the subjects associated with the input ID."
-      description: ""
-      operationId: "getSubjects"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
+      summary: Get all the subjects associated with the input ID.
+      operationId: getSubjects
       parameters:
-      - name: "id"
-        in: "path"
-        description: "Globally unique identifier of the schema"
+      - name: id
+        in: path
+        description: Globally unique identifier of the schema
         required: true
-        type: "integer"
-        format: "int32"
-      - name: "subject"
-        in: "query"
-        required: false
-        type: "string"
-      - name: "deleted"
-        in: "query"
-        required: false
-        type: "boolean"
+        schema:
+          type: integer
+          format: int32
+      - name: subject
+        in: query
+        schema:
+          type: string
+      - name: deleted
+        in: query
+        schema:
+          type: boolean
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              type: "string"
-            uniqueItems: true
-        404:
-          description: "Error code 40403 -- Schema not found\n"
-        500:
-          description: "Error code 50001 -- Error in the backend data store\n"
+        "404":
+          description: |
+            Error code 40403 -- Schema not found
+        "500":
+          description: |
+            Error code 50001 -- Error in the backend data store
   /schemas/ids/{id}/versions:
     get:
-      summary: "Get all the subject-version pairs associated with the input ID."
-      description: ""
-      operationId: "getVersions"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
+      summary: Get all the subject-version pairs associated with the input ID.
+      operationId: getVersions
       parameters:
-      - name: "id"
-        in: "path"
-        description: "Globally unique identifier of the schema"
+      - name: id
+        in: path
+        description: Globally unique identifier of the schema
         required: true
-        type: "integer"
-        format: "int32"
-      - name: "subject"
-        in: "query"
-        required: false
-        type: "string"
-      - name: "deleted"
-        in: "query"
-        required: false
-        type: "boolean"
+        schema:
+          type: integer
+          format: int32
+      - name: subject
+        in: query
+        schema:
+          type: string
+      - name: deleted
+        in: query
+        schema:
+          type: boolean
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              $ref: "#/definitions/SubjectVersion"
-        404:
-          description: "Error code 40403 -- Schema not found\n"
-        500:
-          description: "Error code 50001 -- Error in the backend data store\n"
+        "404":
+          description: |
+            Error code 40403 -- Schema not found
+        "500":
+          description: |
+            Error code 50001 -- Error in the backend data store
   /schemas/types:
     get:
-      summary: "Get the schema types supported by this registry."
-      description: ""
-      operationId: "getSchemaTypes"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
-      parameters: []
+      summary: Get the schema types supported by this registry.
+      operationId: getSchemaTypes
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              type: "string"
-            uniqueItems: true
-        500:
-          description: "Error code 50001 -- Error in the backend data store\n"
+        "500":
+          description: |
+            Error code 50001 -- Error in the backend data store
   /subjects:
     get:
-      summary: "Get a list of registered subjects."
-      description: ""
-      operationId: "list"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
+      summary: Get a list of registered subjects.
+      operationId: list
       parameters:
-      - name: "subjectPrefix"
-        in: "query"
-        required: false
-        type: "string"
-      - name: "deleted"
-        in: "query"
-        required: false
-        type: "boolean"
+      - name: subjectPrefix
+        in: query
+        schema:
+          type: string
+          default: ""
+      - name: deleted
+        in: query
+        schema:
+          type: boolean
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              type: "string"
-            uniqueItems: true
-        500:
-          description: "Error code 50001 -- Error in the backend datastore"
+        "500":
+          description: Error code 50001 -- Error in the backend datastore
   /subjects/{subject}:
     post:
       summary: "Check if a schema has already been registered under the specified\
         \ subject. If so, this returns the schema string along with its globally unique\
         \ identifier, its version under this subject and the subject name."
-      description: ""
-      operationId: "lookUpSchemaUnderSubject"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
+      operationId: lookUpSchemaUnderSubject
       parameters:
-      - name: "subject"
-        in: "path"
-        description: "Subject under which the schema will be registered"
-        required: true
-        type: "string"
-      - name: "deleted"
-        in: "query"
-        required: false
-        type: "boolean"
-      - in: "body"
-        name: "body"
-        description: "Schema"
+      - name: subject
+        in: path
+        description: Subject under which the schema will be registered
         required: true
         schema:
-          $ref: "#/definitions/RegisterSchemaRequest"
-      responses:
-        404:
-          description: "Error code 40401 -- Subject not found\nError code 40403 --\
-            \ Schema not found"
-        500:
-          description: "Internal server error"
-          schema:
-            $ref: "#/definitions/Schema"
-    delete:
-      summary: "Deletes the specified subject and its associated compatibility level\
-        \ if registered. It is recommended to use this API only when a topic needs\
-        \ to be recycled or in development environment."
-      description: ""
-      operationId: "deleteSubject"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
-      parameters:
-      - name: "subject"
-        in: "path"
-        description: "the name of the subject"
+          type: string
+      - name: deleted
+        in: query
+        schema:
+          type: boolean
+      requestBody:
+        description: Schema
+        content:
+          application/vnd.schemaregistry.v1+json:
+            schema:
+              $ref: '#/components/schemas/RegisterSchemaRequest'
+          application/vnd.schemaregistry+json:
+            schema:
+              $ref: '#/components/schemas/RegisterSchemaRequest'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterSchemaRequest'
+          application/octet-stream:
+            schema:
+              $ref: '#/components/schemas/RegisterSchemaRequest'
         required: true
-        type: "string"
-      - name: "permanent"
-        in: "query"
-        required: false
-        type: "boolean"
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              type: "integer"
-              format: "int32"
-        404:
-          description: "Error code 40401 -- Subject not found"
-        500:
-          description: "Error code 50001 -- Error in the backend datastore"
+        default:
+          content:
+            application/vnd.schemaregistry.v1+json:
+              schema:
+                $ref: '#/components/schemas/Schema'
+            application/vnd.schemaregistry+json; qs=0.9:
+              schema:
+                $ref: '#/components/schemas/Schema'
+            application/json; qs=0.5:
+              schema:
+                $ref: '#/components/schemas/Schema'
+        "404":
+          description: |-
+            Error code 40401 -- Subject not found
+            Error code 40403 -- Schema not found
+        "500":
+          description: Internal server error
+    delete:
+      summary: Deletes the specified subject and its associated compatibility level
+        if registered. It is recommended to use this API only when a topic needs to
+        be recycled or in development environment.
+      operationId: deleteSubject
+      parameters:
+      - name: subject
+        in: path
+        description: the name of the subject
+        required: true
+        schema:
+          type: string
+      - name: permanent
+        in: query
+        schema:
+          type: boolean
+      responses:
+        default:
+          content:
+            application/vnd.schemaregistry.v1+json:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: int32
+            application/vnd.schemaregistry+json; qs=0.9:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: int32
+            application/json; qs=0.5:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: int32
+        "404":
+          description: Error code 40401 -- Subject not found
+        "500":
+          description: Error code 50001 -- Error in the backend datastore
   /subjects/{subject}/versions:
     get:
-      summary: "Get a list of versions registered under the specified subject."
-      description: ""
-      operationId: "listVersions"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
+      summary: Get a list of versions registered under the specified subject.
+      operationId: listVersions
       parameters:
-      - name: "subject"
-        in: "path"
-        description: "Name of the Subject"
+      - name: subject
+        in: path
+        description: Name of the Subject
         required: true
-        type: "string"
-      - name: "deleted"
-        in: "query"
-        required: false
-        type: "boolean"
+        schema:
+          type: string
+      - name: deleted
+        in: query
+        schema:
+          type: boolean
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              type: "integer"
-              format: "int32"
-        404:
-          description: "Error code 40401 -- Subject not found"
-        500:
-          description: "Error code 50001 -- Error in the backend data store"
+        "404":
+          description: Error code 40401 -- Subject not found
+        "500":
+          description: Error code 50001 -- Error in the backend data store
     post:
       summary: "Register a new schema under the specified subject. If successfully\
         \ registered, this returns the unique identifier of this schema in the registry.\
@@ -874,87 +766,85 @@ paths:
         \ request will be forwarded to one of the instances designated as the primary.\
         \ If the primary is not available, the client will get an error code indicating\
         \ that the forwarding has failed."
-      description: ""
-      operationId: "register"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
+      operationId: register
       parameters:
-      - name: "subject"
-        in: "path"
-        description: "Name of the Subject"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "body"
-        description: "Schema"
+      - name: subject
+        in: path
+        description: Name of the Subject
         required: true
         schema:
-          $ref: "#/definitions/RegisterSchemaRequest"
+          type: string
+      requestBody:
+        description: Schema
+        content:
+          application/vnd.schemaregistry.v1+json:
+            schema:
+              $ref: '#/components/schemas/RegisterSchemaRequest'
+          application/vnd.schemaregistry+json:
+            schema:
+              $ref: '#/components/schemas/RegisterSchemaRequest'
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RegisterSchemaRequest'
+          application/octet-stream:
+            schema:
+              $ref: '#/components/schemas/RegisterSchemaRequest'
+        required: true
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/RegisterSchemaResponse"
-        409:
-          description: "Incompatible schema"
-        422:
-          description: "Error code 42201 -- Invalid schema or schema type"
-        500:
-          description: "Error code 50001 -- Error in the backend data store\nError\
-            \ code 50002 -- Operation timed out\nError code 50003 -- Error while forwarding\
-            \ the request to the primary"
+        default:
+          content:
+            application/vnd.schemaregistry.v1+json:
+              schema:
+                $ref: '#/components/schemas/RegisterSchemaResponse'
+            application/vnd.schemaregistry+json; qs=0.9:
+              schema:
+                $ref: '#/components/schemas/RegisterSchemaResponse'
+            application/json; qs=0.5:
+              schema:
+                $ref: '#/components/schemas/RegisterSchemaResponse'
+        "409":
+          description: Incompatible schema
+        "422":
+          description: Error code 42201 -- Invalid schema or schema type
+        "500":
+          description: |-
+            Error code 50001 -- Error in the backend data store
+            Error code 50002 -- Operation timed out
+            Error code 50003 -- Error while forwarding the request to the primary
   /subjects/{subject}/versions/{version}:
     get:
-      summary: "Get a specific version of the schema registered under this subject."
-      description: ""
-      operationId: "getSchemaByVersion"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
+      summary: Get a specific version of the schema registered under this subject.
+      operationId: getSchemaByVersion
       parameters:
-      - name: "subject"
-        in: "path"
-        description: "Name of the Subject"
+      - name: subject
+        in: path
+        description: Name of the Subject
         required: true
-        type: "string"
-      - name: "version"
-        in: "path"
+        schema:
+          type: string
+      - name: version
+        in: path
         description: "Version of the schema to be returned. Valid values for versionId\
           \ are between [1,2^31-1] or the string \"latest\". \"latest\" returns the\
           \ last registered schema under the specified subject. Note that there may\
           \ be a new latest schema that gets registered right after this request is\
           \ served."
         required: true
-        type: "string"
-      - name: "deleted"
-        in: "query"
-        required: false
-        type: "boolean"
+        schema:
+          type: string
+      - name: deleted
+        in: query
+        schema:
+          type: boolean
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Schema"
-        404:
-          description: "Error code 40401 -- Subject not found\nError code 40402 --\
-            \ Version not found"
-        422:
-          description: "Error code 42202 -- Invalid version"
-        500:
-          description: "Error code 50001 -- Error in the backend data store"
+        "404":
+          description: |-
+            Error code 40401 -- Subject not found
+            Error code 40402 -- Version not found
+        "422":
+          description: Error code 42202 -- Invalid version
+        "500":
+          description: Error code 50001 -- Error in the backend data store
     delete:
       summary: "Deletes a specific version of the schema registered under this subject.\
         \ This only deletes the version and the schema ID remains intact making it\
@@ -962,294 +852,247 @@ paths:
         \ to be used only in development environments or under extreme circumstances\
         \ where-in, its required to delete a previously registered schema for compatibility\
         \ purposes or re-register previously registered schema."
-      description: ""
-      operationId: "deleteSchemaVersion"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
+      operationId: deleteSchemaVersion
       parameters:
-      - name: "subject"
-        in: "path"
-        description: "Name of the Subject"
+      - name: subject
+        in: path
+        description: Name of the Subject
         required: true
-        type: "string"
-      - name: "version"
-        in: "path"
+        schema:
+          type: string
+      - name: version
+        in: path
         description: "Version of the schema to be returned. Valid values for versionId\
           \ are between [1,2^31-1] or the string \"latest\". \"latest\" returns the\
           \ last registered schema under the specified subject. Note that there may\
           \ be a new latest schema that gets registered right after this request is\
           \ served."
         required: true
-        type: "string"
-      - name: "permanent"
-        in: "query"
-        required: false
-        type: "boolean"
+        schema:
+          type: string
+      - name: permanent
+        in: query
+        schema:
+          type: boolean
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "integer"
-            format: "int32"
-        404:
-          description: "Error code 40401 -- Subject not found\nError code 40402 --\
-            \ Version not found"
-        422:
-          description: "Error code 42202 -- Invalid version"
-        500:
-          description: "Error code 50001 -- Error in the backend data store"
+        default:
+          content:
+            application/vnd.schemaregistry.v1+json:
+              schema:
+                type: integer
+                format: int32
+            application/vnd.schemaregistry+json; qs=0.9:
+              schema:
+                type: integer
+                format: int32
+            application/json; qs=0.5:
+              schema:
+                type: integer
+                format: int32
+        "404":
+          description: |-
+            Error code 40401 -- Subject not found
+            Error code 40402 -- Version not found
+        "422":
+          description: Error code 42202 -- Invalid version
+        "500":
+          description: Error code 50001 -- Error in the backend data store
   /subjects/{subject}/versions/{version}/referencedby:
     get:
-      summary: "Get the schemas that reference the specified schema."
-      description: ""
-      operationId: "getReferencedBy"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
+      summary: Get the schemas that reference the specified schema.
+      operationId: getReferencedBy
       parameters:
-      - name: "subject"
-        in: "path"
-        description: "Name of the Subject"
+      - name: subject
+        in: path
+        description: Name of the Subject
         required: true
-        type: "string"
-      - name: "version"
-        in: "path"
+        schema:
+          type: string
+      - name: version
+        in: path
         description: "Version of the schema to be returned. Valid values for versionId\
           \ are between [1,2^31-1] or the string \"latest\". \"latest\" returns the\
           \ last registered schema under the specified subject. Note that there may\
           \ be a new latest schema that gets registered right after this request is\
           \ served."
         required: true
-        type: "string"
+        schema:
+          type: string
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "array"
-            items:
-              type: "integer"
-              format: "int32"
-        404:
-          description: "Error code 40401 -- Subject not found\nError code 40402 --\
-            \ Version not found"
-        422:
-          description: "Error code 42202 -- Invalid version"
-        500:
-          description: "Error code 50001 -- Error in the backend data store"
+        "404":
+          description: |-
+            Error code 40401 -- Subject not found
+            Error code 40402 -- Version not found
+        "422":
+          description: Error code 42202 -- Invalid version
+        "500":
+          description: Error code 50001 -- Error in the backend data store
   /subjects/{subject}/versions/{version}/schema:
     get:
-      summary: "Get the schema for the specified version of this subject. The unescaped\
-        \ schema only is returned."
-      description: ""
-      operationId: "getSchemaOnly"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
+      summary: Get the schema for the specified version of this subject. The unescaped
+        schema only is returned.
+      operationId: getSchemaOnly
       parameters:
-      - name: "subject"
-        in: "path"
-        description: "Name of the Subject"
+      - name: subject
+        in: path
+        description: Name of the Subject
         required: true
-        type: "string"
-      - name: "version"
-        in: "path"
+        schema:
+          type: string
+      - name: version
+        in: path
         description: "Version of the schema to be returned. Valid values for versionId\
           \ are between [1,2^31-1] or the string \"latest\". \"latest\" returns the\
           \ last registered schema under the specified subject. Note that there may\
           \ be a new latest schema that gets registered right after this request is\
           \ served."
         required: true
-        type: "string"
-      - name: "deleted"
-        in: "query"
-        required: false
-        type: "boolean"
+        schema:
+          type: string
+      - name: deleted
+        in: query
+        schema:
+          type: boolean
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            type: "string"
-        404:
-          description: "Error code 40401 -- Subject not found\nError code 40402 --\
-            \ Version not found"
-        422:
-          description: "Error code 42202 -- Invalid version"
-        500:
-          description: "Error code 50001 -- Error in the backend data store"
+        "404":
+          description: |-
+            Error code 40401 -- Subject not found
+            Error code 40402 -- Version not found
+        "422":
+          description: Error code 42202 -- Invalid version
+        "500":
+          description: Error code 50001 -- Error in the backend data store
   /v1/metadata/id:
     get:
-      summary: "Get the server metadata"
-      description: ""
-      operationId: "getClusterId"
-      consumes:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json"
-      - "application/json"
-      - "application/octet-stream"
-      produces:
-      - "application/vnd.schemaregistry.v1+json"
-      - "application/vnd.schemaregistry+json; qs=0.9"
-      - "application/json; qs=0.5"
-      parameters: []
+      summary: Get the server metadata
+      operationId: getClusterId
       responses:
-        200:
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/ServerClusterId"
-        500:
-          description: "Error code 50001 -- Error in the backend data store\n"
-definitions:
-  CompatibilityCheckResponse:
-    type: "object"
-    properties:
-      is_compatible:
-        type: "boolean"
-      messages:
-        type: "array"
-        items:
-          type: "string"
-  Config:
-    type: "object"
-    properties:
-      compatibilityLevel:
-        type: "string"
-        description: "Compatability Level"
-        enum:
-        - "BACKWARD"
-        - "BACKWARD_TRANSITIVE"
-        - "FORWARD"
-        - "FORWARD_TRANSITIVE"
-        - "FULL"
-        - "FULL_TRANSITIVE"
-        - "NONE"
-  ConfigUpdateRequest:
-    type: "object"
-    properties:
-      compatibility:
-        type: "string"
-        description: "Compatability Level"
-        enum:
-        - "BACKWARD"
-        - "BACKWARD_TRANSITIVE"
-        - "FORWARD"
-        - "FORWARD_TRANSITIVE"
-        - "FULL"
-        - "FULL_TRANSITIVE"
-        - "NONE"
-  Mode:
-    type: "object"
-    properties:
-      mode:
-        type: "string"
-  ModeUpdateRequest:
-    type: "object"
-    properties:
-      mode:
-        type: "string"
-  RegisterSchemaRequest:
-    type: "object"
-    properties:
-      version:
-        type: "integer"
-        format: "int32"
-      id:
-        type: "integer"
-        format: "int32"
-      schemaType:
-        type: "string"
-      references:
-        type: "array"
-        items:
-          $ref: "#/definitions/SchemaReference"
-      schema:
-        type: "string"
-  RegisterSchemaResponse:
-    type: "object"
-    properties:
-      id:
-        type: "integer"
-        format: "int32"
-  Schema:
-    type: "object"
-    properties:
-      subject:
-        type: "string"
-      version:
-        type: "integer"
-        format: "int32"
-      id:
-        type: "integer"
-        format: "int32"
-      schemaType:
-        type: "string"
-      references:
-        type: "array"
-        items:
-          $ref: "#/definitions/SchemaReference"
-      schema:
-        type: "string"
-  SchemaReference:
-    type: "object"
-    properties:
-      name:
-        type: "string"
-      subject:
-        type: "string"
-      version:
-        type: "integer"
-        format: "int32"
-  SchemaString:
-    type: "object"
-    properties:
-      schemaType:
-        type: "string"
-        description: "Schema type"
-      schema:
-        type: "string"
-        description: "Schema string identified by the ID"
-      references:
-        type: "array"
-        description: "Schema references"
-        items:
-          $ref: "#/definitions/SchemaReference"
-      maxId:
-        type: "integer"
-        format: "int32"
-        description: "Maximum ID"
-  ServerClusterId:
-    type: "object"
-    properties:
-      scope:
-        type: "object"
-        readOnly: true
-        additionalProperties:
-          type: "object"
-      id:
-        type: "string"
-  SubjectVersion:
-    type: "object"
-    properties:
-      subject:
-        type: "string"
-      version:
-        type: "integer"
-        format: "int32"
+        "500":
+          description: |
+            Error code 50001 -- Error in the backend data store
+components:
+  schemas:
+    CompatibilityCheckResponse:
+      type: object
+      properties:
+        is_compatible:
+          type: boolean
+        messages:
+          type: array
+          items:
+            type: string
+    RegisterSchemaRequest:
+      type: object
+      properties:
+        version:
+          type: integer
+          format: int32
+        id:
+          type: integer
+          format: int32
+        schemaType:
+          type: string
+        references:
+          type: array
+          items:
+            $ref: '#/components/schemas/SchemaReference'
+        schema:
+          type: string
+    SchemaReference:
+      type: object
+      properties:
+        name:
+          type: string
+        subject:
+          type: string
+        version:
+          type: integer
+          format: int32
+    Config:
+      type: object
+      properties:
+        compatibilityLevel:
+          type: string
+          description: Compatability Level
+          enum:
+          - "BACKWARD, BACKWARD_TRANSITIVE, FORWARD, FORWARD_TRANSITIVE, FULL, FULL_TRANSITIVE,\
+            \ NONE"
+    ConfigUpdateRequest:
+      type: object
+      properties:
+        compatibility:
+          type: string
+          description: Compatability Level
+          enum:
+          - "BACKWARD, BACKWARD_TRANSITIVE, FORWARD, FORWARD_TRANSITIVE, FULL, FULL_TRANSITIVE,\
+            \ NONE"
+    Mode:
+      type: object
+      properties:
+        mode:
+          type: string
+    ModeUpdateRequest:
+      type: object
+      properties:
+        mode:
+          type: string
+    SchemaString:
+      type: object
+      properties:
+        schemaType:
+          type: string
+          description: Schema type
+        schema:
+          type: string
+          description: Schema string identified by the ID
+        references:
+          type: array
+          description: Schema references
+          items:
+            $ref: '#/components/schemas/SchemaReference'
+        maxId:
+          type: integer
+          description: Maximum ID
+          format: int32
+    Schema:
+      type: object
+      properties:
+        subject:
+          type: string
+        version:
+          type: integer
+          format: int32
+        id:
+          type: integer
+          format: int32
+        schemaType:
+          type: string
+        references:
+          type: array
+          items:
+            $ref: '#/components/schemas/SchemaReference'
+        schema:
+          type: string
+    SubjectVersion:
+      type: object
+      properties:
+        subject:
+          type: string
+        version:
+          type: integer
+          format: int32
+    ServerClusterId:
+      type: object
+      properties:
+        scope:
+          type: object
+          additionalProperties:
+            type: object
+        id:
+          type: string
+    RegisterSchemaResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryMain.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryMain.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 import io.confluent.rest.RestConfigException;
+import io.confluent.kafka.schemaregistry.utils.AppInfoParser;
 
 public class SchemaRegistryMain {
 
@@ -42,6 +43,8 @@ public class SchemaRegistryMain {
       Server server = app.createServer();
       server.start();
       log.info("Server started, listening for requests...");
+      log.info("Schema Registry version: {}", AppInfoParser.getVersion());
+      log.info("Schema Registry commitId: {}", AppInfoParser.getCommitId());
       server.join();
     } catch (RestConfigException e) {
       log.error("Server configuration failed: ", e);

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/test/MapReferences.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/test/MapReferences.java
@@ -99,7 +99,7 @@ public final class MapReferences {
   /**
    * Protobuf type {@code MapReferencesMessage}
    */
-  public  static final class MapReferencesMessage extends
+  public static final class MapReferencesMessage extends
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:MapReferencesMessage)
       MapReferencesMessageOrBuilder {
@@ -231,12 +231,14 @@ public final class MapReferences {
     /**
      * <code>repeated .AttributeFieldEntry map1 = 1;</code>
      */
+    @java.lang.Override
     public java.util.List<io.confluent.connect.protobuf.test.MapReferences.AttributeFieldEntry> getMap1List() {
       return map1_;
     }
     /**
      * <code>repeated .AttributeFieldEntry map1 = 1;</code>
      */
+    @java.lang.Override
     public java.util.List<? extends io.confluent.connect.protobuf.test.MapReferences.AttributeFieldEntryOrBuilder> 
         getMap1OrBuilderList() {
       return map1_;
@@ -244,18 +246,21 @@ public final class MapReferences {
     /**
      * <code>repeated .AttributeFieldEntry map1 = 1;</code>
      */
+    @java.lang.Override
     public int getMap1Count() {
       return map1_.size();
     }
     /**
      * <code>repeated .AttributeFieldEntry map1 = 1;</code>
      */
+    @java.lang.Override
     public io.confluent.connect.protobuf.test.MapReferences.AttributeFieldEntry getMap1(int index) {
       return map1_.get(index);
     }
     /**
      * <code>repeated .AttributeFieldEntry map1 = 1;</code>
      */
+    @java.lang.Override
     public io.confluent.connect.protobuf.test.MapReferences.AttributeFieldEntryOrBuilder getMap1OrBuilder(
         int index) {
       return map1_.get(index);
@@ -266,12 +271,14 @@ public final class MapReferences {
     /**
      * <code>repeated .AttributeFieldEntry map2 = 2;</code>
      */
+    @java.lang.Override
     public java.util.List<io.confluent.connect.protobuf.test.MapReferences.AttributeFieldEntry> getMap2List() {
       return map2_;
     }
     /**
      * <code>repeated .AttributeFieldEntry map2 = 2;</code>
      */
+    @java.lang.Override
     public java.util.List<? extends io.confluent.connect.protobuf.test.MapReferences.AttributeFieldEntryOrBuilder> 
         getMap2OrBuilderList() {
       return map2_;
@@ -279,18 +286,21 @@ public final class MapReferences {
     /**
      * <code>repeated .AttributeFieldEntry map2 = 2;</code>
      */
+    @java.lang.Override
     public int getMap2Count() {
       return map2_.size();
     }
     /**
      * <code>repeated .AttributeFieldEntry map2 = 2;</code>
      */
+    @java.lang.Override
     public io.confluent.connect.protobuf.test.MapReferences.AttributeFieldEntry getMap2(int index) {
       return map2_.get(index);
     }
     /**
      * <code>repeated .AttributeFieldEntry map2 = 2;</code>
      */
+    @java.lang.Override
     public io.confluent.connect.protobuf.test.MapReferences.AttributeFieldEntryOrBuilder getMap2OrBuilder(
         int index) {
       return map2_.get(index);
@@ -302,6 +312,7 @@ public final class MapReferences {
      * <code>.AttributeFieldEntry notAMap1 = 3;</code>
      * @return Whether the notAMap1 field is set.
      */
+    @java.lang.Override
     public boolean hasNotAMap1() {
       return notAMap1_ != null;
     }
@@ -309,12 +320,14 @@ public final class MapReferences {
      * <code>.AttributeFieldEntry notAMap1 = 3;</code>
      * @return The notAMap1.
      */
+    @java.lang.Override
     public io.confluent.connect.protobuf.test.MapReferences.AttributeFieldEntry getNotAMap1() {
       return notAMap1_ == null ? io.confluent.connect.protobuf.test.MapReferences.AttributeFieldEntry.getDefaultInstance() : notAMap1_;
     }
     /**
      * <code>.AttributeFieldEntry notAMap1 = 3;</code>
      */
+    @java.lang.Override
     public io.confluent.connect.protobuf.test.MapReferences.AttributeFieldEntryOrBuilder getNotAMap1OrBuilder() {
       return getNotAMap1();
     }
@@ -325,6 +338,7 @@ public final class MapReferences {
      * <code>.AttributeFieldEntry notAMap2 = 4;</code>
      * @return Whether the notAMap2 field is set.
      */
+    @java.lang.Override
     public boolean hasNotAMap2() {
       return notAMap2_ != null;
     }
@@ -332,12 +346,14 @@ public final class MapReferences {
      * <code>.AttributeFieldEntry notAMap2 = 4;</code>
      * @return The notAMap2.
      */
+    @java.lang.Override
     public io.confluent.connect.protobuf.test.MapReferences.AttributeFieldEntry getNotAMap2() {
       return notAMap2_ == null ? io.confluent.connect.protobuf.test.MapReferences.AttributeFieldEntry.getDefaultInstance() : notAMap2_;
     }
     /**
      * <code>.AttributeFieldEntry notAMap2 = 4;</code>
      */
+    @java.lang.Override
     public io.confluent.connect.protobuf.test.MapReferences.AttributeFieldEntryOrBuilder getNotAMap2OrBuilder() {
       return getNotAMap2();
     }
@@ -1600,7 +1616,7 @@ public final class MapReferences {
   /**
    * Protobuf type {@code AttributeFieldEntry}
    */
-  public  static final class AttributeFieldEntry extends
+  public static final class AttributeFieldEntry extends
       com.google.protobuf.GeneratedMessageV3 implements
       // @@protoc_insertion_point(message_implements:AttributeFieldEntry)
       AttributeFieldEntryOrBuilder {
@@ -1694,6 +1710,7 @@ public final class MapReferences {
      * <code>string key = 1;</code>
      * @return The key.
      */
+    @java.lang.Override
     public java.lang.String getKey() {
       java.lang.Object ref = key_;
       if (ref instanceof java.lang.String) {
@@ -1710,6 +1727,7 @@ public final class MapReferences {
      * <code>string key = 1;</code>
      * @return The bytes for key.
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getKeyBytes() {
       java.lang.Object ref = key_;
@@ -1730,6 +1748,7 @@ public final class MapReferences {
      * <code>string value = 2;</code>
      * @return The value.
      */
+    @java.lang.Override
     public java.lang.String getValue() {
       java.lang.Object ref = value_;
       if (ref instanceof java.lang.String) {
@@ -1746,6 +1765,7 @@ public final class MapReferences {
      * <code>string value = 2;</code>
      * @return The bytes for value.
      */
+    @java.lang.Override
     public com.google.protobuf.ByteString
         getValueBytes() {
       java.lang.Object ref = value_;


### PR DESCRIPTION
## What
DGS-1208: Schema Registry should log the version at start up
Added log messages to print the schema registry version and commitID.

## Testing
Tested the changes in CP and verified that the version and commitID are printed in the logs when the SR service comes up.