### PR TITLE
DGS-2871 Add API to delete Global-level compatibility setting

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -631,7 +631,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
 
   @Override
   public void deleteCompatibility(String subject) throws IOException, RestClientException {
-    restService.deleteSubjectConfig(subject);
+    restService.deleteConfig(subject);
   }
 
   @Override

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -672,12 +672,12 @@ public class RestService implements Configurable {
     return config;
   }
 
-  public Config deleteSubjectConfig(String subject)
+  public Config deleteConfig(String subject)
       throws IOException, RestClientException {
-    return deleteSubjectConfig(DEFAULT_REQUEST_PROPERTIES, subject);
+    return deleteConfig(DEFAULT_REQUEST_PROPERTIES, subject);
   }
 
-  public Config deleteSubjectConfig(Map<String, String> requestProperties, String subject)
+  public Config deleteConfig(Map<String, String> requestProperties, String subject)
       throws IOException, RestClientException {
     String path = subject != null
         ? UriBuilder.fromPath("/config/{subject}").build(subject).toString() : "/config";

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -679,8 +679,8 @@ public class RestService implements Configurable {
 
   public Config deleteSubjectConfig(Map<String, String> requestProperties, String subject)
       throws IOException, RestClientException {
-    UriBuilder builder = UriBuilder.fromPath("/config/{subject}");
-    String path = builder.build(subject).toString();
+    String path = subject != null
+        ? UriBuilder.fromPath("/config/{subject}").build(subject).toString() : "/config";
 
     Config response = httpRequest(path, "DELETE", null, requestProperties,
         DELETE_SUBJECT_CONFIG_RESPONSE_TYPE);

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -236,6 +236,35 @@ paths:
           description: |
             Error code 50001 -- Error in the backend data store
             Error code 50003 -- Error while forwarding the request to the primary
+    delete:
+      summary: "Deletes the Global compatibility level config and\
+              \ revert to the global default."
+      description: ""
+      operationId: "deleteTopLevelConfig"
+      consumes:
+        - "application/vnd.schemaregistry.v1+json"
+        - "application/vnd.schemaregistry+json"
+        - "application/json"
+        - "application/octet-stream"
+      produces:
+        - "application/vnd.schemaregistry.v1+json"
+        - "application/vnd.schemaregistry+json; qs=0.9"
+        - "application/json; qs=0.5"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "string"
+            enum:
+              - "NONE"
+              - "BACKWARD"
+              - "BACKWARD_TRANSITIVE"
+              - "FORWARD"
+              - "FORWARD_TRANSITIVE"
+              - "FULL"
+              - "FULL_TRANSITIVE"
+        500:
+          description: "Error code 50001 -- Error in the backend datastore"
   /config/{subject}:
     get:
       summary: Get compatibility level for a subject.

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -202,7 +202,7 @@ public class ConfigResource {
   }
 
   @DELETE
-  @Operation(summary = "Deletes the specified Global-level compatibility level config and "
+  @Operation(summary = "Deletes the Global-level compatibility level config and "
       + "revert to the global default.", responses = {
         @ApiResponse(content = @Content(
             schema = @Schema(implementation = CompatibilityLevel.class))),

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -219,7 +219,7 @@ public class ConfigResource {
       CompatibilityLevel currentCompatibility = schemaRegistry.getCompatibilityLevel(null);
       Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
           headers, schemaRegistry.config().whitelistHeaders());
-      schemaRegistry.deleteSubjectCompatibilityConfigOrForward(null, headerProperties);
+      schemaRegistry.deleteCompatibilityConfigOrForward(null, headerProperties);
       deletedConfig = new Config(currentCompatibility.name);
     } catch (OperationNotPermittedException e) {
       throw Errors.operationNotPermittedException(e.getMessage());
@@ -262,7 +262,7 @@ public class ConfigResource {
 
       Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
           headers, schemaRegistry.config().whitelistHeaders());
-      schemaRegistry.deleteSubjectCompatibilityConfigOrForward(subject, headerProperties);
+      schemaRegistry.deleteCompatibilityConfigOrForward(subject, headerProperties);
       deletedConfig = new Config(currentCompatibility.name);
     } catch (OperationNotPermittedException e) {
       throw Errors.operationNotPermittedException(e.getMessage());

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -646,7 +646,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
             deleteMode(subject);
           }
           if (getCompatibilityLevel(subject) != null) {
-            deleteSubjectCompatibility(subject);
+            deleteCompatibility(subject);
           }
         }
       } else {
@@ -719,7 +719,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
           deleteMode(subject);
         }
         if (getCompatibilityLevel(subject) != null) {
-          deleteSubjectCompatibility(subject);
+          deleteCompatibility(subject);
         }
       } else {
         for (Integer version : deletedVersions) {
@@ -914,7 +914,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     }
   }
 
-  private void forwardDeleteSubjectCompatibilityConfigToLeader(
+  private void forwardDeleteCompatibilityConfigToLeader(
       Map<String, String> requestProperties,
       String subject
   ) throws SchemaRegistryRequestForwardingException {
@@ -923,7 +923,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     log.debug(String.format("Forwarding delete subject compatibility config request %s to %s",
         subject, baseUrl));
     try {
-      leaderRestService.deleteSubjectConfig(requestProperties, subject);
+      leaderRestService.deleteConfig(requestProperties, subject);
     } catch (IOException e) {
       throw new SchemaRegistryRequestForwardingException(
           String.format(
@@ -1454,32 +1454,32 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     }
   }
 
-  public void deleteSubjectCompatibilityConfig(String subject)
+  public void deleteCompatibilityConfig(String subject)
       throws SchemaRegistryStoreException, OperationNotPermittedException {
     if (isReadOnlyMode(subject)) {
       throw new OperationNotPermittedException("Subject " + subject + " is in read-only mode");
     }
     try {
       kafkaStore.waitUntilKafkaReaderReachesLastOffset(subject, kafkaStoreTimeoutMs);
-      deleteSubjectCompatibility(subject);
+      deleteCompatibility(subject);
     } catch (StoreException e) {
       throw new SchemaRegistryStoreException("Failed to delete subject config value from store",
           e);
     }
   }
 
-  public void deleteSubjectCompatibilityConfigOrForward(String subject,
+  public void deleteCompatibilityConfigOrForward(String subject,
                                                         Map<String, String> headerProperties)
       throws SchemaRegistryStoreException, SchemaRegistryRequestForwardingException,
       OperationNotPermittedException, UnknownLeaderException {
     kafkaStore.lockFor(subject).lock();
     try {
       if (isLeader()) {
-        deleteSubjectCompatibilityConfig(subject);
+        deleteCompatibilityConfig(subject);
       } else {
         // forward delete subject config request to the leader
         if (leaderIdentity != null) {
-          forwardDeleteSubjectCompatibilityConfigToLeader(headerProperties, subject);
+          forwardDeleteCompatibilityConfigToLeader(headerProperties, subject);
         } else {
           throw new UnknownLeaderException("Delete config request failed since leader is "
               + "unknown");
@@ -1581,7 +1581,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     this.kafkaStore.delete(modeKey);
   }
 
-  private void deleteSubjectCompatibility(String subject) throws StoreException {
+  private void deleteCompatibility(String subject) throws StoreException {
     ConfigKey configKey = new ConfigKey(subject);
     this.kafkaStore.delete(configKey);
   }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -39,6 +39,7 @@ import java.util.*;
 import java.net.URL;
 import java.net.HttpURLConnection;
 
+import static io.confluent.kafka.schemaregistry.CompatibilityLevel.BACKWARD;
 import static io.confluent.kafka.schemaregistry.CompatibilityLevel.FORWARD;
 import static io.confluent.kafka.schemaregistry.CompatibilityLevel.NONE;
 import static io.confluent.kafka.schemaregistry.utils.QualifiedSubject.DEFAULT_CONTEXT;
@@ -485,6 +486,33 @@ public class RestApiTest extends ClusterTestHarness {
         NONE.name,
         restApp.restClient
             .getConfig(RestService.DEFAULT_REQUEST_PROPERTIES, subject, true)
+            .getCompatibilityLevel());
+  }
+
+  @Test
+  public void testGlobalConfigChange() throws Exception{
+    assertEquals("Default compatibility level should be none for this test instance",
+        NONE.name,
+        restApp.restClient.getConfig(null).getCompatibilityLevel());
+
+    // change subject compatibility to forward
+    restApp.restClient.updateCompatibility(CompatibilityLevel.FORWARD.name, null);
+    assertEquals("New compatibility level for this subject should be forward",
+        FORWARD.name,
+        restApp.restClient.getConfig(null).getCompatibilityLevel());
+
+    // change subject compatibility to backward
+    restApp.restClient.updateCompatibility(BACKWARD.name, null);
+    assertEquals("New compatibility level for this subject should be forward",
+        BACKWARD.name,
+        restApp.restClient.getConfig(null).getCompatibilityLevel());
+
+    // delete Global compatibility
+    restApp.restClient.deleteSubjectConfig(null);
+    assertEquals("Compatibility level for this subject should be reverted to none",
+        NONE.name,
+        restApp.restClient
+            .getConfig(RestService.DEFAULT_REQUEST_PROPERTIES, null, true)
             .getCompatibilityLevel());
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -480,7 +480,7 @@ public class RestApiTest extends ClusterTestHarness {
                  restApp.restClient.getConfig(subject).getCompatibilityLevel());
 
     // delete subject compatibility
-    restApp.restClient.deleteSubjectConfig(subject);
+    restApp.restClient.deleteConfig(subject);
 
     assertEquals("Compatibility level for this subject should be reverted to none",
         NONE.name,
@@ -508,7 +508,7 @@ public class RestApiTest extends ClusterTestHarness {
         restApp.restClient.getConfig(null).getCompatibilityLevel());
 
     // delete Global compatibility
-    restApp.restClient.deleteSubjectConfig(null);
+    restApp.restClient.deleteConfig(null);
     assertEquals("Compatibility level for this subject should be reverted to none",
         NONE.name,
         restApp.restClient

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -497,19 +497,19 @@ public class RestApiTest extends ClusterTestHarness {
 
     // change subject compatibility to forward
     restApp.restClient.updateCompatibility(CompatibilityLevel.FORWARD.name, null);
-    assertEquals("New compatibility level for this subject should be forward",
+    assertEquals("New Global compatibility level should be forward",
         FORWARD.name,
         restApp.restClient.getConfig(null).getCompatibilityLevel());
 
     // change subject compatibility to backward
     restApp.restClient.updateCompatibility(BACKWARD.name, null);
-    assertEquals("New compatibility level for this subject should be forward",
+    assertEquals("New Global compatibility level should be backward",
         BACKWARD.name,
         restApp.restClient.getConfig(null).getCompatibilityLevel());
 
     // delete Global compatibility
     restApp.restClient.deleteConfig(null);
-    assertEquals("Compatibility level for this subject should be reverted to none",
+    assertEquals("Global compatibility level should be reverted to none",
         NONE.name,
         restApp.restClient
             .getConfig(RestService.DEFAULT_REQUEST_PROPERTIES, null, true)


### PR DESCRIPTION
* Added the API Endpoint to delete the global config and revert back to default.

* Added the support for the this new endpoint in RestService.

