### PR TITLE
Changes to log version and commitId when the schema registry service starts up in CP

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryMain.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryMain.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 import io.confluent.rest.RestConfigException;
+import io.confluent.kafka.schemaregistry.utils.AppInfoParser;
 
 public class SchemaRegistryMain {
 
@@ -42,6 +43,8 @@ public class SchemaRegistryMain {
       Server server = app.createServer();
       server.start();
       log.info("Server started, listening for requests...");
+      log.info("Schema Registry version: {}", io.confluent.kafka.schemaregistry.utils.AppInfoParser.getVersion());
+      log.info("Schema Registry commitId: {}", io.confluent.kafka.schemaregistry.utils.AppInfoParser.getCommitId());
       server.join();
     } catch (RestConfigException e) {
       log.error("Server configuration failed: ", e);


### PR DESCRIPTION
## What
DGS-1208: Schema Registry should log the version at start up
Added log messages to print the schema registry version and commitID.

## Testing
Tested the changes in CP and verified that the version and commitID are printed in the logs when the SR service comes up.