### PR TITLE
CVE: Fix swagger pulling in vulnerable snakeyaml 1.26

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -68,22 +68,10 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>1.5.22</version>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-core</artifactId>
-            <version>1.6.2</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>javax.validation</groupId>
-                    <artifactId>validation-api</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
          <dependency>
                  <groupId>com.google.guava</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -241,12 +241,10 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
-            <version>1.5.22</version>
         </dependency>
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-core</artifactId>
-            <version>1.6.2</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <commons.compress.version>1.21</commons.compress.version>
+        <snake.yaml.version>1.27</snake.yaml.version>
     </properties>
 
     <repositories>
@@ -96,6 +97,31 @@
                 <groupId>uk.co.jemos.podam</groupId>
                 <artifactId>podam</artifactId>
                 <version>${podam.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger</groupId>
+                <artifactId>swagger-annotations</artifactId>
+                <version>1.5.22</version>
+            </dependency>
+            <dependency>
+                <groupId>io.swagger</groupId>
+                <artifactId>swagger-core</artifactId>
+                <version>1.6.2</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>javax.validation</groupId>
+                        <artifactId>validation-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>guava</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snake.yaml.version}</version>
             </dependency>
 
             <!--children-->


### PR DESCRIPTION
Problem:
swagger-core pulls in vulnerable snakeyaml 1.26.

Solution:
Consolidate swagger versioning and set version of snakeyaml at the first non-vulnerable version (1.27):
```bash
mvn dependency:tree | grep snakeyaml
[INFO] |  |  \- org.yaml:snakeyaml:jar:1.27:compile
[INFO] |  |  |  \- org.yaml:snakeyaml:jar:1.27:compile
[INFO] |  |  \- org.yaml:snakeyaml:jar:1.27:compile
[INFO] |  |  |  \- org.yaml:snakeyaml:jar:1.27:compile
[INFO] |  |  |  \- org.yaml:snakeyaml:jar:1.27:compile
[INFO] |  |  |  \- org.yaml:snakeyaml:jar:1.27:compile
[INFO] |  |  |  |  \- org.yaml:snakeyaml:jar:1.27:compile
[INFO] |  |  |  \- org.yaml:snakeyaml:jar:1.27:compile
```