### PR TITLE
Incorporated endpoint verification disable for schema registry client

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -20,6 +20,7 @@ import com.google.common.base.Ticker;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
+import org.apache.kafka.common.config.SslConfigs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,6 +52,8 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.requests.ModeUpdat
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.client.security.SslFactory;
 import io.confluent.kafka.schemaregistry.utils.BoundedConcurrentHashMap;
+
+import javax.net.ssl.HostnameVerifier;
 
 
 /**
@@ -200,7 +203,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
         .build();
 
     this.providers = providers != null && !providers.isEmpty()
-                     ? providers.stream().collect(Collectors.toMap(p -> p.schemaType(), p -> p))
+                     ? providers.stream().collect(Collectors.toMap(SchemaProvider::schemaType, p -> p))
                      : Collections.singletonMap(AvroSchema.TYPE, new AvroSchemaProvider());
     Map<String, Object> schemaProviderConfigs = new HashMap<>();
     schemaProviderConfigs.put(SchemaProvider.SCHEMA_VERSION_FETCHER_CONFIG, this);
@@ -228,6 +231,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
       SslFactory sslFactory = new SslFactory(sslConfigs);
       if (sslFactory.sslContext() != null) {
         restService.setSslSocketFactory(sslFactory.sslContext().getSocketFactory());
+        restService.setHostnameVerifier(getHostnameVerifier(sslConfigs));
       }
     }
   }
@@ -250,6 +254,19 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
 
   public Map<String, SchemaProvider> getSchemaProviders() {
     return providers;
+  }
+
+  private HostnameVerifier getHostnameVerifier(Map<String, Object> config) {
+    String sslEndpointIdentificationAlgo =
+        (String) config.get(SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG);
+
+    if (sslEndpointIdentificationAlgo == null
+        || sslEndpointIdentificationAlgo.equals("none")
+        || sslEndpointIdentificationAlgo.isEmpty()) {
+      return (hostname, session) -> true;
+    }
+
+    return null;
   }
 
   private int registerAndGetId(String subject, ParsedSchema schema, boolean normalize)


### PR DESCRIPTION
Why we require this change - 
The sun.net.www.protocol.https.HttpsClient does endpoint identification via 2 ways - 
```
// We have two hostname verification approaches. One is in
// SSL/TLS socket layer, where the algorithm is configured with
// SSLParameters.setEndpointIdentificationAlgorithm(), and the
// hostname verification is done by X509ExtendedTrustManager when
// the algorithm is "HTTPS". The other one is in HTTPS layer,
// where the algorithm is customized by
// HttpsURLConnection.setHostnameVerifier(), and the hostname
// verification is done by HostnameVerifier when the default
// rules for hostname verification fail.
//
// The relationship between two hostname verification approaches
// likes the following:
//
//               |             EIA algorithm
//               +----------------------------------------------
//               |     null      |   HTTPS    |   LDAP/other   |
// -------------------------------------------------------------
//     |         |1              |2           |3               |
// HNV | default | Set HTTPS EIA | use EIA    | HTTPS          |
//     |--------------------------------------------------------
//     | non -   |4              |5           |6               |
//     | default | HTTPS/HNV     | use EIA    | HTTPS/HNV      |
// -------------------------------------------------------------
//
// Abbreviation:
//     EIA: the endpoint identification algorithm in SSL/TLS
//           socket layer
//     HNV: the hostname verification object in HTTPS layer
// Notes:
//     case 1. default HNV and EIA is null
//           Set EIA as HTTPS, hostname check done in SSL/TLS
//           layer.
```
i.e. In all situations we are HTTP endpoint verification is done even though you set `schema.registry.ssl.endpoint.identification.algorithm=`. 

So here we specify our own hostname verification when it's set to null. The PR implements same functionality as https://github.com/confluentinc/schema-registry/pull/1296 and closed #1504 