### PR TITLE
DG-931: throw ConfigException on `401 Unauthorized` error code

### DIFF
--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -253,7 +253,7 @@ public abstract class AbstractKafkaSchemaSerDe {
   }
 
   protected static KafkaException toKafkaException(RestClientException e, String errorMessage) {
-    if (e.getErrorCode() / 100 == 5 /* HTTP 500 Server Error */) {
+    if (e.getErrorCode() == 401 || e.getErrorCode() / 100 == 5 /* HTTP 500 Server Error */) {
       return new InvalidConfigurationException(e.getMessage());
     } else {
       return new SerializationException(errorMessage, e);


### PR DESCRIPTION
https://github.com/confluentinc/schema-registry/pull/1746 included changes to throw ConfigException 5xx errors. 

The original solution for DG-931 (and the issue associated with it)﻿was to throw ConfigExceptions on Authentication errors which include 401 Unauthorized error code. Authentication errors with SR are usually due to a misconfiguration of the connector, relative to the data in their topic. These errors should be instead reported as a ConfigException, indicating that the converter was misconfigured 
