### PR TITLE
Allow passing a specific class when creating a KafkaJsonSchemaSerde with a client (in tests)

### DIFF
--- a/json-schema-serde/src/main/java/io/confluent/kafka/streams/serdes/json/KafkaJsonSchemaSerde.java
+++ b/json-schema-serde/src/main/java/io/confluent/kafka/streams/serdes/json/KafkaJsonSchemaSerde.java
@@ -53,11 +53,19 @@ public class KafkaJsonSchemaSerde<T> implements Serde<T> {
    * For testing purposes only.
    */
   public KafkaJsonSchemaSerde(final SchemaRegistryClient client) {
+    this(client, null);
+  }
+
+  /**
+   * For testing purposes only.
+   */
+  public KafkaJsonSchemaSerde(final SchemaRegistryClient client, final Class<T> specificClass) {
     if (client == null) {
       throw new IllegalArgumentException("schema registry client must not be null");
     }
+    this.specificClass = specificClass;
     inner = Serdes.serdeFrom(new KafkaJsonSchemaSerializer<>(client),
-        new KafkaJsonSchemaDeserializer<>(client));
+            new KafkaJsonSchemaDeserializer<>(client));
   }
 
   @Override

--- a/protobuf-serde/src/main/java/io/confluent/kafka/streams/serdes/protobuf/KafkaProtobufSerde.java
+++ b/protobuf-serde/src/main/java/io/confluent/kafka/streams/serdes/protobuf/KafkaProtobufSerde.java
@@ -54,11 +54,19 @@ public class KafkaProtobufSerde<T extends Message> implements Serde<T> {
    * For testing purposes only.
    */
   public KafkaProtobufSerde(final SchemaRegistryClient client) {
+    this(client, null);
+  }
+
+  /**
+   * For testing purposes only.
+   */
+  public KafkaProtobufSerde(final SchemaRegistryClient client, final Class<T> specificClass) {
     if (client == null) {
       throw new IllegalArgumentException("schema registry client must not be null");
     }
+    this.specificProtobufClass = specificClass;
     inner = Serdes.serdeFrom(new KafkaProtobufSerializer<>(client),
-        new KafkaProtobufDeserializer<>(client));
+            new KafkaProtobufDeserializer<>(client));
   }
 
   @Override


### PR DESCRIPTION
Hello,

I recently faced the following issue: 
In order to write a Kafka Streams test with topologytestdriver, I needed to create a ` KafkaJsonSchemaSerde`. 
The "real" production code uses: ` new KafkaJsonSchemaSerde(MyRecord.class)`.
For testing purposes, I need to mock the schemaRegistryClient, there's a constructor for that.
Unfortunately, there's no constructor with 2 parameters: the client, and the class.

This PR addresses this, adding another constructor "for testing only"

Some notes: 
- you can witness the "bug" (kindof) users can face by reverting the change in ` KafkaJsonSchemaSerde`  and running the `shouldLetTheAbilityToDeserializeToASpecificClass` test. The record will be deserialized as an empty map.
- In case people would face the same issue, and/or the issue would not be addressed, there's a hacky workaround I used: set `specificClass`  on your ` KafkaJsonSchemaSerde`  instance by reflection. (getClass -> getField -> set(instance, ...)). It's hacky but works.

