### PR TITLE
DGS-3672 Allow CachedSchemaRegistryClient to register same schema

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -367,15 +367,13 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
         subject, k -> new BoundedConcurrentHashMap<>(cacheCapacity));
 
     Integer cachedId = schemaIdMap.get(schema);
-    if (cachedId != null) {
-      checkId(id, cachedId);
+    if (cachedId != null && (id < 0 || id == cachedId)) {
       return cachedId;
     }
 
     synchronized (this) {
       cachedId = schemaIdMap.get(schema);
-      if (cachedId != null) {
-        checkId(id, cachedId);
+      if (cachedId != null && (id < 0 || id == cachedId)) {
         return cachedId;
       }
 
@@ -388,13 +386,6 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
           context, k -> new BoundedConcurrentHashMap<>(cacheCapacity));
       idSchemaMap.put(retrievedId, schema);
       return retrievedId;
-    }
-  }
-
-  private void checkId(int id, Integer cachedId) {
-    if (id >= 0 && id != cachedId) {
-      throw new IllegalStateException("Schema already registered with id "
-          + cachedId + " instead of input id " + id);
     }
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -114,8 +114,11 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
       for (Map.Entry<Integer, ParsedSchema> entry : idSchemaMap.entrySet()) {
         if (entry.getValue().canonicalString().equals(schema.canonicalString())) {
           if (registerRequest) {
-            checkId(id, entry.getKey());
-            generateVersion(subject, schema);
+            if (id < 0 || id == entry.getKey()) {
+              generateVersion(subject, schema);
+            } else {
+              continue;
+            }
           }
           return entry.getKey();
         }
@@ -129,11 +132,10 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
       String context = toQualifiedContext(subject);
       Map<ParsedSchema, Integer> schemaIdMap =
           schemaIdCache.computeIfAbsent(context, k -> new ConcurrentHashMap<>());
-      Integer schemaId =
-          schemaIdMap.computeIfAbsent(schema, k -> id >= 0
-              ? id
-              : ids.computeIfAbsent(context, c -> new AtomicInteger(0)).incrementAndGet());
-      checkId(id, schemaId);
+      Integer schemaId = id >= 0
+          ? id
+          : ids.computeIfAbsent(context, c -> new AtomicInteger(0)).incrementAndGet();
+      schemaIdMap.put(schema, schemaId);
       generateVersion(subject, schema);
       idSchemaMap.put(schemaId, schema);
       return schemaId;
@@ -204,15 +206,13 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
         schemaCache.computeIfAbsent(subject, k -> new ConcurrentHashMap<>());
 
     Integer schemaId = schemaIdMap.get(schema);
-    if (schemaId != null) {
-      checkId(id, schemaId);
+    if (schemaId != null && (id < 0 || id == schemaId)) {
       return schemaId;
     }
 
     synchronized (this) {
       schemaId = schemaIdMap.get(schema);
-      if (schemaId != null) {
-        checkId(id, schemaId);
+      if (schemaId != null && (id < 0 || id == schemaId)) {
         return schemaId;
       }
 
@@ -223,13 +223,6 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
           context, k -> new ConcurrentHashMap<>());
       idSchemaMap.put(retrievedId, schema);
       return retrievedId;
-    }
-  }
-
-  private void checkId(int id, Integer cachedId) {
-    if (id >= 0 && id != cachedId) {
-      throw new IllegalStateException("Schema already registered with id "
-          + cachedId + " instead of input id " + id);
     }
   }
 

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
@@ -59,9 +59,51 @@ public class CachedSchemaRegistryClientTest {
   private static final int CACHE_CAPACITY = 5;
   private static final String SCHEMA_STR_0 = avroSchemaString(0);
   private static final AvroSchema AVRO_SCHEMA_0 = avroSchema(0);
+  private static final AvroSchema SCHEMA_WITH_DECIMAL = new AvroSchema(
+          "{\n"
+              + "    \"type\": \"record\",\n"
+              + "    \"name\": \"MyRecord\",\n"
+              + "    \"fields\": [\n"
+              + "        {\n"
+              + "            \"name\": \"field1\",\n"
+              + "            \"type\": [\n"
+              + "                \"null\",\n"
+              + "                {\n"
+              + "                    \"type\": \"bytes\",\n"
+              + "                    \"scale\": 4,\n"
+              + "                    \"precision\": 17,\n"
+              + "                    \"logicalType\": \"decimal\"\n"
+              + "                }\n"
+              + "            ],\n"
+              + "            \"default\": null\n"
+              + "        }\n"
+              + "    ]\n"
+              + "}");
+  private static final AvroSchema SCHEMA_WITH_DECIMAL2 = new AvroSchema(
+          "{\n"
+              + "    \"type\": \"record\",\n"
+              + "    \"name\": \"MyRecord\",\n"
+              + "    \"fields\": [\n"
+              + "        {\n"
+              + "            \"name\": \"field1\",\n"
+              + "            \"type\": [\n"
+              + "                \"null\",\n"
+              + "                {\n"
+              + "                    \"type\": \"bytes\",\n"
+              + "                    \"logicalType\": \"decimal\",\n"
+              + "                    \"precision\": 17,\n"
+              + "                    \"scale\": 4\n"
+              + "                }\n"
+              + "            ],\n"
+              + "            \"default\": null\n"
+              + "        }\n"
+              + "    ]\n"
+              + "}");
   private static final String SUBJECT_0 = "foo";
   private static final int VERSION_1 = 1;
+  private static final int VERSION_2 = 2;
   private static final int ID_25 = 25;
+  private static final int ID_50 = 50;
   private static final io.confluent.kafka.schemaregistry.client.rest.entities.Schema SCHEMA_DETAILS
       = new io.confluent.kafka.schemaregistry.client.rest.entities.Schema(
           SUBJECT_0, 7, ID_25, AvroSchema.TYPE, Collections.emptyList(), SCHEMA_STR_0);
@@ -143,6 +185,25 @@ public class CachedSchemaRegistryClientTest {
 
     assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0, VERSION_1, ID_25));
     assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0, VERSION_1, ID_25)); // hit the cache
+
+    verify(restService);
+  }
+
+  @Test
+  public void testRegisterEquivalentSchemaDifferentid() throws Exception {
+    expect(restService.registerSchema(anyString(), anyString(),
+        anyObject(List.class), eq(SUBJECT_0), eq(VERSION_1), eq(ID_25), anyBoolean()))
+        .andReturn(ID_25)
+        .once();
+    expect(restService.registerSchema(anyString(), anyString(),
+        anyObject(List.class), eq(SUBJECT_0), eq(VERSION_2), eq(ID_50), anyBoolean()))
+        .andReturn(ID_50)
+        .once();
+
+    replay(restService);
+
+    assertEquals(ID_25, client.register(SUBJECT_0, SCHEMA_WITH_DECIMAL, VERSION_1, ID_25));
+    assertEquals(ID_50, client.register(SUBJECT_0, SCHEMA_WITH_DECIMAL2, VERSION_2, ID_50));
 
     verify(restService);
   }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiModeTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiModeTest.java
@@ -36,6 +36,50 @@ public class RestApiModeTest extends ClusterTestHarness {
           + "[{\"type\":\"string\",\"name\":\"f1\"}]}")
       .canonicalString();
 
+  private static String SCHEMA_WITH_DECIMAL = AvroUtils.parseSchema(
+          "{\n"
+              + "    \"type\": \"record\",\n"
+              + "    \"name\": \"MyRecord\",\n"
+              + "    \"fields\": [\n"
+              + "        {\n"
+              + "            \"name\": \"field1\",\n"
+              + "            \"type\": [\n"
+              + "                \"null\",\n"
+              + "                {\n"
+              + "                    \"type\": \"bytes\",\n"
+              + "                    \"scale\": 4,\n"
+              + "                    \"precision\": 17,\n"
+              + "                    \"logicalType\": \"decimal\"\n"
+              + "                }\n"
+              + "            ],\n"
+              + "            \"default\": null\n"
+              + "        }\n"
+              + "    ]\n"
+              + "}")
+      .canonicalString();
+
+  private static String SCHEMA_WITH_DECIMAL2 = AvroUtils.parseSchema(
+          "{\n"
+              + "    \"type\": \"record\",\n"
+              + "    \"name\": \"MyRecord\",\n"
+              + "    \"fields\": [\n"
+              + "        {\n"
+              + "            \"name\": \"field1\",\n"
+              + "            \"type\": [\n"
+              + "                \"null\",\n"
+              + "                {\n"
+              + "                    \"type\": \"bytes\",\n"
+              + "                    \"logicalType\": \"decimal\",\n"
+              + "                    \"precision\": 17,\n"
+              + "                    \"scale\": 4\n"
+              + "                }\n"
+              + "            ],\n"
+              + "            \"default\": null\n"
+              + "        }\n"
+              + "    ]\n"
+              + "}")
+      .canonicalString();
+
   public RestApiModeTest() {
     super(1, true, CompatibilityLevel.BACKWARD.name);
   }
@@ -235,5 +279,35 @@ public class RestApiModeTest extends ClusterTestHarness {
     assertEquals("Getting schema by id should succeed",
             SCHEMA_STRING,
             restApp.restClient.getVersion(subject, 1).getSchema());
+  }
+
+  @Test
+  public void testImportModeWithEquivalentSchemaDifferentId() throws Exception {
+    String subject = "testSubject";
+    String mode = "IMPORT";
+
+    // set mode to import
+    assertEquals(
+        mode,
+        restApp.restClient.setMode(mode).getMode());
+
+    int expectedIdSchema1 = 100;
+    assertEquals("Registering with id should succeed",
+        expectedIdSchema1,
+        restApp.restClient.registerSchema(SCHEMA_WITH_DECIMAL, subject, 1, expectedIdSchema1));
+
+    assertEquals("Getting schema by id should succeed",
+        SCHEMA_WITH_DECIMAL,
+        restApp.restClient.getVersion(subject, 1).getSchema());
+
+    // register equivalent schema with different id
+    expectedIdSchema1 = 200;
+    assertEquals("Registering with id should succeed",
+        expectedIdSchema1,
+        restApp.restClient.registerSchema(SCHEMA_WITH_DECIMAL2, subject, 2, expectedIdSchema1));
+
+    assertEquals("Getting schema by id should succeed",
+        SCHEMA_WITH_DECIMAL2,
+        restApp.restClient.getVersion(subject, 2).getSchema());
   }
 }


### PR DESCRIPTION
In some cases, equivalent schemas may have been registered with SR.  This may be due to fixes in the semantics of schema comparison.  Rather than having the CachedSchemaRegistryClient reject such schemas, allow them to be passed through to SR during IMPORT mode.