### PR TITLE
feat: Update wire-schema version to 4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <json-schema.version>1.12.2</json-schema.version>
         <proto-google-common-protos.version>2.5.1</proto-google-common-protos.version>
         <protoc.jar.maven.plugin.version>3.11.4</protoc.jar.maven.plugin.version>
-        <wire.version>3.7.1</wire.version>
+        <wire.version>4.0.0</wire.version>
         <swagger.version>2.1.10</swagger.version>
         <io.confluent.schema-registry.version>7.2.0-0</io.confluent.schema-registry.version>
         <commons.compress.version>1.21</commons.compress.version>
@@ -133,7 +133,18 @@
             </dependency>
             <dependency>
                 <groupId>com.squareup.wire</groupId>
-                <artifactId>wire-schema</artifactId>
+                <artifactId>wire-schema-jvm</artifactId>
+                <version>${wire.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-stdlib</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.wire</groupId>
+                <artifactId>wire-runtime-jvm</artifactId>
                 <version>${wire.version}</version>
                 <exclusions>
                     <exclusion>

--- a/protobuf-converter/pom.xml
+++ b/protobuf-converter/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>com.squareup.wire</groupId>
-            <artifactId>wire-schema</artifactId>
+            <artifactId>wire-schema-jvm</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/protobuf-provider/pom.xml
+++ b/protobuf-provider/pom.xml
@@ -34,7 +34,11 @@
         </dependency>
         <dependency>
             <groupId>com.squareup.wire</groupId>
-            <artifactId>wire-schema</artifactId>
+            <artifactId>wire-schema-jvm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.wire</groupId>
+            <artifactId>wire-runtime-jvm</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaUtils.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaUtils.java
@@ -649,6 +649,17 @@ public class ProtobufSchemaUtils {
         appendIndented(sb, v);
       }
       sb.append("]");
+    } else if (value instanceof OptionElement.OptionPrimitive) {
+      OptionElement.OptionPrimitive primitive = (OptionElement.OptionPrimitive)value;
+      switch (primitive.getKind()) {
+        case BOOLEAN:
+        case ENUM:
+        case NUMBER:
+          sb.append(primitive.getValue());
+          break;
+        default:
+          sb.append(formatOptionMapValue(primitive.getValue(), normalize));
+      }
     } else {
       sb.append(value);
     }

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -326,6 +326,43 @@ public class ProtobufSchemaTest {
   }
 
   @Test
+  public void testEnumOption() {
+    String optionSchemaString = "import \"google/protobuf/descriptor.proto\";\n"
+        + "enum FooParameterType {\n"
+        + "   NUMBER = 1;\n"
+        + "   STRING = 2;\n"
+        + "}\n"
+        + " \n"
+        + "message FooOptions {\n"
+        + "  optional string name = 1;\n"
+        + "  optional FooParameterType type = 2; \n"
+        + "} \n"
+        + "extend google.protobuf.MessageOptions {\n"
+        + "  repeated FooOptions foo = 12345;\n"
+        + "}\n"
+        + "\n"
+        + "message Message {\n"
+        + "  option (foo) = {\n"
+        + "    name: \"test\"\n"
+        + "    type: STRING\n"
+        + "  };\n"
+        + "  \n"
+        + "  option (foo) = {\n"
+        + "    name: \"test2\"\n"
+        + "    type: NUMBER\n"
+        + "  };\n"
+        + "  \n"
+        + "  optional int32 b = 2;\n"
+        + "}";
+
+    ProtobufSchema schema = new ProtobufSchema(optionSchemaString);
+    String parsed = schema.canonicalString();
+
+    assertTrue(parsed.contains("type: STRING"));
+    assertTrue(parsed.contains("type: NUMBER"));
+  }
+
+  @Test
   public void testRecordToJson() throws Exception {
     DynamicMessage.Builder builder = recordSchema.newMessageBuilder();
     Descriptor desc = builder.getDescriptorForType();


### PR DESCRIPTION
This PR updates the wire-schema and wire-schema runtime to 4.0.0 to improve the way options with enums are handled by the schema registry when the format is protobuf. Previously they were handled as strings instead of the original type definition. See these PRs for reference:

* https://github.com/square/wire/pull/2019
* https://github.com/square/wire/pull/2148