### PR TITLE
Minor: Fix ClusterTestHarness due to upstream changes

### DIFF
--- a/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
@@ -130,11 +130,7 @@ public abstract class ClusterTestHarness {
       servers.add(server);
     }
 
-    brokerList =
-        TestUtils.getBrokerListStrFromServers(
-            JavaConverters.asScalaBuffer(servers),
-            getSecurityProtocol()
-        );
+    brokerList = TestUtils.plaintextBootstrapServers(JavaConverters.asScalaBuffer(servers));
 
     // Initialize the rest app ourselves so we can ensure we don't pass any info about the Kafka
     // zookeeper. The format for this config includes the security protocol scheme in the URLs so

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
@@ -130,13 +130,13 @@ public abstract class ClusterTestHarness {
       servers.add(server);
     }
 
-    brokerList = TestUtils.plaintextBootstrapServers(JavaConverters.asScalaBuffer(servers));
+    ListenerName listenerType = ListenerName.forSecurityProtocol(getSecurityProtocol());
+    brokerList = TestUtils.bootstrapServers(JavaConverters.asScalaBuffer(servers), listenerType);
 
     // Initialize the rest app ourselves so we can ensure we don't pass any info about the Kafka
     // zookeeper. The format for this config includes the security protocol scheme in the URLs so
     // we can't use the pre-generated server list.
     String[] serverUrls = new String[servers.size()];
-    ListenerName listenerType = ListenerName.forSecurityProtocol(getSecurityProtocol());
     for(int i = 0; i < servers.size(); i++) {
       serverUrls[i] = getSecurityProtocol() + "://" +
                       Utils.formatAddress(


### PR DESCRIPTION
`TestUtils.getBrokerListStrFromServers` is removed in https://github.com/apache/kafka/pull/11790, use `TestUtils.bootstrapServers` instead. 