### PR TITLE
Kafka store abstraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ target/
 # Log file from schema registry daemon
 logs/
 nohup.out
+/.metadata/

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/ErrorMessage.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/ErrorMessage.java
@@ -43,8 +43,8 @@ public class ErrorMessage {
   }
 
   @JsonProperty("error_code")
-  public void setErrorCode(int error_code) {
-    this.errorCode = error_code;
+  public void setErrorCode(int errorCode) {
+    this.errorCode = errorCode;
   }
 
   @JsonProperty

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/ServerClusterId.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/ServerClusterId.java
@@ -51,7 +51,9 @@ public class ServerClusterId {
 
   public static ServerClusterId of(String kafkaClusterId, String schemaRegistryClusterId) {
     Map<String, Object> clusters = new HashMap<>();
-    clusters.put(KAFKA_CLUSTER, kafkaClusterId);
+    if (kafkaClusterId != null) {
+      clusters.put(KAFKA_CLUSTER, kafkaClusterId);
+    }
     clusters.put(SCHEMA_REGISTRY_CLUSTER, schemaRegistryClusterId);
     Map<String, Object> serverClusterId = new HashMap<>();
     serverClusterId.put("path", Collections.emptyList());

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
@@ -29,6 +29,7 @@ import io.confluent.kafka.schemaregistry.rest.resources.ServerMetadataResource;
 import io.confluent.kafka.schemaregistry.rest.resources.SubjectVersionsResource;
 import io.confluent.kafka.schemaregistry.rest.resources.SubjectsResource;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
+import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
 import io.confluent.kafka.schemaregistry.storage.serialization.SchemaRegistrySerializer;
 import io.confluent.rest.Application;
 import io.confluent.rest.RestConfigException;
@@ -47,7 +48,7 @@ import java.util.Properties;
 public class SchemaRegistryRestApplication extends Application<SchemaRegistryConfig> {
 
   private static final Logger log = LoggerFactory.getLogger(SchemaRegistryRestApplication.class);
-  private KafkaSchemaRegistry schemaRegistry = null;
+  private SchemaRegistry schemaRegistry = null;
   private List<SchemaRegistryResourceExtension> schemaRegistryResourceExtensions = null;
 
   public SchemaRegistryRestApplication(Properties props) throws RestConfigException {
@@ -65,7 +66,7 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
   }
 
 
-  protected KafkaSchemaRegistry initSchemaRegistry(SchemaRegistryConfig config) {
+  protected SchemaRegistry initSchemaRegistry(SchemaRegistryConfig config) {
     KafkaSchemaRegistry kafkaSchemaRegistry = null;
     try {
       kafkaSchemaRegistry = new KafkaSchemaRegistry(
@@ -158,6 +159,6 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
 
   // for testing purpose only
   public KafkaSchemaRegistry schemaRegistry() {
-    return schemaRegistry;
+    return (KafkaSchemaRegistry)schemaRegistry;
   }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
@@ -67,7 +67,7 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
 
 
   protected SchemaRegistry initSchemaRegistry(SchemaRegistryConfig config) {
-    KafkaSchemaRegistry kafkaSchemaRegistry = null;
+    SchemaRegistry kafkaSchemaRegistry = null;
     try {
       kafkaSchemaRegistry = new KafkaSchemaRegistry(
           config,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -26,7 +26,7 @@ import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException;
 import io.confluent.kafka.schemaregistry.rest.VersionId;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
-import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
+import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
 import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
 import io.confluent.rest.annotations.PerformanceMetric;
 import io.swagger.v3.oas.annotations.Operation;
@@ -59,9 +59,9 @@ import java.util.List;
 public class CompatibilityResource {
 
   private static final Logger log = LoggerFactory.getLogger(CompatibilityResource.class);
-  private final KafkaSchemaRegistry schemaRegistry;
+  private final SchemaRegistry schemaRegistry;
 
-  public CompatibilityResource(KafkaSchemaRegistry schemaRegistry) {
+  public CompatibilityResource(SchemaRegistry schemaRegistry) {
     this.schemaRegistry = schemaRegistry;
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -15,7 +15,7 @@
 
 package io.confluent.kafka.schemaregistry.rest.resources;
 
-import static io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry.GLOBAL_RESOURCE_NAME;
+import static io.confluent.kafka.schemaregistry.storage.SchemaRegistry.GLOBAL_RESOURCE_NAME;
 
 import com.google.common.base.CharMatcher;
 import io.confluent.kafka.schemaregistry.CompatibilityLevel;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -28,7 +28,7 @@ import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException
 import io.confluent.kafka.schemaregistry.exceptions.UnknownLeaderException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidCompatibilityException;
-import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
+import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
 import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -63,11 +63,11 @@ import java.util.Map;
 public class ConfigResource {
 
   private static final Logger log = LoggerFactory.getLogger(ConfigResource.class);
-  private final KafkaSchemaRegistry schemaRegistry;
+  private final SchemaRegistry schemaRegistry;
 
   private final RequestHeaderBuilder requestHeaderBuilder = new RequestHeaderBuilder();
 
-  public ConfigResource(KafkaSchemaRegistry schemaRegistry) {
+  public ConfigResource(SchemaRegistry schemaRegistry) {
     this.schemaRegistry = schemaRegistry;
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ContextsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ContextsResource.java
@@ -19,7 +19,7 @@ import io.confluent.kafka.schemaregistry.client.rest.Versions;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
-import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
+import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
 import io.confluent.rest.annotations.PerformanceMetric;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -42,9 +42,9 @@ import java.util.List;
            Versions.JSON, Versions.GENERIC_REQUEST})
 public class ContextsResource {
 
-  private final KafkaSchemaRegistry schemaRegistry;
+  private final SchemaRegistry schemaRegistry;
 
-  public ContextsResource(KafkaSchemaRegistry schemaRegistry) {
+  public ContextsResource(SchemaRegistry schemaRegistry) {
     this.schemaRegistry = schemaRegistry;
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
@@ -15,9 +15,7 @@
 
 package io.confluent.kafka.schemaregistry.rest.resources;
 
-<<<<<<< HEAD
-import static io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry.GLOBAL_RESOURCE_NAME;
-
+import static io.confluent.kafka.schemaregistry.storage.SchemaRegistry.GLOBAL_RESOURCE_NAME;
 import com.google.common.base.CharMatcher;
 import io.confluent.kafka.schemaregistry.client.rest.Versions;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Mode;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafka.schemaregistry.rest.resources;
 
+<<<<<<< HEAD
 import static io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry.GLOBAL_RESOURCE_NAME;
 
 import com.google.common.base.CharMatcher;
@@ -28,7 +29,7 @@ import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException
 import io.confluent.kafka.schemaregistry.exceptions.UnknownLeaderException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidModeException;
-import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
+import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
 import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -64,11 +65,11 @@ import java.util.Map;
 public class ModeResource {
 
   private static final Logger log = LoggerFactory.getLogger(ModeResource.class);
-  private final KafkaSchemaRegistry schemaRegistry;
+  private final SchemaRegistry schemaRegistry;
 
   private final RequestHeaderBuilder requestHeaderBuilder = new RequestHeaderBuilder();
 
-  public ModeResource(KafkaSchemaRegistry schemaRegistry) {
+  public ModeResource(SchemaRegistry schemaRegistry) {
     this.schemaRegistry = schemaRegistry;
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
@@ -22,7 +22,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
-import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
+import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
 import io.confluent.rest.annotations.PerformanceMetric;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -54,9 +54,9 @@ import java.util.Set;
 public class SchemasResource {
 
   private static final Logger log = LoggerFactory.getLogger(SchemasResource.class);
-  private final KafkaSchemaRegistry schemaRegistry;
+  private final SchemaRegistry schemaRegistry;
 
-  public SchemasResource(KafkaSchemaRegistry schemaRegistry) {
+  public SchemasResource(SchemaRegistry schemaRegistry) {
     this.schemaRegistry = schemaRegistry;
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ServerMetadataResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ServerMetadataResource.java
@@ -17,6 +17,7 @@ package io.confluent.kafka.schemaregistry.rest.resources;
 
 import io.confluent.kafka.schemaregistry.client.rest.Versions;
 import io.confluent.kafka.schemaregistry.client.rest.entities.ServerClusterId;
+import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
 import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
 import io.confluent.rest.annotations.PerformanceMetric;
 import io.swagger.v3.oas.annotations.Operation;
@@ -43,7 +44,7 @@ public class ServerMetadataResource {
   private final SchemaRegistry schemaRegistry;
 
   public ServerMetadataResource(SchemaRegistry schemaRegistry) {
-   this.schemaRegistry = schemaRegistry;
+    this.schemaRegistry = schemaRegistry;
   }
 
   @GET
@@ -54,8 +55,13 @@ public class ServerMetadataResource {
   })
   @PerformanceMetric("metadata.id")
   public ServerClusterId getClusterId() {
-    String kafkaClusterId = schemaRegistry.getKafkaClusterId();
     String schemaRegistryClusterId = schemaRegistry.getGroupId();
+
+    String kafkaClusterId = null;
+    if (schemaRegistry instanceof KafkaSchemaRegistry) {
+      kafkaClusterId = ((KafkaSchemaRegistry)schemaRegistry).getKafkaClusterId();
+    } 
+    
     return ServerClusterId.of(kafkaClusterId, schemaRegistryClusterId);
   }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ServerMetadataResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ServerMetadataResource.java
@@ -17,7 +17,7 @@ package io.confluent.kafka.schemaregistry.rest.resources;
 
 import io.confluent.kafka.schemaregistry.client.rest.Versions;
 import io.confluent.kafka.schemaregistry.client.rest.entities.ServerClusterId;
-import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
+import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
 import io.confluent.rest.annotations.PerformanceMetric;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -39,10 +39,11 @@ import javax.ws.rs.Produces;
 public class ServerMetadataResource {
 
   private static final Logger log = LoggerFactory.getLogger(ServerMetadataResource.class);
-  private final KafkaSchemaRegistry schemaRegistry;
 
-  public ServerMetadataResource(KafkaSchemaRegistry schemaRegistry) {
-    this.schemaRegistry = schemaRegistry;
+  private final SchemaRegistry schemaRegistry;
+
+  public ServerMetadataResource(SchemaRegistry schemaRegistry) {
+   this.schemaRegistry = schemaRegistry;
   }
 
   @GET

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -39,7 +39,7 @@ import io.confluent.kafka.schemaregistry.exceptions.SchemaVersionNotSoftDeletedE
 import io.confluent.kafka.schemaregistry.exceptions.UnknownLeaderException;
 import io.confluent.kafka.schemaregistry.rest.VersionId;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
-import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
+import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
 import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
 import io.confluent.rest.annotations.PerformanceMetric;
 import io.swagger.v3.oas.annotations.Operation;
@@ -79,7 +79,7 @@ public class SubjectVersionsResource {
 
   private static final Logger log = LoggerFactory.getLogger(SubjectVersionsResource.class);
 
-  private final KafkaSchemaRegistry schemaRegistry;
+  private final SchemaRegistry schemaRegistry;
 
   private final RequestHeaderBuilder requestHeaderBuilder = new RequestHeaderBuilder();
 
@@ -88,7 +88,7 @@ public class SubjectVersionsResource {
       + "returns the last registered schema under the specified subject. Note that there may be a "
       + "new latest schema that gets registered right after this request is served.";
 
-  public SubjectVersionsResource(KafkaSchemaRegistry registry) {
+  public SubjectVersionsResource(SchemaRegistry registry) {
     this.schemaRegistry = registry;
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -15,7 +15,7 @@
 
 package io.confluent.kafka.schemaregistry.rest.resources;
 
-import static io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry.GLOBAL_RESOURCE_NAME;
+import static io.confluent.kafka.schemaregistry.storage.SchemaRegistry.GLOBAL_RESOURCE_NAME;
 
 import com.google.common.base.CharMatcher;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -27,7 +27,7 @@ import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryTimeoutException;
 import io.confluent.kafka.schemaregistry.exceptions.SubjectNotSoftDeletedException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
-import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
+import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
 import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
 import io.confluent.rest.annotations.PerformanceMetric;
 import io.swagger.v3.oas.annotations.Operation;
@@ -67,10 +67,10 @@ import java.util.Set;
 public class SubjectsResource {
 
   private static final Logger log = LoggerFactory.getLogger(SubjectsResource.class);
-  private final KafkaSchemaRegistry schemaRegistry;
+  private final SchemaRegistry schemaRegistry;
   private final RequestHeaderBuilder requestHeaderBuilder = new RequestHeaderBuilder();
 
-  public SubjectsResource(KafkaSchemaRegistry schemaRegistry) {
+  public SubjectsResource(SchemaRegistry schemaRegistry) {
     this.schemaRegistry = schemaRegistry;
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -104,8 +104,6 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
    * Schema versions under a particular subject are indexed from MIN_VERSION.
    */
   public static final int MIN_VERSION = 1;
-  // Subject name under which global permissions are stored.
-  public static final String GLOBAL_RESOURCE_NAME = "__GLOBAL";
   public static final int MAX_VERSION = Integer.MAX_VALUE;
   private static final Logger log = LoggerFactory.getLogger(KafkaSchemaRegistry.class);
 
@@ -588,6 +586,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     return subjectMode == Mode.READONLY || subjectMode == Mode.READONLY_OVERRIDE;
   }
 
+  @Override
   public int registerOrForward(String subject,
                                Schema schema,
                                boolean normalize,
@@ -1711,6 +1710,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     }
   }
 
+  @Override
   public void setModeOrForward(String subject, Mode mode, boolean force,
       Map<String, String> headerProperties)
       throws SchemaRegistryStoreException, SchemaRegistryRequestForwardingException,

--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -98,16 +98,6 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
 
     <Match>
         <Class name="~io.confluent.kafka.schemaregistry.utils.BoundedConcurrentHashMap.*"/>
-	<Bug pattern="UUF_UNUSED_FIELD"/>
-    </Match>
-   <Match>
-        <Class name="io.confluent.kafka.schemaregistry.storage.KafkaStoreReaderThread"/>
-        <Bug pattern="UUF_UNUSED_FIELD"/>
-   </Match>
-
-    <Match>
-        <Class name="~io.confluent.connect.*"/>
-        <Bug pattern="UUF_UNUSED_FIELD"/>
     </Match>
 
     <!-- exclude generated code -->

--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -98,6 +98,16 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
 
     <Match>
         <Class name="~io.confluent.kafka.schemaregistry.utils.BoundedConcurrentHashMap.*"/>
+	<Bug pattern="UUF_UNUSED_FIELD"/>
+    </Match>
+   <Match>
+        <Class name="io.confluent.kafka.schemaregistry.storage.KafkaStoreReaderThread"/>
+        <Bug pattern="UUF_UNUSED_FIELD"/>
+   </Match>
+
+    <Match>
+        <Class name="~io.confluent.connect.*"/>
+        <Bug pattern="UUF_UNUSED_FIELD"/>
     </Match>
 
     <!-- exclude generated code -->

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverter.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverter.java
@@ -15,8 +15,9 @@
 
 package io.confluent.connect.json;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.annotations.VisibleForTesting;
+import java.util.Collections;
+import java.util.Map;
+
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.errors.SerializationException;
@@ -25,8 +26,8 @@ import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.storage.Converter;
 
-import java.util.Collections;
-import java.util.Map;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.annotations.VisibleForTesting;
 
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;


### PR DESCRIPTION
This commit is a small commit to ensure that the KafkaSchemaRegistry class is only used from a limited number of places and that the SchemaRegistry interface is used. This would make the interface useful for being able to create Mock schema registry or concrete non-Kafka based Schema implementations. 