### PR TITLE
Update the Snakeyaml dependency to adress multiple CVEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ evolution of schemas according to the configured compatibility setting. It
 provides serializers that plug into Kafka clients that handle schema storage and
 retrieval for Kafka messages that are sent in the Avro format.
 
-
 Documentation
 -------------
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ evolution of schemas according to the configured compatibility setting. It
 provides serializers that plug into Kafka clients that handle schema storage and
 retrieval for Kafka messages that are sent in the Avro format.
 
+
 Documentation
 -------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <commons.compress.version>1.21</commons.compress.version>
-        <snake.yaml.version>1.27</snake.yaml.version>
+        <snake.yaml.version>1.32</snake.yaml.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
During the Q4 2022 CVE review I have realized that schema-registry versions 5.4 - 6.2 import the snakeyaml dependency. This update is to resolve multiple CVEs: CVE-2022-38749, CVE-2022-38750, CVE-2022-38751, CVE-2022-25857