### PR TITLE
DGS-2951 Make Register Api's incompatibility error message verbose

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -56,6 +56,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Context;
@@ -276,7 +277,8 @@ public class SubjectVersionsResource {
       @PathParam("subject") String subjectName,
       @QueryParam("normalize") boolean normalize,
       @Parameter(description = "Schema", required = true)
-      @NotNull RegisterSchemaRequest request) {
+      @NotNull RegisterSchemaRequest request,
+      @DefaultValue("false") @QueryParam("verbose") boolean verbose) {
     log.info("Registering new schema: subject {}, version {}, id {}, type {}, schema size {}",
              subjectName, request.getVersion(), request.getId(), request.getSchemaType(),
             request.getSchema() == null ? 0 : request.getSchema().length());
@@ -318,9 +320,12 @@ public class SubjectVersionsResource {
       throw Errors.requestForwardingFailedException("Error while forwarding register schema request"
                                                     + " to the leader", e);
     } catch (IncompatibleSchemaException e) {
-      throw Errors.incompatibleSchemaException("Schema being registered is incompatible with an"
-                                               + " earlier schema for subject "
-                                               + "\"" + subjectName + "\"", e);
+      StringBuilder errorMessage = new StringBuilder("Schema being registered is incompatible with"
+              + " an earlier schema for subject \"" + subjectName + "\"");
+      if (verbose) {
+        errorMessage.append(e.getMessage());
+      }
+      throw Errors.incompatibleSchemaException(errorMessage.toString(), e);
     } catch (UnknownLeaderException e) {
       throw Errors.unknownLeaderException("Leader not known.", e);
     } catch (SchemaRegistryException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -319,7 +319,8 @@ public class SubjectVersionsResource {
                                                     + " to the leader", e);
     } catch (IncompatibleSchemaException e) {
       throw Errors.incompatibleSchemaException("Schema being registered is incompatible with"
-              + " an earlier schema for subject \"" + subjectName + "\"" + e.getMessage(), e);
+              + " an earlier schema for subject \"" + subjectName + "\" Details : "
+              + e.getMessage(), e);
     } catch (UnknownLeaderException e) {
       throw Errors.unknownLeaderException("Leader not known.", e);
     } catch (SchemaRegistryException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -56,7 +56,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
-import javax.ws.rs.DefaultValue;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Context;
@@ -277,8 +276,7 @@ public class SubjectVersionsResource {
       @PathParam("subject") String subjectName,
       @QueryParam("normalize") boolean normalize,
       @Parameter(description = "Schema", required = true)
-      @NotNull RegisterSchemaRequest request,
-      @DefaultValue("false") @QueryParam("verbose") boolean verbose) {
+      @NotNull RegisterSchemaRequest request) {
     log.info("Registering new schema: subject {}, version {}, id {}, type {}, schema size {}",
              subjectName, request.getVersion(), request.getId(), request.getSchemaType(),
             request.getSchema() == null ? 0 : request.getSchema().length());
@@ -320,12 +318,8 @@ public class SubjectVersionsResource {
       throw Errors.requestForwardingFailedException("Error while forwarding register schema request"
                                                     + " to the leader", e);
     } catch (IncompatibleSchemaException e) {
-      StringBuilder errorMessage = new StringBuilder("Schema being registered is incompatible with"
-              + " an earlier schema for subject \"" + subjectName + "\"");
-      if (verbose) {
-        errorMessage.append(e.getMessage());
-      }
-      throw Errors.incompatibleSchemaException(errorMessage.toString(), e);
+      throw Errors.incompatibleSchemaException("Schema being registered is incompatible with"
+              + " an earlier schema for subject \"" + subjectName + "\"" + e.getMessage(), e);
     } catch (UnknownLeaderException e) {
       throw Errors.unknownLeaderException("Leader not known.", e);
     } catch (SchemaRegistryException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -319,7 +319,7 @@ public class SubjectVersionsResource {
                                                     + " to the leader", e);
     } catch (IncompatibleSchemaException e) {
       throw Errors.incompatibleSchemaException("Schema being registered is incompatible with"
-              + " an earlier schema for subject \"" + subjectName + "\" Details : "
+              + " an earlier schema for subject \"" + subjectName + "\", details: "
               + e.getMessage(), e);
     } catch (UnknownLeaderException e) {
       throw Errors.unknownLeaderException("Leader not known.", e);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -488,8 +488,10 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       }
       Collections.reverse(undeletedVersions);
 
-      final boolean isCompatible =
-              isCompatibleWithPrevious(subject, parsedSchema, undeletedVersions).isEmpty();
+      final List<String> compatibilityErrorLogs = isCompatibleWithPrevious(
+              subject, parsedSchema, undeletedVersions);
+      final boolean isCompatible = compatibilityErrorLogs.isEmpty();
+
       if (normalize) {
         parsedSchema = parsedSchema.normalize();
       }
@@ -548,8 +550,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
 
         return schema.getId();
       } else {
-        throw new IncompatibleSchemaException(
-            "New schema is incompatible with an earlier schema.");
+        throw new IncompatibleSchemaException(compatibilityErrorLogs.toString());
       }
     } catch (StoreTimeoutException te) {
       throw new SchemaRegistryTimeoutException("Write to the Kafka store timed out while", te);

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiCompatibilityTest.java
@@ -22,7 +22,9 @@ import io.confluent.kafka.schemaregistry.rest.exceptions.RestIncompatibleSchemaE
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidSchemaException;
 import org.junit.Test;
 
+import static org.apache.avro.SchemaCompatibility.SchemaIncompatibilityType.READER_FIELD_MISSING_DEFAULT_VALUE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class RestApiCompatibilityTest extends ClusterTestHarness {
@@ -59,6 +61,8 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
       assertEquals("Should get a conflict status",
                    RestIncompatibleSchemaException.DEFAULT_ERROR_CODE,
                    e.getStatus());
+      assertTrue("Verifying error message verbosity",
+              e.getMessage().contains(READER_FIELD_MISSING_DEFAULT_VALUE.toString()));
     }
 
     // register a non-avro


### PR DESCRIPTION
While trying to register an incompatible schema, currently the response doesn't show the reason(s) of incompatibility.

**Example :** 

```
Sample response with current implementation : 
{
    "error_code": 409,
    "message": "Schema being registered is incompatible with an earlier schema for subject \"test-topic-2-value\""
}
```

```
Sample response with proposed change : 
{
    "error_code": 409,
    "message": "Schema being registered is incompatible with an earlier schema for subject \"test-topic-2-value\", details: [Incompatibility{type:TYPE_MISMATCH, location:/fields/2/type, message:reader type: DOUBLE not compatible with writer type: STRING, reader:\"double\", writer:\"string\"}]"
}
```
