### PR TITLE
DGS-3917: Pass isKey via Serde constructors

### DIFF
--- a/avro-serializer/pom.xml
+++ b/avro-serializer/pom.xml
@@ -57,6 +57,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
@@ -33,12 +33,26 @@ public class KafkaAvroDeserializer extends AbstractKafkaAvroDeserializer
 
   }
 
+  public KafkaAvroDeserializer(boolean isKey) {
+    this.isKey = isKey;
+  }
+
   public KafkaAvroDeserializer(SchemaRegistryClient client) {
+    this(client, false);
+  }
+
+  public KafkaAvroDeserializer(SchemaRegistryClient client, boolean isKey) {
     schemaRegistry = client;
+    this.isKey = isKey;
   }
 
   public KafkaAvroDeserializer(SchemaRegistryClient client, Map<String, ?> props) {
+    this(client, props, false);
+  }
+
+  public KafkaAvroDeserializer(SchemaRegistryClient client, Map<String, ?> props, boolean isKey) {
     schemaRegistry = client;
+    this.isKey = isKey;
     configure(deserializerConfig(props));
   }
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
@@ -35,12 +35,26 @@ public class KafkaAvroSerializer extends AbstractKafkaAvroSerializer implements 
 
   }
 
+  public KafkaAvroSerializer(boolean isKey) {
+    this.isKey = isKey;
+  }
+
   public KafkaAvroSerializer(SchemaRegistryClient client) {
+    this(client, false);
+  }
+
+  public KafkaAvroSerializer(SchemaRegistryClient client, boolean isKey) {
     schemaRegistry = client;
+    this.isKey = isKey;
   }
 
   public KafkaAvroSerializer(SchemaRegistryClient client, Map<String, ?> props) {
+    this(client, props, false);
+  }
+
+  public KafkaAvroSerializer(SchemaRegistryClient client, Map<String, ?> props, boolean isKey) {
     schemaRegistry = client;
+    this.isKey = isKey;
     configure(serializerConfig(props));
   }
 

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -68,14 +68,6 @@ paths:
       - "application/vnd.schemaregistry+json; qs=0.9"
       - "application/json; qs=0.5"
       parameters:
-      - name: "Content-Type"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "Accept"
-        in: "header"
-        required: false
-        type: "string"
       - name: "subject"
         in: "path"
         description: "Subject of the schema version against which compatibility is\
@@ -121,14 +113,6 @@ paths:
       - "application/vnd.schemaregistry+json; qs=0.9"
       - "application/json; qs=0.5"
       parameters:
-      - name: "Content-Type"
-        in: "header"
-        required: false
-        type: "string"
-      - name: "Accept"
-        in: "header"
-        required: false
-        type: "string"
       - name: "subject"
         in: "path"
         description: "Subject of the schema version against which compatibility is\
@@ -731,6 +715,7 @@ paths:
         in: "query"
         required: false
         type: "string"
+        default: ":*:"
       - name: "deleted"
         in: "query"
         required: false
@@ -1125,6 +1110,28 @@ paths:
             $ref: "#/definitions/ServerClusterId"
         500:
           description: "Error code 50001 -- Error in the backend data store\n"
+  /v1/metadata/version:
+    get:
+      summary: "Get Schema Registry server version"
+      description: ""
+      operationId: "getSchemaRegistryVersion"
+      consumes:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json"
+      - "application/json"
+      - "application/octet-stream"
+      produces:
+      - "application/vnd.schemaregistry.v1+json"
+      - "application/vnd.schemaregistry+json; qs=0.9"
+      - "application/json; qs=0.5"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/SchemaRegistryServerVersion"
+        500:
+          description: "Error code 50001 -- Error in the backend data store\n"
 definitions:
   CompatibilityCheckResponse:
     type: "object"
@@ -1225,6 +1232,13 @@ definitions:
       version:
         type: "integer"
         format: "int32"
+  SchemaRegistryServerVersion:
+    type: "object"
+    properties:
+      version:
+        type: "string"
+      commitId:
+        type: "string"
   SchemaString:
     type: "object"
     properties:

--- a/core/src/test/java/io/confluent/kafka/serializers/protobuf/test/Ref.java
+++ b/core/src/test/java/io/confluent/kafka/serializers/protobuf/test/Ref.java
@@ -188,7 +188,7 @@ public final class Ref {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getRefIdBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(refId_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, refId_);
       }
       if (isActive_ != false) {
@@ -203,7 +203,7 @@ public final class Ref {
       if (size != -1) return size;
 
       size = 0;
-      if (!getRefIdBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(refId_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, refId_);
       }
       if (isActive_ != false) {

--- a/core/src/test/java/io/confluent/kafka/serializers/protobuf/test/Root.java
+++ b/core/src/test/java/io/confluent/kafka/serializers/protobuf/test/Root.java
@@ -220,7 +220,7 @@ public final class Root {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getRootIdBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(rootId_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, rootId_);
       }
       if (ref_ != null) {
@@ -235,7 +235,7 @@ public final class Root {
       if (size != -1) return size;
 
       size = 0;
-      if (!getRootIdBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(rootId_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, rootId_);
       }
       if (ref_ != null) {

--- a/json-schema-serializer/pom.xml
+++ b/json-schema-serializer/pom.xml
@@ -64,6 +64,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaDeserializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaDeserializer.java
@@ -35,12 +35,27 @@ public class KafkaJsonSchemaDeserializer<T> extends AbstractKafkaJsonSchemaDeser
   public KafkaJsonSchemaDeserializer() {
   }
 
+  public KafkaJsonSchemaDeserializer(boolean isKey) {
+    this.isKey = isKey;
+  }
+
   public KafkaJsonSchemaDeserializer(SchemaRegistryClient client) {
+    this(client, false);
+  }
+
+  public KafkaJsonSchemaDeserializer(SchemaRegistryClient client, boolean isKey) {
     schemaRegistry = client;
+    this.isKey = isKey;
   }
 
   public KafkaJsonSchemaDeserializer(SchemaRegistryClient client, Map<String, ?> props) {
+    this(client, props, false);
+  }
+
+  public KafkaJsonSchemaDeserializer(SchemaRegistryClient client, Map<String, ?> props,
+                                     boolean isKey) {
     this(client, props, null);
+    this.isKey = isKey;
   }
 
   @VisibleForTesting

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializer.java
@@ -30,20 +30,30 @@ import io.confluent.kafka.schemaregistry.json.JsonSchemaUtils;
 public class KafkaJsonSchemaSerializer<T> extends AbstractKafkaJsonSchemaSerializer<T>
     implements Serializer<T> {
 
-  private static int DEFAULT_CACHE_CAPACITY = 1000;
+  private static final int DEFAULT_CACHE_CAPACITY = 1000;
 
   private boolean isKey;
-  private Map<Class<?>, JsonSchema> schemaCache;
+  private final Map<Class<?>, JsonSchema> schemaCache;
 
   /**
    * Constructor used by Kafka producer.
    */
   public KafkaJsonSchemaSerializer() {
+    this(false);
+  }
+
+  public KafkaJsonSchemaSerializer(boolean isKey) {
+    this.isKey = isKey;
     schemaCache = new BoundedConcurrentHashMap<>(DEFAULT_CACHE_CAPACITY);
   }
 
   public KafkaJsonSchemaSerializer(SchemaRegistryClient client) {
+    this(client, false);
+  }
+
+  public KafkaJsonSchemaSerializer(SchemaRegistryClient client, boolean isKey) {
     schemaRegistry = client;
+    this.isKey = isKey;
     schemaCache = new BoundedConcurrentHashMap<>(DEFAULT_CACHE_CAPACITY);
   }
 
@@ -52,10 +62,21 @@ public class KafkaJsonSchemaSerializer<T> extends AbstractKafkaJsonSchemaSeriali
   }
 
   public KafkaJsonSchemaSerializer(SchemaRegistryClient client, Map<String, ?> props,
+                                   boolean isKey) {
+    this(client, props, DEFAULT_CACHE_CAPACITY, isKey);
+  }
+
+  public KafkaJsonSchemaSerializer(SchemaRegistryClient client, Map<String, ?> props,
                                    int cacheCapacity) {
+    this(client, props, cacheCapacity, false);
+  }
+
+  public KafkaJsonSchemaSerializer(SchemaRegistryClient client, Map<String, ?> props,
+                                   int cacheCapacity, boolean isKey) {
     schemaRegistry = client;
     configure(serializerConfig(props));
     schemaCache = new BoundedConcurrentHashMap<>(cacheCapacity);
+    this.isKey = isKey;
   }
 
   @Override

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/test/KeyValue.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/test/KeyValue.java
@@ -191,7 +191,7 @@ public final class KeyValue {
       if (key_ != 0) {
         output.writeInt32(1, key_);
       }
-      if (!getValueBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(value_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, value_);
       }
       unknownFields.writeTo(output);
@@ -207,7 +207,7 @@ public final class KeyValue {
         size += com.google.protobuf.CodedOutputStream
           .computeInt32Size(1, key_);
       }
-      if (!getValueBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(value_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, value_);
       }
       size += unknownFields.getSerializedSize();

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/test/MapReferences.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/test/MapReferences.java
@@ -1794,10 +1794,10 @@ public final class MapReferences {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getKeyBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(key_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, key_);
       }
-      if (!getValueBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(value_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, value_);
       }
       unknownFields.writeTo(output);
@@ -1809,10 +1809,10 @@ public final class MapReferences {
       if (size != -1) return size;
 
       size = 0;
-      if (!getKeyBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(key_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, key_);
       }
-      if (!getValueBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(value_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, value_);
       }
       size += unknownFields.getSerializedSize();

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/test/RecursiveKeyValue.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/test/RecursiveKeyValue.java
@@ -245,7 +245,7 @@ public final class RecursiveKeyValue {
       if (key_ != 0) {
         output.writeInt32(1, key_);
       }
-      if (!getValueBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(value_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, value_);
       }
       if (keyValue_ != null) {
@@ -264,7 +264,7 @@ public final class RecursiveKeyValue {
         size += com.google.protobuf.CodedOutputStream
           .computeInt32Size(1, key_);
       }
-      if (!getValueBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(value_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, value_);
       }
       if (keyValue_ != null) {

--- a/protobuf-serializer/pom.xml
+++ b/protobuf-serializer/pom.xml
@@ -96,6 +96,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufDeserializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufDeserializer.java
@@ -34,12 +34,27 @@ public class KafkaProtobufDeserializer<T extends Message>
 
   }
 
+  public KafkaProtobufDeserializer(boolean isKey) {
+    this.isKey = isKey;
+  }
+
   public KafkaProtobufDeserializer(SchemaRegistryClient client) {
+    this(client, false);
+  }
+
+  public KafkaProtobufDeserializer(SchemaRegistryClient client, boolean isKey) {
     schemaRegistry = client;
+    this.isKey = isKey;
   }
 
   public KafkaProtobufDeserializer(SchemaRegistryClient client, Map<String, ?> props) {
+    this(client, props, false);
+  }
+
+  public KafkaProtobufDeserializer(SchemaRegistryClient client, Map<String, ?> props,
+                                   boolean isKey) {
     this(client, props, null);
+    this.isKey = isKey;
   }
 
   @VisibleForTesting

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufSerializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufSerializer.java
@@ -34,20 +34,30 @@ import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils;
 public class KafkaProtobufSerializer<T extends Message>
     extends AbstractKafkaProtobufSerializer<T> implements Serializer<T> {
 
-  private static int DEFAULT_CACHE_CAPACITY = 1000;
+  private static final int DEFAULT_CACHE_CAPACITY = 1000;
 
   private boolean isKey;
-  private Map<Descriptor, ProtobufSchema> schemaCache;
+  private final Map<Descriptor, ProtobufSchema> schemaCache;
 
   /**
    * Constructor used by Kafka producer.
    */
   public KafkaProtobufSerializer() {
+    this(false);
+  }
+
+  public KafkaProtobufSerializer(boolean isKey) {
+    this.isKey = isKey;
     schemaCache = new BoundedConcurrentHashMap<>(DEFAULT_CACHE_CAPACITY);
   }
 
   public KafkaProtobufSerializer(SchemaRegistryClient client) {
+    this(client, false);
+  }
+
+  public KafkaProtobufSerializer(SchemaRegistryClient client, boolean isKey) {
     schemaRegistry = client;
+    this.isKey = isKey;
     schemaCache = new BoundedConcurrentHashMap<>(DEFAULT_CACHE_CAPACITY);
   }
 
@@ -55,9 +65,19 @@ public class KafkaProtobufSerializer<T extends Message>
     this(client, props, DEFAULT_CACHE_CAPACITY);
   }
 
+  public KafkaProtobufSerializer(SchemaRegistryClient client, Map<String, ?> props, boolean isKey) {
+    this(client, props, DEFAULT_CACHE_CAPACITY, isKey);
+  }
+
   public KafkaProtobufSerializer(SchemaRegistryClient client, Map<String, ?> props,
                                  int cacheCapacity) {
+    this(client, props, cacheCapacity, false);
+  }
+
+  public KafkaProtobufSerializer(SchemaRegistryClient client, Map<String, ?> props,
+                                 int cacheCapacity, boolean isKey) {
     schemaRegistry = client;
+    this.isKey = isKey;
     configure(serializerConfig(props));
     schemaCache = new BoundedConcurrentHashMap<>(cacheCapacity);
   }

--- a/protobuf-serializer/src/test/java/com/acme/glup/ExampleProtoAcme.java
+++ b/protobuf-serializer/src/test/java/com/acme/glup/ExampleProtoAcme.java
@@ -583,7 +583,7 @@ public final class ExampleProtoAcme {
       if (partition_ != null) {
         output.writeMessage(2, getPartition());
       }
-      if (!getUidBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(uid_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 5, uid_);
       }
       com.google.protobuf.GeneratedMessageV3
@@ -612,7 +612,7 @@ public final class ExampleProtoAcme {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getPartition());
       }
-      if (!getUidBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(uid_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, uid_);
       }
       for (java.util.Map.Entry<java.lang.Integer, java.lang.Boolean> entry

--- a/protobuf-serializer/src/test/java/com/acme/glup/MetadataProto.java
+++ b/protobuf-serializer/src/test/java/com/acme/glup/MetadataProto.java
@@ -2713,7 +2713,7 @@ public final class MetadataProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getIdBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(id_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, id_);
       }
       for (int i = 0; i < format_.size(); i++) {
@@ -2722,13 +2722,13 @@ public final class MetadataProto {
       if (partitionScheme_ != com.acme.glup.MetadataProto.PartitionScheme.UNSUPPORTED_PARTITION_SCHEME.getNumber()) {
         output.writeEnum(3, partitionScheme_);
       }
-      if (!getJavaClassBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(javaClass_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 4, javaClass_);
       }
       if (forTests_ != false) {
         output.writeBool(5, forTests_);
       }
-      if (!getOwnerBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(owner_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 6, owner_);
       }
       if (private_ != false) {
@@ -2749,7 +2749,7 @@ public final class MetadataProto {
       if (size != -1) return size;
 
       size = 0;
-      if (!getIdBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(id_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, id_);
       }
       for (int i = 0; i < format_.size(); i++) {
@@ -2760,14 +2760,14 @@ public final class MetadataProto {
         size += com.google.protobuf.CodedOutputStream
           .computeEnumSize(3, partitionScheme_);
       }
-      if (!getJavaClassBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(javaClass_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, javaClass_);
       }
       if (forTests_ != false) {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(5, forTests_);
       }
-      if (!getOwnerBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(owner_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, owner_);
       }
       if (private_ != false) {
@@ -4414,7 +4414,7 @@ public final class MetadataProto {
       if (format_ != null) {
         output.writeMessage(2, getFormat());
       }
-      if (!getDatasetIdBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(datasetId_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 3, datasetId_);
       }
       unknownFields.writeTo(output);
@@ -4434,7 +4434,7 @@ public final class MetadataProto {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, getFormat());
       }
-      if (!getDatasetIdBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(datasetId_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, datasetId_);
       }
       size += unknownFields.getSerializedSize();
@@ -5894,7 +5894,7 @@ public final class MetadataProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getPathBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(path_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, path_);
       }
       if (fileFormat_ != com.acme.glup.MetadataProto.HDFSDataFormat.UNSUPPORTED_DATA_FORMAT.getNumber()) {
@@ -5915,7 +5915,7 @@ public final class MetadataProto {
       if (priority_ != 0) {
         output.writeInt32(8, priority_);
       }
-      if (!getLabelBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(label_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 9, label_);
       }
       if (monitoringLevel_ != com.acme.glup.MetadataProto.MonitoringLevel.DEFAULT.getNumber()) {
@@ -5930,7 +5930,7 @@ public final class MetadataProto {
       if (size != -1) return size;
 
       size = 0;
-      if (!getPathBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(path_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, path_);
       }
       if (fileFormat_ != com.acme.glup.MetadataProto.HDFSDataFormat.UNSUPPORTED_DATA_FORMAT.getNumber()) {
@@ -5957,7 +5957,7 @@ public final class MetadataProto {
         size += com.google.protobuf.CodedOutputStream
           .computeInt32Size(8, priority_);
       }
-      if (!getLabelBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(label_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(9, label_);
       }
       if (monitoringLevel_ != com.acme.glup.MetadataProto.MonitoringLevel.DEFAULT.getNumber()) {
@@ -9786,16 +9786,16 @@ public final class MetadataProto {
           @java.lang.Override
           public void writeTo(com.google.protobuf.CodedOutputStream output)
                               throws java.io.IOException {
-            if (!getInputDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(inputDatasetId_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 1, inputDatasetId_);
             }
-            if (!getInputFormatLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(inputFormatLabel_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 2, inputFormatLabel_);
             }
-            if (!getOutputDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(outputDatasetId_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 3, outputDatasetId_);
             }
-            if (!getOutputFormatLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(outputFormatLabel_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 4, outputFormatLabel_);
             }
             if (useHippoCuttleJob_ != false) {
@@ -9810,16 +9810,16 @@ public final class MetadataProto {
             if (size != -1) return size;
 
             size = 0;
-            if (!getInputDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(inputDatasetId_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, inputDatasetId_);
             }
-            if (!getInputFormatLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(inputFormatLabel_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, inputFormatLabel_);
             }
-            if (!getOutputDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(outputDatasetId_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, outputDatasetId_);
             }
-            if (!getOutputFormatLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(outputFormatLabel_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, outputFormatLabel_);
             }
             if (useHippoCuttleJob_ != false) {
@@ -10972,16 +10972,16 @@ public final class MetadataProto {
           @java.lang.Override
           public void writeTo(com.google.protobuf.CodedOutputStream output)
                               throws java.io.IOException {
-            if (!getTopicBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(topic_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 1, topic_);
             }
             if (deduplicate_ != false) {
               output.writeBool(3, deduplicate_);
             }
-            if (!getOutputDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(outputDatasetId_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 4, outputDatasetId_);
             }
-            if (!getOutputFormatLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(outputFormatLabel_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 5, outputFormatLabel_);
             }
             unknownFields.writeTo(output);
@@ -10993,17 +10993,17 @@ public final class MetadataProto {
             if (size != -1) return size;
 
             size = 0;
-            if (!getTopicBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(topic_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, topic_);
             }
             if (deduplicate_ != false) {
               size += com.google.protobuf.CodedOutputStream
                 .computeBoolSize(3, deduplicate_);
             }
-            if (!getOutputDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(outputDatasetId_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, outputDatasetId_);
             }
-            if (!getOutputFormatLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(outputFormatLabel_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, outputFormatLabel_);
             }
             size += unknownFields.getSerializedSize();
@@ -13657,10 +13657,10 @@ public final class MetadataProto {
           @java.lang.Override
           public void writeTo(com.google.protobuf.CodedOutputStream output)
                               throws java.io.IOException {
-            if (!getTopicBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(topic_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 1, topic_);
             }
-            if (!getOutputDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(outputDatasetId_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 2, outputDatasetId_);
             }
             if (deduplicate_ != false) {
@@ -13669,7 +13669,7 @@ public final class MetadataProto {
             if (config_ != null) {
               output.writeMessage(4, getConfig());
             }
-            if (!getOutputFormatLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(outputFormatLabel_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 5, outputFormatLabel_);
             }
             for (int i = 0; i < configPerDc_.size(); i++) {
@@ -13684,10 +13684,10 @@ public final class MetadataProto {
             if (size != -1) return size;
 
             size = 0;
-            if (!getTopicBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(topic_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, topic_);
             }
-            if (!getOutputDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(outputDatasetId_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, outputDatasetId_);
             }
             if (deduplicate_ != false) {
@@ -13698,7 +13698,7 @@ public final class MetadataProto {
               size += com.google.protobuf.CodedOutputStream
                 .computeMessageSize(4, getConfig());
             }
-            if (!getOutputFormatLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(outputFormatLabel_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, outputFormatLabel_);
             }
             for (int i = 0; i < configPerDc_.size(); i++) {
@@ -16422,7 +16422,7 @@ public final class MetadataProto {
             if (from_ != null) {
               output.writeMessage(1, getFrom());
             }
-            if (!getSourceNamespaceBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(sourceNamespace_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 3, sourceNamespace_);
             }
             if (getPlatformsList().size() > 0) {
@@ -16435,10 +16435,10 @@ public final class MetadataProto {
             if (isBackfilling_ != false) {
               output.writeBool(8, isBackfilling_);
             }
-            if (!getToLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(toLabel_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 9, toLabel_);
             }
-            if (!getToDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(toDatasetId_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 10, toDatasetId_);
             }
             if (withBackfilling_ != false) {
@@ -16460,7 +16460,7 @@ public final class MetadataProto {
               size += com.google.protobuf.CodedOutputStream
                 .computeMessageSize(1, getFrom());
             }
-            if (!getSourceNamespaceBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(sourceNamespace_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, sourceNamespace_);
             }
             {
@@ -16479,10 +16479,10 @@ public final class MetadataProto {
               size += com.google.protobuf.CodedOutputStream
                 .computeBoolSize(8, isBackfilling_);
             }
-            if (!getToLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(toLabel_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(9, toLabel_);
             }
-            if (!getToDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(toDatasetId_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(10, toDatasetId_);
             }
             if (withBackfilling_ != false) {
@@ -18109,7 +18109,7 @@ public final class MetadataProto {
             if (from_ != null) {
               output.writeMessage(1, getFrom());
             }
-            if (!getSourceNamespaceBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(sourceNamespace_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 2, sourceNamespace_);
             }
             if (getPlatformsList().size() > 0) {
@@ -18132,7 +18132,7 @@ public final class MetadataProto {
               size += com.google.protobuf.CodedOutputStream
                 .computeMessageSize(1, getFrom());
             }
-            if (!getSourceNamespaceBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(sourceNamespace_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, sourceNamespace_);
             }
             {
@@ -19485,10 +19485,10 @@ public final class MetadataProto {
           @java.lang.Override
           public void writeTo(com.google.protobuf.CodedOutputStream output)
                               throws java.io.IOException {
-            if (!getInputDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(inputDatasetId_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 1, inputDatasetId_);
             }
-            if (!getOutputDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(outputDatasetId_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 2, outputDatasetId_);
             }
             if (inputFormat_ != com.acme.glup.MetadataProto.HDFSDataFormat.UNSUPPORTED_DATA_FORMAT.getNumber()) {
@@ -19497,10 +19497,10 @@ public final class MetadataProto {
             if (outputFormat_ != com.acme.glup.MetadataProto.HDFSDataFormat.UNSUPPORTED_DATA_FORMAT.getNumber()) {
               output.writeEnum(4, outputFormat_);
             }
-            if (!getInputDatasetLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(inputDatasetLabel_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 5, inputDatasetLabel_);
             }
-            if (!getOutputDatasetLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(outputDatasetLabel_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 6, outputDatasetLabel_);
             }
             if (isByPlatform_ != false) {
@@ -19515,10 +19515,10 @@ public final class MetadataProto {
             if (size != -1) return size;
 
             size = 0;
-            if (!getInputDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(inputDatasetId_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, inputDatasetId_);
             }
-            if (!getOutputDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(outputDatasetId_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, outputDatasetId_);
             }
             if (inputFormat_ != com.acme.glup.MetadataProto.HDFSDataFormat.UNSUPPORTED_DATA_FORMAT.getNumber()) {
@@ -19529,10 +19529,10 @@ public final class MetadataProto {
               size += com.google.protobuf.CodedOutputStream
                 .computeEnumSize(4, outputFormat_);
             }
-            if (!getInputDatasetLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(inputDatasetLabel_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, inputDatasetLabel_);
             }
-            if (!getOutputDatasetLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(outputDatasetLabel_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, outputDatasetLabel_);
             }
             if (isByPlatform_ != false) {
@@ -20922,19 +20922,19 @@ public final class MetadataProto {
           @java.lang.Override
           public void writeTo(com.google.protobuf.CodedOutputStream output)
                               throws java.io.IOException {
-            if (!getInputDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(inputDatasetId_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 1, inputDatasetId_);
             }
-            if (!getInputFormatLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(inputFormatLabel_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 2, inputFormatLabel_);
             }
-            if (!getOutputDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(outputDatasetId_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 3, outputDatasetId_);
             }
-            if (!getOutputFormatLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(outputFormatLabel_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 4, outputFormatLabel_);
             }
-            if (samplingRate_ != 0F) {
+            if (java.lang.Float.floatToRawIntBits(samplingRate_) != 0) {
               output.writeFloat(5, samplingRate_);
             }
             unknownFields.writeTo(output);
@@ -20946,19 +20946,19 @@ public final class MetadataProto {
             if (size != -1) return size;
 
             size = 0;
-            if (!getInputDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(inputDatasetId_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, inputDatasetId_);
             }
-            if (!getInputFormatLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(inputFormatLabel_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, inputFormatLabel_);
             }
-            if (!getOutputDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(outputDatasetId_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, outputDatasetId_);
             }
-            if (!getOutputFormatLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(outputFormatLabel_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, outputFormatLabel_);
             }
-            if (samplingRate_ != 0F) {
+            if (java.lang.Float.floatToRawIntBits(samplingRate_) != 0) {
               size += com.google.protobuf.CodedOutputStream
                 .computeFloatSize(5, samplingRate_);
             }
@@ -22298,22 +22298,22 @@ public final class MetadataProto {
           @java.lang.Override
           public void writeTo(com.google.protobuf.CodedOutputStream output)
                               throws java.io.IOException {
-            if (!getLeftDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(leftDatasetId_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 1, leftDatasetId_);
             }
-            if (!getLeftFormatLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(leftFormatLabel_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 2, leftFormatLabel_);
             }
-            if (!getRightDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(rightDatasetId_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 3, rightDatasetId_);
             }
-            if (!getRightFormatLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(rightFormatLabel_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 4, rightFormatLabel_);
             }
-            if (!getHostnameBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(hostname_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 5, hostname_);
             }
-            if (!getIgnoredFieldsBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(ignoredFields_)) {
               com.google.protobuf.GeneratedMessageV3.writeString(output, 6, ignoredFields_);
             }
             unknownFields.writeTo(output);
@@ -22325,22 +22325,22 @@ public final class MetadataProto {
             if (size != -1) return size;
 
             size = 0;
-            if (!getLeftDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(leftDatasetId_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, leftDatasetId_);
             }
-            if (!getLeftFormatLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(leftFormatLabel_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, leftFormatLabel_);
             }
-            if (!getRightDatasetIdBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(rightDatasetId_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, rightDatasetId_);
             }
-            if (!getRightFormatLabelBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(rightFormatLabel_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, rightFormatLabel_);
             }
-            if (!getHostnameBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(hostname_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, hostname_);
             }
-            if (!getIgnoredFieldsBytes().isEmpty()) {
+            if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(ignoredFields_)) {
               size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, ignoredFields_);
             }
             size += unknownFields.getSerializedSize();
@@ -24259,13 +24259,13 @@ public final class MetadataProto {
           for (int i = 0; i < to_.size(); i++) {
             output.writeMessage(250, to_.get(i));
           }
-          if (!getNamespaceBytes().isEmpty()) {
+          if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
             com.google.protobuf.GeneratedMessageV3.writeString(output, 251, namespace_);
           }
-          if (!getStartDateBytes().isEmpty()) {
+          if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(startDate_)) {
             com.google.protobuf.GeneratedMessageV3.writeString(output, 253, startDate_);
           }
-          if (!getStopDateBytes().isEmpty()) {
+          if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(stopDate_)) {
             com.google.protobuf.GeneratedMessageV3.writeString(output, 254, stopDate_);
           }
           if (ignoreCn_ != false) {
@@ -24324,13 +24324,13 @@ public final class MetadataProto {
             size += com.google.protobuf.CodedOutputStream
               .computeMessageSize(250, to_.get(i));
           }
-          if (!getNamespaceBytes().isEmpty()) {
+          if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(namespace_)) {
             size += com.google.protobuf.GeneratedMessageV3.computeStringSize(251, namespace_);
           }
-          if (!getStartDateBytes().isEmpty()) {
+          if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(startDate_)) {
             size += com.google.protobuf.GeneratedMessageV3.computeStringSize(253, startDate_);
           }
-          if (!getStopDateBytes().isEmpty()) {
+          if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(stopDate_)) {
             size += com.google.protobuf.GeneratedMessageV3.computeStringSize(254, stopDate_);
           }
           if (ignoreCn_ != false) {
@@ -27092,10 +27092,10 @@ public final class MetadataProto {
       @java.lang.Override
       public void writeTo(com.google.protobuf.CodedOutputStream output)
                           throws java.io.IOException {
-        if (!getOwnerBytes().isEmpty()) {
+        if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(owner_)) {
           com.google.protobuf.GeneratedMessageV3.writeString(output, 1, owner_);
         }
-        if (!getNameBytes().isEmpty()) {
+        if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
           com.google.protobuf.GeneratedMessageV3.writeString(output, 2, name_);
         }
         if (partitioning_ != com.acme.glup.MetadataProto.PartitionScheme.UNSUPPORTED_PARTITION_SCHEME.getNumber()) {
@@ -27122,10 +27122,10 @@ public final class MetadataProto {
         if (size != -1) return size;
 
         size = 0;
-        if (!getOwnerBytes().isEmpty()) {
+        if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(owner_)) {
           size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, owner_);
         }
-        if (!getNameBytes().isEmpty()) {
+        if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
           size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, name_);
         }
         if (partitioning_ != com.acme.glup.MetadataProto.PartitionScheme.UNSUPPORTED_PARTITION_SCHEME.getNumber()) {
@@ -32944,7 +32944,7 @@ public final class MetadataProto {
       if (pendingDeletion_ != false) {
         output.writeBool(5, pendingDeletion_);
       }
-      if (!getAddedAtBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(addedAt_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 6, addedAt_);
       }
       unknownFields.writeTo(output);
@@ -32984,7 +32984,7 @@ public final class MetadataProto {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(5, pendingDeletion_);
       }
-      if (!getAddedAtBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(addedAt_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, addedAt_);
       }
       size += unknownFields.getSerializedSize();
@@ -33962,7 +33962,7 @@ public final class MetadataProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getNameBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
       }
       if (skip_ != false) {
@@ -33977,7 +33977,7 @@ public final class MetadataProto {
       if (size != -1) return size;
 
       size = 0;
-      if (!getNameBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
       }
       if (skip_ != false) {
@@ -34670,7 +34670,7 @@ public final class MetadataProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getNameBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, name_);
       }
       if (useEnumFieldId_ != false) {
@@ -34685,7 +34685,7 @@ public final class MetadataProto {
       if (size != -1) return size;
 
       size = 0;
-      if (!getNameBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(name_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, name_);
       }
       if (useEnumFieldId_ != false) {
@@ -37356,10 +37356,10 @@ public final class MetadataProto {
       if (consolidationEnabled_ != false) {
         output.writeBool(7, consolidationEnabled_);
       }
-      if (!getDatasetIdBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(datasetId_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 10, datasetId_);
       }
-      if (!getDatasetFormatLabelBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(datasetFormatLabel_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 11, datasetFormatLabel_);
       }
       for (int i = 0; i < controlMessage_.size(); i++) {
@@ -37386,10 +37386,10 @@ public final class MetadataProto {
         size += com.google.protobuf.CodedOutputStream
           .computeBoolSize(7, consolidationEnabled_);
       }
-      if (!getDatasetIdBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(datasetId_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(10, datasetId_);
       }
-      if (!getDatasetFormatLabelBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(datasetFormatLabel_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(11, datasetFormatLabel_);
       }
       for (int i = 0; i < controlMessage_.size(); i++) {
@@ -38773,10 +38773,10 @@ public final class MetadataProto {
       if (dc_ != com.acme.glup.MetadataProto.DataCenter.UNSUPPORTED_DATACENTER.getNumber()) {
         output.writeEnum(2, dc_);
       }
-      if (!getLabelBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(label_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 3, label_);
       }
-      if (!getDatasetIdBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(datasetId_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 4, datasetId_);
       }
       unknownFields.writeTo(output);
@@ -38796,10 +38796,10 @@ public final class MetadataProto {
         size += com.google.protobuf.CodedOutputStream
           .computeEnumSize(2, dc_);
       }
-      if (!getLabelBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(label_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, label_);
       }
-      if (!getDatasetIdBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(datasetId_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, datasetId_);
       }
       size += unknownFields.getSerializedSize();
@@ -39849,13 +39849,13 @@ public final class MetadataProto {
       if (ip4_ != 0) {
         output.writeFixed32(2, ip4_);
       }
-      if (!getHostnameBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(hostname_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 3, hostname_);
       }
-      if (!getContainerTaskBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(containerTask_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 4, containerTask_);
       }
-      if (!getContainerAppBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(containerApp_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 5, containerApp_);
       }
       unknownFields.writeTo(output);
@@ -39875,13 +39875,13 @@ public final class MetadataProto {
         size += com.google.protobuf.CodedOutputStream
           .computeFixed32Size(2, ip4_);
       }
-      if (!getHostnameBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(hostname_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, hostname_);
       }
-      if (!getContainerTaskBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(containerTask_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, containerTask_);
       }
-      if (!getContainerAppBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(containerApp_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, containerApp_);
       }
       size += unknownFields.getSerializedSize();
@@ -41107,7 +41107,7 @@ public final class MetadataProto {
       @java.lang.Override
       public void writeTo(com.google.protobuf.CodedOutputStream output)
                           throws java.io.IOException {
-        if (!getKafkaTopicBytes().isEmpty()) {
+        if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(kafkaTopic_)) {
           com.google.protobuf.GeneratedMessageV3.writeString(output, 1, kafkaTopic_);
         }
         if (datacenter_ != com.acme.glup.MetadataProto.DataCenter.UNSUPPORTED_DATACENTER.getNumber()) {
@@ -41125,7 +41125,7 @@ public final class MetadataProto {
         if (size != -1) return size;
 
         size = 0;
-        if (!getKafkaTopicBytes().isEmpty()) {
+        if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(kafkaTopic_)) {
           size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, kafkaTopic_);
         }
         if (datacenter_ != com.acme.glup.MetadataProto.DataCenter.UNSUPPORTED_DATACENTER.getNumber()) {
@@ -42494,13 +42494,13 @@ public final class MetadataProto {
       @java.lang.Override
       public void writeTo(com.google.protobuf.CodedOutputStream output)
                           throws java.io.IOException {
-        if (!getTypeBytes().isEmpty()) {
+        if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(type_)) {
           com.google.protobuf.GeneratedMessageV3.writeString(output, 1, type_);
         }
-        if (!getHostnameBytes().isEmpty()) {
+        if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(hostname_)) {
           com.google.protobuf.GeneratedMessageV3.writeString(output, 2, hostname_);
         }
-        if (!getKafkaTopicBytes().isEmpty()) {
+        if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(kafkaTopic_)) {
           com.google.protobuf.GeneratedMessageV3.writeString(output, 3, kafkaTopic_);
         }
         if (partition_ != 0) {
@@ -42512,16 +42512,16 @@ public final class MetadataProto {
         if (!processUuid_.isEmpty()) {
           output.writeBytes(6, processUuid_);
         }
-        if (!getRegionBytes().isEmpty()) {
+        if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(region_)) {
           com.google.protobuf.GeneratedMessageV3.writeString(output, 7, region_);
         }
         if (timestampSeconds_ != 0) {
           output.writeInt32(8, timestampSeconds_);
         }
-        if (!getClusterBytes().isEmpty()) {
+        if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(cluster_)) {
           com.google.protobuf.GeneratedMessageV3.writeString(output, 9, cluster_);
         }
-        if (!getEnvironmentBytes().isEmpty()) {
+        if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(environment_)) {
           com.google.protobuf.GeneratedMessageV3.writeString(output, 10, environment_);
         }
         com.google.protobuf.GeneratedMessageV3
@@ -42539,13 +42539,13 @@ public final class MetadataProto {
         if (size != -1) return size;
 
         size = 0;
-        if (!getTypeBytes().isEmpty()) {
+        if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(type_)) {
           size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, type_);
         }
-        if (!getHostnameBytes().isEmpty()) {
+        if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(hostname_)) {
           size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, hostname_);
         }
-        if (!getKafkaTopicBytes().isEmpty()) {
+        if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(kafkaTopic_)) {
           size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, kafkaTopic_);
         }
         if (partition_ != 0) {
@@ -42560,17 +42560,17 @@ public final class MetadataProto {
           size += com.google.protobuf.CodedOutputStream
             .computeBytesSize(6, processUuid_);
         }
-        if (!getRegionBytes().isEmpty()) {
+        if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(region_)) {
           size += com.google.protobuf.GeneratedMessageV3.computeStringSize(7, region_);
         }
         if (timestampSeconds_ != 0) {
           size += com.google.protobuf.CodedOutputStream
             .computeInt32Size(8, timestampSeconds_);
         }
-        if (!getClusterBytes().isEmpty()) {
+        if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(cluster_)) {
           size += com.google.protobuf.GeneratedMessageV3.computeStringSize(9, cluster_);
         }
-        if (!getEnvironmentBytes().isEmpty()) {
+        if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(environment_)) {
           size += com.google.protobuf.GeneratedMessageV3.computeStringSize(10, environment_);
         }
         for (java.util.Map.Entry<java.lang.Integer, java.lang.Boolean> entry

--- a/protobuf-serializer/src/test/java/io/confluent/kafka/serializers/protobuf/test/EnumUnionOuter.java
+++ b/protobuf-serializer/src/test/java/io/confluent/kafka/serializers/protobuf/test/EnumUnionOuter.java
@@ -236,8 +236,8 @@ public final class EnumUnionOuter {
               break;
             }
             case 16: {
-              someValCase_ = 2;
               someVal_ = input.readInt32();
+              someValCase_ = 2;
               break;
             }
             case 24: {

--- a/protobuf-serializer/src/test/java/io/confluent/kafka/serializers/protobuf/test/NestedTestProto.java
+++ b/protobuf-serializer/src/test/java/io/confluent/kafka/serializers/protobuf/test/NestedTestProto.java
@@ -223,8 +223,8 @@ public final class NestedTestProto {
               break;
             }
             case 16: {
-              userIdCase_ = 2;
               userId_ = input.readInt32();
+              userIdCase_ = 2;
               break;
             }
             case 26: {
@@ -1293,7 +1293,7 @@ public final class NestedTestProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getIdBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(id_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, id_);
       }
       unknownFields.writeTo(output);
@@ -1305,7 +1305,7 @@ public final class NestedTestProto {
       if (size != -1) return size;
 
       size = 0;
-      if (!getIdBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(id_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, id_);
       }
       size += unknownFields.getSerializedSize();
@@ -1801,8 +1801,8 @@ public final class NestedTestProto {
               break;
             }
             case 16: {
-              someValCase_ = 2;
               someVal_ = input.readInt32();
+              someValCase_ = 2;
               break;
             }
             case 24: {
@@ -3229,7 +3229,7 @@ public final class NestedTestProto {
       public void writeTo(com.google.protobuf.CodedOutputStream output)
                           throws java.io.IOException {
         getSerializedSize();
-        if (!getIdBytes().isEmpty()) {
+        if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(id_)) {
           com.google.protobuf.GeneratedMessageV3.writeString(output, 1, id_);
         }
         if (getIdsList().size() > 0) {
@@ -3248,7 +3248,7 @@ public final class NestedTestProto {
         if (size != -1) return size;
 
         size = 0;
-        if (!getIdBytes().isEmpty()) {
+        if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(id_)) {
           size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, id_);
         }
         {
@@ -3946,7 +3946,7 @@ public final class NestedTestProto {
     @java.lang.Override
     public boolean containsMapType(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       return internalGetMapType().getMap().containsKey(key);
     }
     /**
@@ -3973,7 +3973,7 @@ public final class NestedTestProto {
     public java.lang.String getMapTypeOrDefault(
         java.lang.String key,
         java.lang.String defaultValue) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.String> map =
           internalGetMapType().getMap();
       return map.containsKey(key) ? map.get(key) : defaultValue;
@@ -3985,7 +3985,7 @@ public final class NestedTestProto {
 
     public java.lang.String getMapTypeOrThrow(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.String> map =
           internalGetMapType().getMap();
       if (!map.containsKey(key)) {
@@ -5133,7 +5133,7 @@ public final class NestedTestProto {
       @java.lang.Override
       public boolean containsMapType(
           java.lang.String key) {
-        if (key == null) { throw new java.lang.NullPointerException(); }
+        if (key == null) { throw new NullPointerException("map key"); }
         return internalGetMapType().getMap().containsKey(key);
       }
       /**
@@ -5160,7 +5160,7 @@ public final class NestedTestProto {
       public java.lang.String getMapTypeOrDefault(
           java.lang.String key,
           java.lang.String defaultValue) {
-        if (key == null) { throw new java.lang.NullPointerException(); }
+        if (key == null) { throw new NullPointerException("map key"); }
         java.util.Map<java.lang.String, java.lang.String> map =
             internalGetMapType().getMap();
         return map.containsKey(key) ? map.get(key) : defaultValue;
@@ -5172,7 +5172,7 @@ public final class NestedTestProto {
 
       public java.lang.String getMapTypeOrThrow(
           java.lang.String key) {
-        if (key == null) { throw new java.lang.NullPointerException(); }
+        if (key == null) { throw new NullPointerException("map key"); }
         java.util.Map<java.lang.String, java.lang.String> map =
             internalGetMapType().getMap();
         if (!map.containsKey(key)) {
@@ -5192,7 +5192,7 @@ public final class NestedTestProto {
 
       public Builder removeMapType(
           java.lang.String key) {
-        if (key == null) { throw new java.lang.NullPointerException(); }
+        if (key == null) { throw new NullPointerException("map key"); }
         internalGetMutableMapType().getMutableMap()
             .remove(key);
         return this;
@@ -5211,8 +5211,11 @@ public final class NestedTestProto {
       public Builder putMapType(
           java.lang.String key,
           java.lang.String value) {
-        if (key == null) { throw new java.lang.NullPointerException(); }
-        if (value == null) { throw new java.lang.NullPointerException(); }
+        if (key == null) { throw new NullPointerException("map key"); }
+        if (value == null) {
+  throw new NullPointerException("map value");
+}
+
         internalGetMutableMapType().getMutableMap()
             .put(key, value);
         return this;

--- a/protobuf-serializer/src/test/java/io/confluent/kafka/serializers/protobuf/test/TestMessageOptionalProtos.java
+++ b/protobuf-serializer/src/test/java/io/confluent/kafka/serializers/protobuf/test/TestMessageOptionalProtos.java
@@ -238,7 +238,7 @@ public final class TestMessageOptionalProtos {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getTestStringBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(testString_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, testString_);
       }
       if (((bitField0_ & 0x00000001) != 0)) {
@@ -253,7 +253,7 @@ public final class TestMessageOptionalProtos {
       if (size != -1) return size;
 
       size = 0;
-      if (!getTestStringBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(testString_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, testString_);
       }
       if (((bitField0_ & 0x00000001) != 0)) {

--- a/protobuf-serializer/src/test/java/io/confluent/kafka/serializers/protobuf/test/TestMessageProtos.java
+++ b/protobuf-serializer/src/test/java/io/confluent/kafka/serializers/protobuf/test/TestMessageProtos.java
@@ -475,7 +475,7 @@ public final class TestMessageProtos {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getTestStringBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(testString_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, testString_);
       }
       if (testBool_ != false) {
@@ -484,10 +484,10 @@ public final class TestMessageProtos {
       if (!testBytes_.isEmpty()) {
         output.writeBytes(3, testBytes_);
       }
-      if (testDouble_ != 0D) {
+      if (java.lang.Double.doubleToRawLongBits(testDouble_) != 0) {
         output.writeDouble(4, testDouble_);
       }
-      if (testFloat_ != 0F) {
+      if (java.lang.Float.floatToRawIntBits(testFloat_) != 0) {
         output.writeFloat(5, testFloat_);
       }
       if (testFixed32_ != 0) {
@@ -529,7 +529,7 @@ public final class TestMessageProtos {
       if (size != -1) return size;
 
       size = 0;
-      if (!getTestStringBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(testString_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, testString_);
       }
       if (testBool_ != false) {
@@ -540,11 +540,11 @@ public final class TestMessageProtos {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, testBytes_);
       }
-      if (testDouble_ != 0D) {
+      if (java.lang.Double.doubleToRawLongBits(testDouble_) != 0) {
         size += com.google.protobuf.CodedOutputStream
           .computeDoubleSize(4, testDouble_);
       }
-      if (testFloat_ != 0F) {
+      if (java.lang.Float.floatToRawIntBits(testFloat_) != 0) {
         size += com.google.protobuf.CodedOutputStream
           .computeFloatSize(5, testFloat_);
       }
@@ -2091,7 +2091,7 @@ public final class TestMessageProtos {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getTestStringBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(testString_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, testString_);
       }
       if (testBool_ != false) {
@@ -2100,10 +2100,10 @@ public final class TestMessageProtos {
       if (!testBytes_.isEmpty()) {
         output.writeBytes(3, testBytes_);
       }
-      if (testDouble_ != 0D) {
+      if (java.lang.Double.doubleToRawLongBits(testDouble_) != 0) {
         output.writeDouble(4, testDouble_);
       }
-      if (testFloat_ != 0F) {
+      if (java.lang.Float.floatToRawIntBits(testFloat_) != 0) {
         output.writeFloat(5, testFloat_);
       }
       if (testFixed32_ != 0) {
@@ -2148,7 +2148,7 @@ public final class TestMessageProtos {
       if (size != -1) return size;
 
       size = 0;
-      if (!getTestStringBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(testString_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, testString_);
       }
       if (testBool_ != false) {
@@ -2159,11 +2159,11 @@ public final class TestMessageProtos {
         size += com.google.protobuf.CodedOutputStream
           .computeBytesSize(3, testBytes_);
       }
-      if (testDouble_ != 0D) {
+      if (java.lang.Double.doubleToRawLongBits(testDouble_) != 0) {
         size += com.google.protobuf.CodedOutputStream
           .computeDoubleSize(4, testDouble_);
       }
-      if (testFloat_ != 0F) {
+      if (java.lang.Float.floatToRawIntBits(testFloat_) != 0) {
         size += com.google.protobuf.CodedOutputStream
           .computeFloatSize(5, testFloat_);
       }

--- a/protobuf-types/src/main/java/io/confluent/protobuf/MetaProto.java
+++ b/protobuf-types/src/main/java/io/confluent/protobuf/MetaProto.java
@@ -250,7 +250,7 @@ public final class MetaProto {
     @java.lang.Override
     public boolean containsParams(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       return internalGetParams().getMap().containsKey(key);
     }
     /**
@@ -277,7 +277,7 @@ public final class MetaProto {
     public java.lang.String getParamsOrDefault(
         java.lang.String key,
         java.lang.String defaultValue) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.String> map =
           internalGetParams().getMap();
       return map.containsKey(key) ? map.get(key) : defaultValue;
@@ -289,7 +289,7 @@ public final class MetaProto {
 
     public java.lang.String getParamsOrThrow(
         java.lang.String key) {
-      if (key == null) { throw new java.lang.NullPointerException(); }
+      if (key == null) { throw new NullPointerException("map key"); }
       java.util.Map<java.lang.String, java.lang.String> map =
           internalGetParams().getMap();
       if (!map.containsKey(key)) {
@@ -312,7 +312,7 @@ public final class MetaProto {
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (!getDocBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(doc_)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, doc_);
       }
       com.google.protobuf.GeneratedMessageV3
@@ -330,7 +330,7 @@ public final class MetaProto {
       if (size != -1) return size;
 
       size = 0;
-      if (!getDocBytes().isEmpty()) {
+      if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(doc_)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, doc_);
       }
       for (java.util.Map.Entry<java.lang.String, java.lang.String> entry
@@ -760,7 +760,7 @@ public final class MetaProto {
       @java.lang.Override
       public boolean containsParams(
           java.lang.String key) {
-        if (key == null) { throw new java.lang.NullPointerException(); }
+        if (key == null) { throw new NullPointerException("map key"); }
         return internalGetParams().getMap().containsKey(key);
       }
       /**
@@ -787,7 +787,7 @@ public final class MetaProto {
       public java.lang.String getParamsOrDefault(
           java.lang.String key,
           java.lang.String defaultValue) {
-        if (key == null) { throw new java.lang.NullPointerException(); }
+        if (key == null) { throw new NullPointerException("map key"); }
         java.util.Map<java.lang.String, java.lang.String> map =
             internalGetParams().getMap();
         return map.containsKey(key) ? map.get(key) : defaultValue;
@@ -799,7 +799,7 @@ public final class MetaProto {
 
       public java.lang.String getParamsOrThrow(
           java.lang.String key) {
-        if (key == null) { throw new java.lang.NullPointerException(); }
+        if (key == null) { throw new NullPointerException("map key"); }
         java.util.Map<java.lang.String, java.lang.String> map =
             internalGetParams().getMap();
         if (!map.containsKey(key)) {
@@ -819,7 +819,7 @@ public final class MetaProto {
 
       public Builder removeParams(
           java.lang.String key) {
-        if (key == null) { throw new java.lang.NullPointerException(); }
+        if (key == null) { throw new NullPointerException("map key"); }
         internalGetMutableParams().getMutableMap()
             .remove(key);
         return this;
@@ -838,8 +838,11 @@ public final class MetaProto {
       public Builder putParams(
           java.lang.String key,
           java.lang.String value) {
-        if (key == null) { throw new java.lang.NullPointerException(); }
-        if (value == null) { throw new java.lang.NullPointerException(); }
+        if (key == null) { throw new NullPointerException("map key"); }
+        if (value == null) {
+  throw new NullPointerException("map value");
+}
+
         internalGetMutableParams().getMutableMap()
             .put(key, value);
         return this;


### PR DESCRIPTION
- Commit auto generated files
- Pass isKey via Serde constructors
  - Passing a boolean in a constructor isn't perfect because of the low readability. Potentially, a better way could be subclassing, e.g., KafkaAvroKeyDeserializer vs KafkaAvroValueDeserializer so `isKey` can be implicitly set. But it will be a much bigger change. This PR should do it for now.