### PR TITLE
Backport PR2039 to 5.5.x branch

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -45,15 +45,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
-            <groupId>jakarta.ws.rs</groupId>
-            <artifactId>jakarta.ws.rs-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-common</artifactId>
-            <version>${jersey.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
             <scope>test</scope>

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -54,7 +54,6 @@ import java.util.Map;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
-import javax.ws.rs.core.UriBuilder;
 
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.CompatibilityCheckResponse;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.ConfigUpdateRequest;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/UriBuilder.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/UriBuilder.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.client.rest;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+class UriBuilder {
+
+  /**
+   * Escapes all characters but the allowed ones in path segments based on
+   * https://datatracker.ietf.org/doc/html/rfc3986.
+   */
+  static class UriPercentEncoder {
+    static final String CHARS_UNENCODE;
+    private static final BitSet UNENCODE;
+
+    static {
+      // 2.2. General delimiters
+      String gendelims = "@:";
+      // 2.2. Subdelimiters
+      String subdelims = "!$&\'()*+,;=";
+      // 2.3. Unreserved Characters
+      String alpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+      String unreserved = "-._~";
+
+      CHARS_UNENCODE = alpha + unreserved + gendelims + subdelims;
+
+      BitSet unencode = new BitSet(256);
+      for (int i = 0; i < CHARS_UNENCODE.length(); i++) {
+        unencode.set(CHARS_UNENCODE.charAt(i));
+      }
+      UNENCODE = unencode;
+    }
+
+    static String encode(String value, Charset charset) {
+      StringBuilder sb = new StringBuilder(value.length() * 2);
+      for (int i = 0; i < value.length(); i++) {
+        char c = value.charAt(i);
+        if (UNENCODE.get(c & 0xFF)) {
+          sb.append(c);
+        } else {
+          String hex = Integer.toHexString(c).toUpperCase();
+          if (hex.length() == 1) {
+            sb.append("%0").append(hex);
+          } else {
+            sb.append('%').append(hex);
+          }
+        }
+      }
+      return sb.toString();
+    }
+
+  }
+
+  private final String templatePath;
+
+  private StringBuilder queryParamString = new StringBuilder();
+  private final List<String> templateNames;
+
+  public UriBuilder(String templatePath) {
+    this.templatePath = Objects.requireNonNull(templatePath);
+    this.templateNames = findNamesInTemplate(templatePath);
+  }
+
+  public static UriBuilder fromPath(String path) {
+    return new UriBuilder(path);
+  }
+
+  public URI build(Object... templatePathValues) {
+
+    List<String> templateValues = Arrays.asList(templatePathValues).stream()
+        .map(o -> UriPercentEncoder.encode(String.valueOf(o), Charset.defaultCharset()))
+        .collect(Collectors.toList());
+    if (templateValues.size() != this.templateNames.size()) {
+      throw new IllegalArgumentException("Mismatched number of template variable names: expected "
+          + this.templateNames.size() + ", got " + templateValues.size());
+    }
+
+    String encodedPath = templatePath;
+    for (int i = 0; i < templateNames.size(); i++) {
+      encodedPath = encodedPath.replace(templateNames.get(i), templateValues.get(i));
+    }
+
+    if (queryParamString.length() > 0) {
+      if (encodedPath.indexOf('?') < 0) {
+        encodedPath += '?';
+      }
+      encodedPath += queryParamString;
+    }
+
+    try {
+      return new URI(encodedPath);
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  public UriBuilder queryParam(String paramName, String paramValue) {
+    if (queryParamString.length() > 0) {
+      queryParamString.append('&');
+    }
+    try {
+      queryParamString.append(encodeQueryParameter(paramName)).append('=')
+          .append(encodeQueryParameter(paramValue));
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalArgumentException(e);
+    }
+    return this;
+  }
+
+  public UriBuilder queryParam(String paramName, Integer paramValue) {
+    queryParam(paramName, String.valueOf(paramValue));
+    return this;
+  }
+
+  public UriBuilder queryParam(String paramName, boolean paramValue) {
+    queryParam(paramName, Boolean.toString(paramValue));
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    return templatePath;
+  }
+
+  static String encodeQueryParameter(String paramValue) throws UnsupportedEncodingException {
+    return URLEncoder.encode(paramValue, "UTF-8")
+        /*
+         * use percent-encoding which is supported everywhere as per RFC-3986, not
+         * legacy RFC-1866
+         */
+        .replace("+", "%20");
+  }
+
+  static final List<String> findNamesInTemplate(String path) {
+    int counter = 0;
+    List<String> templateNames = new ArrayList<>();
+    StringBuilder sb = null;
+    while (counter < path.length()) {
+      char c = path.charAt(counter++);
+      if (c == '{' && sb == null) {
+        sb = new StringBuilder();
+      }
+      if (sb != null) {
+        sb.append(c);
+      }
+      if (c == '}' && sb != null) {
+        templateNames.add(sb.toString());
+        sb = null;
+      }
+    }
+    return Collections.unmodifiableList(templateNames);
+  }
+}

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/UriBuilderTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/UriBuilderTest.java
@@ -1,0 +1,108 @@
+package io.confluent.kafka.schemaregistry.client.rest;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import io.confluent.kafka.schemaregistry.client.rest.UriBuilder.UriPercentEncoder;
+
+public class UriBuilderTest {
+  private static final Charset UTF8 = Charset.forName("UTF-8");
+
+  @Test
+  public void findTemplateNamesInPath() {
+    List<String> templateNames = UriBuilder
+        .findNamesInTemplate("https://some.host/{subject}/and/{version}/resource");
+    assertEquals(templateNames, Arrays.asList("{subject}", "{version}"));
+  }
+
+  @Test
+  public void encodeCommonPathSegmentChars() throws Exception {
+    assertEquals("%0A", UriPercentEncoder.encode("\n", UTF8));
+    assertEquals("%22", UriPercentEncoder.encode("\"", UTF8));
+    assertEquals("%25", UriPercentEncoder.encode("%", UTF8));
+    assertEquals("%3C", UriPercentEncoder.encode("<", UTF8));
+    assertEquals("%3E", UriPercentEncoder.encode(">", UTF8));
+    assertEquals("%5C", UriPercentEncoder.encode("\\", UTF8));
+    assertEquals("%5E", UriPercentEncoder.encode("^", UTF8));
+    assertEquals("%60", UriPercentEncoder.encode("`", UTF8));
+    assertEquals("%7B", UriPercentEncoder.encode("{", UTF8));
+    assertEquals("%7C", UriPercentEncoder.encode("|", UTF8));
+    assertEquals("%7D", UriPercentEncoder.encode("}", UTF8));
+    assertEquals("%3F", UriPercentEncoder.encode("?", UTF8));
+
+    assertEquals("foo%20bar%3F", UriPercentEncoder.encode("foo bar?", UTF8));
+  }
+
+  @Test
+  public void doNotEncodeAllowedPathSegmentChars() throws Exception {
+    for (char c : UriPercentEncoder.CHARS_UNENCODE.toCharArray()) {
+      String s = Character.toString(c);
+      assertEquals(s, UriPercentEncoder.encode(s, UTF8));
+    }
+  }
+
+  @Test
+  public void verifyPathSegmentPercentEncodingOfCharactersHandledDifferentlyInLegacyRFCs()
+      throws Exception {
+    assertEquals("+", UriPercentEncoder.encode("+", UTF8)); // do not encode subdelim + (RFC 3986)
+    assertEquals("%20", UriPercentEncoder.encode(" ", UTF8)); // do percent encode space (is supported in both path and query segments)
+    assertEquals("~", UriPercentEncoder.encode("~", UTF8)); // do not encode subdelim ~ (RFC 3986)
+    assertEquals("*", UriPercentEncoder.encode("*", UTF8)); // do not encode subdelim * (RFC 3986)
+  }
+
+  @Test
+  public void buildPathTemplateParameters() throws Exception {
+    UriBuilder uriBuilder = UriBuilder.fromPath("/some/site/{part}");
+    URI uri = uriBuilder.build("mypart");
+    assertEquals(uri, new URI("/some/site/mypart"));
+  }
+
+  @Test
+  public void buildEncodedPathTemplateParameters() throws Exception {
+    assertEquals(new URI("/some/site/my%20part"),
+        UriBuilder.fromPath("/some/site/{part}").build("my part"));
+
+    assertEquals(new URI("/some/site/my_part"),
+        UriBuilder.fromPath("/some/site/{part}").build("my_part"));
+
+    assertEquals(new URI("/some/site/my%3Cpart/more"),
+        UriBuilder.fromPath("/some/site/{part}/more").build("my<part"));
+
+    assertEquals(new URI("/some/site/my%2Fpart/more"),
+        UriBuilder.fromPath("/some/site/{part}/more").build("my/part"));
+  }
+
+  @Test
+  public void buildPathQueryParameters() throws Exception {
+    UriBuilder uriBuilder = UriBuilder.fromPath("/some/site");
+    uriBuilder.queryParam("first", "1");
+    uriBuilder.queryParam("second", 2);
+    assertEquals(uriBuilder.build(), new URI("/some/site?first=1&second=2"));
+  }
+
+  @Test
+  public void testApi() throws Exception {
+    String subject = "testTopic";
+    int version = 2;
+    UriBuilder builder = UriBuilder.fromPath("/subjects/{subject}/versions/{version}")
+        .queryParam("deleted", true);
+    String path = builder.build(subject, version).toString();
+
+    assertEquals(path, "/subjects/testTopic/versions/2?deleted=true");
+  }
+
+  @Test
+  public void checkEncodingOfSomeStandardSubjectTopicNames() throws Exception {
+    UriBuilder builder = UriBuilder.fromPath("/subjects/{subject}");
+    assertEquals("/subjects/my1.topic.name", builder.build("my1.topic.name").toString());
+    assertEquals("/subjects/another-topic-name", builder.build("another-topic-name").toString());
+    assertEquals("/subjects/My_topic_name", builder.build("My_topic_name").toString());
+  }
+
+}

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -45,8 +45,6 @@ import io.confluent.kafka.schemaregistry.testutil.MockSchemaRegistry;
 import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
 import io.confluent.kafka.serializers.subject.TopicNameStrategy;
 
-import javax.ws.rs.core.Response.Status.Family;
-
 /**
  * Common fields and helper methods for both the serializer and the deserializer.
  */
@@ -232,7 +230,7 @@ public abstract class AbstractKafkaSchemaSerDe {
   }
 
   protected static KafkaException toKafkaException(RestClientException e, String errorMessage) {
-    if (Family.familyOf(e.getErrorCode()) == Family.CLIENT_ERROR) {
+    if (e.getErrorCode() / 100 == 5 /* HTTP 500 Server Error */) {
       return new InvalidConfigurationException(e.getMessage());
     } else {
       return new SerializationException(errorMessage, e);


### PR DESCRIPTION
We're running into 2.33 and 2.34 jerseey incompatibilities with dropwizard, and saw that jersey-common was removed from schema-regsitry just recently. This is just a cherry-pick of that into 5.5.x branch

https://github.com/confluentinc/schema-registry/pull/2039