### PR TITLE
DGS-4134 Add config to ignore default for nullable fields

### DIFF
--- a/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -333,6 +333,7 @@ public class AvroData {
   private Map<AvroSchema, Schema> toConnectSchemaCache;
   private boolean connectMetaData;
   private boolean generalizedSumTypeSupport;
+  private boolean ignoreDefaultForNullables;
   private boolean enhancedSchemaSupport;
   private boolean scrubInvalidNames;
   private boolean discardTypeDocDefault;
@@ -344,10 +345,11 @@ public class AvroData {
   }
 
   public AvroData(AvroDataConfig avroDataConfig) {
-    fromConnectSchemaCache = new BoundedConcurrentHashMap<>(avroDataConfig.getSchemasCacheSize());
-    toConnectSchemaCache = new BoundedConcurrentHashMap<>(avroDataConfig.getSchemasCacheSize());
+    fromConnectSchemaCache = new BoundedConcurrentHashMap<>(avroDataConfig.schemaCacheSize());
+    toConnectSchemaCache = new BoundedConcurrentHashMap<>(avroDataConfig.schemaCacheSize());
     this.connectMetaData = avroDataConfig.isConnectMetaData();
     this.generalizedSumTypeSupport = avroDataConfig.isGeneralizedSumTypeSupport();
+    this.ignoreDefaultForNullables = avroDataConfig.ignoreDefaultForNullables();
     this.enhancedSchemaSupport = avroDataConfig.isEnhancedAvroSchemaSupport();
     this.scrubInvalidNames = avroDataConfig.isScrubInvalidNames();
     this.discardTypeDocDefault = avroDataConfig.isDiscardTypeDocDefault();
@@ -600,7 +602,8 @@ public class AvroData {
           // one of the union types.
           if (isUnionSchema(schema)) {
             for (Field field : schema.fields()) {
-              Object object = struct.get(field);
+              Object object = ignoreDefaultForNullables
+                  ? struct.getWithoutDefault(field.name()) : struct.get(field);
               if (object != null) {
                 return fromConnectData(
                     field.schema(),
@@ -620,9 +623,11 @@ public class AvroData {
               String fieldName = scrubName(field.name(), scrubInvalidNames);
               org.apache.avro.Schema.Field theField = underlyingAvroSchema.getField(fieldName);
               org.apache.avro.Schema fieldAvroSchema = theField.schema();
+              Object fieldValue = ignoreDefaultForNullables
+                  ? struct.getWithoutDefault(field.name()) : struct.get(field);
               convertedBuilder.set(
                   fieldName,
-                  fromConnectData(field.schema(), fieldAvroSchema, struct.get(field), false, true)
+                  fromConnectData(field.schema(), fieldAvroSchema, fieldValue, false, true)
               );
             }
             return convertedBuilder.build();

--- a/avro-data/src/main/java/io/confluent/connect/avro/AvroDataConfig.java
+++ b/avro-data/src/main/java/io/confluent/connect/avro/AvroDataConfig.java
@@ -16,20 +16,14 @@
 
 package io.confluent.connect.avro;
 
-import org.apache.kafka.common.config.AbstractConfig;
+import io.confluent.connect.schema.AbstractDataConfig;
 import org.apache.kafka.common.config.ConfigDef;
 
 import java.util.HashMap;
 import java.util.Map;
 
 
-public class AvroDataConfig extends AbstractConfig {
-
-  public static final String GENERALIZED_SUM_TYPE_SUPPORT_CONFIG = "generalized.sum.type.support";
-  public static final boolean GENERALIZED_SUM_TYPE_SUPPORT_DEFAULT = false;
-  public static final String GENERALIZED_SUM_TYPE_SUPPORT_DOC =
-      "Toggle for enabling/disabling generalized sum type support: interoperability of enum/union "
-      + "with other schema formats";
+public class AvroDataConfig extends AbstractDataConfig {
 
   public static final String ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG = "enhanced.avro.schema.support";
   public static final boolean ENHANCED_AVRO_SCHEMA_SUPPORT_DEFAULT = false;
@@ -48,11 +42,6 @@ public class AvroDataConfig extends AbstractConfig {
       "Toggle for enabling/disabling connect converter to add its meta data to the output schema "
       + "or not";
 
-  public static final String SCHEMAS_CACHE_SIZE_CONFIG = "schemas.cache.config";
-  public static final int SCHEMAS_CACHE_SIZE_DEFAULT = 1000;
-  public static final String SCHEMAS_CACHE_SIZE_DOC =
-      "Size of the converted schemas cache";
-
   @Deprecated
   public static final String DISCARD_TYPE_DOC_DEFAULT_CONFIG = "discard.type.doc.default";
   public static final boolean DISCARD_TYPE_DOC_DEFAULT_DEFAULT = false;
@@ -61,12 +50,7 @@ public class AvroDataConfig extends AbstractConfig {
           + "and Connect schema.";
 
   public static ConfigDef baseConfigDef() {
-    return new ConfigDef()
-        .define(GENERALIZED_SUM_TYPE_SUPPORT_CONFIG,
-                ConfigDef.Type.BOOLEAN,
-                GENERALIZED_SUM_TYPE_SUPPORT_DEFAULT,
-                ConfigDef.Importance.MEDIUM,
-                GENERALIZED_SUM_TYPE_SUPPORT_DOC)
+    return AbstractDataConfig.baseConfigDef()
         .define(ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG,
                 ConfigDef.Type.BOOLEAN,
                 ENHANCED_AVRO_SCHEMA_SUPPORT_DEFAULT,
@@ -76,8 +60,6 @@ public class AvroDataConfig extends AbstractConfig {
                 ConfigDef.Importance.MEDIUM, SCRUB_INVALID_NAMES_DOC)
         .define(CONNECT_META_DATA_CONFIG, ConfigDef.Type.BOOLEAN, CONNECT_META_DATA_DEFAULT,
                 ConfigDef.Importance.LOW, CONNECT_META_DATA_DOC)
-        .define(SCHEMAS_CACHE_SIZE_CONFIG, ConfigDef.Type.INT, SCHEMAS_CACHE_SIZE_DEFAULT,
-                ConfigDef.Importance.LOW, SCHEMAS_CACHE_SIZE_DOC)
         .define(DISCARD_TYPE_DOC_DEFAULT_CONFIG,
                 ConfigDef.Type.BOOLEAN,
                 DISCARD_TYPE_DOC_DEFAULT_DEFAULT,
@@ -87,10 +69,6 @@ public class AvroDataConfig extends AbstractConfig {
 
   public AvroDataConfig(Map<?, ?> props) {
     super(baseConfigDef(), props);
-  }
-
-  public boolean isGeneralizedSumTypeSupport() {
-    return this.getBoolean(GENERALIZED_SUM_TYPE_SUPPORT_CONFIG);
   }
 
   public boolean isEnhancedAvroSchemaSupport() {
@@ -105,10 +83,6 @@ public class AvroDataConfig extends AbstractConfig {
     return this.getBoolean(SCRUB_INVALID_NAMES_CONFIG);
   }
 
-  public int getSchemasCacheSize() {
-    return Math.max(1, this.getInt(SCHEMAS_CACHE_SIZE_CONFIG));
-  }
-
   public boolean isDiscardTypeDocDefault() {
     return this.getBoolean(DISCARD_TYPE_DOC_DEFAULT_CONFIG);
   }
@@ -116,7 +90,7 @@ public class AvroDataConfig extends AbstractConfig {
 
   public static class Builder {
 
-    private Map<String, Object> props = new HashMap<>();
+    private final Map<String, Object> props = new HashMap<>();
 
     public Builder with(String key, Object value) {
       props.put(key, value);

--- a/avro-data/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-data/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -978,6 +978,30 @@ public class AvroDataTest {
   }
 
   @Test
+  public void testFromConnectStructIgnoreDefaultForNullables() {
+    AvroDataConfig avroDataConfig = new AvroDataConfig.Builder()
+        .with(AvroDataConfig.IGNORE_DEFAULT_FOR_NULLABLES_CONFIG, true)
+        .build();
+    AvroData avroData = new AvroData(avroDataConfig);
+
+    Schema connectStringSchema = SchemaBuilder.string().optional().defaultValue("default-string").build();
+    // The string field is not set
+    Schema schema = SchemaBuilder.struct()
+        .name("Record")
+        .field("int32", Schema.INT32_SCHEMA)
+        .field("string", connectStringSchema)
+        .build();
+
+    Struct struct = new Struct(schema).put("int32", 12);
+
+    Object convertedRecord = avroData.fromConnectData(schema, struct);
+
+    assertThat(convertedRecord, instanceOf(GenericRecord.class));
+    assertThat(((GenericRecord)convertedRecord).get("int32"), equalTo(12));
+    assertNull(((GenericRecord)convertedRecord).get("string"));
+  }
+
+  @Test
   public void testFromConnectOptionalComplex() {
     Schema optionalStructSchema = SchemaBuilder.struct().optional()
         .name("optionalStruct")

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
@@ -402,7 +402,7 @@ public class JsonSchemaData {
         // Any schema is valid and we don't have a default, so treat this as an optional schema
         return null;
       }
-      if (schema.defaultValue() != null) {
+      if (schema.defaultValue() != null && !config.ignoreDefaultForNullables()) {
         return fromConnectData(schema, schema.defaultValue());
       }
       if (schema.isOptional()) {
@@ -521,7 +521,8 @@ public class JsonSchemaData {
           // one of the union types.
           if (isUnionSchema(schema)) {
             for (Field field : schema.fields()) {
-              Object object = struct.get(field);
+              Object object = config.ignoreDefaultForNullables()
+                  ? struct.getWithoutDefault(field.name()) : struct.get(field);
               if (object != null) {
                 return fromConnectData(field.schema(), object);
               }
@@ -530,7 +531,9 @@ public class JsonSchemaData {
           } else {
             ObjectNode obj = JSON_NODE_FACTORY.objectNode();
             for (Field field : schema.fields()) {
-              JsonNode jsonNode = fromConnectData(field.schema(), struct.get(field));
+              Object fieldValue = config.ignoreDefaultForNullables()
+                  ? struct.getWithoutDefault(field.name()) : struct.get(field);
+              JsonNode jsonNode = fromConnectData(field.schema(), fieldValue);
               if (jsonNode != null) {
                 obj.set(field.name(), jsonNode);
               }

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaDataConfig.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaDataConfig.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.json;
 
+import io.confluent.connect.schema.AbstractDataConfig;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.json.DecimalFormat;
 
@@ -26,17 +27,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
-public class JsonSchemaDataConfig extends AbstractConfig {
-
-  public static final String GENERALIZED_SUM_TYPE_SUPPORT_CONFIG = "generalized.sum.type.support";
-  public static final boolean GENERALIZED_SUM_TYPE_SUPPORT_DEFAULT = false;
-  public static final String GENERALIZED_SUM_TYPE_SUPPORT_DOC =
-      "Toggle for enabling/disabling generalized sum type support: interoperability of enum/union "
-      + "with other schema formats";
+public class JsonSchemaDataConfig extends AbstractDataConfig {
 
   public static final String OBJECT_ADDITIONAL_PROPERTIES_CONFIG = "object.additional.properties";
   public static final boolean OBJECT_ADDITIONAL_PROPERTIES_DEFAULT = true;
@@ -48,10 +42,6 @@ public class JsonSchemaDataConfig extends AbstractConfig {
   public static final String USE_OPTIONAL_FOR_NON_REQUIRED_DOC =
       "Whether to set non-required properties to be optional.";
 
-  public static final String SCHEMAS_CACHE_SIZE_CONFIG = "schemas.cache.size";
-  public static final int SCHEMAS_CACHE_SIZE_DEFAULT = 1000;
-  public static final String SCHEMAS_CACHE_SIZE_DOC = "Size of the converted schemas cache";
-
   public static final String DECIMAL_FORMAT_CONFIG = "decimal.format";
   public static final String DECIMAL_FORMAT_DEFAULT = DecimalFormat.BASE64.name();
   private static final String DECIMAL_FORMAT_DOC =
@@ -59,13 +49,7 @@ public class JsonSchemaDataConfig extends AbstractConfig {
       + " This value is case insensitive and can be either 'BASE64' (default) or 'NUMERIC'";
 
   public static ConfigDef baseConfigDef() {
-    return new ConfigDef().define(
-        GENERALIZED_SUM_TYPE_SUPPORT_CONFIG,
-        ConfigDef.Type.BOOLEAN,
-        GENERALIZED_SUM_TYPE_SUPPORT_DEFAULT,
-        ConfigDef.Importance.MEDIUM,
-        GENERALIZED_SUM_TYPE_SUPPORT_DOC
-    ).define(
+    return AbstractDataConfig.baseConfigDef().define(
         OBJECT_ADDITIONAL_PROPERTIES_CONFIG,
         ConfigDef.Type.BOOLEAN,
         OBJECT_ADDITIONAL_PROPERTIES_DEFAULT,
@@ -77,12 +61,6 @@ public class JsonSchemaDataConfig extends AbstractConfig {
         USE_OPTIONAL_FOR_NON_REQUIRED_DEFAULT,
         ConfigDef.Importance.MEDIUM,
         USE_OPTIONAL_FOR_NON_REQUIRED_DOC
-    ).define(
-        SCHEMAS_CACHE_SIZE_CONFIG,
-        ConfigDef.Type.INT,
-        SCHEMAS_CACHE_SIZE_DEFAULT,
-        ConfigDef.Importance.LOW,
-        SCHEMAS_CACHE_SIZE_DOC
     ).define(
         DECIMAL_FORMAT_CONFIG,
         ConfigDef.Type.STRING,
@@ -98,20 +76,12 @@ public class JsonSchemaDataConfig extends AbstractConfig {
     super(baseConfigDef(), props);
   }
 
-  public boolean isGeneralizedSumTypeSupport() {
-    return this.getBoolean(GENERALIZED_SUM_TYPE_SUPPORT_CONFIG);
-  }
-
   public boolean allowAdditionalProperties() {
     return getBoolean(OBJECT_ADDITIONAL_PROPERTIES_CONFIG);
   }
 
   public boolean useOptionalForNonRequiredProperties() {
     return getBoolean(USE_OPTIONAL_FOR_NON_REQUIRED_CONFIG);
-  }
-
-  public int schemaCacheSize() {
-    return Math.max(1, this.getInt(SCHEMAS_CACHE_SIZE_CONFIG));
   }
 
   /**

--- a/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
+++ b/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
@@ -67,7 +67,6 @@ import static io.confluent.connect.json.JsonSchemaData.CONNECT_TYPE_PROP;
 import static io.confluent.connect.json.JsonSchemaData.GENERALIZED_TYPE_ENUM;
 import static io.confluent.connect.json.JsonSchemaData.GENERALIZED_TYPE_UNION;
 import static io.confluent.connect.json.JsonSchemaData.GENERALIZED_TYPE_UNION_FIELD_PREFIX;
-import static io.confluent.connect.json.JsonSchemaData.GENERALIZED_TYPE_UNION_PREFIX;
 import static io.confluent.connect.json.JsonSchemaData.JSON_TYPE_ENUM;
 import static io.confluent.connect.json.JsonSchemaData.JSON_TYPE_ONE_OF;
 import static io.confluent.connect.json.JsonSchemaData.KEY_FIELD;
@@ -514,6 +513,42 @@ public class JsonSchemaDataTest {
     checkNonObjectConversion(schema, obj, actualSchema, struct);
   }
 
+  @Test
+  public void testFromConnectRecordIgnoreDefaultForNullables() {
+    jsonSchemaData =
+        new JsonSchemaData(new JsonSchemaDataConfig(
+            Collections.singletonMap(JsonSchemaDataConfig.IGNORE_DEFAULT_FOR_NULLABLES_CONFIG, "true")));
+    NumberSchema numberSchema = NumberSchema.builder()
+        .requiresInteger(true)
+        .unprocessedProperties(ImmutableMap.of("connect.index", 0, "connect.type", "int8"))
+        .build();
+    StringSchema stringSchema = StringSchema.builder()
+        .defaultValue(TextNode.valueOf("default-string"))
+        .build();
+    CombinedSchema oneof = CombinedSchema.oneOf(ImmutableList.of(NullSchema.INSTANCE,
+            stringSchema
+        ))
+        .unprocessedProperties(ImmutableMap.of("connect.index", 1))
+        .build();
+    ObjectSchema schema = ObjectSchema.builder()
+        .addPropertySchema("int8", numberSchema)
+        .addPropertySchema("string", oneof)
+        .title("Record")
+        .build();
+    ObjectNode obj = JsonNodeFactory.instance.objectNode();
+    obj.set("int8", ShortNode.valueOf((short) 12));
+    obj.set("string", NullNode.getInstance());
+    Schema connectStringSchema = SchemaBuilder.string().optional().defaultValue("default-string").build();
+    // The string field is not set
+    Schema actualSchema = SchemaBuilder.struct()
+        .name("Record")
+        .field("int8", Schema.INT8_SCHEMA)
+        .field("string", connectStringSchema)
+        .build();
+    Struct struct = new Struct(actualSchema).put("int8", (byte) 12);
+    checkNonObjectConversion(schema, obj, actualSchema, struct);
+  }
+
   private void checkNonObjectConversion(
       org.everit.json.schema.Schema expectedSchema, Object expected, Schema schema, Object value
   ) {
@@ -651,6 +686,7 @@ public class JsonSchemaDataTest {
     Schema expectedSchema = Schema.STRING_SCHEMA;
     checkNonObjectConversion(expectedSchema, "teststring", schema, TextNode.valueOf("teststring"));
   }
+
 
   @Test
   public void testToConnectBytes() {

--- a/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufDataConfig.java
+++ b/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufDataConfig.java
@@ -16,19 +16,13 @@
 
 package io.confluent.connect.protobuf;
 
+import io.confluent.connect.schema.AbstractDataConfig;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 
-public class ProtobufDataConfig extends AbstractConfig {
-
-  public static final String GENERALIZED_SUM_TYPE_SUPPORT_CONFIG = "generalized.sum.type.support";
-  public static final boolean GENERALIZED_SUM_TYPE_SUPPORT_DEFAULT = false;
-  public static final String GENERALIZED_SUM_TYPE_SUPPORT_DOC =
-      "Toggle for enabling/disabling generalized sum type support: interoperability of enum/union "
-          + "with other schema formats";
+public class ProtobufDataConfig extends AbstractDataConfig {
 
   public static final String ENHANCED_PROTOBUF_SCHEMA_SUPPORT_CONFIG =
       "enhanced.protobuf.schema.support";
@@ -61,17 +55,8 @@ public class ProtobufDataConfig extends AbstractConfig {
   public static final String WRAPPER_FOR_RAW_PRIMITIVES_DOC = "Whether a wrapper message "
       + "should be interpreted as a raw primitive at the root level";
 
-  public static final String SCHEMAS_CACHE_SIZE_CONFIG = "schemas.cache.config";
-  public static final int SCHEMAS_CACHE_SIZE_DEFAULT = 1000;
-  public static final String SCHEMAS_CACHE_SIZE_DOC = "Size of the converted schemas cache";
-
   public static ConfigDef baseConfigDef() {
-    return new ConfigDef()
-        .define(GENERALIZED_SUM_TYPE_SUPPORT_CONFIG,
-            ConfigDef.Type.BOOLEAN,
-            GENERALIZED_SUM_TYPE_SUPPORT_DEFAULT,
-            ConfigDef.Importance.MEDIUM,
-            GENERALIZED_SUM_TYPE_SUPPORT_DOC)
+    return AbstractDataConfig.baseConfigDef()
         .define(ENHANCED_PROTOBUF_SCHEMA_SUPPORT_CONFIG,
             ConfigDef.Type.BOOLEAN,
             ENHANCED_PROTOBUF_SCHEMA_SUPPORT_DEFAULT,
@@ -98,21 +83,12 @@ public class ProtobufDataConfig extends AbstractConfig {
             ConfigDef.Type.BOOLEAN,
             WRAPPER_FOR_RAW_PRIMITIVES_DEFAULT,
             ConfigDef.Importance.MEDIUM,
-            WRAPPER_FOR_RAW_PRIMITIVES_DOC)
-        .define(SCHEMAS_CACHE_SIZE_CONFIG,
-            ConfigDef.Type.INT,
-            SCHEMAS_CACHE_SIZE_DEFAULT,
-            ConfigDef.Importance.LOW,
-            SCHEMAS_CACHE_SIZE_DOC
+            WRAPPER_FOR_RAW_PRIMITIVES_DOC
         );
   }
 
   public ProtobufDataConfig(Map<?, ?> props) {
     super(baseConfigDef(), props);
-  }
-
-  public boolean isGeneralizedSumTypeSupportDefault() {
-    return this.getBoolean(GENERALIZED_SUM_TYPE_SUPPORT_CONFIG);
   }
 
   public boolean isEnhancedProtobufSchemaSupport() {
@@ -137,10 +113,6 @@ public class ProtobufDataConfig extends AbstractConfig {
 
   public boolean useWrapperForRawPrimitives() {
     return this.getBoolean(WRAPPER_FOR_RAW_PRIMITIVES_CONFIG);
-  }
-
-  public int schemaCacheSize() {
-    return Math.max(1, this.getInt(SCHEMAS_CACHE_SIZE_CONFIG));
   }
 
   public static class Builder {

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
@@ -36,6 +36,7 @@ import com.google.protobuf.util.Timestamps;
 import com.squareup.wire.schema.internal.parser.FieldElement;
 import com.squareup.wire.schema.internal.parser.MessageElement;
 import io.confluent.connect.protobuf.ProtobufData.SchemaWrapper;
+import io.confluent.connect.protobuf.test.KeyValue;
 import io.confluent.connect.protobuf.test.KeyValueOptional;
 import io.confluent.connect.protobuf.test.KeyValueWrapper;
 import io.confluent.connect.protobuf.test.MapReferences.AttributeFieldEntry;
@@ -93,7 +94,6 @@ import static io.confluent.connect.protobuf.ProtobufData.GENERALIZED_TYPE_UNION;
 import static io.confluent.connect.protobuf.ProtobufData.PROTOBUF_TYPE_ENUM;
 import static io.confluent.connect.protobuf.ProtobufData.PROTOBUF_TYPE_PROP;
 import static io.confluent.connect.protobuf.ProtobufData.PROTOBUF_TYPE_TAG;
-import static io.confluent.connect.protobuf.ProtobufData.PROTOBUF_TYPE_UNION;
 import static io.confluent.connect.protobuf.ProtobufData.PROTOBUF_TYPE_UNION_PREFIX;
 import static io.confluent.kafka.serializers.protobuf.test.TimestampValueOuterClass.TimestampValue.newBuilder;
 import static org.junit.Assert.assertArrayEquals;
@@ -1879,6 +1879,44 @@ public class ProtobufDataTest {
     assertEquals("invalid_record_name", messageDescriptor.getName());
     assertEquals("invalid_field_name", messageDescriptor.getFields().get(0).getName());
     assertEquals("foo", message.getField(messageDescriptor.getFields().get(0)));
+  }
+
+  @Test
+  public void testFromConnectIgnoreDefaultForNullables() throws Exception {
+    ProtobufDataConfig protobufDataConfig = new ProtobufDataConfig.Builder()
+        .with(ProtobufDataConfig.IGNORE_DEFAULT_FOR_NULLABLES_CONFIG, true)
+        .build();
+    ProtobufData protobufData = new ProtobufData(protobufDataConfig);
+    KeyValue.KeyValueMessage message =
+        KeyValue.KeyValueMessage.newBuilder()
+            .setKey(123)
+            .build();
+    Schema connectSchema = getIgnoreDefaultForNullablesSchema();
+    Struct data = getIgnoreDefaultForNullablesData();
+
+    byte[] messageBytes = getMessageBytes(protobufData, new SchemaAndValue(connectSchema, data));
+    assertArrayEquals(messageBytes, message.toByteArray());
+  }
+
+  private Schema getIgnoreDefaultForNullablesSchema() {
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct();
+    schemaBuilder.name("KeyValueMessage");
+    schemaBuilder.field("key",
+        SchemaBuilder.int32().optional().parameter(PROTOBUF_TYPE_TAG, String.valueOf(1)).build()
+    );
+    schemaBuilder.field("value",
+        SchemaBuilder.string().optional().defaultValue("string-value")
+            .parameter(PROTOBUF_TYPE_TAG, String.valueOf(2)).build()
+    );
+    return schemaBuilder.build();
+  }
+
+  private Struct getIgnoreDefaultForNullablesData() {
+    Schema schema = getIgnoreDefaultForNullablesSchema();
+    Struct result = new Struct(schema.schema());
+    result.put("key", 123);
+    result.put("value", null);
+    return result;
   }
 
   @Test

--- a/schema-converter/src/main/java/io/confluent/connect/schema/AbstractDataConfig.java
+++ b/schema-converter/src/main/java/io/confluent/connect/schema/AbstractDataConfig.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+
+package io.confluent.connect.schema;
+
+import java.util.Map;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+public class AbstractDataConfig extends AbstractConfig {
+
+  public static final String GENERALIZED_SUM_TYPE_SUPPORT_CONFIG = "generalized.sum.type.support";
+  public static final boolean GENERALIZED_SUM_TYPE_SUPPORT_DEFAULT = false;
+  public static final String GENERALIZED_SUM_TYPE_SUPPORT_DOC =
+      "Toggle for enabling/disabling generalized sum type support: interoperability of enum/union "
+          + "with other schema formats";
+
+  public static final String IGNORE_DEFAULT_FOR_NULLABLES_CONFIG =
+      "ignore.default.for.nullables";
+  public static final boolean IGNORE_DEFAULT_FOR_NULLABLES_DEFAULT = false;
+  public static final String IGNORE_DEFAULT_FOR_NULLABLES_DOC =
+      "Whether to ignore the default for nullable fields when the value is null";
+
+  public static final String SCHEMAS_CACHE_SIZE_CONFIG = "schemas.cache.config";
+  public static final int SCHEMAS_CACHE_SIZE_DEFAULT = 1000;
+  public static final String SCHEMAS_CACHE_SIZE_DOC = "Size of the converted schemas cache";
+
+  public static ConfigDef baseConfigDef() {
+    return new ConfigDef()
+        .define(GENERALIZED_SUM_TYPE_SUPPORT_CONFIG,
+            ConfigDef.Type.BOOLEAN,
+            GENERALIZED_SUM_TYPE_SUPPORT_DEFAULT,
+            ConfigDef.Importance.MEDIUM,
+            GENERALIZED_SUM_TYPE_SUPPORT_DOC)
+        .define(IGNORE_DEFAULT_FOR_NULLABLES_CONFIG,
+            ConfigDef.Type.BOOLEAN,
+            IGNORE_DEFAULT_FOR_NULLABLES_DEFAULT,
+            ConfigDef.Importance.MEDIUM,
+            IGNORE_DEFAULT_FOR_NULLABLES_DOC)
+        .define(SCHEMAS_CACHE_SIZE_CONFIG,
+            ConfigDef.Type.INT,
+            SCHEMAS_CACHE_SIZE_DEFAULT,
+            ConfigDef.Importance.LOW,
+            SCHEMAS_CACHE_SIZE_DOC
+        );
+  }
+
+  public AbstractDataConfig(Map<?, ?> props) {
+    super(baseConfigDef(), props);
+  }
+
+  public AbstractDataConfig(ConfigDef definition, Map<?, ?> props) {
+    super(definition, props);
+  }
+
+  public boolean isGeneralizedSumTypeSupport() {
+    return this.getBoolean(GENERALIZED_SUM_TYPE_SUPPORT_CONFIG);
+  }
+
+  public boolean ignoreDefaultForNullables() {
+    return this.getBoolean(IGNORE_DEFAULT_FOR_NULLABLES_CONFIG);
+  }
+
+  public int schemaCacheSize() {
+    return Math.max(1, this.getInt(SCHEMAS_CACHE_SIZE_CONFIG));
+  }
+}


### PR DESCRIPTION
Adds a new converter config property `ignore.default.for.nullables` which defaults to `false`.  Fixes #2314 .