### PR TITLE
DGS-3087: Accommodate upstream change in AbstractCoordinator

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java
@@ -149,7 +149,15 @@ final class SchemaRegistryCoordinator extends AbstractCoordinator implements Clo
     listener.onAssigned(assignmentSnapshot, generation);
   }
 
-  @Override
+  // todo: to be removed
+  protected Map<String, ByteBuffer> performAssignment(
+      String kafkaLeaderId, // Kafka group "leader" who does assignment, *not* the SR leader
+      String protocol,
+      List<JoinGroupResponseData.JoinGroupResponseMember> allMemberMetadata
+  ) {
+    return onLeaderElected(kafkaLeaderId, protocol, allMemberMetadata, false);
+  }
+
   protected Map<String, ByteBuffer> onLeaderElected(
       String kafkaLeaderId, // Kafka group "leader" who does assignment, *not* the SR leader
       String protocol,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java
@@ -150,10 +150,11 @@ final class SchemaRegistryCoordinator extends AbstractCoordinator implements Clo
   }
 
   @Override
-  protected Map<String, ByteBuffer> performAssignment(
+  protected Map<String, ByteBuffer> onLeaderElected(
       String kafkaLeaderId, // Kafka group "leader" who does assignment, *not* the SR leader
       String protocol,
-      List<JoinGroupResponseData.JoinGroupResponseMember> allMemberMetadata
+      List<JoinGroupResponseData.JoinGroupResponseMember> allMemberMetadata,
+      boolean skipAssignment
   ) {
     log.debug("Performing assignment");
 


### PR DESCRIPTION
Ref: https://github.com/apache/kafka/pull/11688

Todo:
Have a follow-up PR to remove the old method once the AK -> CCS sync is done. 