### PR TITLE
DGS-2750 Add API to SchemaRegistryClient interface to get deleted subjects and schemas 

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -464,6 +464,17 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
     List<SchemaReference> references = response.getReferences();
     return new SchemaMetadata(id, version, schemaType, references, schema);
   }
+  @Override
+  public SchemaMetadata getSchemaMetadata(String subject, int version, boolean lookupDeletedSchema)
+      throws IOException, RestClientException {
+    io.confluent.kafka.schemaregistry.client.rest.entities.Schema response
+        = restService.getVersion(subject, version, lookupDeletedSchema);
+    int id = response.getId();
+    String schemaType = response.getSchemaType();
+    String schema = response.getSchema();
+    List<SchemaReference> references = response.getReferences();
+    return new SchemaMetadata(id, version, schemaType, references, schema);
+  }
 
   @Override
   public SchemaMetadata getLatestSchemaMetadata(String subject)
@@ -511,6 +522,12 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   public List<Integer> getAllVersions(String subject)
       throws IOException, RestClientException {
     return restService.getAllVersions(subject);
+  }
+  @Override
+  public List<Integer> getAllVersions(String subject, boolean lookupDeletedSchema)
+      throws IOException, RestClientException {
+    return restService.getAllVersions(RestService.DEFAULT_REQUEST_PROPERTIES,
+        subject,lookupDeletedSchema);
   }
 
   @Override
@@ -649,6 +666,12 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   @Override
   public Collection<String> getAllSubjects() throws IOException, RestClientException {
     return restService.getAllSubjects();
+  }
+
+  @Override
+  public Collection<String> getAllSubjects(boolean lookupDeletedSubject)
+      throws IOException, RestClientException {
+    return restService.getAllSubjects(lookupDeletedSubject);
   }
 
   @Override

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -529,7 +529,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   public List<Integer> getAllVersions(String subject, boolean lookupDeletedSchema)
       throws IOException, RestClientException {
     return restService.getAllVersions(RestService.DEFAULT_REQUEST_PROPERTIES,
-        subject,lookupDeletedSchema);
+        subject, lookupDeletedSchema);
   }
 
   @Override

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -464,6 +464,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
     List<SchemaReference> references = response.getReferences();
     return new SchemaMetadata(id, version, schemaType, references, schema);
   }
+
   @Override
   public SchemaMetadata getSchemaMetadata(String subject, int version, boolean lookupDeletedSchema)
       throws IOException, RestClientException {
@@ -523,6 +524,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
       throws IOException, RestClientException {
     return restService.getAllVersions(subject);
   }
+
   @Override
   public List<Integer> getAllVersions(String subject, boolean lookupDeletedSchema)
       throws IOException, RestClientException {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -137,9 +137,9 @@ public interface SchemaRegistryClient extends SchemaVersionFetcher {
       throws IOException, RestClientException;
 
   default SchemaMetadata getSchemaMetadata(String subject, int version,
-      boolean lookupDeletedSchema) throws IOException, RestClientException{
+      boolean lookupDeletedSchema) throws IOException, RestClientException {
     throw new UnsupportedOperationException();
-  };
+  }
 
   @Deprecated
   default int getVersion(String subject, org.apache.avro.Schema schema)
@@ -161,6 +161,7 @@ public interface SchemaRegistryClient extends SchemaVersionFetcher {
       throws IOException, RestClientException {
     throw new UnsupportedOperationException();
   }
+
   @Deprecated
   default boolean testCompatibility(String subject, org.apache.avro.Schema schema)
       throws IOException, RestClientException {
@@ -201,7 +202,7 @@ public interface SchemaRegistryClient extends SchemaVersionFetcher {
   public Collection<String> getAllSubjects() throws IOException, RestClientException;
 
   default Collection<String> getAllSubjects(boolean lookupDeletedSubject) throws IOException,
-      RestClientException{
+      RestClientException {
     throw new UnsupportedOperationException();
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -136,6 +136,11 @@ public interface SchemaRegistryClient extends SchemaVersionFetcher {
   public SchemaMetadata getSchemaMetadata(String subject, int version)
       throws IOException, RestClientException;
 
+  default SchemaMetadata getSchemaMetadata(String subject, int version,
+      boolean lookupDeletedSchema) throws IOException, RestClientException{
+    throw new UnsupportedOperationException();
+  };
+
   @Deprecated
   default int getVersion(String subject, org.apache.avro.Schema schema)
       throws IOException, RestClientException {
@@ -152,6 +157,10 @@ public interface SchemaRegistryClient extends SchemaVersionFetcher {
 
   public List<Integer> getAllVersions(String subject) throws IOException, RestClientException;
 
+  default List<Integer> getAllVersions(String subject, boolean lookupDeletedSchema)
+      throws IOException, RestClientException {
+    throw new UnsupportedOperationException();
+  }
   @Deprecated
   default boolean testCompatibility(String subject, org.apache.avro.Schema schema)
       throws IOException, RestClientException {
@@ -190,6 +199,11 @@ public interface SchemaRegistryClient extends SchemaVersionFetcher {
   }
 
   public Collection<String> getAllSubjects() throws IOException, RestClientException;
+
+  default Collection<String> getAllSubjects(boolean lookupDeletedSubject) throws IOException,
+      RestClientException{
+    throw new UnsupportedOperationException();
+  }
 
   default Collection<String> getAllSubjectsByPrefix(String subjectPrefix) throws IOException,
       RestClientException {


### PR DESCRIPTION
Added methods to SchemaRegistryClient Interface to get subjects, versions and metadata for soft deleted schemas as well.