### PR TITLE
avro-converter: guava dependency missing in kafka-connect-avro-converter package

### DIFF
--- a/avro-converter/pom.xml
+++ b/avro-converter/pom.xml
@@ -58,11 +58,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
The converter `confluentinc/kafka-connect-avro-converter:7.0.1` does not work on a plain Apache Kafka Connect 3.0 installation.

If `io.confluent.connect.avro.AvroConverter` is used as serializer, during the startup of the connector the following exception is thrown:

```
2021-12-16 20:04:57,111] ERROR Failed to start task http-source-0 (org.apache.kafka.connect.runtime.Worker)
java.lang.NoClassDefFoundError: com/google/common/base/Ticker
	at io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient.<init>(CachedSchemaRegistryClient.java:170)
	at io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient.<init>(CachedSchemaRegistryClient.java:153)
```

An analysis showed, that the Schema Registry client has a dependency to Guava. However, the Kafka Connect converter package does not contain the guava library:

```bash
λ ls -alh avro-converter/target/components/packages/confluentinc-kafka-connect-avro-converter-7.2.0-0/confluentinc-kafka-connect-avro-converter-7.2.0-0/lib
total 3,9M
drwxr-xr-x 2 ue ue 4,0K 16. Dez 20:54 .
drwxr-xr-x 5 ue ue 4,0K 16. Dez 20:54 ..
-rw-r--r-- 1 ue ue 576K  8. Aug 12:43 avro-1.10.1.jar
-rw-r--r-- 1 ue ue 995K  8. Aug 12:43 commons-compress-1.21.jar
-rw-r--r-- 1 ue ue  17K 16. Dez 20:38 common-utils-7.1.0-20211216.044205-104.jar
-rw-r--r-- 1 ue ue  74K  8. Aug 12:21 jackson-annotations-2.12.3.jar
-rw-r--r-- 1 ue ue 357K  8. Aug 12:21 jackson-core-2.12.3.jar
-rw-r--r-- 1 ue ue 1,5M  8. Aug 12:21 jackson-databind-2.12.3.jar
-rw-r--r-- 1 ue ue  31K 16. Dez 20:53 kafka-avro-serializer-7.2.0-0.jar
-rw-r--r-- 1 ue ue 8,5K 16. Dez 20:54 kafka-connect-avro-converter-7.2.0-0.jar
-rw-r--r-- 1 ue ue  44K 16. Dez 20:54 kafka-connect-avro-data-7.2.0-0.jar
-rw-r--r-- 1 ue ue 173K 16. Dez 20:53 kafka-schema-registry-client-7.2.0-0.jar
-rw-r--r-- 1 ue ue  32K 16. Dez 20:53 kafka-schema-serializer-7.2.0-0.jar
-rw-r--r-- 1 ue ue  41K  8. Aug 12:18 slf4j-api-1.7.30.jar
-rw-r--r-- 1 ue ue  34K  8. Aug 12:46 swagger-annotations-2.1.10.jar
```

It looks like, that the dependency was not added to the package, because the avro-converter Maven project also contains guava as test dependency. After this dependency was removed, the guava library was added to the Kafka Connect converter package:

```bash
λ ls -alh avro-converter/target/components/packages/confluentinc-kafka-connect-avro-converter-7.2.0-0/confluentinc-kafka-connect-avro-converter-7.2.0-0/lib
total 6,9M
drwxr-xr-x 2 ue ue 4,0K 16. Dez 20:56 .
drwxr-xr-x 5 ue ue 4,0K 16. Dez 20:56 ..
-rw-r--r-- 1 ue ue 576K  8. Aug 12:43 avro-1.10.1.jar
-rw-r--r-- 1 ue ue 226K  8. Aug 12:19 checker-qual-3.8.0.jar
-rw-r--r-- 1 ue ue 995K  8. Aug 12:43 commons-compress-1.21.jar
-rw-r--r-- 1 ue ue  17K 16. Dez 20:38 common-utils-7.1.0-20211216.044205-104.jar
-rw-r--r-- 1 ue ue  14K  8. Aug 12:19 error_prone_annotations-2.5.1.jar
-rw-r--r-- 1 ue ue 4,6K  8. Aug 12:19 failureaccess-1.0.1.jar
-rw-r--r-- 1 ue ue 2,8M  8. Aug 12:19 guava-30.1.1-jre.jar
-rw-r--r-- 1 ue ue 8,6K  8. Aug 12:19 j2objc-annotations-1.3.jar
-rw-r--r-- 1 ue ue  74K  8. Aug 12:21 jackson-annotations-2.12.3.jar
-rw-r--r-- 1 ue ue 357K  8. Aug 12:21 jackson-core-2.12.3.jar
-rw-r--r-- 1 ue ue 1,5M  8. Aug 12:21 jackson-databind-2.12.3.jar
-rw-r--r-- 1 ue ue  20K  8. Aug 12:16 jsr305-3.0.2.jar
-rw-r--r-- 1 ue ue  31K 16. Dez 20:53 kafka-avro-serializer-7.2.0-0.jar
-rw-r--r-- 1 ue ue 8,4K 16. Dez 20:56 kafka-connect-avro-converter-7.2.0-0.jar
-rw-r--r-- 1 ue ue  44K 16. Dez 20:54 kafka-connect-avro-data-7.2.0-0.jar
-rw-r--r-- 1 ue ue 173K 16. Dez 20:53 kafka-schema-registry-client-7.2.0-0.jar
-rw-r--r-- 1 ue ue  32K 16. Dez 20:53 kafka-schema-serializer-7.2.0-0.jar
-rw-r--r-- 1 ue ue 2,2K  8. Aug 12:19 listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
-rw-r--r-- 1 ue ue  41K  8. Aug 12:18 slf4j-api-1.7.30.jar
-rw-r--r-- 1 ue ue  34K  8. Aug 12:46 swagger-annotations-2.1.10.jar
```

Though this solution works, I would like to note, that a test of the avro-converter uses the guava library, too. The usage would now no longer be explicitly marked in the pom.xml file.
It's not exactly clear to me why Guava is no longer added to the Kafka Connect package when Guava is additionally listed as a test dependency, though it is still a dependency of the Schema Registry Client .
Maybe there is another issue with regards to packaging.