### PR TITLE
Fix upgrade to Jackson 2.13

### DIFF
--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/Jackson.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/Jackson.java
@@ -89,7 +89,8 @@ public class Jackson {
 
   static class DefaultSerializerProviderImpl extends DefaultSerializerProvider {
     private static final long serialVersionUID = 1L;
-    protected static final JsonSerializer<Object> DEFAULT_UNKNOWN_SERIALIZER = new UnknownSerializerImpl();
+    protected static final JsonSerializer<Object> DEFAULT_UNKNOWN_SERIALIZER
+        = new UnknownSerializerImpl();
 
     public DefaultSerializerProviderImpl() {
       super();
@@ -101,16 +102,20 @@ public class Jackson {
       _unknownTypeSerializer = DEFAULT_UNKNOWN_SERIALIZER;
     }
 
-    protected DefaultSerializerProviderImpl(SerializerProvider src, SerializationConfig config, SerializerFactory f) {
+    protected DefaultSerializerProviderImpl(
+        SerializerProvider src, SerializationConfig config, SerializerFactory f) {
       super(src, config, f);
       _unknownTypeSerializer = DEFAULT_UNKNOWN_SERIALIZER;
     }
 
     public DefaultSerializerProvider copy() {
-      return this.getClass() != DefaultSerializerProviderImpl.class ? super.copy() : new DefaultSerializerProviderImpl(this);
+      return this.getClass() != DefaultSerializerProviderImpl.class
+          ? super.copy()
+          : new DefaultSerializerProviderImpl(this);
     }
 
-    public DefaultSerializerProviderImpl createInstance(SerializationConfig config, SerializerFactory jsf) {
+    public DefaultSerializerProviderImpl createInstance(
+        SerializationConfig config, SerializerFactory jsf) {
       return new DefaultSerializerProviderImpl(this, config, jsf);
     }
   }
@@ -130,7 +135,8 @@ public class Jackson {
      * until mbknor-jackson-jsonSchema ever changes it's behavior w.r.t. Jackson 2.13
      * See https://github.com/FasterXML/jackson-dataformats-binary/issues/281
      */
-    public void acceptJsonFormatVisitor(JsonFormatVisitorWrapper visitor, JavaType typeHint) throws JsonMappingException {
+    public void acceptJsonFormatVisitor(JsonFormatVisitorWrapper visitor, JavaType typeHint)
+        throws JsonMappingException {
       visitor.expectAnyFormat(typeHint);
     }
   }

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/Jackson.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/Jackson.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.ser.DefaultSerializerProvider;
 import com.fasterxml.jackson.databind.ser.SerializerFactory;
 import com.fasterxml.jackson.databind.ser.impl.UnknownSerializer;
@@ -36,7 +35,6 @@ import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
-import java.util.TreeMap;
 
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 
@@ -87,17 +85,6 @@ public class Jackson {
     mapper.setSerializerProvider(new DefaultSerializerProviderImpl());
 
     return mapper;
-  }
-
-  static class SortingNodeFactory extends JsonNodeFactory {
-    public SortingNodeFactory(boolean bigDecimalExact) {
-      super(bigDecimalExact);
-    }
-
-    @Override
-    public ObjectNode objectNode() {
-      return new ObjectNode(this, new TreeMap<>());
-    }
   }
 
   static class DefaultSerializerProviderImpl extends DefaultSerializerProvider {


### PR DESCRIPTION
This PR maintains the pre-2.13 behavior for the UnknownSerializer.  It can be changed if and when mbknor-jackson-jsonSchema ever changes it's behavior w.r.t Jackson 2.13