### PR TITLE
chore: Switch to pinned nanoversion strategy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ common {
     "confluent-security-plugins", "kafka-connect-replicator",
     "ce-kafka-rest", "confluent-cloud-plugins", "schema-registry-plugins"]
   nanoVersion = true
+  pinnedNanoVersions = true
   timeoutHours = 3
   disableConcurrentBuilds = true
 }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>rest-utils-parent</artifactId>
-        <version>[7.4.0-0, 7.4.1-0)</version>
+        <version>7.4.0-340</version>
     </parent>
 
     <artifactId>kafka-schema-registry-parent</artifactId>


### PR DESCRIPTION
## what

This PR adds `pinnedNanoVersions` property, so that project will try to pin each upstream version update in pom.xml instead of using version range which always selects the latest version.

e.g.
[7.3.0, 7.4.0) -> 7.3.0-99 after each build
![image](https://user-images.githubusercontent.com/13213562/192655953-26e429f6-9454-4871-8885-07488423f648.png)


## why

- better reproducible builds, master/release branch won't follow latest upstream dependency because of version range. Local build dependencies can be traced more easily.
- branch become more stable since it will reject broken changes from upstream.
- version bump commit will be serperated from actual code change so that broken change can be targeted easily.

The current git workflow:

That is brought up by Ksql team initially because they want to have better reproducible builds. And with that change, version bumps will only happen when the upstream build is compatible. That means the mater branch will be more stable and reject broken upstream changes.
