### PR TITLE
DGS-3535: Remove enforcement of building with JDK8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,5 @@
 #!/usr/bin/env groovy
 common {
-  nodeLabel = 'docker-debian-10-jdk8'
   slackChannel = '#data-governance-eng'
   upstreamProjects = 'confluentinc/rest-utils'
   timeoutHours = 3


### PR DESCRIPTION
Remove the line so that PR will build with JDK11.