### PR TITLE
DGS-3061 Only cache top-level schemas in AvroData

### DIFF
--- a/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -732,8 +732,15 @@ public class AvroData {
 
   public org.apache.avro.Schema fromConnectSchema(Schema schema,
                                                   Map<Schema, org.apache.avro.Schema> schemaMap) {
+    org.apache.avro.Schema cached = fromConnectSchemaCache.get(schema);
+    if (cached != null) {
+      return cached;
+    }
+
     FromConnectContext fromConnectContext = new FromConnectContext(schemaMap);
-    return fromConnectSchema(schema, fromConnectContext, false);
+    org.apache.avro.Schema finalSchema = fromConnectSchema(schema, fromConnectContext, false);
+    fromConnectSchemaCache.put(schema, finalSchema);
+    return finalSchema;
   }
 
   /**
@@ -755,13 +762,11 @@ public class AvroData {
       return ANYTHING_SCHEMA;
     }
 
-    org.apache.avro.Schema cached = fromConnectSchemaCache.get(schema);
-
-    if (cached == null && !AVRO_TYPE_UNION.equals(schema.name()) && !schema.isOptional()) {
-      cached = fromConnectContext.schemaMap.get(schema);
-    }
-    if (cached != null) {
-      return cached;
+    if (!AVRO_TYPE_UNION.equals(schema.name()) && !schema.isOptional()) {
+      org.apache.avro.Schema cached = fromConnectContext.schemaMap.get(schema);
+      if (cached != null) {
+        return cached;
+      }
     }
 
     // Extra type annotation information for otherwise lossy conversions
@@ -1039,7 +1044,6 @@ public class AvroData {
     if (!schema.isOptional()) {
       fromConnectContext.schemaMap.put(schema, finalSchema);
     }
-    fromConnectSchemaCache.put(schema, finalSchema);
     return finalSchema;
   }
 


### PR DESCRIPTION
Only cache top-level schemas in the global cache when converting from the Connect Schema in AvroData.

This is to prevent subschemas with the default schema name prefix from getting cached, which may result in `Can't redefine: io.confluent.connect.avro.ConnectDefault`.  Also, some caching of subschemas already occurs using the FromConnectContext.