### PR TITLE
Downloading specific version of schemas capability added

### DIFF
--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/DownloadSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/DownloadSchemaRegistryMojo.java
@@ -59,6 +59,10 @@ public class DownloadSchemaRegistryMojo extends SchemaRegistryMojo {
       throws MojoExecutionException {
     Map<String, ParsedSchema> results = new LinkedHashMap<>();
 
+    if (versionsToDownload.size() != subjects.size()) {
+      throw new MojoExecutionException("Number of versions specified should "
+          + "be same as number of subjects");
+    }
     for (int i = 0; i < subjects.size(); i++) {
       SchemaMetadata schemaMetadata;
       try {
@@ -105,26 +109,7 @@ public class DownloadSchemaRegistryMojo extends SchemaRegistryMojo {
       getLog().info("Plugin execution has been skipped");
       return;
     }
-
-    try {
-      getLog().debug(
-          String.format("Checking if '%s' exists and is not a directory.", this.outputDirectory));
-      if (outputDirectory.exists() && !outputDirectory.isDirectory()) {
-        throw new IllegalStateException("outputDirectory must be a directory");
-      }
-      getLog()
-          .debug(String.format("Checking if outputDirectory('%s') exists.", this.outputDirectory));
-      if (!outputDirectory.isDirectory()) {
-        getLog().debug(String.format("Creating outputDirectory('%s').", this.outputDirectory));
-        if (!outputDirectory.mkdirs()) {
-          throw new IllegalStateException(
-              "Could not create output directory " + this.outputDirectory);
-        }
-      }
-    } catch (Exception ex) {
-      throw new MojoExecutionException("Exception thrown while creating outputDirectory", ex);
-    }
-
+    outputDirValidation();
     List<Pattern> patterns = new ArrayList<>();
 
     for (String subject : subjectPatterns) {
@@ -139,7 +124,6 @@ public class DownloadSchemaRegistryMojo extends SchemaRegistryMojo {
         );
       }
     }
-
     Collection<String> allSubjects;
     try {
       getLog().info("Getting all subjects on schema registry...");
@@ -147,12 +131,15 @@ public class DownloadSchemaRegistryMojo extends SchemaRegistryMojo {
     } catch (Exception ex) {
       throw new MojoExecutionException("Exception thrown", ex);
     }
-
     getLog().info(String.format("Schema Registry has %s subject(s).", allSubjects.size()));
     List<String> subjectsToDownload = new ArrayList<>();
     List<String> versionsToDownload = new ArrayList<>();
 
-
+    if (!versions.isEmpty()) {
+      if (versions.size() != subjectPatterns.size()) {
+        throw new IllegalStateException("versions size should be same as subjectPatterns size");
+      }
+    }
     for (String subject : allSubjects) {
       for (int i = 0 ; i < patterns.size() ; i++) {
         getLog()
@@ -174,7 +161,6 @@ public class DownloadSchemaRegistryMojo extends SchemaRegistryMojo {
         }
       }
     }
-
     Map<String, ParsedSchema> subjectToSchema =
         downloadSchemas(subjectsToDownload,versionsToDownload);
 
@@ -196,6 +182,27 @@ public class DownloadSchemaRegistryMojo extends SchemaRegistryMojo {
             ex
         );
       }
+    }
+  }
+
+  public void outputDirValidation() throws MojoExecutionException, MojoFailureException {
+    try {
+      getLog().debug(
+          String.format("Checking if '%s' exists and is not a directory.", this.outputDirectory));
+      if (outputDirectory.exists() && !outputDirectory.isDirectory()) {
+        throw new IllegalStateException("outputDirectory must be a directory");
+      }
+      getLog()
+          .debug(String.format("Checking if outputDirectory('%s') exists.", this.outputDirectory));
+      if (!outputDirectory.isDirectory()) {
+        getLog().debug(String.format("Creating outputDirectory('%s').", this.outputDirectory));
+        if (!outputDirectory.mkdirs()) {
+          throw new IllegalStateException(
+              "Could not create output directory " + this.outputDirectory);
+        }
+      }
+    } catch (Exception ex) {
+      throw new MojoExecutionException("Exception thrown while creating outputDirectory", ex);
     }
   }
 

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/DownloadSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/DownloadSchemaRegistryMojo.java
@@ -162,7 +162,7 @@ public class DownloadSchemaRegistryMojo extends SchemaRegistryMojo {
       }
     }
     Map<String, ParsedSchema> subjectToSchema =
-        downloadSchemas(subjectsToDownload,versionsToDownload);
+        downloadSchemas(subjectsToDownload, versionsToDownload);
 
     for (Map.Entry<String, ParsedSchema> kvp : subjectToSchema.entrySet()) {
       String fileName = String.format("%s%s", kvp.getKey(), getExtension(kvp.getValue()));

--- a/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/DownloadSchemaRegistryMojoTest.java
+++ b/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/DownloadSchemaRegistryMojoTest.java
@@ -22,11 +22,14 @@ import org.apache.avro.Schema;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.security.auth.Subject;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.regex.Matcher;
 
 public class DownloadSchemaRegistryMojoTest extends SchemaRegistryTest {
   DownloadSchemaRegistryMojo mojo;
@@ -55,12 +58,11 @@ public class DownloadSchemaRegistryMojoTest extends SchemaRegistryTest {
       File valueSchemaFile = new File(this.tempDirectory, valueSubject + ".avsc");
 
       if (i % 10 == 0) {
-        String subjectPattern = String.format("^TestSubject%03d-(Key|Value)$", i);
-        files.add(keySchemaFile);
-        files.add(valueSchemaFile);
-        this.mojo.subjectPatterns.add(subjectPattern);
+        this.mojo.client().getSchemaMetadata(keySubject,1);
+        this.mojo.client().getLatestSchemaMetadata(keySubject);
+        this.mojo.client().getSchemaMetadata(valueSubject,1);
+        this.mojo.client().getLatestSchemaMetadata(valueSubject);
       }
     }
   }
-
 }


### PR DESCRIPTION
Objective : To download a specific version associated with a subjectPattern.

To run:
```
mvn io.confluent:kafka-schema-registry-maven-plugin:7.2.0-0:download
```

Parameters to be passed while using this goal :

- schemaRegistryUrls
Type : List<String>
Required = true

- outputDirectory
Type : File
Required = true

- versions
Type : List<String>
Required = true

- subjectPatterns
Type : List<String>
Required = true