### PR TITLE
DGS-2716 Add support for generic Registries in SR

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/Registry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/Registry.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.storage;
+
+import com.google.protobuf.Timestamp;
+
+public interface Registry {
+  public String getRegistryValue(String key);
+
+  public Timestamp getCreatedTimeStamp(String key);
+
+  public Timestamp getModifiedTimeStamp(String key);
+}

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
@@ -108,6 +108,10 @@ public interface SchemaRegistry extends SchemaVersionFetcher {
   default void setTenant(String tenant) {
   }
 
+  default Registry getRegistry(SchemaRegistryConfig config) {
+    return null;
+  }
+
   SchemaRegistryConfig config();
 
   // Can be used to pass values between extensions


### PR DESCRIPTION
* schema registry is extensible by design. We can enhance schema registry by plugins. But to share objects between plugins we should need to include that object in the KafkaSchemaRegistry object.