### PR TITLE
DGS-3548 Optimize cache for JSON Schema converter

### DIFF
--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
@@ -361,9 +361,9 @@ public class JsonSchemaData {
     });
   }
 
-  private JsonSchemaDataConfig config;
-  private Cache<Schema, org.everit.json.schema.Schema> fromConnectSchemaCache;
-  private Cache<JsonSchema, Schema> toConnectSchemaCache;
+  private final JsonSchemaDataConfig config;
+  private final Cache<Schema, JsonSchema> fromConnectSchemaCache;
+  private final Cache<JsonSchema, Schema> toConnectSchemaCache;
 
   public JsonSchemaData() {
     this(new JsonSchemaDataConfig.Builder().with(
@@ -604,22 +604,22 @@ public class JsonSchemaData {
   }
 
   public JsonSchema fromConnectSchema(Schema schema) {
+    if (schema == null) {
+      return null;
+    }
+    JsonSchema cachedSchema = fromConnectSchemaCache.get(schema);
+    if (cachedSchema != null) {
+      return cachedSchema;
+    }
     FromConnectContext ctx = new FromConnectContext();
-    return new JsonSchema(rawSchemaFromConnectSchema(ctx, schema));
+    JsonSchema resultSchema = new JsonSchema(rawSchemaFromConnectSchema(ctx, schema));
+    fromConnectSchemaCache.put(schema, resultSchema);
+    return resultSchema;
   }
 
   private org.everit.json.schema.Schema rawSchemaFromConnectSchema(
       FromConnectContext ctx, Schema schema) {
-    if (schema == null) {
-      return null;
-    }
-    org.everit.json.schema.Schema cachedSchema = fromConnectSchemaCache.get(schema);
-    if (cachedSchema != null) {
-      return cachedSchema;
-    }
-    org.everit.json.schema.Schema resultSchema = rawSchemaFromConnectSchema(ctx, schema, null);
-    fromConnectSchemaCache.put(schema, resultSchema);
-    return resultSchema;
+    return rawSchemaFromConnectSchema(ctx, schema, null);
   }
 
   private org.everit.json.schema.Schema rawSchemaFromConnectSchema(
@@ -742,7 +742,7 @@ public class JsonSchemaData {
               refId = fieldSchema.parameters().get(JSON_ID_PROP);
             }
             org.everit.json.schema.Schema jsonSchema;
-            if (refId != null && ctx.contains(refId)) {
+            if (ctx.contains(refId)) {
               jsonSchema = ReferenceSchema.builder().refValue(refId).build();
             } else {
               jsonSchema = rawSchemaFromConnectSchema(ctx, fieldSchema, field.index());
@@ -937,7 +937,7 @@ public class JsonSchemaData {
     } else if (jsonSchema instanceof CombinedSchema) {
       CombinedSchema combinedSchema = (CombinedSchema) jsonSchema;
       CombinedSchema.ValidationCriterion criterion = combinedSchema.getCriterion();
-      String name = null;
+      String name;
       if (criterion == CombinedSchema.ONE_CRITERION || criterion == CombinedSchema.ANY_CRITERION) {
         name = JSON_TYPE_ONE_OF;
       } else if (criterion == CombinedSchema.ALL_CRITERION) {
@@ -1352,7 +1352,7 @@ public class JsonSchemaData {
     }
 
     public boolean contains(String id) {
-      return id != null ? ids.contains(id) : false;
+      return id != null && ids.contains(id);
     }
 
     public void add(String id) {


### PR DESCRIPTION
Fixes https://github.com/confluentinc/schema-registry/issues/2249.  Cache the `JsonSchema` rather than the lower level `Schema` to avoid constructor calls to `JsonSchema`.