### PR TITLE
Fix compile error from KAFKA-13456 fix: effectiveAdvertisedListeners

### DIFF
--- a/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
@@ -144,7 +144,7 @@ public abstract class ClusterTestHarness {
     for(int i = 0; i < servers.size(); i++) {
       serverUrls[i] = getSecurityProtocol() + "://" +
                       Utils.formatAddress(
-                          servers.get(i).config().advertisedListeners().head().host(),
+                          servers.get(i).config().effectiveAdvertisedListeners().head().host(),
                           servers.get(i).boundPort(listenerType)
                       );
     }


### PR DESCRIPTION
https://github.com/apache/kafka/pull/11503 renamed `KafkaConfig.advertisedListeners` to `effectiveAdvertisedListeners`.  This patch fixes the resulting compile error in this downstream project.