### PR TITLE
Migrate from confluent-log4j to reload4j

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -56,12 +56,11 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
         </dependency>
-        <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
         <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>confluent-log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
        </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>

--- a/package-schema-registry/pom.xml
+++ b/package-schema-registry/pom.xml
@@ -18,13 +18,12 @@
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <scope>compile</scope>
         </dependency>
-        <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
         <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>confluent-log4j</artifactId>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>reload4j</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Due to the [commit](https://github.com/confluentinc/common/commit/8bbb6d60f8fcd29a95c5e73e39ecd25e93adc5b8) in `common`.