### PR TITLE
Avoid deprecated method usage

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
@@ -149,12 +149,12 @@ public class AvroSchema implements ParsedSchema {
     }
     if (canonicalString == null) {
       Schema.Parser parser = getParser();
-      List<Schema> schemaRefs = new ArrayList<>();
+      Schema.Names names = new Schema.Names();
       for (String schema : resolvedReferences.values()) {
         Schema schemaRef = parser.parse(schema);
-        schemaRefs.add(schemaRef);
+        names.add(schemaRef);
       }
-      canonicalString = schemaObj.toString(schemaRefs, false);
+      canonicalString = schemaObj.toString(names, false);
     }
     return canonicalString;
   }


### PR DESCRIPTION
Confluent schema registry uses deprecated method present in apache avro lib. Existing code uses following signature, 

// Use at your own risk. This method should be removed with AVRO-2832.
toString(Collection<Schema> referencedSchemas, boolean pretty)

The new PR, uses toString(Names names, boolean pretty) method in the avro library. Internally the deprecated method was referring to toString(names, pretty) method, so the desired functionality will be met by directly calling the method. 