### PR TITLE
DGS-1648 Allow Protobuf msg fullname to be passed for console producer

### DIFF
--- a/protobuf-serializer/src/main/java/io/confluent/kafka/formatter/protobuf/ProtobufMessageReader.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/formatter/protobuf/ProtobufMessageReader.java
@@ -17,6 +17,7 @@ package io.confluent.kafka.formatter.protobuf;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
+import java.util.Properties;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Serializer;
 
@@ -73,6 +74,19 @@ public class ProtobufMessageReader extends SchemaMessageReader<Message> {
   ) {
     super(schemaRegistryClient, keySchema, valueSchema, topic,
         parseKey, reader, autoRegister, useLatest);
+  }
+
+  @Override
+  public void init(java.io.InputStream inputStream, Properties props) {
+    super.init(inputStream, props);
+    if (props.containsKey("key.schema.full.name")) {
+      String keySchemaFullName = props.getProperty("key.schema.full.name").trim();
+      keySchema = ((ProtobufSchema) keySchema).copy(keySchemaFullName);
+    }
+    if (props.containsKey("value.schema.full.name")) {
+      String valueSchemaFullName = props.getProperty("value.schema.full.name").trim();
+      valueSchema = ((ProtobufSchema) valueSchema).copy(valueSchemaFullName);
+    }
   }
 
   @Override

--- a/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageReader.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageReader.java
@@ -55,8 +55,8 @@ public abstract class SchemaMessageReader<T> implements MessageReader {
   private Boolean parseKey = false;
   private String keySeparator = "\t";
   private boolean ignoreError = false;
-  private ParsedSchema keySchema = null;
-  private ParsedSchema valueSchema = null;
+  protected ParsedSchema keySchema = null;
+  protected ParsedSchema valueSchema = null;
   private String keySubject = null;
   private String valueSubject = null;
   private SchemaMessageSerializer<T> serializer;


### PR DESCRIPTION
Adds two configs for Protobuf console producer `key.schema.full.name` and `value.schema.full.name`, to be used when the Protobuf schema contains more than one message type.