### PR TITLE
Skip set-compatibility goal if skip flag is set

### DIFF
--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SetCompatibilityMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SetCompatibilityMojo.java
@@ -34,6 +34,11 @@ public class SetCompatibilityMojo extends SchemaRegistryMojo {
   Map<String, String> compatibilityLevels = new HashMap<>();
 
   public void execute() throws MojoExecutionException {
+    if (skip) {
+      getLog().info("Plugin execution has been skipped");
+      return;
+    }
+
     for (Map.Entry<String, String> entry : compatibilityLevels.entrySet()) {
       if (entry.getValue().equalsIgnoreCase("null")) {
         deleteConfig(entry.getKey());


### PR DESCRIPTION
We use maven execution in our pipeline as follows:

```
 <execution>
    <id>register-schema</id>
    <phase>install</phase>
    <goals>
        <goal>register</goal>
        <goal>set-compatibility</goal>
    </goals>
    <configuration>
        <skip>${schema.registry.skip.registration}</skip>
    </configuration>
</execution>
```

When _schema.registry.skip.registration_ is _true,_ register goal is skipped but set-compatibility still executes. We want to be able to skip it as well. 