### PR TITLE
Fix build breakage caused by KAFKA-14334

### DIFF
--- a/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
@@ -198,7 +198,8 @@ public abstract class ClusterTestHarness {
         1,
         false,
         1,
-        (short) 1
+        (short) 1,
+        false
     );
     injectProperties(props);
     return KafkaConfig.fromProps(props);

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/SASLClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/SASLClusterTestHarness.java
@@ -111,7 +111,7 @@ public class SASLClusterTestHarness extends ClusterTestHarness {
             brokerId, zkConnect, false, false, TestUtils.RandomPort(), saslInterBrokerSecurityProtocol,
             trustStoreFileOption, EMPTY_SASL_PROPERTIES, false, true, TestUtils.RandomPort(),
             false, TestUtils.RandomPort(),
-            false, TestUtils.RandomPort(), Option.<String>empty(), 1, false, 1, (short) 1);
+            false, TestUtils.RandomPort(), Option.<String>empty(), 1, false, 1, (short) 1, false);
 
     injectProperties(props);
     props.setProperty("zookeeper.connection.timeout.ms", "30000");

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/SSLClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/SSLClusterTestHarness.java
@@ -52,7 +52,7 @@ public class SSLClusterTestHarness extends ClusterTestHarness {
             brokerId, zkConnect, false, false, TestUtils.RandomPort(), sslInterBrokerSecurityProtocol,
             trustStoreFileOption, EMPTY_SASL_PROPERTIES, false, false, TestUtils.RandomPort(),
             true, TestUtils.RandomPort(), false, TestUtils.RandomPort(), Option.<String>empty(), 1, false,
-            1, (short) 1);
+            1, (short) 1, false);
 
     // setup client SSL. Needs to happen before the broker is initialized, because the client's cert
     // needs to be added to the broker's trust store.

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinatorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinatorTest.java
@@ -321,7 +321,7 @@ public class SchemaRegistryCoordinatorTest {
             .setProtocolName(SchemaRegistryCoordinator.SR_SUBPROTOCOL_V0)
             .setMemberId(memberId)
             .setLeader(memberId)
-            .setMembers(metadata));
+            .setMembers(metadata), (short) 0);
   }
 
   private JoinGroupResponse joinGroupFollowerResponse(
@@ -336,7 +336,8 @@ public class SchemaRegistryCoordinatorTest {
         .setProtocolName(SchemaRegistryCoordinator.SR_SUBPROTOCOL_V0)
         .setMemberId(memberId)
         .setLeader(leaderId)
-        .setMembers(Collections.emptyList())
+        .setMembers(Collections.emptyList()),
+        (short) 0
     );
   }
 


### PR DESCRIPTION
KAFKA-14334 changed a kafka.utils.TestUtils method [by adding a default argument](https://github.com/confluentinc/kafka/commit/dbf5826cd545820652ed6d136727aa80a03f4f54#diff-b8f9f9d1b191457cbdb332a3429f0ad65b50fa4cef5af8562abcfd1f177a2cfeR216-R218) (Scala). Unfortunately this is a breaking change for Java downstream dependencies.