### PR TITLE
Minor: Maps 4xx error to InvalidConfigurationException

### DIFF
--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -230,7 +230,7 @@ public abstract class AbstractKafkaSchemaSerDe {
   }
 
   protected static KafkaException toKafkaException(RestClientException e, String errorMessage) {
-    if (e.getErrorCode() / 100 == 5 /* HTTP 500 Server Error */) {
+    if (e.getErrorCode() / 100 == 4 /* Client Error */) {
       return new InvalidConfigurationException(e.getMessage());
     } else {
       return new SerializationException(errorMessage, e);


### PR DESCRIPTION
Fix a bug introduced in https://github.com/confluentinc/schema-registry/pull/1933 that maps server error to InvalidConfigurationException.
Address https://github.com/confluentinc/schema-registry/pull/2235