### PR TITLE
DGS-2989 Update function return type due to changes in parent class

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java
@@ -211,11 +211,16 @@ final class SchemaRegistryCoordinator extends AbstractCoordinator implements Clo
   }
 
   @Override
-  protected void onJoinPrepare(int generation, String memberId) {
+  protected boolean onJoinPrepare(int generation, String memberId) {
     log.debug("Revoking previous assignment {}", assignmentSnapshot);
     if (assignmentSnapshot != null) {
       listener.onRevoked();
     }
+    // return true if the cleanup succeeds or if it fails with a non-retriable exception.
+    // return false otherwise.
+    // listener.onRevoked() called above removes this instance as the leader
+    // and even if we got an exception, it wouldn't help retrying.
+    return true;
   }
 
   @Override


### PR DESCRIPTION
Updated return type of onJoinPrepare due to changes in parent class.
Refer below snippets for guidance on the return type
`* @return true If onJoinPrepare async commit succeeded, false otherwise
******************************************************************
        // return true when
         // 1. future is null, which means no commit request sent, so it is still considered completed
         // 2. offset commit completed
         // 3. offset commit failed with non-retriable exception`
source: https://github.com/apache/kafka/pull/11340/files
Also refer https://github.com/apache/kafka/pull/11340/files#diff-9075bf1ce4e8d878d16f25add001986e3e319cd5ce93290e4f10e4fd60e60155L221 for another example of a usage similar to ours