### PR TITLE
DGS-3040 Configure Schema Registry Client [m]TLS using PEM (#2062) [skip secret scan] 

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/SslFactory.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/SslFactory.java
@@ -16,29 +16,60 @@
 
 package io.confluent.kafka.schemaregistry.client.security;
 
-import org.apache.kafka.common.config.SslConfigs;
+import static org.apache.kafka.common.security.ssl.DefaultSslEngineFactory.PEM_TYPE;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.GeneralSecurityException;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.crypto.Cipher;
+import javax.crypto.EncryptedPrivateKeyInfo;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.security.GeneralSecurityException;
-import java.security.KeyStore;
-import java.security.SecureRandom;
-import java.util.Map;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.common.errors.InvalidConfigurationException;
+import org.apache.kafka.common.utils.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SslFactory {
 
+  private static final Logger log = LoggerFactory.getLogger(SslFactory.class);
+  private final String provider;
+  private final String kmfAlgorithm;
+  private final String tmfAlgorithm;
+  private final SecurityStore keystore;
+  private final SecurityStore truststore;
+  private final SSLContext sslContext;
+  private final SecureRandom secureRandomImplementation;
   private String protocol;
-  private String provider;
-  private String kmfAlgorithm;
-  private String tmfAlgorithm;
-  private SecurityStore keystore = null;
-  private String keyPassword;
-  private SecurityStore truststore;
-  private SSLContext sslContext;
 
 
   public SslFactory(Map<String, ?> configs) {
@@ -53,62 +84,142 @@ public class SslFactory {
     this.tmfAlgorithm = (String) configs.get(
         SslConfigs.SSL_TRUSTMANAGER_ALGORITHM_CONFIG);
 
-    try {
-      createKeystore(
-          (String) configs.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG),
-          (String) configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG),
-          (String) configs.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG),
-          (String) configs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG)
-      );
+    this.secureRandomImplementation = createSecureRandom((String)
+        configs.get(SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG));
 
-      createTruststore(
+    try {
+      this.keystore = createKeystore((String) configs.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG),
+          (String) configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG),
+          passwordOf(configs.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG)),
+          passwordOf(configs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG)),
+          passwordOf(configs.get(SslConfigs.SSL_KEYSTORE_KEY_CONFIG)),
+          passwordOf(configs.get(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG)));
+
+      this.truststore = createTruststore(
           (String) configs.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG),
           (String) configs.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG),
-          (String) configs.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG)
-      );
+          passwordOf(configs.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG)),
+          passwordOf(configs.get(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG)));
 
-      this.sslContext = createSslContext();
+      this.sslContext = createSslContext(keystore, truststore);
     } catch (Exception e) {
-      throw new RuntimeException("Error initializing the ssl context for RestService" , e);
+      throw new RuntimeException("Error initializing the ssl context for RestService", e);
     }
   }
 
-  private static boolean isNotBlank(String str) {
-    return str != null && !str.trim().isEmpty();
-  }
-
-  private SSLContext createSslContext() throws GeneralSecurityException, IOException {
-    if (truststore == null && keystore == null) {
+  private static SecureRandom createSecureRandom(String key) {
+    if (key == null) {
       return null;
     }
-    SSLContext sslContext;
-    if (isNotBlank(provider)) {
-      sslContext = SSLContext.getInstance(protocol, provider);
+    try {
+      return SecureRandom.getInstance(key);
+    } catch (GeneralSecurityException e) {
+      throw new KafkaException(e);
+    }
+  }
+
+  private static boolean isNotEmpty(CharSequence cs) {
+    return !isEmpty(cs);
+  }
+
+  private static boolean isEmpty(CharSequence cs) {
+    return cs == null || cs.length() == 0;
+  }
+
+  private static SecurityStore createTruststore(String type, String path, Password password,
+                                                Password trustStoreCerts) {
+    if (trustStoreCerts != null) {
+      return createPemTrustStore(type, path, password, trustStoreCerts);
+    } else if (PEM_TYPE.equals(type) && isNotEmpty(path)) {
+      if (password != null) {
+        throw new InvalidConfigurationException(
+            "SSL trust store password cannot be specified for PEM format.");
+      } else {
+        return new FileBasedPemStore(path, null, false);
+      }
+    } else if (path == null && password != null) {
+      throw new InvalidConfigurationException(
+          "SSL trust store is not specified, but trust store password is specified.");
+    } else if (isNotEmpty(path)) {
+      return new FileBasedStore(type, path, password, null, false);
     } else {
-      sslContext = SSLContext.getInstance(protocol);
+      return null;
     }
+  }
 
-    KeyManager[] keyManagers = null;
-    if (keystore != null) {
-      String kmfAlgorithm =
-          isNotBlank(this.kmfAlgorithm) ? this.kmfAlgorithm
-              : KeyManagerFactory.getDefaultAlgorithm();
-      KeyManagerFactory kmf = KeyManagerFactory.getInstance(kmfAlgorithm);
-      KeyStore ks = keystore.load();
-      String keyPassword = this.keyPassword != null ? this.keyPassword : keystore.password;
-      kmf.init(ks, keyPassword.toCharArray());
-      keyManagers = kmf.getKeyManagers();
+  private static SecurityStore createPemTrustStore(String type, String path, Password password,
+                                                   Password trustStoreCerts) {
+    if (!PEM_TYPE.equals(type)) {
+      throw new InvalidConfigurationException(
+          "SSL trust store certs can be specified only for PEM, but trust store type is "
+              + type + ".");
+    } else if (isNotEmpty(path)) {
+      throw new InvalidConfigurationException(
+          "Both SSL trust store location and separate trust certificates are specified.");
+    } else if (password != null) {
+      throw new InvalidConfigurationException(
+          "SSL trust store password cannot be specified for PEM format.");
+    } else {
+      return new PemStore(trustStoreCerts);
     }
+  }
 
-    String tmfAlgorithm =
-        isNotBlank(this.tmfAlgorithm) ? this.tmfAlgorithm
-            : TrustManagerFactory.getDefaultAlgorithm();
-    TrustManagerFactory tmf = TrustManagerFactory.getInstance(tmfAlgorithm);
-    KeyStore ts = truststore == null ? null : truststore.load();
-    tmf.init(ts);
+  // Visibility for testing
+  SecurityStore keyStore() {
+    return this.keystore;
+  }
 
-    sslContext.init(keyManagers, tmf.getTrustManagers(), new SecureRandom());
-    return sslContext;
+  // Visibility for testing
+  SecurityStore trustStore() {
+    return this.truststore;
+  }
+
+  private Password passwordOf(Object val) {
+    if (val == null || val.toString().trim().isEmpty()) {
+      return null;
+    }
+    return new Password(val.toString());
+  }
+
+  private SSLContext createSslContext(SecurityStore keystore, SecurityStore truststore) {
+    try {
+      SSLContext sslContext;
+      if (isNotEmpty(provider)) {
+        sslContext = SSLContext.getInstance(protocol, provider);
+      } else {
+        sslContext = SSLContext.getInstance(protocol);
+      }
+
+      KeyManager[] keyManagers = null;
+      if (keystore != null || isNotEmpty(kmfAlgorithm)) {
+        String kmfAlgorithm;
+        if (isNotEmpty(this.kmfAlgorithm)) {
+          kmfAlgorithm = this.kmfAlgorithm;
+        } else {
+          kmfAlgorithm = KeyManagerFactory.getDefaultAlgorithm();
+        }
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(kmfAlgorithm);
+        if (keystore != null) {
+          kmf.init(keystore.get(), keystore.keyPassword());
+        } else {
+          kmf.init(null, null);
+        }
+        keyManagers = kmf.getKeyManagers();
+      }
+
+      String tmfAlgorithm = isNotEmpty(this.tmfAlgorithm) ? this.tmfAlgorithm :
+          TrustManagerFactory.getDefaultAlgorithm();
+      TrustManagerFactory tmf = TrustManagerFactory.getInstance(tmfAlgorithm);
+      KeyStore ts = truststore == null ? null : truststore.get();
+      tmf.init(ts);
+
+      sslContext.init(keyManagers, tmf.getTrustManagers(), this.secureRandomImplementation);
+      log.debug("Created SSL context with keystore {}, truststore {}, provider {}.",
+          keystore, truststore, sslContext.getProvider().getName());
+      return sslContext;
+    } catch (Exception e) {
+      throw new KafkaException(e);
+    }
   }
 
   /**
@@ -120,53 +231,338 @@ public class SslFactory {
     return sslContext;
   }
 
-  private void createKeystore(String type, String path, String password, String keyPassword) {
-    if (path == null && password != null) {
-      throw new RuntimeException(
+  // Visibility to override for testing
+  protected SecurityStore createKeystore(String type, String path, Password password,
+                                         Password keyPassword, Password privateKey,
+                                         Password certificateChain) {
+    if (privateKey != null) {
+      return createPemKeyStore(type, path, password, keyPassword, privateKey, certificateChain);
+    } else if (certificateChain != null) {
+      throw new InvalidConfigurationException(
+          "SSL certificate chain is specified, but private key is not specified");
+    } else if (PEM_TYPE.equals(type) && path != null) {
+      return createFileBasedPemStore(path, password, keyPassword);
+    } else if (path == null && password != null) {
+      throw new InvalidConfigurationException(
           "SSL key store is not specified, but key store password is specified.");
-    } else if (path != null && password == null) {
-      throw new RuntimeException(
-          "SSL key store is specified, but key store password is not specified.");
-    } else if (isNotBlank(path) && isNotBlank(password)) {
-      this.keystore = new SecurityStore(type, path, password);
-      this.keyPassword = keyPassword;
+    } else if (isNotEmpty(path)) {
+      if (password == null) {
+        throw new InvalidConfigurationException(
+            "SSL key store is specified, but key store password is not specified.");
+      } else if (isEmpty(type)) {
+        throw new InvalidConfigurationException(
+            "SSL key store is specified, but store type is null or empty");
+      }
+      return new FileBasedStore(type, path, password, keyPassword, true);
+    } else {
+      // path is null/empty, clients may use this path with brokers that don't require client auth
+      return null;
     }
   }
 
-  private void createTruststore(String type, String path, String password) {
-    if (path == null && password != null) {
-      throw new RuntimeException(
-          "SSL trust store is not specified, but trust store password is specified.");
-    } else if (isNotBlank(path)) {
-      this.truststore = new SecurityStore(type, path, password);
+  private static SecurityStore createPemKeyStore(String type, String path, Password password,
+                                        Password keyPassword, Password privateKey,
+                                        Password certificateChain) {
+    if (!PEM_TYPE.equals(type)) {
+      throw new InvalidConfigurationException("SSL private key can be specified only for "
+          + "PEM, but key store type is " + type + ".");
+    } else if (certificateChain == null) {
+      throw new InvalidConfigurationException("SSL private key is specified, "
+          + "but certificate chain is not specified.");
+    } else if (path != null) {
+      throw new InvalidConfigurationException("Both SSL key store location and separate "
+          + "private key are specified.");
+    } else if (password != null) {
+      throw new InvalidConfigurationException(
+          "SSL key store password cannot be specified with PEM format, "
+              + "only key password may be specified.");
+    }
+    return new PemStore(certificateChain, privateKey, keyPassword);
+  }
+
+  private static SecurityStore createFileBasedPemStore(String path, Password password,
+                                                       Password keyPassword) {
+    if (password != null) {
+      throw new InvalidConfigurationException(
+          "SSL key store password cannot be specified with PEM format, "
+              + "only key password may be specified");
+    } else if (keyPassword == null) {
+      throw new InvalidConfigurationException(
+          "SSL PEM key store is specified, but key password is not specified.");
+    } else {
+      return new FileBasedPemStore(path, keyPassword, true);
     }
   }
 
-  private static class SecurityStore {
+  interface SecurityStore {
+    KeyStore get();
 
+    char[] keyPassword();
+
+    boolean modified();
+  }
+
+  // package access for testing
+  static class FileBasedStore implements SecurityStore {
+    protected final String path;
+    protected final Password keyPassword;
     private final String type;
-    private final String path;
-    private final String password;
+    private final Password password;
+    private final Long fileLastModifiedMs;
+    private final KeyStore keyStore;
 
-    private SecurityStore(String type, String path, String password) {
-      this.type = type == null ? KeyStore.getDefaultType() : type;
+    FileBasedStore(String type, String path, Password password, Password keyPassword,
+                   boolean isKeyStore) {
+      Objects.requireNonNull(type, "type must not be null");
+      this.type = type;
       this.path = path;
       this.password = password;
+      this.keyPassword = keyPassword;
+      fileLastModifiedMs = lastModifiedMs(path);
+      this.keyStore = load(isKeyStore);
     }
 
-    private KeyStore load() throws GeneralSecurityException, IOException {
-      FileInputStream in = null;
-      try {
+    @Override
+    public KeyStore get() {
+      return keyStore;
+    }
+
+    @Override
+    public char[] keyPassword() {
+      Password passwd = keyPassword != null ? keyPassword : password;
+      return passwd == null ? null : passwd.value().toCharArray();
+    }
+
+    /**
+     * Loads this keystore.
+     *
+     * @return the keystore
+     * @throws KafkaException if the file could not be read or if the keystore could not be loaded
+     *                        using the specified configs (e.g. if the password or keystore
+     *                        type is invalid)
+     */
+    protected KeyStore load(boolean isKeyStore) {
+      try (InputStream in = Files.newInputStream(Paths.get(path))) {
         KeyStore ks = KeyStore.getInstance(type);
-        in = new FileInputStream(path);
-        char[] passwordChars = password != null ? password.toCharArray() : null;
+        // If a password is not set access to the truststore is
+        // still available, but integrity checking is disabled.
+        char[] passwordChars = password != null ? password.value().toCharArray() : null;
         ks.load(in, passwordChars);
         return ks;
-      } finally {
-        if (in != null) {
-          in.close();
+      } catch (GeneralSecurityException | IOException e) {
+        throw new KafkaException("Failed to load SSL keystore " + path + " of type " + type, e);
+      }
+    }
+
+    private Long lastModifiedMs(String path) {
+      try {
+        return Files.getLastModifiedTime(Paths.get(path)).toMillis();
+      } catch (IOException e) {
+        log.error("Modification time of key store could not be obtained: " + path, e);
+        return null;
+      }
+    }
+
+    public boolean modified() {
+      Long modifiedMs = lastModifiedMs(path);
+      return modifiedMs != null && !Objects.equals(modifiedMs, this.fileLastModifiedMs);
+    }
+
+    @Override
+    public String toString() {
+      return "SecurityStore(" + "path=" + path + ", modificationTime="
+          + (fileLastModifiedMs == null ? null : new Date(fileLastModifiedMs)) + ")";
+    }
+  }
+
+  static class FileBasedPemStore extends FileBasedStore {
+    FileBasedPemStore(String path, Password keyPassword, boolean isKeyStore) {
+      super(PEM_TYPE, path, null, keyPassword, isKeyStore);
+    }
+
+    @Override
+    protected KeyStore load(boolean isKeyStore) {
+      try {
+        Password storeContents = new Password(Utils.readFileAsString(path));
+        PemStore pemStore = isKeyStore ? new PemStore(storeContents, storeContents, keyPassword) :
+            new PemStore(storeContents);
+        return pemStore.keyStore;
+      } catch (Exception e) {
+        throw new InvalidConfigurationException("Failed to load PEM SSL keystore " + path, e);
+      }
+    }
+  }
+
+  static class PemStore implements SecurityStore {
+    private static final PemParser CERTIFICATE_PARSER = new PemParser("CERTIFICATE");
+    private static final PemParser PRIVATE_KEY_PARSER = new PemParser("PRIVATE KEY");
+    private static final List<KeyFactory> KEY_FACTORIES = Arrays.asList(
+        keyFactory("RSA"),
+        keyFactory("DSA"),
+        keyFactory("EC")
+    );
+
+    private final char[] keyPassword;
+    private final KeyStore keyStore;
+
+    PemStore(Password certificateChain, Password privateKey, Password keyPassword) {
+      this.keyPassword = keyPassword == null ? null : keyPassword.value().toCharArray();
+      keyStore =
+          createKeyStoreFromPem(privateKey.value(), certificateChain.value(), this.keyPassword);
+    }
+
+    PemStore(Password trustStoreCerts) {
+      this.keyPassword = null;
+      keyStore = createTrustStoreFromPem(trustStoreCerts.value());
+    }
+
+    private static KeyFactory keyFactory(String algorithm) {
+      try {
+        return KeyFactory.getInstance(algorithm);
+      } catch (Exception e) {
+        throw new InvalidConfigurationException(
+            "Could not create key factory for algorithm " + algorithm, e);
+      }
+    }
+
+    @Override
+    public KeyStore get() {
+      return keyStore;
+    }
+
+    @Override
+    public char[] keyPassword() {
+      return keyPassword;
+    }
+
+    @Override
+    public boolean modified() {
+      return false;
+    }
+
+    private KeyStore createKeyStoreFromPem(String privateKeyPem, String certChainPem,
+                                           char[] keyPassword) {
+      try {
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+        ks.load(null, null);
+        Key key = privateKey(privateKeyPem, keyPassword);
+        Certificate[] certChain = certs(certChainPem);
+        ks.setKeyEntry("kafka", key, keyPassword, certChain);
+        return ks;
+      } catch (Exception e) {
+        throw new InvalidConfigurationException("Invalid PEM keystore configs", e);
+      }
+    }
+
+    private KeyStore createTrustStoreFromPem(String trustedCertsPem) {
+      try {
+        KeyStore ts = KeyStore.getInstance("PKCS12");
+        ts.load(null, null);
+        Certificate[] certs = certs(trustedCertsPem);
+        for (int i = 0; i < certs.length; i++) {
+          ts.setCertificateEntry("kafka" + i, certs[i]);
+        }
+        return ts;
+      } catch (InvalidConfigurationException e) {
+        throw e;
+      } catch (Exception e) {
+        throw new InvalidConfigurationException("Invalid PEM keystore configs", e);
+      }
+    }
+
+    private Certificate[] certs(String pem) throws GeneralSecurityException {
+      List<byte[]> certEntries = CERTIFICATE_PARSER.pemEntries(pem);
+      if (certEntries.isEmpty()) {
+        throw new InvalidConfigurationException(
+            "At least one certificate expected, but none found");
+      }
+
+      Certificate[] certs = new Certificate[certEntries.size()];
+      for (int i = 0; i < certs.length; i++) {
+        certs[i] = CertificateFactory.getInstance("X.509")
+            .generateCertificate(new ByteArrayInputStream(certEntries.get(i)));
+      }
+      return certs;
+    }
+
+    private PrivateKey privateKey(String pem, char[] keyPassword) throws Exception {
+      List<byte[]> keyEntries = PRIVATE_KEY_PARSER.pemEntries(pem);
+      if (keyEntries.isEmpty()) {
+        throw new InvalidConfigurationException("Private key not provided");
+      }
+      if (keyEntries.size() != 1) {
+        throw new InvalidConfigurationException(
+            "Expected one private key, but found " + keyEntries.size());
+      }
+
+      byte[] keyBytes = keyEntries.get(0);
+      PKCS8EncodedKeySpec keySpec;
+      if (keyPassword == null) {
+        keySpec = new PKCS8EncodedKeySpec(keyBytes);
+      } else {
+        EncryptedPrivateKeyInfo keyInfo = new EncryptedPrivateKeyInfo(keyBytes);
+        String algorithm = keyInfo.getAlgName();
+        SecretKeyFactory keyFactory = SecretKeyFactory.getInstance(algorithm);
+        SecretKey pbeKey = keyFactory.generateSecret(new PBEKeySpec(keyPassword));
+        Cipher cipher = Cipher.getInstance(algorithm);
+        cipher.init(Cipher.DECRYPT_MODE, pbeKey, keyInfo.getAlgParameters());
+        keySpec = keyInfo.getKeySpec(cipher);
+      }
+
+      InvalidKeySpecException firstException = null;
+      for (KeyFactory factory : KEY_FACTORIES) {
+        try {
+          return factory.generatePrivate(keySpec);
+        } catch (InvalidKeySpecException e) {
+          if (firstException == null) {
+            firstException = e;
+          }
         }
       }
+      throw new InvalidConfigurationException("Private key could not be loaded", firstException);
+    }
+  }
+
+  /**
+   * Parser to process certificate/private key entries from PEM files
+   * Examples:
+   * -----BEGIN CERTIFICATE-----
+   * Base64 cert
+   * -----END CERTIFICATE-----
+   *
+   * <p>-----BEGIN ENCRYPTED PRIVATE KEY-----
+   * Base64 private key
+   * -----END ENCRYPTED PRIVATE KEY-----
+   * Additional data may be included before headers, so we match all entries within the PEM.
+   */
+  static class PemParser {
+    private final String name;
+    private final Pattern pattern;
+
+    PemParser(String name) {
+      this.name = name;
+      String beginOrEndFormat = "-+%s\\s*.*%s[^-]*-+\\s+";
+      String nameIgnoreSpace = name.replace(" ", "\\s+");
+
+      String encodingParams = "\\s*[^\\r\\n]*:[^\\r\\n]*[\\r\\n]+";
+      String base64Pattern = "([a-zA-Z0-9/+=\\s]*)";
+      String patternStr = String.format(beginOrEndFormat, "BEGIN", nameIgnoreSpace)
+          + String.format("(?:%s)*", encodingParams)
+          + base64Pattern + String.format(beginOrEndFormat, "END", nameIgnoreSpace);
+      pattern = Pattern.compile(patternStr);
+    }
+
+    private List<byte[]> pemEntries(String pem) {
+      Matcher matcher = pattern.matcher(pem + "\n"); // allow last newline to be omitted in value
+      List<byte[]> entries = new ArrayList<>();
+      while (matcher.find()) {
+        String base64Str = matcher.group(1).replaceAll("\\s", "");
+        entries.add(Base64.getDecoder().decode(base64Str));
+      }
+      if (entries.isEmpty()) {
+        throw new InvalidConfigurationException("No matching " + name + " entries in PEM file");
+      }
+      return entries;
     }
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/SslFactory.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/SslFactory.java
@@ -70,12 +70,22 @@ public class SslFactory {
   private final SSLContext sslContext;
   private final SecureRandom secureRandomImplementation;
   private String protocol;
+  private String keystoreType;
+  private String truststoreType;
 
 
   public SslFactory(Map<String, ?> configs) {
     this.protocol = (String) configs.get(SslConfigs.SSL_PROTOCOL_CONFIG);
     if (this.protocol == null) {
       this.protocol = SslConfigs.DEFAULT_SSL_PROTOCOL;
+    }
+    this.keystoreType = (String) configs.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG);
+    if (this.keystoreType == null) {
+      this.keystoreType = SslConfigs.DEFAULT_SSL_KEYSTORE_TYPE;
+    }
+    this.truststoreType = (String) configs.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG);
+    if (this.truststoreType == null) {
+      this.truststoreType = SslConfigs.DEFAULT_SSL_TRUSTSTORE_TYPE;
     }
     this.provider = (String) configs.get(SslConfigs.SSL_PROVIDER_CONFIG);
 
@@ -88,7 +98,8 @@ public class SslFactory {
         configs.get(SslConfigs.SSL_SECURE_RANDOM_IMPLEMENTATION_CONFIG));
 
     try {
-      this.keystore = createKeystore((String) configs.get(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG),
+      this.keystore = createKeystore(
+          keystoreType,
           (String) configs.get(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG),
           passwordOf(configs.get(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG)),
           passwordOf(configs.get(SslConfigs.SSL_KEY_PASSWORD_CONFIG)),
@@ -96,7 +107,7 @@ public class SslFactory {
           passwordOf(configs.get(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG)));
 
       this.truststore = createTruststore(
-          (String) configs.get(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG),
+          truststoreType,
           (String) configs.get(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG),
           passwordOf(configs.get(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG)),
           passwordOf(configs.get(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG)));
@@ -249,9 +260,6 @@ public class SslFactory {
       if (password == null) {
         throw new InvalidConfigurationException(
             "SSL key store is specified, but key store password is not specified.");
-      } else if (isEmpty(type)) {
-        throw new InvalidConfigurationException(
-            "SSL key store is specified, but store type is null or empty");
       }
       return new FileBasedStore(type, path, password, keyPassword, true);
     } else {

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/SslFactoryTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/SslFactoryTest.java
@@ -1,0 +1,312 @@
+package io.confluent.kafka.schemaregistry.client.security;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.KeyStore;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.confluent.common.utils.TestUtils;
+
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.common.security.ssl.DefaultSslEngineFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SslFactoryTest {
+
+  /*
+   * Key and certificates were extracted using openssl from a key store file created with 100 years validity using:
+   *
+   * openssl pkcs12 -in server.keystore.p12 -nodes -nocerts -out test.key.pem -passin pass:key-password
+   * openssl pkcs12 -in server.keystore.p12 -nodes -nokeys -out test.certchain.pem  -passin pass:key-password
+   * openssl pkcs12 -in server.keystore.p12 -nodes  -out test.keystore.pem -passin pass:key-password
+   * openssl pkcs8 -topk8 -v1 pbeWithSHA1And3-KeyTripleDES-CBC -in test.key.pem -out test.key.encrypted.pem -passout pass:key-password
+   */
+
+  private static final String CA1 = "-----BEGIN CERTIFICATE-----\n"
+      + "MIIC0zCCAbugAwIBAgIEStdXHTANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDEwdU\n"
+      + "ZXN0Q0ExMCAXDTIwMDkyODA5MDI0MFoYDzIxMjAwOTA0MDkwMjQwWjASMRAwDgYD\n"
+      + "VQQDEwdUZXN0Q0ExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo3Gr\n"
+      + "WJAkjnvgcuIfjArDhNdtAlRTt094WMUXhYDibgGtd+CLcWqA+c4PEoK4oybnKZqU\n"
+      + "6MlDfPgesIK2YiNBuSVWMtZ2doageOBnd80Iwbg8DqGtQpUsvw8X5fOmuza+4inv\n"
+      + "/8IpiTizq8YjSMT4nYDmIjyyRCSNY4atjgMnskutJ0v6i69+ZAA520Y6nn2n4RD5\n"
+      + "8Yc+y7yCkbZXnYS5xBOFEExmtc0Xa7S9nM157xqKws9Z+rTKZYLrryaHI9JNcXgG\n"
+      + "kzQEH9fBePASeWfi9AGRvAyS2GMSIBOsihIDIha/mqQcJOGCEqTMtefIj2FaErO2\n"
+      + "bL9yU7OpW53iIC8y0QIDAQABoy8wLTAMBgNVHRMEBTADAQH/MB0GA1UdDgQWBBRf\n"
+      + "svKcoQ9ZBvjwyUSV2uMFzlkOWDANBgkqhkiG9w0BAQsFAAOCAQEAEE1ZG2MGE248\n"
+      + "glO83ROrHbxmnVWSQHt/JZANR1i362sY1ekL83wlhkriuvGVBlHQYWezIfo/4l9y\n"
+      + "JTHNX3Mrs9eWUkaDXADkHWj3AyLXN3nfeU307x1wA7OvI4YKpwvfb4aYS8RTPz9d\n"
+      + "JtrfR0r8aGTgsXvCe4SgwDBKv7bckctOwD3S7D/b6y3w7X0s7JCU5+8ZjgoYfcLE\n"
+      + "gNqQEaOwdT2LHCvxHmGn/2VGs/yatPQIYYuufe5i8yX7pp4Xbd2eD6LULYkHFs3x\n"
+      + "uJzMRI7BukmIIWuBbAkYI0atxLQIysnVFXdL9pBgvgso2nA3FgP/XeORhkyHVvtL\n"
+      + "REH2YTlftQ==\n"
+      + "-----END CERTIFICATE-----";
+
+  private static final String CA2 = "-----BEGIN CERTIFICATE-----\n"
+      + "MIIC0zCCAbugAwIBAgIEfk9e9DANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDEwdU\n"
+      + "ZXN0Q0EyMCAXDTIwMDkyODA5MDI0MVoYDzIxMjAwOTA0MDkwMjQxWjASMRAwDgYD\n"
+      + "VQQDEwdUZXN0Q0EyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvCh0\n"
+      + "UO5op9eHfz7mvZ7IySK7AOCTC56QYFJcU+hD6yk1wKg2qot7naI5ozAc8n7c4pMt\n"
+      + "LjI3D0VtC/oHC29R2HNMSWyHcxIXw8z127XeCLRkCqYWuVAl3nBuWfWVPObjKetH\n"
+      + "TWlQANYWAfk1VbS6wfzgp9cMaK7wQ+VoGEo4x3pjlrdlyg4k4O2yubcpWmJ2TjxS\n"
+      + "gg7TfKGizUVAvF9wUG9Q4AlCg4uuww5RN9w6vnzDKGhWJhkQ6pf/m1xB+WueFOeU\n"
+      + "aASGhGqCTqiz3p3M3M4OZzG3KptjQ/yb67x4T5U5RxqoiN4L57E7ZJLREpa6ZZNs\n"
+      + "ps/gQ8dR9Uo/PRyAkQIDAQABoy8wLTAMBgNVHRMEBTADAQH/MB0GA1UdDgQWBBRg\n"
+      + "IAOVH5LeE6nZmdScEE3JO/AhvTANBgkqhkiG9w0BAQsFAAOCAQEAHkk1iybwy/Lf\n"
+      + "iEQMVRy7XfuC008O7jfCUBMgUvE+oO2RadH5MmsXHG3YerdsDM90dui4JqQNZOUh\n"
+      + "kF8dIWPQHE0xDsR9jiUsemZFpVMN7DcvVZ3eFhbvJA8Q50rxcNGA+tn9xT/xdQ6z\n"
+      + "1eRq9IPoYcRexQ7s9mincM4T4lLm8GGcd7ZPHy8kw0Bp3E/enRHWaF5b8KbXezXD\n"
+      + "I3SEYUyRL2K3px4FImT4X9XQm2EX6EONlu4GRcJpD6RPc0zC7c9dwEnSo+0NnewR\n"
+      + "gjgO34CLzShB/kASLS9VQXcUC6bsggAVK2rWQMmy35SOEUufSuvg8kUFoyuTzfhn\n"
+      + "hL+PVwIu7g==\n"
+      + "-----END CERTIFICATE-----";
+
+  private static final String CERTCHAIN = "Bag Attributes\n"
+      + "    friendlyName: server\n"
+      + "    localKeyID: 54 69 6D 65 20 31 36 30 31 32 38 33 37 36 35 34 32 33 \n"
+      + "subject=/CN=TestBroker\n"
+      + "issuer=/CN=TestCA1\n"
+      + "-----BEGIN CERTIFICATE-----\n"
+      + "MIIC/zCCAeegAwIBAgIEatBnEzANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDEwdU\n"
+      + "ZXN0Q0ExMCAXDTIwMDkyODA5MDI0NFoYDzIxMjAwOTA0MDkwMjQ0WjAVMRMwEQYD\n"
+      + "VQQDEwpUZXN0QnJva2VyMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\n"
+      + "pkw1AS71ej/iOMvzVgVL1dkQOYzI842NcPmx0yFFsue2umL8WVd3085NgWRb3SS1\n"
+      + "4X676t7zxjPGzYi7jwmA8stCrDt0NAPWd/Ko6ErsCs87CUs4u1Cinf+b3o9NF5u0\n"
+      + "UPYBQLF4Ir8T1jQ+tKiqsChGDt6urRAg1Cro5i7r10jN1uofY2tBs+r8mALhJ17c\n"
+      + "T5LKawXeYwNOQ86c5djClbcP0RrfcPyRyj1/Cp1axo28iO0fXFyO2Zf3a4vtt+Ih\n"
+      + "PW+A2tL+t3JTBd8g7Fl3ozzpcotAi7MDcZaYA9GiTP4DOiKUeDt6yMYQQr3VEqGa\n"
+      + "pXp4fKY+t9slqnAmcBZ4kQIDAQABo1gwVjAfBgNVHSMEGDAWgBRfsvKcoQ9ZBvjw\n"
+      + "yUSV2uMFzlkOWDAUBgNVHREEDTALgglsb2NhbGhvc3QwHQYDVR0OBBYEFGWt+27P\n"
+      + "INk/S5X+PRV/jW3WOhtaMA0GCSqGSIb3DQEBCwUAA4IBAQCLHCjFFvqa+0GcG9eq\n"
+      + "v1QWaXDohY5t5CCwD8Z+lT9wcSruTxDPwL7LrR36h++D6xJYfiw4iaRighoA40xP\n"
+      + "W6+0zGK/UtWV4t+ODTDzyAWgls5w+0R5ki6447qGqu5tXlW5DCHkkxWiozMnhNU2\n"
+      + "G3P/Drh7DhmADDBjtVLsu5M1sagF/xwTP/qCLMdChlJNdeqyLnAUa9SYG1eNZS/i\n"
+      + "wrCC8m9RUQb4+OlQuFtr0KhaaCkBXfmhigQAmh44zSyO+oa3qQDEavVFo/Mcui9o\n"
+      + "WBYetcgVbXPNoti+hQEMqmJYBHlLbhxMnkooGn2fa70f453Bdu/Xh6Yphi5NeCHn\n"
+      + "1I+y\n"
+      + "-----END CERTIFICATE-----\n"
+      + "Bag Attributes\n"
+      + "    friendlyName: CN=TestCA1\n"
+      + "subject=/CN=TestCA1\n"
+      + "issuer=/CN=TestCA1\n"
+      + "-----BEGIN CERTIFICATE-----\n"
+      + "MIIC0zCCAbugAwIBAgIEStdXHTANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDEwdU\n"
+      + "ZXN0Q0ExMCAXDTIwMDkyODA5MDI0MFoYDzIxMjAwOTA0MDkwMjQwWjASMRAwDgYD\n"
+      + "VQQDEwdUZXN0Q0ExMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo3Gr\n"
+      + "WJAkjnvgcuIfjArDhNdtAlRTt094WMUXhYDibgGtd+CLcWqA+c4PEoK4oybnKZqU\n"
+      + "6MlDfPgesIK2YiNBuSVWMtZ2doageOBnd80Iwbg8DqGtQpUsvw8X5fOmuza+4inv\n"
+      + "/8IpiTizq8YjSMT4nYDmIjyyRCSNY4atjgMnskutJ0v6i69+ZAA520Y6nn2n4RD5\n"
+      + "8Yc+y7yCkbZXnYS5xBOFEExmtc0Xa7S9nM157xqKws9Z+rTKZYLrryaHI9JNcXgG\n"
+      + "kzQEH9fBePASeWfi9AGRvAyS2GMSIBOsihIDIha/mqQcJOGCEqTMtefIj2FaErO2\n"
+      + "bL9yU7OpW53iIC8y0QIDAQABoy8wLTAMBgNVHRMEBTADAQH/MB0GA1UdDgQWBBRf\n"
+      + "svKcoQ9ZBvjwyUSV2uMFzlkOWDANBgkqhkiG9w0BAQsFAAOCAQEAEE1ZG2MGE248\n"
+      + "glO83ROrHbxmnVWSQHt/JZANR1i362sY1ekL83wlhkriuvGVBlHQYWezIfo/4l9y\n"
+      + "JTHNX3Mrs9eWUkaDXADkHWj3AyLXN3nfeU307x1wA7OvI4YKpwvfb4aYS8RTPz9d\n"
+      + "JtrfR0r8aGTgsXvCe4SgwDBKv7bckctOwD3S7D/b6y3w7X0s7JCU5+8ZjgoYfcLE\n"
+      + "gNqQEaOwdT2LHCvxHmGn/2VGs/yatPQIYYuufe5i8yX7pp4Xbd2eD6LULYkHFs3x\n"
+      + "uJzMRI7BukmIIWuBbAkYI0atxLQIysnVFXdL9pBgvgso2nA3FgP/XeORhkyHVvtL\n"
+      + "REH2YTlftQ==\n"
+      + "-----END CERTIFICATE-----";
+
+  private static final String KEY =  "Bag Attributes\n"
+      + "    friendlyName: server\n"
+      + "    localKeyID: 54 69 6D 65 20 31 36 30 31 32 38 33 37 36 35 34 32 33\n"
+      + "Key Attributes: <No Attributes>\n"
+      + "-----BEGIN PRIVATE KEY-----\n"
+      + "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCmTDUBLvV6P+I4\n"
+      + "y/NWBUvV2RA5jMjzjY1w+bHTIUWy57a6YvxZV3fTzk2BZFvdJLXhfrvq3vPGM8bN\n"
+      + "iLuPCYDyy0KsO3Q0A9Z38qjoSuwKzzsJSzi7UKKd/5vej00Xm7RQ9gFAsXgivxPW\n"
+      + "ND60qKqwKEYO3q6tECDUKujmLuvXSM3W6h9ja0Gz6vyYAuEnXtxPksprBd5jA05D\n"
+      + "zpzl2MKVtw/RGt9w/JHKPX8KnVrGjbyI7R9cXI7Zl/dri+234iE9b4Da0v63clMF\n"
+      + "3yDsWXejPOlyi0CLswNxlpgD0aJM/gM6IpR4O3rIxhBCvdUSoZqlenh8pj632yWq\n"
+      + "cCZwFniRAgMBAAECggEAOfC/XwQvf0KW3VciF0yNGZshbgvBUCp3p284J+ml0Smu\n"
+      + "ns4yQiaZl3B/zJ9c6nYJ8OEpNDIuGVac46vKPZIAHZf4SO4GFMFpji078IN6LmH5\n"
+      + "nclZoNn9brNKaYbgQ2N6teKgmRu8Uc7laHKXjnZd0jaWAkRP8/h0l7fDob+jaERj\n"
+      + "oJBx4ux2Z62TTCP6W4VY3KZgSL1p6dQswqlukPVytMeI2XEwWnO+w8ED0BxCxM4F\n"
+      + "K//dw7nUMGS9GUNkgyDcH1akYSCDzdBeymQBp2latBotVfGNK1hq9nC1iaxmRkJL\n"
+      + "sYjwVc24n37u+txOovy3daq2ySj9trF7ySAPVYkh4QKBgQDWeN/MR6cy1TLF2j3g\n"
+      + "eMMeM32LxXArIPsar+mft+uisKWk5LDpsKpph93sl0JjFi4x0t1mqw23h23I+B2c\n"
+      + "JWiPAHUG3FGvvkPPcfMUvd7pODyE2XaXi+36UZAH7qc94VZGJEb+sPITckSruREE\n"
+      + "QErWZyrbBRgvQXsmVme5B2/kRQKBgQDGf2HQH0KHl54O2r9vrhiQxWIIMSWlizJC\n"
+      + "hjboY6DkIsAMwnXp3wn3Bk4tSgeLk8DEVlmEaE3gvGpiIp0vQnSOlME2TXfEthdM\n"
+      + "uS3+BFXN4Vxxx/qjKL2WfZloyzdaaaF7s+LIwmXgLsFFCUSq+uLtBqfpH2Qv+paX\n"
+      + "Xqm7LN3V3QKBgH5ssj/Q3RZx5oQKqf7wMNRUteT2dbB2uI56s9SariQwzPPuevrG\n"
+      + "US30ETWt1ExkfsaP7kLfAi71fhnBaHLq+j+RnWp15REbrw1RtmC7q/L+W25UYjvj\n"
+      + "GF0+RxDl9V/cvOaL6+2mkIw2B5TSet1uqK7KEdEZp6/zgYyP0oSXhbWhAoGAdnlZ\n"
+      + "HCtMPjnUcPFHCZVTvDTTSihrW9805FfPNe0g/olvLy5xymEBRZtR1d41mq1ZhNY1\n"
+      + "H75RnS1YIbKfNrHnd6J5n7ulHJfCWFy+grp7rCIyVwcRJYkPf17/zXhdVW1uoLLB\n"
+      + "TSoaPDAr0tSxU4vjHa23UoEV/z0F3Nr3W2xwC1ECgYBHKjv6ekLhx7HbP797+Ai+\n"
+      + "wkHvS2L/MqEBxuHzcQ9G6Mj3ANAeyDB8YSC8qGtDQoEyukv2dO73lpodNgbR8P+Q\n"
+      + "PDBb6eyntAo2sSeo0jZkiXvDOfRaGuGVrxjuTfaqcVB33jC6BYfi61/3Sr5oG9Nd\n"
+      + "tDGh1HlOIRm1jD9KQNVZ/Q==\n"
+      + "-----END PRIVATE KEY-----";
+
+  private static final String ENCRYPTED_KEY =  "-----BEGIN ENCRYPTED PRIVATE KEY-----\n"
+      + "MIIE6jAcBgoqhkiG9w0BDAEDMA4ECGyAEWAXlaXzAgIIAASCBMgt7QD1Bbz7MAHI\n"
+      + "Ni0eTrwNiuAPluHirLXzsV57d1O9i4EXVp5nzRy6753cjXbGXARbBeaJD+/+jbZp\n"
+      + "CBZTHMG8rTCfbsg5kMqxT6XuuqWlKLKc4gaq+QNgHHleKqnpwZQmOQ+awKWEK/Ow\n"
+      + "Z0KxXqkp+b4/qJK3MqKZDsJtVdyUhO0tLVxd+BHDg9B93oExc87F16h3R0+T4rxE\n"
+      + "Tvz2c2upBqva49AbLDxpWXLCJC8CRkxM+KHrPkYjpNx3jCjtwiiXfzJCWjuCkVrL\n"
+      + "2F4bqvpYPIseoPtMvWaplNtoPwhpzBB/hoJ+R+URr4XHX3Y+bz6k6iQnhoCOIviy\n"
+      + "oEEUvWtKnaEEKSauR+Wyj3MoeB64g9NWMEHv7+SQeA4WqlgV2s4txwRxFGKyKLPq\n"
+      + "caMSpfxvYujtSh0DOv9GI3cVHPM8WsebCz9cNrbKSR8/8JufcoonTitwF/4vm1Et\n"
+      + "AdmCuH9JIYVvmFKFVxY9SvRAvo43OQaPmJQHMUa4yDfMtpTSgmB/7HFgxtksYs++\n"
+      + "Gbrq6F/hon+0bLx+bMz2FK635UU+iVno+qaScKWN3BFqDl+KnZprBhLSXTT3aHmp\n"
+      + "fisQit/HWp71a0Vzq85WwI4ucMKNc8LemlwNBxWLLiJDp7sNPLb5dIl8yIwSEIgd\n"
+      + "vC5px9KWEdt3GxTUEqtIeBmagbBhahcv+c9Dq924DLI+Slv6TJKZpIcMqUECgzvi\n"
+      + "hb8gegyEscBEcDSzl0ojlFVz4Va5eZS/linTjNJhnkx8BKLn/QFco7FpEE6uOmQ3\n"
+      + "0kF64M2Rv67cJbYVrhD46TgIzH3Y/FOMSi1zFHQ14nVXWMu0yAlBX+QGk7Xl+/aF\n"
+      + "BIq+i9WcBqbttR3CwyeTnIFXkdC66iTZYhDl9HT6yMcazql2Or2TjIIWr6tfNWH/\n"
+      + "5dWSEHYM5m8F2/wF0ANWJyR1oPr4ckcUsfl5TfOWVj5wz4QVF6EGV7FxEnQHrdx0\n"
+      + "6rXThRKFjqxUubsNt1yUEwdlTNz2UFhobGF9MmFeB97BZ6T4v8G825de/Caq9FzO\n"
+      + "yMFFCRcGC7gIzMXRPEjHIvBdTThm9rbNzKPXHqw0LHG478yIqzxvraCYTRw/4eWN\n"
+      + "Q+hyOL/5T5QNXHpR8Udp/7sptw7HfRnecQ/Vz9hOKShQq3h4Sz6eQMQm7P9qGo/N\n"
+      + "bltEAIECRVcNYLN8LuEORfeecNcV3BX+4BBniFtdD2bIRsWC0ZUsGf14Yhr4P1OA\n"
+      + "PtMJzy99mrcq3h+o+hEW6bhIj1gA88JSMJ4iRuwTLRKE81w7EyziScDsotYKvDPu\n"
+      + "w4+PFbQO3fr/Zga3LgYis8/DMqZoWjVCjAeVoypuOZreieZYC/BgBS8qSUAmDPKq\n"
+      + "jK+T5pwMMchfXbkV80LTu1kqLfKWdE0AmZfGy8COE/NNZ/FeiWZPdwu2Ix6u/RoY\n"
+      + "LTjNy4YLIBdVELFXaFJF2GfzLpnwrW5tyNPVVrGmUoiyOzgx8gMyCLGavGtduyoY\n"
+      + "tBiUTmd05Ugscn4Rz9X30S4NbnjL/h+bWl1m6/M+9FHEe85FPxmt/GRmJPbFPMR5\n"
+      + "q5EgQGkt4ifiaP6qvyFulwvVwx+m0bf1q6Vb/k3clIyLMcVZWFE1TqNH2Ife46AE\n"
+      + "2I39ZnGTt0mbWskpHBA=\n"
+      + "-----END ENCRYPTED PRIVATE KEY-----";
+
+  private static final Password KEY_PASSWORD = new Password("key-password");
+
+  Map<String, Object> configs = new HashMap<>();
+
+  @Before
+  public void setUp() {
+    configs.put(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2");
+  }
+
+  @Test
+  public void testPemTrustStoreConfigWithOneCert() throws Exception {
+    configs.put(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, pemAsConfigValue(CA1).value());
+    configs.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, DefaultSslEngineFactory.PEM_TYPE);
+    SslFactory factory = new SslFactory(configs);
+
+    KeyStore trustStore = factory.trustStore().get();
+    List<String> aliases = Collections.list(trustStore.aliases());
+    assertEquals(Collections.singletonList("kafka0"), aliases);
+    assertNotNull("Certificate not loaded", trustStore.getCertificate("kafka0"));
+    assertNull("Unexpected private key", trustStore.getKey("kafka0", null));
+  }
+
+  @Test
+  public void testPemTrustStoreConfigWithMultipleCerts() throws Exception {
+    configs.put(SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, pemAsConfigValue(CA1, CA2).value());
+    configs.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, DefaultSslEngineFactory.PEM_TYPE);
+    SslFactory factory = new SslFactory(configs);
+
+    KeyStore trustStore = factory.trustStore().get();
+    List<String> aliases = Collections.list(trustStore.aliases());
+    assertEquals(Arrays.asList("kafka0", "kafka1"), aliases);
+    assertNotNull("Certificate not loaded", trustStore.getCertificate("kafka0"));
+    assertNull("Unexpected private key", trustStore.getKey("kafka0", null));
+    assertNotNull("Certificate not loaded", trustStore.getCertificate("kafka1"));
+    assertNull("Unexpected private key", trustStore.getKey("kafka1", null));
+  }
+
+  @Test
+  public void testPemKeyStoreConfigNoPassword() throws Exception {
+    verifyPemKeyStoreConfig(KEY, null);
+  }
+
+  @Test
+  public void testPemKeyStoreConfigWithKeyPassword() throws Exception {
+    verifyPemKeyStoreConfig(ENCRYPTED_KEY, KEY_PASSWORD);
+  }
+
+  @Test
+  public void testTrailingNewLines() throws Exception {
+    verifyPemKeyStoreConfig(ENCRYPTED_KEY + "\n\n", KEY_PASSWORD);
+  }
+
+  @Test
+  public void testLeadingNewLines() throws Exception {
+    verifyPemKeyStoreConfig("\n\n" + ENCRYPTED_KEY, KEY_PASSWORD);
+  }
+
+  @Test
+  public void testCarriageReturnLineFeed() throws Exception {
+    verifyPemKeyStoreConfig(ENCRYPTED_KEY.replaceAll("\n", "\r\n"), KEY_PASSWORD);
+  }
+
+  private void verifyPemKeyStoreConfig(String keyFileName, Password keyPassword) throws Exception {
+    configs.put(SslConfigs.SSL_KEYSTORE_KEY_CONFIG, pemAsConfigValue(keyFileName).value());
+    configs.put(SslConfigs.SSL_KEYSTORE_CERTIFICATE_CHAIN_CONFIG, pemAsConfigValue(CERTCHAIN).value());
+    configs.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, keyPassword == null ? null : keyPassword.value());
+    configs.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, DefaultSslEngineFactory.PEM_TYPE);
+    SslFactory factory = new SslFactory(configs);
+
+    KeyStore keyStore = factory.keyStore().get();
+    List<String> aliases = Collections.list(keyStore.aliases());
+    assertEquals(Collections.singletonList("kafka"), aliases);
+    assertNotNull("Certificate not loaded", keyStore.getCertificate("kafka"));
+    assertNotNull("Private key not loaded", keyStore.getKey("kafka", keyPassword == null ? null : keyPassword.value().toCharArray()));
+  }
+
+  @Test
+  public void testPemTrustStoreFile() throws Exception {
+    configs.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, pemFilePath(CA1));
+    configs.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, DefaultSslEngineFactory.PEM_TYPE);
+    SslFactory factory = new SslFactory(configs);
+
+    KeyStore trustStore = factory.trustStore().get();
+    List<String> aliases = Collections.list(trustStore.aliases());
+    assertEquals(Collections.singletonList("kafka0"), aliases);
+    assertNotNull("Certificate not found", trustStore.getCertificate("kafka0"));
+    assertNull("Unexpected private key", trustStore.getKey("kafka0", null));
+  }
+
+  @Test
+  public void testPemKeyStoreFileNoKeyPassword() throws Exception {
+    configs.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,
+        pemFilePath(pemAsConfigValue(KEY, CERTCHAIN).value()));
+    configs.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, DefaultSslEngineFactory.PEM_TYPE);
+    assertThrows(RuntimeException.class, () -> new SslFactory(configs));
+  }
+
+  @Test
+  public void testPemKeyStoreFileWithKeyPassword() throws Exception {
+    configs.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG,
+        pemFilePath(pemAsConfigValue(ENCRYPTED_KEY, CERTCHAIN).value()));
+    configs.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, KEY_PASSWORD.value());
+    configs.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, DefaultSslEngineFactory.PEM_TYPE);
+    SslFactory factory = new SslFactory(configs);
+
+    KeyStore keyStore = factory.keyStore().get();
+    List<String> aliases = Collections.list(keyStore.aliases());
+    assertEquals(Collections.singletonList("kafka"), aliases);
+    assertNotNull("Certificate not found", keyStore.getCertificate("kafka"));
+    assertNotNull("Private key not found", keyStore.getKey("kafka", KEY_PASSWORD.value().toCharArray()));
+  }
+
+  private String pemFilePath(String pem) throws Exception {
+    File pemFile = File.createTempFile(getClass().getSimpleName(),".pem", TestUtils.tempDirectory());
+    Files.write(pemFile.toPath(), pem.getBytes(StandardCharsets.UTF_8));
+    return pemFile.getAbsolutePath();
+  }
+
+  private Password pemAsConfigValue(String... pemValues) {
+    StringBuilder builder = new StringBuilder();
+    for (String pem : pemValues) {
+      builder.append(pem);
+      builder.append("\n");
+    }
+    return new Password(builder.toString().trim());
+  }
+
+}

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiSslTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiSslTest.java
@@ -119,11 +119,17 @@ public class RestApiSslTest extends ClusterTestHarness {
         SchemaRegistryClientConfig.CLIENT_NAMESPACE + SchemaRegistryConfig.SSL_KEYSTORE_PASSWORD_CONFIG,
         props.get(SchemaRegistryConfig.SSL_KEYSTORE_PASSWORD_CONFIG));
     clientsslConfigs.put(
+        SchemaRegistryClientConfig.CLIENT_NAMESPACE + SchemaRegistryConfig.SSL_KEYSTORE_TYPE_CONFIG,
+        props.get(SchemaRegistryConfig.SSL_KEYSTORE_TYPE_CONFIG));
+    clientsslConfigs.put(
         SchemaRegistryClientConfig.CLIENT_NAMESPACE + SchemaRegistryConfig.SSL_TRUSTSTORE_LOCATION_CONFIG,
         props.get(SchemaRegistryConfig.SSL_TRUSTSTORE_LOCATION_CONFIG));
     clientsslConfigs.put(
         SchemaRegistryClientConfig.CLIENT_NAMESPACE + SchemaRegistryConfig.SSL_TRUSTSTORE_PASSWORD_CONFIG,
         props.get(SchemaRegistryConfig.SSL_TRUSTSTORE_PASSWORD_CONFIG));
+    clientsslConfigs.put(
+        SchemaRegistryClientConfig.CLIENT_NAMESPACE + SchemaRegistryConfig.SSL_TRUSTSTORE_TYPE_CONFIG,
+        props.get(SchemaRegistryConfig.SSL_TRUSTSTORE_TYPE_CONFIG));
     CachedSchemaRegistryClient schemaRegistryClient = new CachedSchemaRegistryClient(restApp.restClient, 10, clientsslConfigs);
 
     assertEquals(

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiSslTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiSslTest.java
@@ -119,17 +119,11 @@ public class RestApiSslTest extends ClusterTestHarness {
         SchemaRegistryClientConfig.CLIENT_NAMESPACE + SchemaRegistryConfig.SSL_KEYSTORE_PASSWORD_CONFIG,
         props.get(SchemaRegistryConfig.SSL_KEYSTORE_PASSWORD_CONFIG));
     clientsslConfigs.put(
-        SchemaRegistryClientConfig.CLIENT_NAMESPACE + SchemaRegistryConfig.SSL_KEYSTORE_TYPE_CONFIG,
-        props.get(SchemaRegistryConfig.SSL_KEYSTORE_TYPE_CONFIG));
-    clientsslConfigs.put(
         SchemaRegistryClientConfig.CLIENT_NAMESPACE + SchemaRegistryConfig.SSL_TRUSTSTORE_LOCATION_CONFIG,
         props.get(SchemaRegistryConfig.SSL_TRUSTSTORE_LOCATION_CONFIG));
     clientsslConfigs.put(
         SchemaRegistryClientConfig.CLIENT_NAMESPACE + SchemaRegistryConfig.SSL_TRUSTSTORE_PASSWORD_CONFIG,
         props.get(SchemaRegistryConfig.SSL_TRUSTSTORE_PASSWORD_CONFIG));
-    clientsslConfigs.put(
-        SchemaRegistryClientConfig.CLIENT_NAMESPACE + SchemaRegistryConfig.SSL_TRUSTSTORE_TYPE_CONFIG,
-        props.get(SchemaRegistryConfig.SSL_TRUSTSTORE_TYPE_CONFIG));
     CachedSchemaRegistryClient schemaRegistryClient = new CachedSchemaRegistryClient(restApp.restClient, 10, clientsslConfigs);
 
     assertEquals(


### PR DESCRIPTION

(This is a cherry pick of https://github.com/confluentinc/schema-registry/pull/2062 to 7.1.x.)

* PEM implementation

* logging

* No password

* Test

* Minor changes to config checks, fixing tests and checkstyle

* Remove apache commons dependency

Co-authored-by: Elliot West <ewest@expediagroup.com>
Co-authored-by: Paul McDermott <pmcdermott@expediagroup.com>