### PR TITLE
Adding timer in onJoinPrepare

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java
@@ -212,7 +212,7 @@ final class SchemaRegistryCoordinator extends AbstractCoordinator implements Clo
   }
 
   @Override
-  protected boolean onJoinPrepare(int generation, String memberId) {
+  protected boolean onJoinPrepare(Timer timer, int generation, String memberId) {
     log.debug("Revoking previous assignment {}", assignmentSnapshot);
     if (assignmentSnapshot != null) {
       listener.onRevoked();


### PR DESCRIPTION
There is a change in function onJoinPrepare and causing a build failure. Hence, adding new parameter `timer' in the parameters. [Change in kafka](https://github.com/confluentinc/kafka/commit/4b52700bc07cd8b838c27869ed695066e03db866)

Cherry-picked changes from [master-change](https://github.com/confluentinc/schema-registry/pull/2363)

Error:
```
registry_master/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java:[46,7] io.confluent.kafka.schemaregistry.leaderelector.kafka.SchemaRegistryCoordinator is not abstract and does not override abstract method onJoinPrepare(org.apache.kafka.common.utils.Timer,int,java.lang.String) in org.apache.kafka.clients.consumer.internals.AbstractCoordinator
**06:16:15**  [ERROR] /home/jenkins/workspace/fluentinc_schema-registry_master/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java:[214,3] method does not override or implement a method from a supertype
```