### PR TITLE
APPSEC-1156: Patch Gson to be 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,11 @@
                 <version>${avro.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.google.code.gson</groupId>
+                <artifactId>gson</artifactId>
+                <version>${gson.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
                 <version>${commons.compress.version}</version>


### PR DESCRIPTION
This is needed to enforce gson version. Otherewise, it inherits from com.google.protobuf:protobuf-java-util which is 2.8.6.