### PR TITLE
Backport Netty version Override change.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -74,6 +74,17 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-codec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>com.101tec</groupId>


### PR DESCRIPTION
This is backport the same change applied to 6.2.x and later of SR.