### PR TITLE
SUP-49: Improve Error reporting on incompatibility for better usability

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
@@ -94,10 +94,11 @@ public class AvroMessageReader extends SchemaMessageReader<Object> {
       BufferedReader reader,
       boolean normalizeSchema,
       boolean autoRegister,
-      boolean useLatest
+      boolean useLatest,
+      boolean showVerboseErrors
   ) {
     super(schemaRegistryClient, new AvroSchema(keySchema), new AvroSchema(valueSchema), topic,
-        parseKey, reader, normalizeSchema, autoRegister, useLatest);
+        parseKey, reader, normalizeSchema, autoRegister, useLatest, showVerboseErrors);
   }
 
   @Override
@@ -106,10 +107,12 @@ public class AvroMessageReader extends SchemaMessageReader<Object> {
       boolean normalizeSchema,
       boolean autoRegister,
       boolean useLatest,
-      Serializer keySerializer
+      Serializer keySerializer,
+      boolean showVerboseErrors
   ) {
     return new AvroMessageSerializer(
-        schemaRegistryClient, normalizeSchema, autoRegister, useLatest, keySerializer);
+        schemaRegistryClient, normalizeSchema, autoRegister, useLatest, keySerializer,
+      showVerboseErrors);
   }
 
   @Override
@@ -142,13 +145,15 @@ public class AvroMessageReader extends SchemaMessageReader<Object> {
 
     AvroMessageSerializer(
         SchemaRegistryClient schemaRegistryClient,
-        boolean normalizeSchema, boolean autoRegister, boolean useLatest, Serializer keySerializer
+        boolean normalizeSchema, boolean autoRegister, boolean useLatest, Serializer keySerializer,
+        boolean showVerboseErrors
     ) {
       this.schemaRegistry = schemaRegistryClient;
       this.normalizeSchema = normalizeSchema;
       this.autoRegisterSchema = autoRegister;
       this.useLatestVersion = useLatest;
       this.keySerializer = keySerializer;
+      this.showVerboseErrors = showVerboseErrors;
     }
 
     @Override

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -49,6 +49,7 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
   protected boolean latestCompatStrict;
   protected boolean avroReflectionAllowNull = false;
   protected boolean avroUseLogicalTypeConverters = false;
+  protected boolean showVerboseErrors = false;
   private final Cache<Schema, DatumWriter<Object>> datumWriterCache;
 
   public AbstractKafkaAvroSerializer() {
@@ -69,6 +70,7 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
     useSchemaId = config.useSchemaId();
     idCompatStrict = config.getIdCompatibilityStrict();
     latestCompatStrict = config.getLatestCompatibilityStrict();
+    showVerboseErrors = config.autoRegisterSchemaVerbose();
     avroReflectionAllowNull = config
         .getBoolean(KafkaAvroSerializerConfig.AVRO_REFLECTION_ALLOW_NULL_CONFIG);
     avroUseLogicalTypeConverters = config
@@ -110,7 +112,7 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
       int id;
       if (autoRegisterSchema) {
         restClientErrorMsg = "Error registering Avro schema";
-        id = schemaRegistry.register(subject, schema, normalizeSchema);
+        id = schemaRegistry.register(subject, schema, normalizeSchema, showVerboseErrors);
       } else if (useSchemaId >= 0) {
         restClientErrorMsg = "Error retrieving schema ID";
         schema = (AvroSchema)

--- a/avro-serializer/src/test/java/io/confluent/kafka/formatter/KafkaAvroFormatterTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/formatter/KafkaAvroFormatterTest.java
@@ -89,7 +89,7 @@ public class KafkaAvroFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     AvroMessageReader avroReader =
         new AvroMessageReader(schemaRegistry, null, recordSchema, "topic1", false, reader,
-            false, true, false);
+            false, true, false, false);
     ProducerRecord<byte[], byte[]> message = avroReader.readMessage();
 
     byte[] serializedValue = message.value();
@@ -114,7 +114,7 @@ public class KafkaAvroFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     AvroMessageReader avroReader =
         new AvroMessageReader(schemaRegistry, intSchema, recordSchema, "topic1", true, reader,
-            false, true, false);
+            false, true, false, false);
     ProducerRecord<byte[], byte[]> message = avroReader.readMessage();
 
     byte[] serializedKey = message.key();
@@ -145,7 +145,7 @@ public class KafkaAvroFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     AvroMessageReader avroReader =
         new AvroMessageReader(schemaRegistry, null, recordSchema, "topic1", false, reader,
-            false, true, false);
+            false, true, false, false);
     ProducerRecord<byte[], byte[]> message = avroReader.readMessage();
 
     byte[] serializedValue = message.value();
@@ -167,7 +167,7 @@ public class KafkaAvroFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     AvroMessageReader avroReader =
         new AvroMessageReader(schemaRegistry, null, recordSchema, "topic1", false, reader,
-            false, true, false);
+            false, true, false, false);
     try {
       avroReader.readMessage();
       fail("Registering an invalid schema should fail");
@@ -189,7 +189,7 @@ public class KafkaAvroFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     AvroMessageReader avroReader =
         new AvroMessageReader(schemaRegistry, null, recordSchema, "topic1", false, reader,
-            false, true, false);
+            false, true, false, false);
     ProducerRecord<byte[], byte[]> message = avroReader.readMessage();
 
     byte[] serializedKey = "TestKey".getBytes();
@@ -222,7 +222,7 @@ public class KafkaAvroFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     AvroMessageReader avroReader =
         new AvroMessageReader(schemaRegistry, null, recordSchema, "topic1", false, reader,
-            false, true, false);
+            false, true, false, false);
     ProducerRecord<byte[], byte[]> message = avroReader.readMessage();
 
     byte[] serializedKey = "TestKey".getBytes();
@@ -249,7 +249,7 @@ public class KafkaAvroFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     AvroMessageReader avroReader =
         new AvroMessageReader(schemaRegistry, null, recordSchema, "topic1", false, reader,
-            false, false, true);
+            false, false, true, false);
     ProducerRecord<byte[], byte[]> message = avroReader.readMessage();
 
     byte[] serializedValue = message.value();

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/CompatibilityChecker.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/CompatibilityChecker.java
@@ -64,7 +64,7 @@ public class CompatibilityChecker {
       FULL_TRANSITIVE_VALIDATOR);
 
   private static final SchemaValidator NO_OP_VALIDATOR =
-      (schema, schemas) -> Collections.emptyList();
+      (schema, schemas, verbose) -> Collections.emptyList();
 
   public static final CompatibilityChecker NO_OP_CHECKER =
       new CompatibilityChecker(NO_OP_VALIDATOR);
@@ -77,12 +77,20 @@ public class CompatibilityChecker {
 
   // visible for testing
   public List<String> isCompatible(
-      ParsedSchema newSchema, List<? extends ParsedSchema> previousSchemas
+      ParsedSchema newSchema, List<? extends ParsedSchema> previousSchemas) {
+    return isCompatible(newSchema, previousSchemas, false);
+
+  }
+
+  // visible for testing
+  public List<String> isCompatible(
+      ParsedSchema newSchema, List<? extends ParsedSchema> previousSchemas,
+      boolean verbose
   ) {
     List<? extends ParsedSchema> previousSchemasCopy = new ArrayList<>(previousSchemas);
     // Validator checks in list order, but checks should occur in reverse chronological order
     Collections.reverse(previousSchemasCopy);
-    return validator.validate(newSchema, previousSchemasCopy);
+    return validator.validate(newSchema, previousSchemasCopy, verbose);
   }
 
   public static CompatibilityChecker checker(CompatibilityLevel level) {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
@@ -148,7 +148,21 @@ public interface ParsedSchema {
    * @return an empty list if this schema is backward compatible with the previous schema,
    *         otherwise the list of error messages
    */
-  List<String> isBackwardCompatible(ParsedSchema previousSchema);
+  default List<String> isBackwardCompatible(ParsedSchema previousSchema) {
+    return isBackwardCompatible(previousSchema, false);
+  }
+
+  /**
+   * Checks the backward compatibility between this schema and the specified schema.
+   * <p/>
+   * Custom providers may choose to modify this schema during this check,
+   * to ensure that it is compatible with the specified schema.
+   *
+   * @param previousSchema previous schema
+   * @return an empty list if this schema is backward compatible with the previous schema,
+   *         otherwise the list of error messages
+   */
+  List<String> isBackwardCompatible(ParsedSchema previousSchema, boolean verbose);
 
   /**
    * Checks the compatibility between this schema and the specified schemas.
@@ -163,6 +177,23 @@ public interface ParsedSchema {
    */
   default List<String> isCompatible(
       CompatibilityLevel level, List<? extends ParsedSchema> previousSchemas) {
+    return isCompatible(level, previousSchemas, false);
+  }
+
+  /**
+   * Checks the compatibility between this schema and the specified schemas.
+   * <p/>
+   * Custom providers may choose to modify this schema during this check,
+   * to ensure that it is compatible with the specified schemas.
+   *
+   * @param level the compatibility level
+   * @param previousSchemas full schema history in chronological order
+   * @return an empty list if this schema is backward compatible with the previous schema, otherwise
+   *         the list of error messages
+   */
+  default List<String> isCompatible(
+      CompatibilityLevel level, List<? extends ParsedSchema> previousSchemas,
+      boolean verbose) {
     if (level != CompatibilityLevel.NONE) {
       for (ParsedSchema previousSchema : previousSchemas) {
         if (!schemaType().equals(previousSchema.schemaType())) {
@@ -170,7 +201,10 @@ public interface ParsedSchema {
         }
       }
     }
-    return CompatibilityChecker.checker(level).isCompatible(this, previousSchemas);
+    return CompatibilityChecker.checker(level).isCompatible(
+      this,
+      previousSchemas,
+      verbose);
   }
 
   /**

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidationStrategy.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidationStrategy.java
@@ -38,5 +38,5 @@ public interface SchemaValidationStrategy {
    * @param existing The schema to validate against
    * @return List of error message, otherwise empty list
    */
-  List<String> validate(ParsedSchema toValidate, ParsedSchema existing);
+  List<String> validate(ParsedSchema toValidate, ParsedSchema existing, boolean verbose);
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidator.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidator.java
@@ -46,5 +46,6 @@ public interface SchemaValidator {
    *     applicable
    * @return List of error message, otherwise empty list
    */
-  List<String> validate(ParsedSchema toValidate, Iterable<? extends ParsedSchema> existing);
+  List<String> validate(ParsedSchema toValidate, Iterable<? extends ParsedSchema> existing,
+                        boolean verbose);
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidatorBuilder.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidatorBuilder.java
@@ -38,7 +38,8 @@ public final class SchemaValidatorBuilder {
    * schema(s) according to the JSON default schema resolution.
    */
   public SchemaValidatorBuilder canReadStrategy() {
-    this.strategy = (toValidate, existing) -> toValidate.isBackwardCompatible(existing);
+    this.strategy = (toValidate, existing, verbose) ->
+                      toValidate.isBackwardCompatible(existing, verbose);
     return this;
   }
 
@@ -47,7 +48,8 @@ public final class SchemaValidatorBuilder {
    * schema(s) according to the JSON default schema resolution.
    */
   public SchemaValidatorBuilder canBeReadStrategy() {
-    this.strategy = (toValidate, existing) -> existing.isBackwardCompatible(toValidate);
+    this.strategy = (toValidate, existing, verbose) ->
+                      existing.isBackwardCompatible(toValidate, verbose);
     return this;
   }
 
@@ -57,10 +59,10 @@ public final class SchemaValidatorBuilder {
    */
   public SchemaValidatorBuilder mutualReadStrategy() {
 
-    this.strategy = (toValidate, existing) -> {
+    this.strategy = (toValidate, existing, verbose) -> {
       List<String> result = new ArrayList<>();
-      result.addAll(existing.isBackwardCompatible(toValidate));
-      result.addAll(toValidate.isBackwardCompatible(existing));
+      result.addAll(existing.isBackwardCompatible(toValidate, verbose));
+      result.addAll(toValidate.isBackwardCompatible(existing, verbose));
       return result;
     };
     return this;
@@ -68,11 +70,11 @@ public final class SchemaValidatorBuilder {
 
   public SchemaValidator validateLatest() {
     valid();
-    return (toValidate, schemasInOrder) -> {
+    return (toValidate, schemasInOrder, verbose) -> {
       Iterator<? extends ParsedSchema> schemas = schemasInOrder.iterator();
       if (schemas.hasNext()) {
         ParsedSchema existing = schemas.next();
-        return strategy.validate(toValidate, existing);
+        return strategy.validate(toValidate, existing, verbose);
       }
       return Collections.emptyList();
     };
@@ -80,9 +82,9 @@ public final class SchemaValidatorBuilder {
 
   public SchemaValidator validateAll() {
     valid();
-    return (toValidate, schemasInOrder) -> {
+    return (toValidate, schemasInOrder, verbose) -> {
       for (ParsedSchema existing : schemasInOrder) {
-        List<String> errorMessages = strategy.validate(toValidate, existing);
+        List<String> errorMessages = strategy.validate(toValidate, existing, verbose);
         if (!errorMessages.isEmpty()) {
           return errorMessages;
         }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/Difference.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/Difference.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.avro;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.avro.SchemaCompatibility;
+import org.apache.avro.SchemaCompatibility.Incompatibility;
+import org.apache.avro.SchemaCompatibility.SchemaIncompatibilityType;
+
+public class Difference {
+  private final Incompatibility incompatibility;
+  private final Map<SchemaIncompatibilityType, String> errorDescription;
+
+  public Difference(final SchemaCompatibility.Incompatibility incompatibility) {
+    this.incompatibility = incompatibility;
+    String path = incompatibility.getLocation();
+
+    errorDescription = new HashMap<>();
+    errorDescription.put(SchemaIncompatibilityType.FIXED_SIZE_MISMATCH,
+        String.format("The size of FIXED type field at path: '%s' in the reader schema has "
+                        + "changed", path));
+    errorDescription.put(SchemaIncompatibilityType.TYPE_MISMATCH,
+        String.format("The type (path: '%s') of a field in the reader schema has changed. ",
+          path));
+    errorDescription.put(SchemaIncompatibilityType.NAME_MISMATCH,
+        String.format("The name of the schema (path: '%s') has changed", path));
+    errorDescription.put(SchemaIncompatibilityType.MISSING_ENUM_SYMBOLS,
+        String.format("Enum symbols '%s' at path: '%s' in the writer schema are missing in the "
+                        + "reader schema", incompatibility.getMessage(), path));
+    errorDescription.put(SchemaIncompatibilityType.MISSING_UNION_BRANCH,
+        String.format("A type inside a union field at path: '%s' in the writer schema is "
+                        + "missing in the reader schema", path));
+    errorDescription.put(SchemaIncompatibilityType.READER_FIELD_MISSING_DEFAULT_VALUE,
+        String.format("The reader schema has an additional field '%s' at path: '%s' without a "
+                        + "default value", incompatibility.getMessage(), path));
+  }
+
+  public String error() {
+    SchemaIncompatibilityType errorType = incompatibility.getType();
+    return "errorType:'" + errorType.toString() + '\''
+             + ", description:'" + errorDescription.getOrDefault(errorType, "") + '\''
+             + ", additionalInfo:'" + incompatibility.getMessage() + "'";
+  }
+
+  public String toString() {
+    return "{" + error() + "}";
+  }
+
+  public String toStringVerbose() {
+    return "{" + error()
+             + ", readerFragment:'" + incompatibility.getReaderFragment() + '\''
+             + ", writerFragment:'" + incompatibility.getWriterFragment() + "'}";
+  }
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -218,6 +218,12 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
+  public int register(String subject, ParsedSchema schema, boolean normalize, boolean verbose)
+      throws IOException, RestClientException {
+    return register(subject, schema, 0, -1, normalize);
+  }
+
+  @Override
   public int register(String subject, ParsedSchema schema, int version, int id)
       throws IOException, RestClientException {
     return register(subject, schema, version, id, false);

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -70,6 +70,11 @@ public interface SchemaRegistryClient extends SchemaVersionFetcher {
 
   public int register(String subject, ParsedSchema schema) throws IOException, RestClientException;
 
+  default int register(String subject, ParsedSchema schema, boolean normalize, boolean verbose)
+      throws IOException, RestClientException {
+    return register(subject, schema, normalize);
+  }
+
   default int register(String subject, ParsedSchema schema, boolean normalize)
       throws IOException, RestClientException {
     throw new UnsupportedOperationException();

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -481,57 +481,59 @@ public class RestService implements Configurable {
   // Visible for testing
   public int registerSchema(String schemaString, String subject)
       throws IOException, RestClientException {
-    return registerSchema(schemaString, subject, false);
+    return registerSchema(schemaString, subject, false, false);
   }
 
-  public int registerSchema(String schemaString, String subject, boolean normalize)
+  public int registerSchema(String schemaString, String subject, boolean normalize, boolean verbose)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
-    return registerSchema(request, subject, normalize);
+    return registerSchema(request, subject, normalize, verbose);
   }
 
   public int registerSchema(String schemaString, String schemaType,
                             List<SchemaReference> references, String subject)
       throws IOException, RestClientException {
-    return registerSchema(schemaString, schemaType, references, subject, false);
+    return registerSchema(schemaString, schemaType, references, subject, false, false);
   }
 
   public int registerSchema(String schemaString, String schemaType,
-                            List<SchemaReference> references, String subject, boolean normalize)
+                            List<SchemaReference> references, String subject, boolean normalize,
+                            boolean verbose)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
     request.setSchemaType(schemaType);
     request.setReferences(references);
-    return registerSchema(request, subject, normalize);
+    return registerSchema(request, subject, normalize, verbose);
   }
 
   // Visible for testing
   public int registerSchema(String schemaString, String subject, int version, int id)
       throws IOException, RestClientException {
-    return registerSchema(schemaString, subject, version, id, false);
+    return registerSchema(schemaString, subject, version, id, false, false);
   }
 
   public int registerSchema(String schemaString, String subject,
-                            int version, int id, boolean normalize)
+                            int version, int id, boolean normalize, boolean verbose)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
     request.setVersion(version);
     request.setId(id);
-    return registerSchema(request, subject, normalize);
+    return registerSchema(request, subject, normalize, verbose);
   }
 
   public int registerSchema(String schemaString, String schemaType,
                             List<SchemaReference> references, String subject, int version, int id)
       throws IOException, RestClientException {
-    return registerSchema(schemaString, schemaType, references, subject, version, id, false);
+    return registerSchema(schemaString, schemaType, references, subject, version, id,
+      false, false);
   }
 
   public int registerSchema(String schemaString, String schemaType,
                             List<SchemaReference> references, String subject, int version, int id,
-                            boolean normalize)
+                            boolean normalize, boolean verbose)
                             throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
@@ -539,23 +541,34 @@ public class RestService implements Configurable {
     request.setReferences(references);
     request.setVersion(version);
     request.setId(id);
-    return registerSchema(request, subject, normalize);
+    return registerSchema(request, subject, normalize, verbose);
   }
 
   public int registerSchema(RegisterSchemaRequest registerSchemaRequest,
                             String subject,
                             boolean normalize)
       throws IOException, RestClientException {
-    return registerSchema(DEFAULT_REQUEST_PROPERTIES, registerSchemaRequest, subject, normalize);
+    return registerSchema(registerSchemaRequest, subject, normalize, false);
+  }
+
+  public int registerSchema(RegisterSchemaRequest registerSchemaRequest,
+                            String subject,
+                            boolean normalize,
+                            boolean verbose)
+      throws IOException, RestClientException {
+    return registerSchema(DEFAULT_REQUEST_PROPERTIES, registerSchemaRequest, subject,
+      normalize, verbose);
   }
 
   public int registerSchema(Map<String, String> requestProperties,
                             RegisterSchemaRequest registerSchemaRequest,
                             String subject,
-                            boolean normalize)
+                            boolean normalize,
+                            boolean verbose)
       throws IOException, RestClientException {
     UriBuilder builder = UriBuilder.fromPath("/subjects/{subject}/versions")
-        .queryParam("normalize", normalize);
+        .queryParam("normalize", normalize)
+        .queryParam("verbose", verbose);
     String path = builder.build(subject).toString();
 
     RegisterSchemaResponse response = httpRequest(
@@ -580,6 +593,14 @@ public class RestService implements Configurable {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
     return testCompatibility(request, subject, version, false);
+  }
+
+  public List<String> testCompatibility(String schemaString, String subject, String version,
+                                        boolean verbose)
+      throws IOException, RestClientException {
+    RegisterSchemaRequest request = new RegisterSchemaRequest();
+    request.setSchema(schemaString);
+    return testCompatibility(request, subject, version, verbose);
   }
 
   public List<String> testCompatibility(String schemaString,

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
@@ -162,7 +162,7 @@ public class CachedSchemaRegistryClientTest {
   public void testRegisterSchemaCache() throws Exception {
     // Expect one call to register schema
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
-        eq(SUBJECT_0), anyBoolean()))
+        eq(SUBJECT_0), anyBoolean(), anyBoolean()))
         .andReturn(ID_25)
         .once();
 
@@ -178,7 +178,7 @@ public class CachedSchemaRegistryClientTest {
   public void testRegisterSchemaCacheWithVersionAndId() throws Exception {
     // Expect one call to register schema
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
-        eq(SUBJECT_0), anyBoolean()))
+        eq(SUBJECT_0), anyBoolean(), anyBoolean()))
         .andReturn(ID_25)
         .once();
 
@@ -193,11 +193,11 @@ public class CachedSchemaRegistryClientTest {
   @Test
   public void testRegisterEquivalentSchemaDifferentid() throws Exception {
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
-        eq(SUBJECT_0), anyBoolean()))
+        eq(SUBJECT_0), anyBoolean(), anyBoolean()))
         .andReturn(ID_25)
         .once();
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
-        eq(SUBJECT_0), anyBoolean()))
+        eq(SUBJECT_0), anyBoolean(), anyBoolean()))
         .andReturn(ID_50)
         .once();
 
@@ -212,7 +212,7 @@ public class CachedSchemaRegistryClientTest {
   @Test
   public void testRegisterOverCapacity() throws Exception {
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
-        anyString(), anyBoolean()))
+        anyString(), anyBoolean(), anyBoolean()))
         .andReturn(ID_25)
         .andReturn(26)
         .andReturn(27)
@@ -235,7 +235,7 @@ public class CachedSchemaRegistryClientTest {
   @Test
   public void testIdCache() throws Exception {
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
-        eq(SUBJECT_0), anyBoolean()))
+        eq(SUBJECT_0), anyBoolean(), anyBoolean()))
         .andReturn(ID_25);
 
     // Expect only one call to getId (the rest should hit the cache)
@@ -262,7 +262,7 @@ public class CachedSchemaRegistryClientTest {
     int version = 7;
 
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
-        eq(SUBJECT_0), anyBoolean()))
+        eq(SUBJECT_0), anyBoolean(), anyBoolean()))
         .andReturn(ID_25);
 
     // Expect only one call to lookup the subject (the rest should hit the cache)
@@ -291,10 +291,10 @@ public class CachedSchemaRegistryClientTest {
     String subjectTwo = "subjectTwo";
 
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
-        eq(subjectOne), anyBoolean()))
+        eq(subjectOne), anyBoolean(), anyBoolean()))
         .andReturn(ID_25);
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
-        eq(subjectTwo), anyBoolean()))
+        eq(subjectTwo), anyBoolean(), anyBoolean()))
         .andReturn(ID_25);
 
     expect(restService.getId(ID_25, subjectOne))
@@ -332,7 +332,7 @@ public class CachedSchemaRegistryClientTest {
   @Test
   public void testDeleteSchemaCache() throws Exception {
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
-        eq(SUBJECT_0), anyBoolean()))
+        eq(SUBJECT_0), anyBoolean(), anyBoolean()))
         .andReturn(ID_25)
         .once();
 
@@ -358,7 +358,7 @@ public class CachedSchemaRegistryClientTest {
     int version = 7;
 
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
-        eq(SUBJECT_0), anyBoolean()))
+        eq(SUBJECT_0), anyBoolean(), anyBoolean()))
         .andReturn(ID_25);
 
     // Expect only one call to lookup the subject (the rest should hit the cache)
@@ -449,7 +449,7 @@ public class CachedSchemaRegistryClientTest {
   @Test
   public void testThreadSafe() throws Exception {
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
-        eq(SUBJECT_0), anyBoolean()))
+        eq(SUBJECT_0), anyBoolean(), anyBoolean()))
         .andReturn(ID_25)
         .anyTimes();
 
@@ -501,7 +501,7 @@ public class CachedSchemaRegistryClientTest {
   @Test
   public void testGetSchemas() throws Exception {
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
-        anyString(), anyBoolean()))
+        anyString(), anyBoolean(), anyBoolean()))
             .andReturn(ID_25)
             .andReturn(26)
             .andReturn(27)

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -1570,6 +1570,12 @@ paths:
         description: Whether to register the normalized schema
         schema:
           type: boolean
+      - name: verbose
+        in: query
+        description: Whether to return verbose error messages
+        schema:
+          type: boolean
+          default: true
       requestBody:
         description: Schema
         content:
@@ -2071,6 +2077,56 @@ paths:
         "500":
           description: |
             Error code 50001 -- Error in the backend data store
+  /subjects/{subject}/metadata:
+    get:
+      summary: Retrieve the latest version with the given metadata.
+      description: Retrieve the latest version with the given metadata.
+      operationId: getLatestWithMetadata_1
+      parameters:
+      - name: subject
+        in: path
+        description: Subject under which the schema will be registered
+        required: true
+        schema:
+          type: string
+      - name: key
+        in: query
+        description: The metadata key
+        schema:
+          type: array
+          items:
+            type: string
+      - name: value
+        in: query
+        description: The metadata value
+        schema:
+          type: array
+          items:
+            type: string
+      - name: deleted
+        in: query
+        description: Whether to lookup deleted schemas
+        schema:
+          type: boolean
+      responses:
+        "200":
+          description: The schema
+          content:
+            application/vnd.schemaregistry.v1+json:
+              schema:
+                $ref: '#/components/schemas/Schema'
+            application/vnd.schemaregistry+json; qs=0.9:
+              schema:
+                $ref: '#/components/schemas/Schema'
+            application/json; qs=0.5:
+              schema:
+                $ref: '#/components/schemas/Schema'
+        "404":
+          description: |-
+            Error code 40401 -- Subject not found
+            Error code 40403 -- Schema not found
+        "500":
+          description: Internal server error
 components:
   schemas:
     CompatibilityCheckResponse:
@@ -2107,6 +2163,10 @@ components:
           description: References to other schemas
           items:
             $ref: '#/components/schemas/SchemaReference'
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        ruleSet:
+          $ref: '#/components/schemas/RuleSet'
         schema:
           type: string
           description: Schema definition string
@@ -2202,6 +2262,10 @@ components:
           description: References to other schemas
           items:
             $ref: '#/components/schemas/SchemaReference'
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        ruleSet:
+          $ref: '#/components/schemas/RuleSet'
         maxId:
           type: integer
           description: Maximum ID
@@ -2234,10 +2298,16 @@ components:
           description: References to other schemas
           items:
             $ref: '#/components/schemas/SchemaReference'
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        ruleset:
+          $ref: '#/components/schemas/RuleSet'
         schema:
           type: string
           description: Schema definition string
           example: "{\"schema\": \"{\"type\": \"string\"}\"}"
+        ruleSet:
+          $ref: '#/components/schemas/RuleSet'
       description: Schema
     SubjectVersion:
       type: object
@@ -2288,3 +2358,80 @@ components:
           type: string
         commitId:
           type: string
+    Metadata:
+      type: object
+      properties:
+        annotations:
+          type: object
+          additionalProperties:
+            uniqueItems: true
+            type: array
+            items:
+              type: string
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+        sensitive:
+          uniqueItems: true
+          type: array
+          items:
+            type: string
+      description: User-defined metadata
+    Rule:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Rule name
+        kind:
+          type: string
+          description: Rule kind
+          enum:
+          - TRANSFORM
+          - CONSTRAINT
+        mode:
+          type: string
+          description: Rule mode
+          enum:
+          - UPGRADE
+          - DOWNGRADE
+          - UPDOWN
+          - READ
+          - WRITE
+          - READWRITE
+        type:
+          type: string
+          description: Rule type
+        annotations:
+          uniqueItems: true
+          type: array
+          description: The annotations to which this rule applies
+          items:
+            type: string
+            description: The annotations to which this rule applies
+        expr:
+          type: string
+          description: Rule expression
+        onSuccess:
+          type: string
+          description: Rule action on success
+        onFailure:
+          type: string
+          description: Rule action on failure
+        disabled:
+          type: boolean
+          description: Whether the rule is disabled
+      description: Rule
+    RuleSet:
+      type: object
+      properties:
+        migrationRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/Rule'
+        domainRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/Rule'
+      description: Schema rule set

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -147,7 +147,8 @@ public class CompatibilityResource {
           subject, schema,
           schemaForSpecifiedVersion != null
               ? Collections.singletonList(schemaForSpecifiedVersion)
-              : Collections.emptyList()
+              : Collections.emptyList(),
+          verbose
       );
     } catch (InvalidSchemaException e) {
       if (verbose) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -61,6 +61,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Context;
@@ -376,6 +377,8 @@ public class SubjectVersionsResource {
       @PathParam("subject") String subjectName,
       @Parameter(description = "Whether to register the normalized schema")
       @QueryParam("normalize") boolean normalize,
+      @Parameter(description = "Whether to return verbose error messages")
+      @QueryParam("verbose") @DefaultValue("true") boolean verbose,
       @Parameter(description = "Schema", required = true)
       @NotNull RegisterSchemaRequest request) {
     log.info("Registering new schema: subject {}, version {}, id {}, type {}, schema size {}",
@@ -396,7 +399,8 @@ public class SubjectVersionsResource {
     Schema schema = new Schema(subjectName, request);
     int id;
     try {
-      id = schemaRegistry.registerOrForward(subjectName, schema, normalize, headerProperties);
+      id = schemaRegistry.registerOrForward(subjectName, schema, normalize, verbose,
+        headerProperties);
     } catch (IdDoesNotMatchException e) {
       throw Errors.idDoesNotMatchException(e);
     } catch (InvalidSchemaException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
@@ -36,10 +36,14 @@ public interface SchemaRegistry extends SchemaVersionFetcher {
   Set<String> schemaTypes();
 
   default int register(String subject, Schema schema) throws SchemaRegistryException {
-    return register(subject, schema, false);
+    return register(subject, schema, false, false);
   }
 
-  int register(String subject, Schema schema, boolean normalize) throws SchemaRegistryException;
+  int register(String subject, Schema schema, boolean normalize)
+      throws SchemaRegistryException;
+
+  int register(String subject, Schema schema, boolean normalize, boolean verbose)
+      throws SchemaRegistryException;
 
   default Schema getByVersion(String subject, int version, boolean returnDeletedSchema) {
     try {
@@ -91,9 +95,16 @@ public interface SchemaRegistry extends SchemaVersionFetcher {
                             Schema newSchema,
                             Schema targetSchema) throws SchemaRegistryException;
 
+  default List<String> isCompatible(String subject,
+                            Schema newSchema,
+                            List<Schema> previousSchemas) throws SchemaRegistryException {
+    return isCompatible(subject, newSchema,previousSchemas,false);
+  }
+
   List<String> isCompatible(String subject,
                             Schema newSchema,
-                            List<Schema> previousSchemas) throws SchemaRegistryException;
+                            List<Schema> previousSchemas,
+                            boolean verbose) throws SchemaRegistryException;
 
   void close();
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -26,6 +26,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.ServerClusterId;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.CompatibilityCheckResponse;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
@@ -393,6 +394,56 @@ public class RestApiTest extends ClusterTestHarness {
   }
 
   @Test
+  public void testIncompatibleSchemaWithVerbose() throws Exception {
+    String subject = "testSubject";
+
+    // Make two incompatible schemas - field 'f' has different types
+    String schema1String = "{\"type\":\"record\","
+                             + "\"name\":\"myrecord\","
+                             + "\"fields\":"
+                             + "[{\"type\":\"string\",\"name\":"
+                             + "\"f" + "\"}]}";
+    String schema1 = AvroUtils.parseSchema(schema1String).canonicalString();
+
+    String schema2String = "{\"type\":\"record\","
+                             + "\"name\":\"myrecord\","
+                             + "\"fields\":"
+                             + "[{\"type\":\"int\",\"name\":"
+                             + "\"f" + "\"}]}";
+    String schema2 = AvroUtils.parseSchema(schema2String).canonicalString();
+
+    // ensure registering incompatible schemas will raise an error
+    restApp.restClient.updateCompatibility(
+      CompatibilityLevel.FULL.name, subject);
+
+    // test that compatibility check for incompatible schema returns false and the appropriate
+    // error response from Avro
+    restApp.restClient.registerSchema(schema1, subject, true, true);
+
+    int versionOfRegisteredSchema =
+      restApp.restClient.lookUpSubjectVersion(schema1, subject).getVersion();
+
+    try {
+      restApp.restClient.registerSchema(schema2, subject, false, true);
+      fail("Registering incompatible schema should fail with "
+             + Errors.INCOMPATIBLE_SCHEMA_ERROR_CODE);
+    } catch (RestClientException e) {
+        assertTrue(e.getMessage().length() > 0);
+        assertTrue(e.getMessage().contains("Schema being registered is incompatible"));
+        assertTrue(e.getMessage().contains("readerFragment:"));
+        assertTrue(e.getMessage().contains("writerFragment:"));
+    }
+
+    List<String> response = restApp.restClient.testCompatibility(schema2, subject,
+        String.valueOf(
+          versionOfRegisteredSchema),
+        true);
+    assertTrue(response.size() > 0);
+    assertTrue(response.get(0).contains("readerFragment:"));
+    assertTrue(response.get(0).contains("writerFragment:"));
+  }
+
+  @Test
   public void testIncompatibleSchemaBySubject() throws Exception {
     String subject = "testSubject";
 
@@ -753,7 +804,8 @@ public class RestApiTest extends ClusterTestHarness {
     request.setSchema(schemas.get(1));
     SchemaReference ref = new SchemaReference("otherns.Subrecord", "reference", 1);
     request.setReferences(Collections.singletonList(ref));
-    int registeredId = restApp.restClient.registerSchema(request, "referrer", false);
+    int registeredId = restApp.restClient.registerSchema(request, "referrer", false,
+      false);
     assertEquals("Registering a new schema should succeed", 2, registeredId);
 
     SchemaString schemaString = restApp.restClient.getId(2);
@@ -854,14 +906,14 @@ public class RestApiTest extends ClusterTestHarness {
     request.setSchema(ref1);
     SchemaReference ref = new SchemaReference("myavro.currencies.Currency", "shared", 1);
     request.setReferences(Collections.singletonList(ref));
-    int registeredId = restApp.restClient.registerSchema(request, "ref1", false);
+    int registeredId = restApp.restClient.registerSchema(request, "ref1", false, false);
     assertEquals("Registering a new schema should succeed", 2, registeredId);
 
     request = new RegisterSchemaRequest();
     request.setSchema(ref2);
     ref = new SchemaReference("myavro.currencies.Currency", "shared", 1);
     request.setReferences(Collections.singletonList(ref));
-    registeredId = restApp.restClient.registerSchema(request, "ref2", false);
+    registeredId = restApp.restClient.registerSchema(request, "ref2", false, false);
     assertEquals("Registering a new schema should succeed", 3, registeredId);
 
     request = new RegisterSchemaRequest();
@@ -869,7 +921,7 @@ public class RestApiTest extends ClusterTestHarness {
     SchemaReference r1 = new SchemaReference("myavro.BudgetDecreased", "ref1", 1);
     SchemaReference r2 = new SchemaReference("myavro.BudgetUpdated", "ref2", 1);
     request.setReferences(Arrays.asList(r1, r2));
-    registeredId = restApp.restClient.registerSchema(request, "root", false);
+    registeredId = restApp.restClient.registerSchema(request, "root", false, false);
     assertEquals("Registering a new schema should succeed", 4, registeredId);
 
     SchemaString schemaString = restApp.restClient.getId(4);
@@ -890,7 +942,7 @@ public class RestApiTest extends ClusterTestHarness {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemas.get(1));
     request.setReferences(Collections.emptyList());
-    restApp.restClient.registerSchema(request, "referrer", false);
+    restApp.restClient.registerSchema(request, "referrer", false, false);
   }
 
   @Test
@@ -937,7 +989,7 @@ public class RestApiTest extends ClusterTestHarness {
     registerRequest.setSchema(schemaString1);
     registerRequest.setReferences(Arrays.asList(ref1, ref2));
     int idOfRegisteredSchema1Subject1 =
-        restApp.restClient.registerSchema(registerRequest, subject1, true);
+        restApp.restClient.registerSchema(registerRequest, subject1, true, false);
     RegisterSchemaRequest lookUpRequest = new RegisterSchemaRequest();
     lookUpRequest.setSchema(schemaString2);
     lookUpRequest.setReferences(Arrays.asList(ref2, ref1));

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/json/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/json/RestApiTest.java
@@ -16,6 +16,8 @@
 package io.confluent.kafka.schemaregistry.rest.json;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.kafka.schemaregistry.CompatibilityLevel;
+import io.confluent.kafka.schemaregistry.avro.AvroUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -147,7 +149,7 @@ public class RestApiTest extends ClusterTestHarness {
     request.setSchemaType(JsonSchema.TYPE);
     SchemaReference ref = new SchemaReference("ref.json", "reference", 1);
     request.setReferences(Collections.singletonList(ref));
-    int registeredId = restApp.restClient.registerSchema(request, "referrer", false);
+    int registeredId = restApp.restClient.registerSchema(request, "referrer", false, false);
     assertEquals("Registering a new schema should succeed", 2, registeredId);
 
     SchemaString schemaString = restApp.restClient.getId(2);
@@ -218,7 +220,7 @@ public class RestApiTest extends ClusterTestHarness {
     request.setSchema(schemas.get("main.json"));
     request.setSchemaType(JsonSchema.TYPE);
     request.setReferences(Collections.emptyList());
-    restApp.restClient.registerSchema(request, "referrer", false);
+    restApp.restClient.registerSchema(request, "referrer", false, false);
   }
 
   @Test
@@ -258,7 +260,7 @@ public class RestApiTest extends ClusterTestHarness {
     registerRequest.setSchemaType(JsonSchema.TYPE);
     registerRequest.setReferences(Arrays.asList(ref1, ref2));
     int idOfRegisteredSchema1Subject1 =
-        restApp.restClient.registerSchema(registerRequest, subject1, true);
+        restApp.restClient.registerSchema(registerRequest, subject1, true, false);
     RegisterSchemaRequest lookUpRequest = new RegisterSchemaRequest();
     lookUpRequest.setSchema(schemaString2);
     lookUpRequest.setSchemaType(JsonSchema.TYPE);
@@ -307,6 +309,64 @@ public class RestApiTest extends ClusterTestHarness {
         restApp.restClient.getAllSubjects()
     );
   }
+
+  @Test
+  public void testIncompatibleSchemaWithVerbose() throws Exception {
+    String subject = "testSubject";
+
+    // Make two incompatible schemas - field 'myField2' has different types
+    String schema1String = "{"
+                            + "\"$schema\": \"http://json-schema.org/draft-07/schema#\","
+                            + "\"$id\": \"https://acme.com/referrer.json\","
+                            + "\"type\":\"object\",\"properties\":{"
+                            + "\"myField1\": {\"type\":\"string\"},"
+                            + "\"myField2\": {\"type\":\"number\"}"
+                            + "},\"additionalProperties\":false"
+                            + "}";
+
+    RegisterSchemaRequest registerRequest = new RegisterSchemaRequest();
+    registerRequest.setSchema(schema1String);
+    registerRequest.setSchemaType(JsonSchema.TYPE);
+
+    String schema2String = "{"
+                             + "\"$schema\": \"http://json-schema.org/draft-07/schema#\","
+                             + "\"$id\": \"https://acme.com/referrer.json\","
+                             + "\"type\":\"object\",\"properties\":{"
+                             + "\"myField1\": {\"type\":\"string\"},"
+                             + "\"myField2\": {\"type\":\"string\"}"
+                             + "},\"additionalProperties\":false"
+                             + "}";
+
+    // ensure registering incompatible schemas will raise an error
+    restApp.restClient.updateCompatibility(
+      CompatibilityLevel.FULL.name, subject);
+
+    // test that compatibility check for incompatible schema returns false and the appropriate
+    // error response from Avro
+    int idOfRegisteredSchema1Subject1 = restApp.restClient.registerSchema(registerRequest, subject, true, true);
+
+    try {
+      registerRequest.setSchema(schema2String);
+      registerRequest.setSchemaType(JsonSchema.TYPE);
+      restApp.restClient.registerSchema(registerRequest, subject, true, true);
+      fail("Registering incompatible schema should fail with "
+             + Errors.INCOMPATIBLE_SCHEMA_ERROR_CODE);
+    } catch(RestClientException e) {
+      assertTrue(e.getMessage().length() > 0);
+      assertTrue(e.getMessage().contains("Schema being registered is incompatible"));
+      assertTrue(e.getMessage().contains("readerSchema:"));
+      assertTrue(e.getMessage().contains("writerSchema:"));
+    }
+
+    List<String> response = restApp.restClient.testCompatibility(registerRequest, subject,
+      String.valueOf(
+        idOfRegisteredSchema1Subject1),
+      true);
+    assertTrue(response.size() > 0);
+    assertTrue(response.get(1).contains("readerSchema:"));
+    assertTrue(response.get(1).contains("writerSchema:"));
+  }
+
 
   public static void registerAndVerifySchema(
       RestService restService,

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/protobuf/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/protobuf/RestApiTest.java
@@ -20,6 +20,8 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import com.google.protobuf.UnknownFieldSet;
+import io.confluent.kafka.schemaregistry.CompatibilityLevel;
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
 import io.confluent.kafka.schemaregistry.utils.ResourceLoader;
 import org.junit.Assert;
 import org.junit.Test;
@@ -48,8 +50,8 @@ import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.serializers.protobuf.test.Ref;
 import io.confluent.kafka.serializers.protobuf.test.Root;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 public class RestApiTest extends ClusterTestHarness {
 
@@ -154,7 +156,7 @@ public class RestApiTest extends ClusterTestHarness {
     SchemaReference meta = new SchemaReference("confluent/meta.proto", "confluent/meta.proto", 1);
     List<SchemaReference> refs = Arrays.asList(ref, meta);
     request.setReferences(refs);
-    int registeredId = restApp.restClient.registerSchema(request, "referrer", false);
+    int registeredId = restApp.restClient.registerSchema(request, "referrer", false, false);
     assertEquals("Registering a new schema should succeed", 3, registeredId);
 
     SchemaString schemaString = restApp.restClient.getId(3);
@@ -213,7 +215,7 @@ public class RestApiTest extends ClusterTestHarness {
     SchemaReference meta = new SchemaReference("pkg1/msg1.proto", "pkg1/msg1.proto", 1);
     List<SchemaReference> refs = Arrays.asList(meta);
     request.setReferences(refs);
-    int registeredId = restApp.restClient.registerSchema(request, subject, false);
+    int registeredId = restApp.restClient.registerSchema(request, subject, false, false);
     assertEquals("Registering a new schema should succeed", 2, registeredId);
   }
 
@@ -225,7 +227,62 @@ public class RestApiTest extends ClusterTestHarness {
     request.setSchema(schemas.get("root.proto"));
     request.setSchemaType(ProtobufSchema.TYPE);
     request.setReferences(Collections.emptyList());
-    restApp.restClient.registerSchema(request, "referrer", false);
+    restApp.restClient.registerSchema(request, "referrer", false, false);
+  }
+
+  @Test
+  public void testIncompatibleSchemaWithVerbose() throws Exception {
+    String subject = "testSubject";
+
+    // Make two incompatible schemas - field 'myField2' has different types
+    String schema1String = "syntax = \"proto3\";\n" +
+                             "package pkg3;\n" +
+                             "\n" +
+                             "message Schema1 {\n" +
+                             "  string f1 = 1;\n" +
+                             "  string f2 = 2;\n" +
+                             "}\n";
+
+    RegisterSchemaRequest registerRequest = new RegisterSchemaRequest();
+    registerRequest.setSchema(schema1String);
+    registerRequest.setSchemaType(ProtobufSchema.TYPE);
+
+    String schema2String = "syntax = \"proto3\";\n" +
+                             "package pkg3;\n" +
+                             "\n" +
+                             "message Schema1 {\n" +
+                             "  string f1 = 1;\n" +
+                             "  int32 f2 = 2;\n" +
+                             "}\n";
+
+    // ensure registering incompatible schemas will raise an error
+    restApp.restClient.updateCompatibility(
+      CompatibilityLevel.FULL.name, subject);
+
+    // test that compatibility check for incompatible schema returns false and the appropriate
+    // error response from Avro
+    int idOfRegisteredSchema1Subject1 = restApp.restClient.registerSchema(registerRequest, subject, true, true);
+
+    try {
+      registerRequest.setSchema(schema2String);
+      registerRequest.setSchemaType(ProtobufSchema.TYPE);
+      restApp.restClient.registerSchema(registerRequest, subject, true, true);
+      fail("Registering incompatible schema should fail with "
+             + Errors.INCOMPATIBLE_SCHEMA_ERROR_CODE);
+    } catch (RestClientException e) {
+      assertTrue(e.getMessage().length() > 0);
+      assertTrue(e.getMessage().contains("Schema being registered is incompatible"));
+      assertTrue(e.getMessage().contains("readerSchema:"));
+      assertTrue(e.getMessage().contains("writerSchema:"));
+    }
+
+    List<String> response = restApp.restClient.testCompatibility(registerRequest, subject,
+      String.valueOf(
+        idOfRegisteredSchema1Subject1),
+      true);
+    assertTrue(response.size() > 0);
+    assertTrue(response.get(1).contains("readerSchema:"));
+    assertTrue(response.get(1).contains("writerSchema:"));
   }
 
   @Test
@@ -282,7 +339,7 @@ public class RestApiTest extends ClusterTestHarness {
     SchemaReference ref2 = new SchemaReference("pkg2/msg2.proto", "pkg2/msg2.proto", 1);
     List<SchemaReference> refs = Arrays.asList(ref1, ref2);
     request.setReferences(refs);
-    int registeredId = restApp.restClient.registerSchema(request, subject1, true);
+    int registeredId = restApp.restClient.registerSchema(request, subject1, true, false);
     assertEquals("Registering a new schema should succeed", 3, registeredId);
 
     // Alternate version of same schema

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -431,7 +431,7 @@ public class JsonSchema implements ParsedSchema {
   }
 
   @Override
-  public List<String> isBackwardCompatible(ParsedSchema previousSchema) {
+  public List<String> isBackwardCompatible(ParsedSchema previousSchema, boolean verbose) {
     if (!schemaType().equals(previousSchema.schemaType())) {
       return Collections.singletonList("Incompatible because of different schema type");
     }
@@ -444,18 +444,13 @@ public class JsonSchema implements ParsedSchema {
         .collect(Collectors.toList());
     boolean isCompatible = incompatibleDiffs.isEmpty();
     if (!isCompatible) {
-      boolean first = true;
       List<String> errorMessages = new ArrayList<>();
       for (Difference incompatibleDiff : incompatibleDiffs) {
-        if (first) {
-          // Log first incompatible change as warning
-          log.warn("Found incompatible change: {}", incompatibleDiff);
-          errorMessages.add(String.format("Found incompatible change: %s", incompatibleDiff));
-          first = false;
-        } else {
-          log.debug("Found incompatible change: {}", incompatibleDiff);
-          errorMessages.add(String.format("Found incompatible change: %s", incompatibleDiff));
-        }
+        errorMessages.add(String.format("%s", incompatibleDiff.toString()));
+      }
+      if (verbose) {
+        errorMessages.add("{ readerSchema: '" + this
+                            + "', writerSchema: '" + previousSchema + "'}");
       }
       return errorMessages;
     } else {

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/Difference.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/Difference.java
@@ -15,6 +15,8 @@
 
 package io.confluent.kafka.schemaregistry.json.diff;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import java.util.Objects;
 
 public class Difference {
@@ -76,6 +78,120 @@ public class Difference {
 
   private final String jsonPath;
   private final Type type;
+  private final Map<Type, String> errorDescription = ImmutableMap.<Type, String>builder()
+      .put(Type.SCHEMA_ADDED, "A new reader schema (path: '%s') was added")
+      .put(Type.TYPE_NARROWED, "The list of types at path: '%s' in the reader schema was narrowed")
+      .put(Type.TYPE_CHANGED, "The type of a field at path '%s' in the reader schema has changed")
+      .put(Type.MAX_LENGTH_ADDED,
+        "The 'maxLength' keyword (path: '%s') was added to the reader schema")
+      .put(Type.MAX_LENGTH_DECREASED,
+        "The value of 'maxLength' at path: '%s' was decreased in the reader schema")
+      .put(Type.MIN_LENGTH_ADDED,
+        "The 'minLength' keyword (path: '%s') was added to the reader schema")
+      .put(Type.MIN_LENGTH_INCREASED,
+        "The value of 'minLength' at path: '%s' was increased in the reader schema")
+      .put(Type.PATTERN_ADDED,
+        "The 'pattern' keyword (path: '%s') was added to the reader schema")
+      .put(Type.PATTERN_CHANGED,
+        "The value of 'pattern' at path: '%s' was changed in the reader schema")
+      .put(Type.MAXIMUM_ADDED,
+        "The 'maximum' keyword (path: '%s') was added to the reader schema")
+      .put(Type.MAXIMUM_DECREASED,
+        "The value of 'maximum' at path: '%s' was decreased in the reader schema")
+      .put(Type.MINIMUM_ADDED,
+        "The 'minimum' keyword (path: '%s') was added to the reader schema")
+      .put(Type.MINIMUM_INCREASED,
+        "The value of 'minimum' at path: '%s' was increased in the reader schema")
+      .put(Type.EXCLUSIVE_MAXIMUM_ADDED,
+        "The 'exclusiveMaximum' keyword (path: '%s') was added to the reader schema")
+      .put(Type.EXCLUSIVE_MAXIMUM_DECREASED,
+        "The value of 'exclusiveMaximum' at path: '%s' was decreased in the reader schema")
+      .put(Type.EXCLUSIVE_MINIMUM_ADDED,
+        "The 'exclusiveMinimum' keyword (path: '%s') was added to the reader schema")
+      .put(Type.EXCLUSIVE_MINIMUM_INCREASED,
+        "The value of 'exclusiveMinimum' at path: '%s' was increased in the reader schema")
+      .put(Type.MULTIPLE_OF_ADDED,
+        "The 'multipleOf' keyword was added at path: '%s' in the reader schema")
+      .put(Type.MULTIPLE_OF_EXPANDED,
+        "The value of 'multipleOf' at path: '%s' in the reader schema was expanded")
+      .put(Type.MULTIPLE_OF_CHANGED,
+        "The value of 'multipleOf' at path: '%s' in the reader schema was changed")
+      .put(Type.REQUIRED_ATTRIBUTE_ADDED,
+        "The 'required' keyword was added to an object type at path: '%s' in the reader schema")
+      .put(Type.MAX_PROPERTIES_ADDED,
+        "The 'maxProperties' keyword was added to object type path: '%s' in the reader schema")
+      .put(Type.MAX_PROPERTIES_DECREASED,
+        "The value of 'maxProperties' at path: '%s' was decreased in the "
+          + "reader schema")
+      .put(Type.MIN_PROPERTIES_ADDED,
+        "The 'minProperties' keyword was added to an object type at path: '%s' in the "
+          + "reader schema")
+      .put(Type.MIN_PROPERTIES_INCREASED,
+        "The value of 'maxProperties' at path: '%s' was increased in the reader schema")
+      .put(Type.ADDITIONAL_PROPERTIES_REMOVED,
+        "The 'additionalProperties' keyword at path '%s' was removed from the reader schema")
+      .put(Type.ADDITIONAL_PROPERTIES_NARROWED,
+        "The value of 'additionalProperties' at path '%s' was narrowed in the reader schema")
+      .put(Type.DEPENDENCY_ARRAY_ADDED,
+        "The 'dependentRequired' array was added at path '%s' in the reader schema")
+      .put(Type.DEPENDENCY_ARRAY_EXTENDED,
+        "The 'dependentRequired' array at path '%s' was extended in the reader schema")
+      .put(Type.DEPENDENCY_ARRAY_CHANGED,
+        "The 'dependentRequired' array at path '%s' was changed in the reader schema")
+      .put(Type.DEPENDENCY_SCHEMA_ADDED,
+        "The 'dependentSchemas' keyword was added at path '%s' in the reader schema")
+      .put(Type.PROPERTY_ADDED_TO_OPEN_CONTENT_MODEL,
+        "A property (path '%s') was added  to the reader schema which has an open content model ")
+      .put(Type.REQUIRED_PROPERTY_ADDED_TO_UNOPEN_CONTENT_MODEL,
+        "A required property (path '%s') was added to the reader schema which has an "
+          + "unopen content model ")
+      .put(Type.PROPERTY_REMOVED_FROM_CLOSED_CONTENT_MODEL,
+        "A property (path '%s') was removed from the reader schema which has a closed content "
+          + "model")
+      .put(Type.PROPERTY_REMOVED_NOT_COVERED_BY_PARTIALLY_OPEN_CONTENT_MODEL,
+      "A property (path '%s') was removed at  from the reader schema and is not covered by "
+        + "its partially open content model")
+      .put(Type.PROPERTY_ADDED_NOT_COVERED_BY_PARTIALLY_OPEN_CONTENT_MODEL,
+        "A property (path '%s') that as added to the reader schema is not covered by its partially "
+          + "open content model")
+      .put(Type.MAX_ITEMS_ADDED,
+        "The 'maxItems' keyword (path '%s') was added to the reader schema")
+      .put(Type.MAX_ITEMS_DECREASED,
+        "The value of 'maxItems' at path '%s' was decreased in the reader schema")
+      .put(Type.MIN_ITEMS_ADDED,
+        "The 'minItems' keyword (path '%s') was added in the reader schema")
+      .put(Type.MIN_ITEMS_INCREASED,
+        "The value of 'minItems' of an array at path '%s' was increased in the reader schema")
+      .put(Type.UNIQUE_ITEMS_ADDED,
+        "The 'uniqueItems' keyword was added to an array at path '%s' in the reader schema")
+      .put(Type.ADDITIONAL_ITEMS_REMOVED,
+        "The 'additionalItems' keyword at path '%s' was removed from the reader schema")
+      .put(Type.ADDITIONAL_ITEMS_NARROWED,
+        "The list of 'additionalItems' at path '%s' was narrowed in the reader schema")
+      .put(Type.ITEM_ADDED_TO_OPEN_CONTENT_MODEL,
+        "An item at path '%s' was added to the reader schema which has an open content model")
+      .put(Type.ITEM_REMOVED_FROM_CLOSED_CONTENT_MODEL,
+        "An item at path '%s' was removed from the reader schema which"
+          + "has a closed content model")
+      .put(Type.ITEM_REMOVED_NOT_COVERED_BY_PARTIALLY_OPEN_CONTENT_MODEL,
+        "An item was removed at path '%s' from the reader schema and is not covered by its "
+          + "partially closed content model")
+      .put(Type.ITEM_ADDED_NOT_COVERED_BY_PARTIALLY_OPEN_CONTENT_MODEL,
+        "An item was added at path '%s' to the reader schema and is not covered by its partially"
+          + "open content model")
+      .put(Type.ENUM_ARRAY_NARROWED,
+        "The enum array at path '%s' in the reader schema was narrowed")
+      .put(Type.ENUM_ARRAY_CHANGED, "The enum array at path '%s' in the reader schema was changed")
+      .put(Type.COMBINED_TYPE_CHANGED,
+        "A combined type at path '%s' in the reader schema was changed")
+      .put(Type.PRODUCT_TYPE_EXTENDED,
+        "A product type (allOf) at path '%s' in the reader schema was changed")
+      .put(Type.SUM_TYPE_NARROWED,
+        "A sum type (anyOf) at path '%s' in the reader schema was changed")
+      .put(Type.COMBINED_TYPE_SUBSCHEMAS_CHANGED,
+        "Subschemas of a combined type at path '%s' in the reader schema changed")
+      .put(Type.NOT_TYPE_EXTENDED, "A 'NOT' type at path '%s' in the reader schema was extended")
+      .build();
 
   public Difference(final Type type, final String jsonPath) {
     this.jsonPath = jsonPath;
@@ -109,6 +225,8 @@ public class Difference {
 
   @Override
   public String toString() {
-    return "Difference{" + "jsonPath='" + jsonPath + '\'' + ", type=" + type + '}';
+    return "{ errorType:\"" + type + "\""
+             + ", errorMessage:\""
+             + String.format(errorDescription.getOrDefault(type, "%s"), jsonPath) + "'}";
   }
 }

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/TestSchemaValidation.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/TestSchemaValidation.java
@@ -228,7 +228,8 @@ public class TestSchemaValidation {
       SchemaValidator validator = builder.canReadStrategy().validateAll();
       List<String> valid = validator.validate(
           new JsonSchema(reader),
-          Collections.singleton(new JsonSchema(writer))
+          Collections.singleton(new JsonSchema(writer)),
+          false
       );
       Assert.assertFalse(valid.isEmpty());
     }
@@ -239,7 +240,7 @@ public class TestSchemaValidation {
     for (int i = prev.length - 1; i >= 0; i--) {
       prior.add(new JsonSchema(prev[i]));
     }
-    validator.validate(new JsonSchema(schema), prior);
+    validator.validate(new JsonSchema(schema), prior, false);
   }
 
   private void testValidatorFails(SchemaValidator validator, Schema schemaFails, Schema... prev) {
@@ -247,7 +248,7 @@ public class TestSchemaValidation {
     for (int i = prev.length - 1; i >= 0; i--) {
       prior.add(new JsonSchema(prev[i]));
     }
-    List<String> valid = validator.validate(new JsonSchema(schemaFails), prior);
+    List<String> valid = validator.validate(new JsonSchema(schemaFails), prior, false);
     Assert.assertFalse(valid.isEmpty());
   }
 }

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageReader.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageReader.java
@@ -99,10 +99,11 @@ public class JsonSchemaMessageReader extends SchemaMessageReader<JsonNode>
       BufferedReader reader,
       boolean normalizeSchema,
       boolean autoRegister,
-      boolean useLatest
+      boolean useLatest,
+      boolean showVerboseErrors
   ) {
     super(schemaRegistryClient, keySchema, valueSchema, topic,
-        parseKey, reader, normalizeSchema, autoRegister, useLatest);
+        parseKey, reader, normalizeSchema, autoRegister, useLatest, showVerboseErrors);
   }
 
   @Override
@@ -111,10 +112,12 @@ public class JsonSchemaMessageReader extends SchemaMessageReader<JsonNode>
       boolean normalizeSchema,
       boolean autoRegister,
       boolean useLatest,
-      Serializer keySerializer
+      Serializer keySerializer,
+      boolean showVerboseErrors
   ) {
     return new JsonSchemaMessageSerializer(
-        schemaRegistryClient, normalizeSchema, autoRegister, useLatest, keySerializer);
+        schemaRegistryClient, normalizeSchema, autoRegister, useLatest, keySerializer,
+        showVerboseErrors);
   }
 
   @Override
@@ -138,7 +141,8 @@ public class JsonSchemaMessageReader extends SchemaMessageReader<JsonNode>
 
     JsonSchemaMessageSerializer(
         SchemaRegistryClient schemaRegistryClient,
-        boolean normalizeSchema, boolean autoRegister, boolean useLatest, Serializer keySerializer
+        boolean normalizeSchema, boolean autoRegister, boolean useLatest, Serializer keySerializer,
+        boolean showVerboseErrors
     ) {
       this.schemaRegistry = schemaRegistryClient;
       this.normalizeSchema = normalizeSchema;
@@ -146,6 +150,7 @@ public class JsonSchemaMessageReader extends SchemaMessageReader<JsonNode>
       this.useLatestVersion = useLatest;
       this.keySerializer = keySerializer;
       this.validate = true;
+      this.showVerboseErrors = showVerboseErrors;
     }
 
     @Override

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaSerializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaSerializer.java
@@ -50,6 +50,7 @@ public abstract class AbstractKafkaJsonSchemaSerializer<T> extends AbstractKafka
   protected boolean oneofForNullables;
   protected boolean failUnknownProperties;
   protected boolean validate;
+  protected boolean showVerboseErrors;
 
   protected void configure(KafkaJsonSchemaSerializerConfig config) {
     configureClientProperties(config, new JsonSchemaProvider());
@@ -58,6 +59,7 @@ public abstract class AbstractKafkaJsonSchemaSerializer<T> extends AbstractKafka
     this.useSchemaId = config.useSchemaId();
     this.idCompatStrict = config.getIdCompatibilityStrict();
     this.latestCompatStrict = config.getLatestCompatibilityStrict();
+    this.showVerboseErrors = config.autoRegisterSchemaVerbose();
     boolean prettyPrint = config.getBoolean(KafkaJsonSchemaSerializerConfig.JSON_INDENT_OUTPUT);
     this.objectMapper.configure(SerializationFeature.INDENT_OUTPUT, prettyPrint);
     boolean writeDatesAsIso8601 = config.getBoolean(
@@ -118,7 +120,7 @@ public abstract class AbstractKafkaJsonSchemaSerializer<T> extends AbstractKafka
       int id;
       if (autoRegisterSchema) {
         restClientErrorMsg = "Error registering JSON schema: ";
-        id = schemaRegistry.register(subject, schema, normalizeSchema);
+        id = schemaRegistry.register(subject, schema, normalizeSchema, showVerboseErrors);
       } else if (useSchemaId >= 0) {
         restClientErrorMsg = "Error retrieving schema ID";
         schema = (JsonSchema)

--- a/json-schema-serializer/src/test/java/io/confluent/kafka/formatter/json/KafkaJsonSchemaFormatterTest.java
+++ b/json-schema-serializer/src/test/java/io/confluent/kafka/formatter/json/KafkaJsonSchemaFormatterTest.java
@@ -71,7 +71,7 @@ public class KafkaJsonSchemaFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     JsonSchemaMessageReader jsonSchemaReader =
         new JsonSchemaMessageReader(schemaRegistry, null, recordSchema, "topic1", false, reader,
-            false, true, false);
+            false, true, false, false);
     ProducerRecord<byte[], byte[]> message = jsonSchemaReader.readMessage();
 
     byte[] serializedValue = message.value();
@@ -98,7 +98,7 @@ public class KafkaJsonSchemaFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     JsonSchemaMessageReader jsonSchemaReader =
         new JsonSchemaMessageReader(schemaRegistry, keySchema, recordSchema, "topic1", true, reader,
-            false, true, false);
+            false, true, false, false);
     ProducerRecord<byte[], byte[]> message = jsonSchemaReader.readMessage();
 
     byte[] serializedKey = message.key();
@@ -123,7 +123,7 @@ public class KafkaJsonSchemaFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     JsonSchemaMessageReader jsonSchemaReader =
         new JsonSchemaMessageReader(schemaRegistry, null, recordSchema, "topic1", false, reader,
-            false, true, false);
+            false, true, false, false);
     try {
       jsonSchemaReader.readMessage();
       fail("Registering an invalid schema should fail");

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -1860,7 +1860,7 @@ public class ProtobufSchema implements ParsedSchema {
   }
 
   @Override
-  public List<String> isBackwardCompatible(ParsedSchema previousSchema) {
+  public List<String> isBackwardCompatible(ParsedSchema previousSchema, boolean verbose) {
     if (!schemaType().equals(previousSchema.schemaType())) {
       return Collections.singletonList("Incompatible because of different schema type");
     }
@@ -1872,18 +1872,13 @@ public class ProtobufSchema implements ParsedSchema {
         .collect(Collectors.toList());
     boolean isCompatible = incompatibleDiffs.isEmpty();
     if (!isCompatible) {
-      boolean first = true;
       List<String> errorMessages = new ArrayList<>();
       for (Difference incompatibleDiff : incompatibleDiffs) {
-        if (first) {
-          // Log first incompatible change as warning
-          log.warn("Found incompatible change: {}", incompatibleDiff);
-          errorMessages.add(String.format("Found incompatible change: %s", incompatibleDiff));
-          first = false;
-        } else {
-          log.debug("Found incompatible change: {}", incompatibleDiff);
-          errorMessages.add(String.format("Found incompatible change: %s", incompatibleDiff));
-        }
+        errorMessages.add(String.format("%s", incompatibleDiff));
+      }
+      if (verbose) {
+        errorMessages.add("{ readerSchema: '" + this
+                            + "', writerSchema: '" + previousSchema + "'}");
       }
       return errorMessages;
     } else {

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/diff/Difference.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/diff/Difference.java
@@ -16,6 +16,8 @@
 
 package io.confluent.kafka.schemaregistry.protobuf.diff;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 public class Difference {
@@ -32,10 +34,39 @@ public class Difference {
 
   private final String fullPath;
   private final Type type;
+  private final Map<Type, String> errorDescription;
 
   public Difference(final Type type, final String fullPath) {
     this.fullPath = fullPath;
     this.type = type;
+    errorDescription = new HashMap<>();
+    errorDescription.put(Type.MESSAGE_REMOVED,
+        String.format("A field of type message at path: '%s' in the writer schema is missing in the"
+                        + " reader schema", fullPath));
+    errorDescription.put(Type.FIELD_KIND_CHANGED,
+        String.format("The type of a field at path: '%s' in the reader schema has changed to MAP, "
+                        + "SCALAR or MESSAGE", fullPath));
+    errorDescription.put(Type.FIELD_SCALAR_KIND_CHANGED,
+        String.format("The kind of a SCALAR field at path: '%s' in the reader schema has changed",
+          fullPath));
+    errorDescription.put(Type.FIELD_NAMED_TYPE_CHANGED,
+        String.format("The type of a MESSAGE field at path: '%s' in the reader schema has changed",
+          fullPath));
+    errorDescription.put(Type.FIELD_NUMERIC_LABEL_CHANGED,
+        String.format("The label for a numeric field at path: '%s' in the reader schema has "
+                        + "changed", fullPath));
+    errorDescription.put(Type.REQUIRED_FIELD_ADDED,
+        String.format("The reader schema has an additional required field at path: '%s'",
+          fullPath));
+    errorDescription.put(Type.REQUIRED_FIELD_REMOVED,
+        String.format("A required field at path: '%s' in the writer schema is missing in the "
+                        + "reader schema", fullPath));
+    errorDescription.put(Type.ONEOF_FIELD_REMOVED,
+        String.format("A oneof field at path: '%s' in the writer schema is missing in the reader "
+                        + "schema", fullPath));
+    errorDescription.put(Type.MULTIPLE_FIELDS_MOVED_TO_ONEOF,
+        String.format("Multiple fields were moved into a oneof field at path: '%s' in the reader "
+                        + "schema", fullPath));
   }
 
   public String getFullPath() {
@@ -65,6 +96,7 @@ public class Difference {
 
   @Override
   public String toString() {
-    return "Difference{" + "fullPath='" + fullPath + '\'' + ", type=" + type + '}';
+    return "{ errorType:\"" + type + '"'
+             + ", description:\"" + errorDescription.getOrDefault(type, "") + "\"}";
   }
 }

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/formatter/protobuf/ProtobufMessageReader.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/formatter/protobuf/ProtobufMessageReader.java
@@ -71,10 +71,11 @@ public class ProtobufMessageReader extends SchemaMessageReader<Message> {
       BufferedReader reader,
       boolean normalizeSchema,
       boolean autoRegister,
-      boolean useLatest
+      boolean useLatest,
+      boolean showVerboseErrors
   ) {
     super(schemaRegistryClient, keySchema, valueSchema, topic,
-        parseKey, reader, normalizeSchema, autoRegister, useLatest);
+        parseKey, reader, normalizeSchema, autoRegister, useLatest, showVerboseErrors);
   }
 
   @Override
@@ -96,10 +97,12 @@ public class ProtobufMessageReader extends SchemaMessageReader<Message> {
       boolean normalizeSchema,
       boolean autoRegister,
       boolean useLatest,
-      Serializer keySerializer
+      Serializer keySerializer,
+      boolean showVerboseErrors
   ) {
     return new ProtobufMessageSerializer(
-        schemaRegistryClient, normalizeSchema, autoRegister, useLatest, keySerializer);
+        schemaRegistryClient, normalizeSchema, autoRegister, useLatest, keySerializer,
+        showVerboseErrors);
   }
 
   @Override
@@ -127,13 +130,15 @@ public class ProtobufMessageReader extends SchemaMessageReader<Message> {
 
     ProtobufMessageSerializer(
         SchemaRegistryClient schemaRegistryClient,
-        boolean normalizeSchema, boolean autoRegister, boolean useLatest, Serializer keySerializer
+        boolean normalizeSchema, boolean autoRegister, boolean useLatest, Serializer keySerializer,
+        boolean showVerboseErrors
     ) {
       this.schemaRegistry = schemaRegistryClient;
       this.normalizeSchema = normalizeSchema;
       this.autoRegisterSchema = autoRegister;
       this.useLatestVersion = useLatest;
       this.keySerializer = keySerializer;
+      this.showVerboseErrors = showVerboseErrors;
     }
 
     @Override

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufSerializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufSerializer.java
@@ -53,6 +53,7 @@ public abstract class AbstractKafkaProtobufSerializer<T extends Message>
   protected boolean latestCompatStrict;
   protected String schemaFormat;
   protected boolean skipKnownTypes;
+  protected boolean showVerboseErrors;
   protected ReferenceSubjectNameStrategy referenceSubjectNameStrategy;
 
   protected void configure(KafkaProtobufSerializerConfig config) {
@@ -65,6 +66,7 @@ public abstract class AbstractKafkaProtobufSerializer<T extends Message>
     this.latestCompatStrict = config.getLatestCompatibilityStrict();
     this.schemaFormat = config.getSchemaFormat();
     this.skipKnownTypes = config.skipKnownTypes();
+    this.showVerboseErrors = config.autoRegisterSchemaVerbose();
     this.referenceSubjectNameStrategy = config.referenceSubjectNameStrategyInstance();
   }
 
@@ -113,7 +115,7 @@ public abstract class AbstractKafkaProtobufSerializer<T extends Message>
           String formatted = schema.formattedString(schemaFormat);
           schema = schema.copyWithSchema(formatted);
         }
-        id = schemaRegistry.register(subject, schema, normalizeSchema);
+        id = schemaRegistry.register(subject, schema, normalizeSchema, showVerboseErrors);
       } else if (useSchemaId >= 0) {
         restClientErrorMsg = "Error retrieving schema ID";
         if (schemaFormat != null) {

--- a/protobuf-serializer/src/test/java/io/confluent/kafka/formatter/protobuf/KafkaProtobufFormatterTest.java
+++ b/protobuf-serializer/src/test/java/io/confluent/kafka/formatter/protobuf/KafkaProtobufFormatterTest.java
@@ -81,7 +81,7 @@ public class KafkaProtobufFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     ProtobufMessageReader protobufReader =
         new ProtobufMessageReader(schemaRegistry, null, recordSchema, "topic1", false, reader,
-            false, true, false);
+            false, true, false, false);
     ProducerRecord<byte[], byte[]> message = protobufReader.readMessage();
 
     byte[] serializedValue = message.value();
@@ -107,7 +107,7 @@ public class KafkaProtobufFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     ProtobufMessageReader protobufReader =
         new ProtobufMessageReader(schemaRegistry, null, enumSchema, "topic1", false, reader,
-            false, true, false);
+            false, true, false, false);
     ProducerRecord<byte[], byte[]> message = protobufReader.readMessage();
 
     byte[] serializedValue = message.value();
@@ -133,7 +133,7 @@ public class KafkaProtobufFormatterTest {
             new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     ProtobufMessageReader protobufReader =
             new ProtobufMessageReader(schemaRegistry, null, snakeCaseSchema, "topic1", false, reader,
-                    false, true, false);
+                    false, true, false, false);
     ProducerRecord<byte[], byte[]> message = protobufReader.readMessage();
 
     byte[] serializedValue = message.value();
@@ -160,7 +160,7 @@ public class KafkaProtobufFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     ProtobufMessageReader protobufReader =
         new ProtobufMessageReader(schemaRegistry, keySchema, recordSchema, "topic1", true, reader,
-            false, true, false);
+            false, true, false, false);
     ProducerRecord<byte[], byte[]> message = protobufReader.readMessage();
 
     byte[] serializedKey = message.key();
@@ -203,7 +203,7 @@ public class KafkaProtobufFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     ProtobufMessageReader protobufReader =
         new ProtobufMessageReader(schemaRegistry, null, recordSchema.copy("User2"), "topic1", false, reader,
-            false, true, false);
+            false, true, false, false);
     ProducerRecord<byte[], byte[]> message = protobufReader.readMessage();
 
     byte[] serializedValue = message.value();
@@ -227,7 +227,7 @@ public class KafkaProtobufFormatterTest {
         new BufferedReader(new InputStreamReader(new ByteArrayInputStream(inputJson.getBytes())));
     ProtobufMessageReader protobufReader =
         new ProtobufMessageReader(schemaRegistry, null, recordSchema, "topic1", false, reader,
-            false, true, false);
+            false, true, false, false);
     try {
       protobufReader.readMessage();
       fail("Registering an invalid schema should fail");

--- a/protobuf-serializer/src/test/java/io/confluent/kafka/schemaregistry/protobuf/rest/RestApiSerializerTest.java
+++ b/protobuf-serializer/src/test/java/io/confluent/kafka/schemaregistry/protobuf/rest/RestApiSerializerTest.java
@@ -373,7 +373,8 @@ public class RestApiSerializerTest extends ClusterTestHarness {
     ReferenceSubjectNameStrategy strategy = new DefaultReferenceSubjectNameStrategy();
     ProtobufSchema resolvedSchema = ProtobufSchemaUtils.getSchema(descMessage);
     resolvedSchema = KafkaProtobufSerializer.resolveDependencies(
-        schemaRegistry, false, false, true, null, true, strategy, subject, false, resolvedSchema);
+        schemaRegistry, false, false, true, null,
+      true, strategy, subject, false, resolvedSchema);
     assertEquals(schema, resolvedSchema);
   }
 

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -336,6 +336,11 @@ public abstract class AbstractKafkaSchemaSerDe {
     return schemaRegistry.register(subject, schema, normalize);
   }
 
+  public int register(String subject, ParsedSchema schema, boolean normalize, boolean verbose)
+      throws IOException, RestClientException {
+    return schemaRegistry.register(subject, schema, normalize, verbose);
+  }
+
   @Deprecated
   public Schema getById(int id) throws IOException, RestClientException {
     return schemaRegistry.getById(id);

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDeConfig.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDeConfig.java
@@ -72,6 +72,12 @@ public class AbstractKafkaSchemaSerDeConfig extends AbstractConfig {
   public static final String AUTO_REGISTER_SCHEMAS_DOC =
       "Specify if the Serializer should attempt to register the Schema with Schema Registry";
 
+  public static final String AUTO_REGISTER_SCHEMAS_VERBOSE = "auto.register.schemas.verbose";
+  public static final boolean AUTO_REGISTER_SCHEMAS_VERBOSE_DEFAULT = true;
+  public static final String AUTO_REGISTER_SCHEMAS_VERBOSE_DOC =
+      "Specify if the Serializer should attempt to register the Schema with Schema Registry and "
+      + "include verbose error messages for schema compatibility checks.";
+
   public static final String USE_SCHEMA_ID = "use.schema.id";
   public static final int USE_SCHEMA_ID_DEFAULT = -1;
   public static final String USE_SCHEMA_ID_DOC = "Schema ID to use for serialization";
@@ -243,6 +249,8 @@ public class AbstractKafkaSchemaSerDeConfig extends AbstractConfig {
                 Importance.MEDIUM, NORMALIZE_SCHEMAS_DOC)
         .define(AUTO_REGISTER_SCHEMAS, Type.BOOLEAN, AUTO_REGISTER_SCHEMAS_DEFAULT,
                 Importance.MEDIUM, AUTO_REGISTER_SCHEMAS_DOC)
+        .define(AUTO_REGISTER_SCHEMAS_VERBOSE, Type.BOOLEAN, AUTO_REGISTER_SCHEMAS_VERBOSE_DEFAULT,
+                Importance.MEDIUM, AUTO_REGISTER_SCHEMAS_VERBOSE_DOC)
         .define(USE_SCHEMA_ID, Type.INT, USE_SCHEMA_ID_DEFAULT,
                 Importance.LOW, USE_SCHEMA_ID_DOC)
         .define(ID_COMPATIBILITY_STRICT, Type.BOOLEAN, ID_COMPATIBILITY_STRICT_DEFAULT,
@@ -299,6 +307,7 @@ public class AbstractKafkaSchemaSerDeConfig extends AbstractConfig {
                 Importance.LOW, PROXY_HOST_DOC)
         .define(PROXY_PORT, Type.INT, PROXY_PORT_DEFAULT,
                 Importance.LOW, PROXY_PORT_DOC);
+
     SchemaRegistryClientConfig.withClientSslSupport(
         configDef, SchemaRegistryClientConfig.CLIENT_NAMESPACE);
     return configDef;
@@ -326,6 +335,10 @@ public class AbstractKafkaSchemaSerDeConfig extends AbstractConfig {
 
   public boolean autoRegisterSchema() {
     return this.getBoolean(AUTO_REGISTER_SCHEMAS);
+  }
+
+  public boolean autoRegisterSchemaVerbose() {
+    return this.getBoolean(AUTO_REGISTER_SCHEMAS_VERBOSE);
   }
 
   public int useSchemaId() {


### PR DESCRIPTION
The changes in this PR are based on the proposal described in https://confluentinc.atlassian.net/wiki/spaces/~945736141/pages/2906754169/Proposal+for+SUP-49+Improve+Error+reporting+on+incompatibility+for+better+usability

In summary, the changes include:
- Output error message format changes with verbose and non-verbose suport - the error message will now include three sections:
- {errorType, description} for each error type. For Avro, this section will also include {additionalInfo, readerFragment, writerFragment}
- {readerSchema, writerSchema} for each error type if verbose is true
- {compatibility}
- 'verbose' query param support in the SR register API
- Ability to turn off verbosity in the serializers when auto.register.schemas is true using a new config parameter (auto.register.schemas.verbose)