### PR TITLE
DGS-4303: Support different stat types in SchemaRegistryMetric

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java
@@ -174,7 +174,7 @@ final class SchemaRegistryCoordinator extends AbstractCoordinator implements Clo
     log.debug("Member information: {}", memberConfigs);
 
     if (nodeCountMetric != null) {
-      nodeCountMetric.set(memberConfigs.size());
+      nodeCountMetric.record(memberConfigs.size());
     }
 
     // Compute the leader as the leader-eligible member with the "smallest" (lexicographically) ID.

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/metrics/SchemaRegistryMetric.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/metrics/SchemaRegistryMetric.java
@@ -16,6 +16,7 @@
 package io.confluent.kafka.schemaregistry.metrics;
 
 import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.MeasurableStat;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
 import org.apache.kafka.common.metrics.stats.Value;
@@ -23,24 +24,42 @@ import org.apache.kafka.common.metrics.stats.Value;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class SchemaRegistryMetric {
+  @Deprecated
   private final AtomicLong count = new AtomicLong();
   private final Sensor sensor;
 
+  @Deprecated
   public SchemaRegistryMetric(Metrics metrics, String sensorName, MetricName metricName) {
-    sensor = metrics.sensor(sensorName);
-    sensor.add(metricName, new Value());
+    this(metrics, sensorName, metricName, new Value());
   }
 
+  public SchemaRegistryMetric(Metrics metrics, String sensorName, MetricName metricName,
+                              MeasurableStat measurableStat) {
+    sensor = metrics.sensor(sensorName);
+    sensor.add(metricName, measurableStat);
+  }
+
+  @Deprecated
   public void increment() {
     sensor.record(count.addAndGet(1));
   }
 
+  @Deprecated
   public void set(long value) {
     count.set(value);
     sensor.record(value);
   }
 
+  @Deprecated
   public long get() {
     return count.get();
+  }
+
+  public void record() {
+    sensor.record();
+  }
+
+  public void record(double value) {
+    sensor.record(value);
   }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/metrics/SchemaRegistryMetric.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/metrics/SchemaRegistryMetric.java
@@ -35,7 +35,9 @@ public class SchemaRegistryMetric {
 
   public SchemaRegistryMetric(Metrics metrics, String sensorName, MetricName metricName,
                               MeasurableStat measurableStat) {
+    // a new sensor is only created if the sensor name doesn't already exist in metrics
     sensor = metrics.sensor(sensorName);
+    // a new metric is only created if the metric name doesn't already exist in the sensor
     sensor.add(metricName, measurableStat);
   }
 
@@ -56,6 +58,7 @@ public class SchemaRegistryMetric {
   }
 
   public void record() {
+    // equivalent to record(1.0);
     sensor.record();
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/filters/RestCallMetricFilter.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/filters/RestCallMetricFilter.java
@@ -37,11 +37,11 @@ public class RestCallMetricFilter implements ContainerResponseFilter {
                      ContainerResponseContext containerResponseContext) throws IOException {
     switch (containerResponseContext.getStatusInfo().getFamily()) {
       case SUCCESSFUL:
-        metricSucceeded.increment();
+        metricSucceeded.record();
         break;
       case CLIENT_ERROR:
       case SERVER_ERROR:
-        metricFailed.increment();
+        metricFailed.record();
         break;
       default:
         break;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -191,7 +191,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
             schemaProviderConfigs);
     // Allow custom providers to override default providers
     registerProviders(providerMap, customSchemaProviders);
-    metricsContainer.getCustomSchemaProviderCount().set(customSchemaProviders.size());
+    metricsContainer.getCustomSchemaProviderCount().record(customSchemaProviders.size());
     return providerMap;
   }
 
@@ -384,7 +384,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
         }
         idGenerator.init();
       }
-      metricsContainer.getLeaderNode().set(isLeader() ? 1 : 0);
+      metricsContainer.getLeaderNode().record(isLeader() ? 1 : 0);
     } finally {
       kafkaStore.leaderLock().unlock();
     }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -166,9 +166,9 @@ public class KafkaStoreMessageHandler implements SchemaUpdateHandler {
   }
 
   private static void updateMetrics(SchemaRegistryMetric total, SchemaRegistryMetric perType) {
-    total.increment();
+    total.record();
     if (perType != null) {
-      perType.increment();
+      perType.record();
     }
   }
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/metrics/CustomSchemaProviderMetricTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/metrics/CustomSchemaProviderMetricTest.java
@@ -22,10 +22,14 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import org.junit.Test;
 
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 
+import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_NAME_CUSTOM_SCHEMA_PROVIDER;
 import static org.junit.Assert.assertEquals;
 
 public class CustomSchemaProviderMetricTest extends ClusterTestHarness {
@@ -41,9 +45,11 @@ public class CustomSchemaProviderMetricTest extends ClusterTestHarness {
   }
 
   @Test
-  public void testCustomSchemaProviderMetricCount() {
-    MetricsContainer container = restApp.restApp.schemaRegistry().getMetricsContainer();
-    assertEquals(1, container.getCustomSchemaProviderCount().get());
+  public void testCustomSchemaProviderMetricCount() throws Exception {
+    MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+    ObjectName customSchemaProviderCount =
+            new ObjectName("kafka.schema.registry:type=" + METRIC_NAME_CUSTOM_SCHEMA_PROVIDER);
+    assertEquals(1.0, mBeanServer.getAttribute(customSchemaProviderCount, METRIC_NAME_CUSTOM_SCHEMA_PROVIDER));
   }
 
   public static class CustomSchemaProvider implements SchemaProvider {


### PR DESCRIPTION
There are limitations in `SchemaRegistryMetric` at the moment:
- It maintains a counter but the implementation is not protected against race conditions. Among concurrent calls, the last caller of `sensor.record` overwrites the value, which is not necessarily the latest value of the counter
- It doesn't support other stat types like count, avg, max, etc.

This PR enables `SchemaRegistryMetric` to take a stat type and no longer maintains the internal state (to be deprecated).
