### PR TITLE
DGS-3133: Compare canonical string instead of jsonNode when comparing JsonSchema

### DIFF
--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -336,7 +336,7 @@ public class JsonSchema implements ParsedSchema {
       return false;
     }
     JsonSchema that = (JsonSchema) o;
-    return Objects.equals(jsonNode, that.jsonNode)
+    return Objects.equals(canonicalString(), that.canonicalString())
         && Objects.equals(references, that.references)
         && Objects.equals(version, that.version);
   }

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -322,6 +323,39 @@ public class JsonSchemaTest {
     JsonSchema jsonSchema = new JsonSchema(schema);
     List<Difference> diff = SchemaDiff.compare(jsonSchema.rawSchema(), jsonSchema.rawSchema());
     assertEquals(0, diff.size());
+  }
+
+  @Test
+  public void testSchemasDifferentFieldOrder() {
+    String schema1 = "{\n"
+        + "  \"title\": \"Person\",\n"
+        + "  \"type\": \"object\",\n"
+        + "  \"properties\": {\n"
+        + "    \"lastName\": {\n"
+        + "      \"type\": \"string\",\n"
+        + "      \"description\": \"The person's last name.\"\n"
+        + "    },\n"
+        + "    \"firstName\": {\n"
+        + "      \"type\": \"string\",\n"
+        + "      \"description\": \"The person's first name.\"\n"
+        + "    }\n" + "  }\n"
+        + "}";
+    String schema2 = "{\n"
+        + "  \"title\": \"Person\",\n"
+        + "  \"type\": \"object\",\n"
+        + "  \"properties\": {\n"
+        + "    \"firstName\": {\n"
+        + "      \"type\": \"string\",\n"
+        + "      \"description\": \"The person's first name.\"\n"
+        + "    },\n"
+        + "    \"lastName\": {\n"
+        + "      \"type\": \"string\",\n"
+        + "      \"description\": \"The person's last name.\"\n"
+        + "    }\n" + "  }\n"
+        + "}";
+    JsonSchema jsonSchema1 = new JsonSchema(schema1);
+    JsonSchema jsonSchema2 = new JsonSchema(schema2);
+    assertNotEquals(jsonSchema1, jsonSchema2);
   }
 
   private static Map<String, String> getJsonSchemaWithReferences() {


### PR DESCRIPTION
Solves https://confluentinc.atlassian.net/browse/RCCA-6039