### PR TITLE
Migrate PowerMock to Mockito in RestServiceTest

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -45,13 +45,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-easymock</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -43,6 +43,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -263,7 +264,7 @@ public class RestService implements Configurable {
 
     HttpURLConnection connection = null;
     try {
-      URL url = new URL(requestUrl);
+      URL url = url(requestUrl);
 
       connection = buildConnection(url, method, requestProperties);
 
@@ -1250,5 +1251,17 @@ public class RestService implements Configurable {
 
   public void setProxy(String proxyHost, int proxyPort) {
     this.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+  }
+
+  /**
+   * Convert url string to URL. This method is package-private so that it can be mocked for unit
+   * tests.
+   *
+   * @param requestUrl url string
+   * @return {@link URL}
+   * @throws MalformedURLException if the input string is a malformed URL
+   */
+  URL url(String requestUrl) throws MalformedURLException {
+    return new URL(requestUrl);
   }
 }

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/RestServiceTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/RestServiceTest.java
@@ -16,19 +16,17 @@
 package io.confluent.kafka.schemaregistry.client.rest;
 
 import static junit.framework.TestCase.assertEquals;
-import static org.easymock.EasyMock.anyInt;
-import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.anyString;
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.createNiceMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.verify;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.powermock.api.easymock.PowerMock.expectNew;
-import static org.powermock.api.easymock.PowerMock.replay;
-import java.io.ByteArrayInputStream;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.io.InputStream;
 import java.net.*;
 import java.nio.charset.StandardCharsets;
@@ -38,19 +36,16 @@ import java.util.Map;
 import io.confluent.kafka.schemaregistry.client.security.bearerauth.BearerAuthCredentialProvider;
 
 import com.google.common.collect.ImmutableMap;
-import org.easymock.EasyMock;
-import org.easymock.IArgumentMatcher;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.api.easymock.annotation.Mock;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.client.security.basicauth.BasicAuthCredentialProvider;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(RestService.class)
+@RunWith(MockitoJUnitRunner.class)
 public class RestServiceTest {
 
   @Test
@@ -94,37 +89,31 @@ public class RestServiceTest {
   @Test
   public void testSetBasicAuthRequestHeader() throws Exception {
     RestService restService = new RestService("http://localhost:8081");
+    RestService restServiceSpy = spy(restService);
 
-    BasicAuthCredentialProvider basicAuthCredentialProvider = createMock(BasicAuthCredentialProvider.class);
-    restService.setBasicAuthCredentialProvider(basicAuthCredentialProvider);
+    BasicAuthCredentialProvider basicAuthCredentialProvider = mock(BasicAuthCredentialProvider.class);
+    restServiceSpy.setBasicAuthCredentialProvider(basicAuthCredentialProvider);
 
-    HttpURLConnection httpURLConnection = createNiceMock(HttpURLConnection.class);
-    InputStream inputStream = createNiceMock(InputStream.class);
+    HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
+    InputStream inputStream = mock(InputStream.class);
 
-    expectNew(URL.class, anyString()).andReturn(url);
-    expect(url.openConnection()).andReturn(httpURLConnection);
-    expect(httpURLConnection.getURL()).andReturn(url);
-    expect(basicAuthCredentialProvider.getUserInfo(anyObject(URL.class))).andReturn("user:password");
-    expect(httpURLConnection.getResponseCode()).andReturn(HttpURLConnection.HTTP_OK);
+    doReturn(url).when(restServiceSpy).url(anyString());
+    when(url.openConnection()).thenReturn(httpURLConnection);
+    when(httpURLConnection.getURL()).thenReturn(url);
+    when(basicAuthCredentialProvider.getUserInfo(any(URL.class))).thenReturn("user:password");
+    when(httpURLConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
 
+    when(httpURLConnection.getInputStream()).thenReturn(inputStream);
+    when(inputStream.read(any(), anyInt(), anyInt())).thenAnswer(invocationOnMock -> {
+      byte[] b = invocationOnMock.getArgument(0);
+      byte[] json = "[\"abc\"]".getBytes(StandardCharsets.UTF_8);
+      System.arraycopy(json, 0, b, 0, json.length);
+      return json.length;
+    });
+
+    restServiceSpy.getAllSubjects();
     // Make sure that the Authorization header is set with the correct value for "user:password"
-    httpURLConnection.setRequestProperty("Authorization", "Basic dXNlcjpwYXNzd29yZA==");
-    expectLastCall().once();
-
-    expect(httpURLConnection.getInputStream()).andReturn(inputStream);
-
-    expect(inputStream.read(anyObject(), anyInt(), anyInt()))
-        .andDelegateTo(createInputStream("[\"abc\"]"))
-        .anyTimes();
-
-    replay(URL.class, url);
-    replay(HttpURLConnection.class, httpURLConnection);
-    replay(basicAuthCredentialProvider);
-    replay(InputStream.class, inputStream);
-
-    restService.getAllSubjects();
-
-    verify(httpURLConnection);
+    verify(httpURLConnection).setRequestProperty("Authorization", "Basic dXNlcjpwYXNzd29yZA==");
   }
 
 
@@ -134,36 +123,32 @@ public class RestServiceTest {
   @Test
   public void testSetBearerAuthRequestHeader() throws Exception {
     RestService restService = new RestService("http://localhost:8081");
+    RestService restServiceSpy = spy(restService);
 
-    BearerAuthCredentialProvider bearerAuthCredentialProvider = createMock(BearerAuthCredentialProvider.class);
-    restService.setBearerAuthCredentialProvider(bearerAuthCredentialProvider);
+    BearerAuthCredentialProvider bearerAuthCredentialProvider = mock(BearerAuthCredentialProvider.class);
+    restServiceSpy.setBearerAuthCredentialProvider(bearerAuthCredentialProvider);
 
-    HttpURLConnection httpURLConnection = createNiceMock(HttpURLConnection.class);
-    InputStream inputStream = createNiceMock(InputStream.class);
+    HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
+    InputStream inputStream = mock(InputStream.class);
 
-    expectNew(URL.class, anyString()).andReturn(url);
-    expect(url.openConnection()).andReturn(httpURLConnection);
-    expect(httpURLConnection.getURL()).andReturn(url);
-    expect(bearerAuthCredentialProvider.getBearerToken(anyObject(URL.class))).andReturn("auth-token");
-    expect(httpURLConnection.getResponseCode()).andReturn(HttpURLConnection.HTTP_OK);
+    doReturn(url).when(restServiceSpy).url(anyString());
+    when(url.openConnection()).thenReturn(httpURLConnection);
+    when(httpURLConnection.getURL()).thenReturn(url);
+    when(bearerAuthCredentialProvider.getBearerToken(any(URL.class))).thenReturn("auth-token");
+    when(httpURLConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
 
-    // Make sure that the Authorization header is set with the correct value for "user:password"
-    httpURLConnection.setRequestProperty("Authorization", "Bearer auth-token");
-    expectLastCall().once();
+    when(httpURLConnection.getInputStream()).thenReturn(inputStream);
+    when(inputStream.read(any(), anyInt(), anyInt())).thenAnswer(invocationOnMock -> {
+      byte[] b = invocationOnMock.getArgument(0);
+      byte[] json = "[\"abc\"]".getBytes(StandardCharsets.UTF_8);
+      System.arraycopy(json, 0, b, 0, json.length);
+      return json.length;
+    });
 
-    expect(httpURLConnection.getInputStream()).andReturn(inputStream);
+    restServiceSpy.getAllSubjects();
 
-    expect(inputStream.read((byte[]) anyObject(), anyInt(), anyInt()))
-            .andDelegateTo(createInputStream("[\"abc\"]")).anyTimes();
-
-    replay(URL.class, url);
-    replay(HttpURLConnection.class, httpURLConnection);
-    replay(bearerAuthCredentialProvider);
-    replay(InputStream.class, inputStream);
-
-    restService.getAllSubjects();
-
-    verify(httpURLConnection);
+    // Make sure that the Authorization header is set with the correct token
+    verify(httpURLConnection).setRequestProperty("Authorization", "Bearer auth-token");
   }
 
   /*
@@ -172,64 +157,47 @@ public class RestServiceTest {
   @Test
   public void testSetHttpHeaders() throws Exception {
     RestService restService = new RestService("http://localhost:8081");
+    RestService restServiceSpy = spy(restService);
 
-    BasicAuthCredentialProvider basicAuthCredentialProvider = createMock(BasicAuthCredentialProvider.class);
-    restService.setHttpHeaders(
+    restServiceSpy.setHttpHeaders(
         ImmutableMap.of("api-key", "test-api-key","source-app", "foo"));
 
-    HttpURLConnection httpURLConnection = createNiceMock(HttpURLConnection.class);
-    InputStream inputStream = createNiceMock(InputStream.class);
+    HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
+    InputStream inputStream = mock(InputStream.class);
 
-    expectNew(URL.class, anyString()).andReturn(url);
-    expect(url.openConnection()).andReturn(httpURLConnection);
-    expect(httpURLConnection.getResponseCode()).andReturn(HttpURLConnection.HTTP_OK);
+    doReturn(url).when(restServiceSpy).url(anyString());
+    when(url.openConnection()).thenReturn(httpURLConnection);
+    when(httpURLConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
 
-    // Make sure that the Authorization header is set with the correct value for "user:password"
-    httpURLConnection.setRequestProperty("api-key", "test-api-key");
-    httpURLConnection.setRequestProperty("source-app", "foo");
-    expectLastCall().once();
+    when(httpURLConnection.getInputStream()).thenReturn(inputStream);
+    when(inputStream.read(any(), anyInt(), anyInt())).thenAnswer(invocationOnMock -> {
+      byte[] b = invocationOnMock.getArgument(0);
+      byte[] json = "[\"abc\"]".getBytes(StandardCharsets.UTF_8);
+      System.arraycopy(json, 0, b, 0, json.length);
+      return json.length;
+    });
 
-    expect(httpURLConnection.getInputStream()).andReturn(inputStream);
+    restServiceSpy.getAllSubjects();
 
-    expect(inputStream.read(anyObject(), anyInt(), anyInt()))
-        .andDelegateTo(createInputStream("[\"abc\"]"))
-        .anyTimes();
-
-    replay(URL.class, url);
-    replay(HttpURLConnection.class, httpURLConnection);
-    replay(InputStream.class, inputStream);
-
-    restService.getAllSubjects();
-
-    verify(httpURLConnection);
+    // Make sure that the correct header is set
+    verify(httpURLConnection).setRequestProperty("api-key", "test-api-key");
+    verify(httpURLConnection).setRequestProperty("source-app", "foo");
   }
 
   @Test
   public void testErrorResponseWithNullErrorStreamFromConnection() throws Exception {
     RestService restService = new RestService("http://localhost:8081");
+    RestService restServiceSpy = spy(restService);
 
-    HttpURLConnection httpURLConnection = createNiceMock(HttpURLConnection.class);
-    InputStream inputStream = createNiceMock(InputStream.class);
+    HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
 
-    expectNew(URL.class, anyString()).andReturn(url);
-    expect(url.openConnection()).andReturn(httpURLConnection);
-    expect(httpURLConnection.getResponseCode()).andReturn(HttpURLConnection.HTTP_BAD_REQUEST);
-
-    expectLastCall().once();
-
-    expect(httpURLConnection.getInputStream()).andReturn(inputStream);
-    expect(httpURLConnection.getErrorStream()).andReturn(null);
-
-    expect(inputStream.read(anyObject(), anyInt(), anyInt()))
-        .andDelegateTo(createInputStream("[\"abc\"]"))
-        .anyTimes();
-
-    replay(URL.class, url);
-    replay(HttpURLConnection.class, httpURLConnection);
-    replay(InputStream.class, inputStream);
+    doReturn(url).when(restServiceSpy).url(anyString());
+    when(url.openConnection()).thenReturn(httpURLConnection);
+    when(httpURLConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_BAD_REQUEST);
+    when(httpURLConnection.getErrorStream()).thenReturn(null);
 
     try {
-      restService.getAllSubjects();
+      restServiceSpy.getAllSubjects();
       fail("Expected RestClientException to be thrown");
     } catch (RestClientException exception) {
       assertTrue(exception.getMessage().endsWith("error code: 50005"));
@@ -239,58 +207,33 @@ public class RestServiceTest {
   @Test
   public void testSetProxy() throws Exception {
     RestService restService = new RestService("http://localhost:8081");
+    RestService restServiceSpy = spy(restService);
 
-    HttpURLConnection httpURLConnection = createNiceMock(HttpURLConnection.class);
-    InputStream inputStream = createNiceMock(InputStream.class);
+    HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
+    InputStream inputStream = mock(InputStream.class);
     Map<String, Object> configs = new HashMap<>();
     configs.put("proxy.host", "http://localhost");
     configs.put("proxy.port", 8080);
-    restService.configure(configs);
+    restServiceSpy.configure(configs);
 
-    expectNew(URL.class, anyString()).andReturn(url);
-    expect(url.openConnection(withProxy())).andReturn(httpURLConnection);
-    expect(httpURLConnection.getResponseCode()).andReturn(HttpURLConnection.HTTP_OK);
-    expect(httpURLConnection.getInputStream()).andReturn(inputStream);
-    expect(inputStream.read(anyObject(), anyInt(), anyInt()))
-            .andDelegateTo(createInputStream("[\"abc\"]")).anyTimes();
+    doReturn(url).when(restServiceSpy).url(anyString());
 
-    replay(URL.class, url);
-    replay(HttpURLConnection.class, httpURLConnection);
-    replay(InputStream.class, inputStream);
-
-    restService.getAllSubjects();
-
-    verify(httpURLConnection);
-  }
-
-  private ByteArrayInputStream createInputStream(String content) {
-    return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
-  }
-
-  private static Proxy withProxy() {
-    EasyMock.reportMatcher(new IArgumentMatcher() {
-      private final String proxyHost = "http://localhost";
-      private final int proxyPort = 8080;
-
-      @Override
-      public boolean matches(Object proxyObj) {
-        if (proxyObj instanceof Proxy) {
-          Proxy proxy = (Proxy) proxyObj;
-          SocketAddress socketAddress = proxy.address();
-          if (socketAddress instanceof InetSocketAddress) {
-            InetSocketAddress inetAddress = (InetSocketAddress) socketAddress;
-            return inetAddress.getHostName().equals(proxyHost) &&
-                    inetAddress.getPort() == proxyPort;
-          }
-        }
-        return false;
-      }
-
-      @Override
-      public void appendTo(StringBuffer stringBuffer) {
-        stringBuffer.append("HTTP @ ").append(proxyHost).append(":").append(proxyPort);
-      }
+    when(httpURLConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
+    when(url.openConnection(any())).thenReturn(httpURLConnection);
+    when(httpURLConnection.getInputStream()).thenReturn(inputStream);
+    when(inputStream.read(any(), anyInt(), anyInt())).thenAnswer(invocationOnMock -> {
+      byte[] b = invocationOnMock.getArgument(0);
+      byte[] json = "[\"abc\"]".getBytes(StandardCharsets.UTF_8);
+      System.arraycopy(json, 0, b, 0, json.length);
+      return json.length;
     });
-    return null;
+
+    restServiceSpy.getAllSubjects();
+
+    ArgumentCaptor<Proxy> proxyCaptor = ArgumentCaptor.forClass(Proxy.class);
+    verify(url).openConnection(proxyCaptor.capture());
+    InetSocketAddress inetAddress = (InetSocketAddress) proxyCaptor.getValue().address();
+    assertEquals("http://localhost", inetAddress.getHostName());
+    assertEquals(8080, inetAddress.getPort());
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -358,12 +358,12 @@
                     <configuration>
                         <documentationUrl>https://docs.confluent.io/${io.confluent.schema-registry.version}/schema-registry/docs/connect.html</documentationUrl>
                         <sourceUrl>https://github.com/confluentinc/schema-registry</sourceUrl>
-                        
+
                         <supportProviderName>${project.organization.name}</supportProviderName>
                         <supportSummary>Confluent supports the Avro Converter alongside community members as part of its Confluent Platform offering.</supportSummary>
                         <supportUrl>https://docs.confluent.io/current/</supportUrl>
                         <supportLogo>logos/confluent.png</supportLogo>
-                        
+
                         <ownerUsername>confluentinc</ownerUsername>
                         <ownerType>organization</ownerType>
                         <ownerName>${project.organization.name}</ownerName>
@@ -447,4 +447,35 @@
         </plugins>
 
     </build>
+
+    <profiles>
+        <profile>
+            <id>surefire-failsafe</id>
+            <activation>
+                <jdk>(1.8,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>
+                                --add-opens java.base/java.lang=ALL-UNNAMED
+                            </argLine>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <argLine>
+                                --add-opens java.security.jgss/sun.security.krb5=ALL-UNNAMED
+                            </argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
1. Migrate PowerMock to Mockito in RestServiceTest so the project can be built with JDK 17 on PR builders.
2. Added the JDK option of surefire plugin so that EasyMock can be used with JDK 17

ref: https://github.com/confluentinc/secret-registry/pull/70