### PR TITLE
7.1.x jsonschemacache

### DIFF
--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
@@ -29,7 +29,6 @@ import java.util.LinkedHashMap;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.apache.avro.data.Json;
 import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
@@ -605,6 +604,9 @@ public class JsonSchemaData {
 
   public JsonSchema fromConnectSchema(Schema schema) {
     FromConnectContext ctx = new FromConnectContext();
+    if (schema == null) {
+      return new JsonSchema(rawSchemaFromConnectSchema(ctx, null));
+    }
     // using the name as the cache key, example:cdc_marqeta_jcard_trancache.Envelope
     JsonSchema cachedJsonSchema = jsonSchemaCache.get(schema.name());
     if (cachedJsonSchema != null) {

--- a/json-schema-provider/pom.xml
+++ b/json-schema-provider/pom.xml
@@ -56,6 +56,11 @@
             <artifactId>jackson-module-parameter-names</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-blackbird</artifactId>
+            <version>2.13.1</version>
+        </dependency>
+        <dependency>
             <groupId>com.kjetland</groupId>
             <artifactId>mbknor-jackson-jsonschema_${kafka.scala.version}</artifactId>
         </dependency>

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/Jackson.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/Jackson.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.blackbird.BlackbirdModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import java.util.TreeMap;
 
@@ -75,6 +76,7 @@ public class Jackson {
     mapper.registerModule(new Jdk8Module());
     mapper.registerModule(new JavaTimeModule());
     mapper.registerModule(new JsonOrgModule());
+    mapper.registerModule(new BlackbirdModule());
     mapper.enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
     mapper.disable(FAIL_ON_UNKNOWN_PROPERTIES);
     mapper.setNodeFactory(sorted

--- a/package-schema-registry/pom.xml
+++ b/package-schema-registry/pom.xml
@@ -47,6 +47,36 @@
             <artifactId>kafka-schema-registry</artifactId>
             <version>${io.confluent.schema-registry.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-json-schema-converter</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-json-schema-provider</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-json-schema-serializer</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-json-serializer</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-streams-json-schema-serde</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-serializer</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+        </dependency>
         <!-- kafka -> zookeeper -> jline ends up including junit 3.8.1 here. Explicitly list the
              dependency and scope it to test to avoid pulling it in -->
         <dependency>


### PR DESCRIPTION
- adds blackbird module
- `jsonSchemaCache` to cache the json schemas instead of instantiating a new object each time.