### PR TITLE
Add OpenAPI operation tags

### DIFF
--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -5,6 +5,8 @@ info:
 paths:
   /compatibility/subjects/{subject}/versions/{version}:
     post:
+      tags:
+      - Compatibility (v1)
       summary: Test schema compatibility against a particular schema subject-version
       description: "Test input schema against a particular version of a subject's\
         \ schema for compatibility. The compatibility level applied for the check\
@@ -135,6 +137,8 @@ paths:
                   type: string
   /compatibility/subjects/{subject}/versions:
     post:
+      tags:
+      - Compatibility (v1)
       summary: Test schema compatibility against all schemas under a subject
       description: "Test input schema against a subject's schemas for compatibility,\
         \ based on the configured compatibility level of the subject. In other words,\
@@ -194,6 +198,8 @@ paths:
           description: Error code 50001 -- Error in the backend data store
   /config:
     get:
+      tags:
+      - Config (v1)
       summary: Get global compatibility level.
       operationId: getTopLevelConfig
       responses:
@@ -212,6 +218,8 @@ paths:
         "500":
           description: Error code 50001 -- Error in the backend data store
     put:
+      tags:
+      - Config (v1)
       summary: Update global compatibility level
       description: "Updates the global compatibility level. On success, echoes the\
         \ original request back to the client."
@@ -252,6 +260,8 @@ paths:
             Error code 50001 -- Error in the backend data store
             Error code 50003 -- Error while forwarding the request to the primary
     delete:
+      tags:
+      - Config (v1)
       summary: Deletes the Global-level compatibility level config and revert to the
         global default.
       operationId: deleteTopLevelConfig
@@ -295,6 +305,8 @@ paths:
           description: Error code 50001 -- Error in the backend datastore
   /config/{subject}:
     get:
+      tags:
+      - Config (v1)
       summary: Get subject compatibility level
       description: Retrieves compatibility level for a subject.
       operationId: getSubjectLevelConfig
@@ -329,6 +341,8 @@ paths:
         "500":
           description: Error code 50001 -- Error in the backend data store
     put:
+      tags:
+      - Config (v1)
       summary: Update subject compatibility level
       description: "Update compatibility level for the specified subject. On success,\
         \ echoes the original request back to the client."
@@ -378,6 +392,8 @@ paths:
             Error code 50001 -- Error in the backend data store
             Error code 50003 -- Error while forwarding the request to the primary
     delete:
+      tags:
+      - Config (v1)
       summary: Delete subject compatibility level
       description: Deletes the specified subject-level compatibility level config
         and reverts to the global default.
@@ -432,6 +448,8 @@ paths:
           description: Error code 50001 -- Error in the backend datastore
   /contexts:
     get:
+      tags:
+      - Contexts (v1)
       summary: List contexts
       description: Retrieves a list of contexts.
       operationId: listContexts
@@ -458,6 +476,8 @@ paths:
           description: Error code 50001 -- Error in the backend data store
   /mode:
     get:
+      tags:
+      - Modes (v1)
       summary: Get global mode
       description: Retrieves global mode.
       operationId: getTopLevelMode
@@ -477,6 +497,8 @@ paths:
         "500":
           description: Error code 50001 -- Error in the backend data store
     put:
+      tags:
+      - Modes (v1)
       summary: Update global mode
       description: "Update global mode. On success, echoes the original request back\
         \ to the client."
@@ -528,6 +550,8 @@ paths:
             Error code 50004 -- Unknown leader
   /mode/{subject}:
     get:
+      tags:
+      - Modes (v1)
       summary: Get subject mode
       description: Retrieves the subject mode.
       operationId: getMode
@@ -561,6 +585,8 @@ paths:
         "500":
           description: Error code 50001 -- Error in the backend data store
     put:
+      tags:
+      - Modes (v1)
       summary: Update subject mode
       description: "Update mode for the specified subject. On success, echoes the\
         \ original request back to the client."
@@ -617,6 +643,8 @@ paths:
             Error code 50003 -- Error while forwarding the request to the primary
             Error code 50004 -- Unknown leader
     delete:
+      tags:
+      - Modes (v1)
       summary: Delete subject mode
       description: Deletes the specified subject-level mode and reverts to the global
         default.
@@ -647,6 +675,8 @@ paths:
           description: Error code 50001 -- Error in the backend datastore
   /schemas:
     get:
+      tags:
+      - Schemas (v1)
       summary: List schemas
       description: Get the schemas matching the specified parameters.
       operationId: getSchemas
@@ -708,6 +738,8 @@ paths:
             Error code 50001 -- Error in the backend data store
   /schemas/ids/{id}:
     get:
+      tags:
+      - Schemas (v1)
       summary: Get schema string by ID
       description: Retrieves the schema string identified by the input ID.
       operationId: getSchema
@@ -757,6 +789,8 @@ paths:
             Error code 50001 -- Error in the backend data store
   /schemas/ids/{id}/subjects:
     get:
+      tags:
+      - Schemas (v1)
       summary: List subjects associated to schema ID
       description: Retrieves all the subjects associated with a particular schema
         ID.
@@ -806,6 +840,8 @@ paths:
             Error code 50001 -- Error in the backend data store
   /schemas/ids/{id}/versions:
     get:
+      tags:
+      - Schemas (v1)
       summary: List subject-versions associated to schema ID
       description: Get all the subject-version pairs associated with the input ID.
       operationId: getVersions
@@ -854,6 +890,8 @@ paths:
             Error code 50001 -- Error in the backend data store
   /schemas/types:
     get:
+      tags:
+      - Schemas (v1)
       summary: List supported schema types
       description: Retrieve the schema types supported by this registry.
       operationId: getSchemaTypes
@@ -881,6 +919,8 @@ paths:
             Error code 50001 -- Error in the backend data store
   /subjects:
     get:
+      tags:
+      - Subjects (v1)
       summary: List subjects
       description: Retrieves a list of registered subjects matching specified parameters.
       operationId: list
@@ -919,6 +959,8 @@ paths:
           description: Error code 50001 -- Error in the backend datastore
   /subjects/{subject}:
     post:
+      tags:
+      - Subjects (v1)
       summary: Lookup schema under subject
       description: "Check if a schema has already been registered under the specified\
         \ subject. If so, this returns the schema string along with its globally unique\
@@ -977,6 +1019,8 @@ paths:
         "500":
           description: Internal server error
     delete:
+      tags:
+      - Subjects (v1)
       summary: Delete subject
       description: Deletes the specified subject and its associated compatibility
         level if registered. It is recommended to use this API only when a topic needs
@@ -1022,6 +1066,8 @@ paths:
           description: Error code 50001 -- Error in the backend datastore
   /subjects/{subject}/versions:
     get:
+      tags:
+      - Subject Versions (v1)
       summary: List versions under subject
       description: Retrieves a list of versions registered under the specified subject.
       operationId: listVersions
@@ -1064,6 +1110,8 @@ paths:
         "500":
           description: Error code 50001 -- Error in the backend data store
     post:
+      tags:
+      - Subject Versions (v1)
       summary: Register schema under a subject
       description: |-
         Register a new schema under the specified subject. If successfully registered, this returns the unique identifier of this schema in the registry. The returned identifier should be used to retrieve this schema from the schemas resource and is different from the schema's version which is associated with the subject. If the same schema is registered under a different subject, the same identifier will be returned. However, the version of the schema may be different under different subjects.
@@ -1122,6 +1170,8 @@ paths:
             Error code 50003 -- Error while forwarding the request to the primary
   /subjects/{subject}/versions/{version}:
     get:
+      tags:
+      - Subject Versions (v1)
       summary: Get schema by version
       description: Retrieves a specific version of the schema registered under this
         subject.
@@ -1200,6 +1250,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorMessage'
     delete:
+      tags:
+      - Subject Versions (v1)
       summary: Delete schema version
       description: "Deletes a specific version of the schema registered under this\
         \ subject. This only deletes the version and the schema ID remains intact\
@@ -1256,6 +1308,8 @@ paths:
           description: Error code 50001 -- Error in the backend data store
   /subjects/{subject}/versions/{version}/referencedby:
     get:
+      tags:
+      - Subject Versions (v1)
       summary: List schemas referencing a schema
       description: Retrieves the IDs of schemas that reference the specified schema.
       operationId: getReferencedBy
@@ -1308,10 +1362,12 @@ paths:
           description: Error code 50001 -- Error in the backend data store
   /subjects/{subject}/versions/{version}/schema:
     get:
+      tags:
+      - Subject Versions (v1)
       summary: Get schema string by version
       description: Retrieves the schema for the specified version of this subject.
         Only the unescaped schema string is returned.
-      operationId: getSchemaOnly_2
+      operationId: getSchemaOnly_1
       parameters:
       - name: subject
         in: path
@@ -1357,6 +1413,8 @@ paths:
           description: Error code 50001 -- Error in the backend data store
   /v1/metadata/id:
     get:
+      tags:
+      - Server Metadata (v1)
       summary: Get the server metadata
       operationId: getClusterId
       responses:
@@ -1365,9 +1423,11 @@ paths:
             Error code 50001 -- Error in the backend data store
   /schemas/ids/{id}/schema:
     get:
+      tags:
+      - Schemas (v1)
       summary: Get schema by ID
       description: Retrieves the schema identified by the input ID.
-      operationId: getSchemaOnly
+      operationId: getSchemaOnly_2
       parameters:
       - name: id
         in: path
@@ -1387,12 +1447,6 @@ paths:
         schema:
           type: string
           default: ""
-      - name: fetchMaxId
-        in: query
-        description: Whether to fetch the maximum schema identifier that exists
-        schema:
-          type: boolean
-          default: false
       responses:
         "200":
           description: schema
@@ -1414,6 +1468,8 @@ paths:
             Error code 50001 -- Error in the backend data store
   /v1/metadata/version:
     get:
+      tags:
+      - Server Metadata (v1)
       summary: Get Schema Registry server version
       operationId: getSchemaRegistryVersion
       responses:

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -32,6 +32,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,6 +59,7 @@ import java.util.List;
            Versions.JSON, Versions.GENERIC_REQUEST})
 public class CompatibilityResource {
 
+  private static final String apiTag = "Compatibility (v1)";
   private static final Logger log = LoggerFactory.getLogger(CompatibilityResource.class);
   private final KafkaSchemaRegistry schemaRegistry;
 
@@ -86,6 +89,7 @@ public class CompatibilityResource {
           @ApiResponse(responseCode = "500", description = "Error code 50001 -- Error in the "
               + "backend data store")
       })
+  @Tags(@Tag(name = apiTag))
   @PerformanceMetric("compatibility.subjects.versions.verify")
   public void testCompatibilityBySubjectName(
       final @Suspended AsyncResponse asyncResponse,
@@ -176,7 +180,7 @@ public class CompatibilityResource {
           @ApiResponse(responseCode = "500", description = "Error code 50001 -- Error in the "
               + "backend data store")
       })
-
+  @Tags(@Tag(name = apiTag))
   @PerformanceMetric("compatibility.subjects.versions.verify")
   public void testCompatibilityForSubject(
       final @Suspended AsyncResponse asyncResponse,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -35,6 +35,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,6 +64,7 @@ import java.util.Map;
            Versions.JSON, Versions.GENERIC_REQUEST})
 public class ConfigResource {
 
+  private static final String apiTag = "Config (v1)";
   private static final Logger log = LoggerFactory.getLogger(ConfigResource.class);
   private final KafkaSchemaRegistry schemaRegistry;
 
@@ -86,6 +89,7 @@ public class ConfigResource {
         @ApiResponse(responseCode = "500", description =
            "Error code 50001 -- Error in the backend data store\n"
                 + "Error code 50003 -- Error while forwarding the request to the primary")})
+  @Tags(@Tag(name = apiTag))
   public ConfigUpdateRequest updateSubjectLevelConfig(
       @Parameter(description = "Name of the subject", required = true)
       @PathParam("subject") String subject,
@@ -136,6 +140,7 @@ public class ConfigResource {
         @ApiResponse(responseCode = "500", description = "Error code 50001 -- Error in the backend "
           + "data store")
       })
+  @Tags(@Tag(name = apiTag))
   public Config getSubjectLevelConfig(
       @Parameter(description = "Name of the subject", required = true)
       @PathParam("subject") String subject,
@@ -176,6 +181,7 @@ public class ConfigResource {
         @ApiResponse(responseCode = "500", description =
             "Error code 50001 -- Error in the backend data store\n"
                + "Error code 50003 -- Error while forwarding the request to the primary\n")})
+  @Tags(@Tag(name = apiTag))
   public ConfigUpdateRequest updateTopLevelConfig(
       @Context HttpHeaders headers,
       @Parameter(description = "Config Update Request", required = true)
@@ -211,6 +217,7 @@ public class ConfigResource {
       @ApiResponse(responseCode = "500", description = "Error code 50001 -- Error in the backend "
           + "data store")
   })
+  @Tags(@Tag(name = apiTag))
   public Config getTopLevelConfig() {
     Config config;
     try {
@@ -231,6 +238,7 @@ public class ConfigResource {
         @ApiResponse(responseCode = "500", description = "Error code 50001 -- Error in the backend "
           + "datastore")
       })
+  @Tags(@Tag(name = apiTag))
   public void deleteTopLevelConfig(
       final @Suspended AsyncResponse asyncResponse,
       @Context HttpHeaders headers) {
@@ -269,6 +277,7 @@ public class ConfigResource {
         @ApiResponse(responseCode = "500", description = "Error code 50001 -- Error in the backend "
           + "datastore")
       })
+  @Tags(@Tag(name = apiTag))
   public void deleteSubjectConfig(
       final @Suspended AsyncResponse asyncResponse,
       @Context HttpHeaders headers,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ContextsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ContextsResource.java
@@ -26,6 +26,8 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -42,6 +44,7 @@ import java.util.List;
            Versions.JSON, Versions.GENERIC_REQUEST})
 public class ContextsResource {
 
+  private static final String apiTag = "Contexts (v1)";
   private final KafkaSchemaRegistry schemaRegistry;
 
   public ContextsResource(KafkaSchemaRegistry schemaRegistry) {
@@ -58,6 +61,7 @@ public class ContextsResource {
         @ApiResponse(responseCode = "500",
                      description = "Error code 50001 -- Error in the backend data store")
       })
+  @Tags(@Tag(name = apiTag))
   @PerformanceMetric("contexts.list")
   public List<String> listContexts() {
     try {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
@@ -35,6 +35,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,6 +65,7 @@ import java.util.Map;
            Versions.JSON, Versions.GENERIC_REQUEST})
 public class ModeResource {
 
+  private static final String apiTag = "Modes (v1)";
   private static final Logger log = LoggerFactory.getLogger(ModeResource.class);
   private final KafkaSchemaRegistry schemaRegistry;
 
@@ -87,6 +90,7 @@ public class ModeResource {
             description = "Error code 50001 -- Error in the backend data store\n"
             + "Error code 50003 -- Error while forwarding the request to the primary\n"
             + "Error code 50004 -- Unknown leader")})
+  @Tags(@Tag(name = apiTag))
   public ModeUpdateRequest updateMode(
       @Parameter(description = "Name of the subject", required = true)
       @PathParam("subject") String subject,
@@ -143,6 +147,7 @@ public class ModeResource {
         @ApiResponse(responseCode = "500",
             description = "Error code 50001 -- Error in the backend data store")
       })
+  @Tags(@Tag(name = apiTag))
   public Mode getMode(
       @Parameter(description = "Name of the subject", required = true)
       @PathParam("subject") String subject,
@@ -178,6 +183,7 @@ public class ModeResource {
             "Error code 50001 -- Error in the backend data store\n"
                 + "Error code 50003 -- Error while forwarding the request to the primary\n"
                 + "Error code 50004 -- Unknown leader")})
+  @Tags(@Tag(name = apiTag))
   public ModeUpdateRequest updateTopLevelMode(
       @Context HttpHeaders headers,
       @Parameter(description = "Update Request", required = true)
@@ -198,6 +204,7 @@ public class ModeResource {
         @ApiResponse(responseCode = "500",
             description = "Error code 50001 -- Error in the backend data store")
       })
+  @Tags(@Tag(name = apiTag))
   public Mode getTopLevelMode() {
     return getMode(null, false);
   }
@@ -215,6 +222,7 @@ public class ModeResource {
         @ApiResponse(responseCode = "500", description = "Error code 50001 -- Error in the backend "
           + "datastore")
       })
+  @Tags(@Tag(name = apiTag))
   public void deleteSubjectMode(
       final @Suspended AsyncResponse asyncResponse,
       @Context HttpHeaders headers,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
@@ -29,6 +29,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +55,7 @@ import java.util.Set;
            Versions.JSON, Versions.GENERIC_REQUEST})
 public class SchemasResource {
 
+  private static final String apiTag = "Schemas (v1)";
   private static final Logger log = LoggerFactory.getLogger(SchemasResource.class);
   private final KafkaSchemaRegistry schemaRegistry;
 
@@ -72,6 +75,7 @@ public class SchemasResource {
         @ApiResponse(responseCode = "500",
             description = "Error code 50001 -- Error in the backend data store\n")
       })
+  @Tags(@Tag(name = apiTag))
   @PerformanceMetric("schemas.get-schemas")
   public List<Schema> getSchemas(
       @Parameter(description = "Filters results by the respective subject prefix")
@@ -121,6 +125,7 @@ public class SchemasResource {
         @ApiResponse(responseCode = "500",
             description = "Error code 50001 -- Error in the backend data store\n")
       })
+  @Tags(@Tag(name = apiTag))
   @PerformanceMetric("schemas.ids.get-schema")
   public SchemaString getSchema(
       @Parameter(description = "Globally unique identifier of the schema", required = true)
@@ -162,6 +167,7 @@ public class SchemasResource {
         @ApiResponse(responseCode = "500",
             description = "Error code 50001 -- Error in the backend data store\n")
       })
+  @Tags(@Tag(name = apiTag))
   public Set<String> getSubjects(
       @Parameter(description = "Globally unique identifier of the schema", required = true)
       @PathParam("id") Integer id,
@@ -205,6 +211,7 @@ public class SchemasResource {
         @ApiResponse(responseCode = "500", description = "Error code 50001 -- Error in the "
             + "backend data store\n")
       })
+  @Tags(@Tag(name = apiTag))
   public List<SubjectVersion> getVersions(
       @Parameter(description = "Globally unique identifier of the schema", required = true)
       @PathParam("id") Integer id,
@@ -245,6 +252,7 @@ public class SchemasResource {
           @ApiResponse(responseCode = "500", description = "Error code "
                   + "50001 -- Error in the backend data store\n")
       })
+  @Tags(@Tag(name = apiTag))
   @PerformanceMetric("schemas.ids.get-schema.only")
   public String getSchemaOnly(
       @Parameter(description = "Globally unique "
@@ -284,6 +292,7 @@ public class SchemasResource {
         @ApiResponse(responseCode = "500",
             description = "Error code 50001 -- Error in the backend data store\n")
       })
+  @Tags(@Tag(name = apiTag))
   public Set<String> getSchemaTypes() {
     return schemaRegistry.schemaTypes();
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ServerMetadataResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ServerMetadataResource.java
@@ -23,6 +23,8 @@ import io.confluent.kafka.schemaregistry.utils.AppInfoParser;
 import io.confluent.rest.annotations.PerformanceMetric;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +42,7 @@ import javax.ws.rs.Produces;
            Versions.JSON, Versions.GENERIC_REQUEST})
 public class ServerMetadataResource {
 
+  private static final String apiTag = "Server Metadata (v1)";
   private static final Logger log = LoggerFactory.getLogger(ServerMetadataResource.class);
   private final KafkaSchemaRegistry schemaRegistry;
 
@@ -54,6 +57,7 @@ public class ServerMetadataResource {
       @ApiResponse(responseCode = "500",
                        description = "Error code 50001 -- Error in the backend data store\n")
   })
+  @Tags(@Tag(name = apiTag))
   @PerformanceMetric("metadata.id")
   public ServerClusterId getClusterId() {
     String kafkaClusterId = schemaRegistry.getKafkaClusterId();
@@ -68,6 +72,7 @@ public class ServerMetadataResource {
       @ApiResponse(responseCode = "500",
                       description = "Error code 50001 -- Error in the backend data store\n")
   })
+  @Tags(@Tag(name = apiTag))
   public SchemaRegistryServerVersion getSchemaRegistryVersion() {
     return new SchemaRegistryServerVersion(AppInfoParser.getVersion(), AppInfoParser.getCommitId());
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -46,6 +46,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,6 +78,7 @@ import java.util.Map;
            Versions.JSON, Versions.GENERIC_REQUEST})
 public class SubjectVersionsResource {
 
+  private static final String apiTag = "Subject Versions (v1)";
   private static final Logger log = LoggerFactory.getLogger(SubjectVersionsResource.class);
 
   private final KafkaSchemaRegistry schemaRegistry;
@@ -113,6 +116,7 @@ public class SubjectVersionsResource {
               content = @Content(schema = @io.swagger.v3.oas.annotations.media.Schema(
                   implementation = ErrorMessage.class)))
       })
+  @Tags(@Tag(name = apiTag))
   public Schema getSchemaByVersion(
       @Parameter(description = "Name of the subject", required = true)
       @PathParam("subject") String subject,
@@ -172,6 +176,7 @@ public class SubjectVersionsResource {
           @ApiResponse(responseCode = "500", description = "Error code 50001 -- Error in the "
               + "backend data store")
       })
+  @Tags(@Tag(name = apiTag))
   public String getSchemaOnly(
       @Parameter(description = "Name of the subject", required = true)
       @PathParam("subject") String subject,
@@ -198,6 +203,7 @@ public class SubjectVersionsResource {
         @ApiResponse(responseCode = "500",
           description = "Error code 50001 -- Error in the backend data store")
       })
+  @Tags(@Tag(name = apiTag))
   public List<Integer> getReferencedBy(
       @Parameter(description = "Name of the subject", required = true)
       @PathParam("subject") String subject,
@@ -245,6 +251,7 @@ public class SubjectVersionsResource {
           @ApiResponse(responseCode = "404", description = "Error code 40401 -- Subject not found"),
           @ApiResponse(responseCode = "500", description =
               "Error code 50001 -- Error in the backend data store")})
+  @Tags(@Tag(name = apiTag))
   public List<Integer> listVersions(
       @Parameter(description = "Name of the subject", required = true)
       @PathParam("subject") String subject,
@@ -315,6 +322,7 @@ public class SubjectVersionsResource {
               + "Error code 50002 -- Operation timed out\n"
               + "Error code 50003 -- Error while forwarding the request to the primary")
       })
+  @Tags(@Tag(name = apiTag))
   public void register(
       final @Suspended AsyncResponse asyncResponse,
       @Context HttpHeaders headers,
@@ -394,6 +402,7 @@ public class SubjectVersionsResource {
         @ApiResponse(responseCode = "500", description = "Error code 50001 -- Error in the backend "
           + "data store")
       })
+  @Tags(@Tag(name = apiTag))
   public void deleteSchemaVersion(
       final @Suspended AsyncResponse asyncResponse,
       @Context HttpHeaders headers,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -34,6 +34,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,6 +67,7 @@ import java.util.Set;
            Versions.JSON, Versions.GENERIC_REQUEST})
 public class SubjectsResource {
 
+  private static final String apiTag = "Subjects (v1)";
   private static final Logger log = LoggerFactory.getLogger(SubjectsResource.class);
   private final KafkaSchemaRegistry schemaRegistry;
   private final RequestHeaderBuilder requestHeaderBuilder = new RequestHeaderBuilder();
@@ -87,6 +90,7 @@ public class SubjectsResource {
           + "Error code 40403 -- Schema not found"),
         @ApiResponse(responseCode = "500", description = "Internal server error")
       })
+  @Tags(@Tag(name = apiTag))
   @PerformanceMetric("subjects.get-schema")
   public void lookUpSchemaUnderSubject(
       final @Suspended AsyncResponse asyncResponse,
@@ -138,6 +142,7 @@ public class SubjectsResource {
         @ApiResponse(responseCode = "500",
             description = "Error code 50001 -- Error in the backend datastore")
       })
+  @Tags(@Tag(name = apiTag))
   @PerformanceMetric("subjects.list")
   public Set<String> list(
       @DefaultValue(QualifiedSubject.CONTEXT_WILDCARD)
@@ -172,6 +177,7 @@ public class SubjectsResource {
         @ApiResponse(responseCode = "500",
           description = "Error code 50001 -- Error in the backend datastore")
       })
+  @Tags(@Tag(name = apiTag))
   @PerformanceMetric("subjects.delete-subject")
   public void deleteSubject(
       final @Suspended AsyncResponse asyncResponse,


### PR DESCRIPTION
Adds operation tags to the HTTP endpoint resources, allowing us to group similar APIs together in the generated documentation (similar to the Data Catalog docs: https://docs.confluent.io/cloud/current/api.html#tag/Entity-(v1)).