### PR TITLE
Remove deprecated methods in SchemaRegistryMetric

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/metrics/SchemaRegistryMetric.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/metrics/SchemaRegistryMetric.java
@@ -19,19 +19,9 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.MeasurableStat;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.metrics.stats.Value;
-
-import java.util.concurrent.atomic.AtomicLong;
 
 public class SchemaRegistryMetric {
-  @Deprecated
-  private final AtomicLong count = new AtomicLong();
   private final Sensor sensor;
-
-  @Deprecated
-  public SchemaRegistryMetric(Metrics metrics, String sensorName, MetricName metricName) {
-    this(metrics, sensorName, metricName, new Value());
-  }
 
   public SchemaRegistryMetric(Metrics metrics, String sensorName, MetricName metricName,
                               MeasurableStat measurableStat) {
@@ -39,22 +29,6 @@ public class SchemaRegistryMetric {
     sensor = metrics.sensor(sensorName);
     // a new metric is only created if the metric name doesn't already exist in the sensor
     sensor.add(metricName, measurableStat);
-  }
-
-  @Deprecated
-  public void increment() {
-    sensor.record(count.addAndGet(1));
-  }
-
-  @Deprecated
-  public void set(long value) {
-    count.set(value);
-    sensor.record(value);
-  }
-
-  @Deprecated
-  public long get() {
-    return count.get();
   }
 
   public void record() {


### PR DESCRIPTION
Follow up on https://github.com/confluentinc/schema-registry/pull/2350 to clean up deprecated methods.