### PR TITLE
MMA-11803: Update kotlin-scripting-compiler-embeddable & kotlin-stdlib-common to Kotlin version 1.6

### DIFF
--- a/json-schema-provider/pom.xml
+++ b/json-schema-provider/pom.xml
@@ -68,6 +68,11 @@
             <version>${kotlin.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-scripting-compiler-embeddable</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/protobuf-converter/pom.xml
+++ b/protobuf-converter/pom.xml
@@ -44,10 +44,25 @@
         <dependency>
             <groupId>com.squareup.wire</groupId>
             <artifactId>wire-schema</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib-jdk8</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib-common</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-common</artifactId>
+            <version>${kotlin.version}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>


### PR DESCRIPTION
* Bumping version for `kotlin-scripting-compiler-embeddable` to 1.6 in `json-schema-provider`
* Bumping version for `kotlin-stdlib-common` to 1.6 in `protobuf-converter`

Jira Link -> https://confluentinc.atlassian.net/browse/MMA-11803
