### PR TITLE
Exclude log4j2 dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -66,6 +66,16 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>confluent-log4j</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                </exclusion>
+            </exclusions>
        </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Excludes the log4j2 dependency pulled in by confluent-log4j.