### PR TITLE
DGS-5514 Enhance config APIs with additional parameters

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -632,20 +632,20 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
-  public String updateCompatibility(String subject, String compatibility)
+  public Config updateConfig(String subject, Config config)
       throws IOException, RestClientException {
-    ConfigUpdateRequest response = restService.updateCompatibility(compatibility, subject);
-    return response.getCompatibilityLevel();
+    ConfigUpdateRequest response = restService.updateConfig(
+        new ConfigUpdateRequest(config), subject);
+    return new Config(response);
   }
 
   @Override
-  public String getCompatibility(String subject) throws IOException, RestClientException {
-    Config response = restService.getConfig(subject);
-    return response.getCompatibilityLevel();
+  public Config getConfig(String subject) throws IOException, RestClientException {
+    return restService.getConfig(subject);
   }
 
   @Override
-  public void deleteCompatibility(String subject) throws IOException, RestClientException {
+  public void deleteConfig(String subject) throws IOException, RestClientException {
     restService.deleteConfig(subject);
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -16,6 +16,7 @@
 
 package io.confluent.kafka.schemaregistry.client;
 
+import io.confluent.kafka.schemaregistry.client.rest.entities.Config;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet;
 import java.io.IOException;
@@ -202,12 +203,29 @@ public interface SchemaRegistryClient extends SchemaVersionFetcher {
     throw new UnsupportedOperationException();
   }
 
-  public String updateCompatibility(String subject, String compatibility)
-      throws IOException, RestClientException;
+  default String updateCompatibility(String subject, String compatibility)
+      throws IOException, RestClientException {
+    return updateConfig(subject, new Config(compatibility)).getCompatibilityLevel();
+  }
 
-  public String getCompatibility(String subject) throws IOException, RestClientException;
+  default String getCompatibility(String subject) throws IOException, RestClientException {
+    return getConfig(subject).getCompatibilityLevel();
+  }
 
   default void deleteCompatibility(String subject) throws IOException, RestClientException {
+    deleteConfig(subject);
+  }
+
+  default Config updateConfig(String subject, Config config)
+      throws IOException, RestClientException {
+    throw new UnsupportedOperationException();
+  }
+
+  default Config getConfig(String subject) throws IOException, RestClientException {
+    throw new UnsupportedOperationException();
+  }
+
+  default void deleteConfig(String subject) throws IOException, RestClientException {
     throw new UnsupportedOperationException();
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Config.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Config.java
@@ -31,18 +31,24 @@ public class Config {
 
   private String compatibilityLevel;
   private String compatibilityGroup;
-  private Metadata metadataOverride;
-  private RuleSet ruleSetOverride;
+  private Metadata initialMetadata;
+  private Metadata finalMetadata;
+  private RuleSet initialRuleSet;
+  private RuleSet finalRuleSet;
 
   @JsonCreator
   public Config(@JsonProperty("compatibilityLevel") String compatibilityLevel,
                 @JsonProperty("compatibilityGroup") String compatibilityGroup,
-                @JsonProperty("metadataOverride") Metadata metadataOverride,
-                @JsonProperty("ruleSetOverride") RuleSet ruleSetOverride) {
+                @JsonProperty("initialMetadata") Metadata initialMetadata,
+                @JsonProperty("finalMetadata") Metadata finalMetadata,
+                @JsonProperty("initialRuleSet") RuleSet initialRuleSet,
+                @JsonProperty("finalRuleSet") RuleSet finalRuleSet) {
     this.compatibilityLevel = compatibilityLevel;
     this.compatibilityGroup = compatibilityGroup;
-    this.metadataOverride = metadataOverride;
-    this.ruleSetOverride = ruleSetOverride;
+    this.initialMetadata = initialMetadata;
+    this.finalMetadata = finalMetadata;
+    this.initialRuleSet = initialRuleSet;
+    this.finalRuleSet = finalRuleSet;
   }
 
   public Config(@JsonProperty("compatibilityLevel") String compatibilityLevel) {
@@ -55,8 +61,10 @@ public class Config {
   public Config(ConfigUpdateRequest request) {
     this.compatibilityLevel = request.getCompatibilityLevel();
     this.compatibilityGroup = request.getCompatibilityGroup();
-    this.metadataOverride = request.getMetadataOverride();
-    this.ruleSetOverride = request.getRuleSetOverride();
+    this.initialMetadata = request.getInitialMetadata();
+    this.finalMetadata = request.getInitialMetadata();
+    this.initialRuleSet = request.getInitialRuleSet();
+    this.finalRuleSet = request.getFinalRuleSet();
   }
 
   @Schema(description = "Compatibility Level",
@@ -83,24 +91,44 @@ public class Config {
     this.compatibilityGroup = compatibilityGroup;
   }
 
-  @JsonProperty("metadataOverride")
-  public Metadata getMetadataOverride() {
-    return this.metadataOverride;
+  @JsonProperty("initialMetadata")
+  public Metadata getInitialMetadata() {
+    return this.initialMetadata;
   }
 
-  @JsonProperty("metadataOverride")
-  public void setMetadataOverride(Metadata metadataOverride) {
-    this.metadataOverride = metadataOverride;
+  @JsonProperty("initialMetadata")
+  public void setInitialMetadata(Metadata initialMetadata) {
+    this.initialMetadata = initialMetadata;
   }
 
-  @JsonProperty("ruleSetOverride")
-  public RuleSet getRuleSetOverride() {
-    return this.ruleSetOverride;
+  @JsonProperty("finalMetadata")
+  public Metadata getFinalMetadata() {
+    return this.finalMetadata;
   }
 
-  @JsonProperty("ruleSetOverride")
-  public void setRuleSetOverride(RuleSet ruleSetOverride) {
-    this.ruleSetOverride = ruleSetOverride;
+  @JsonProperty("finalMetadata")
+  public void setFinalMetadata(Metadata finalMetadata) {
+    this.finalMetadata = finalMetadata;
+  }
+
+  @JsonProperty("initialRuleSet")
+  public RuleSet getInitialRuleSet() {
+    return this.initialRuleSet;
+  }
+
+  @JsonProperty("initialRuleSet")
+  public void setInitialRuleSet(RuleSet initialRuleSet) {
+    this.initialRuleSet = initialRuleSet;
+  }
+
+  @JsonProperty("finalRuleSet")
+  public RuleSet getFinalRuleSet() {
+    return this.finalRuleSet;
+  }
+
+  @JsonProperty("finalRuleSet")
+  public void setFinalRuleSet(RuleSet finalRuleSet) {
+    this.finalRuleSet = finalRuleSet;
   }
 
   @Override
@@ -114,13 +142,16 @@ public class Config {
     Config config = (Config) o;
     return Objects.equals(compatibilityLevel, config.compatibilityLevel)
         && Objects.equals(compatibilityGroup, config.compatibilityGroup)
-        && Objects.equals(metadataOverride, config.metadataOverride)
-        && Objects.equals(ruleSetOverride, config.ruleSetOverride);
+        && Objects.equals(initialMetadata, config.initialMetadata)
+        && Objects.equals(finalMetadata, config.finalMetadata)
+        && Objects.equals(initialRuleSet, config.initialRuleSet)
+        && Objects.equals(finalRuleSet, config.finalRuleSet);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(compatibilityLevel, compatibilityGroup, metadataOverride, ruleSetOverride);
+    return Objects.hash(compatibilityLevel, compatibilityGroup,
+        initialMetadata, finalMetadata, initialRuleSet, finalRuleSet);
   }
 
   @Override
@@ -128,8 +159,10 @@ public class Config {
     return "Config{"
         + "compatibilityLevel='" + compatibilityLevel + '\''
         + ", compatibilityGroup='" + compatibilityGroup + '\''
-        + ", metadataOverride=" + metadataOverride
-        + ", ruleSetOverride=" + ruleSetOverride
+        + ", initialMetadata=" + initialMetadata
+        + ", finalMetadata=" + finalMetadata
+        + ", initialRuleSet=" + initialRuleSet
+        + ", finalRuleSet=" + finalRuleSet
         + '}';
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Config.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Config.java
@@ -16,6 +16,7 @@
 
 package io.confluent.kafka.schemaregistry.client.rest.entities;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -31,6 +32,17 @@ public class Config {
   private String compatibilityGroup;
   private Metadata metadataOverride;
   private RuleSet ruleSetOverride;
+
+  @JsonCreator
+  public Config(@JsonProperty("compatibilityLevel") String compatibilityLevel,
+                @JsonProperty("compatibilityGroup") String compatibilityGroup,
+                @JsonProperty("metadataOverride") Metadata metadataOverride,
+                @JsonProperty("ruleSetOverride") RuleSet ruleSetOverride) {
+    this.compatibilityLevel = compatibilityLevel;
+    this.compatibilityGroup = compatibilityGroup;
+    this.metadataOverride = metadataOverride;
+    this.ruleSetOverride = ruleSetOverride;
+  }
 
   public Config(@JsonProperty("compatibilityLevel") String compatibilityLevel) {
     this.compatibilityLevel = compatibilityLevel;
@@ -106,11 +118,11 @@ public class Config {
 
   @Override
   public String toString() {
-    return "Config{" +
-        "compatibilityLevel='" + compatibilityLevel + '\'' +
-        ", compatibilityGroup='" + compatibilityGroup + '\'' +
-        ", metadataOverride=" + metadataOverride +
-        ", ruleSetOverride=" + ruleSetOverride +
-        '}';
+    return "Config{"
+        + "compatibilityLevel='" + compatibilityLevel + '\''
+        + ", compatibilityGroup='" + compatibilityGroup + '\''
+        + ", metadataOverride=" + metadataOverride
+        + ", ruleSetOverride=" + ruleSetOverride
+        + '}';
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Config.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Config.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.ConfigUpdateRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Objects;
 
@@ -49,7 +50,13 @@ public class Config {
   }
 
   public Config() {
-    compatibilityLevel = null;
+  }
+
+  public Config(ConfigUpdateRequest request) {
+    this.compatibilityLevel = request.getCompatibilityLevel();
+    this.compatibilityGroup = request.getCompatibilityGroup();
+    this.metadataOverride = request.getMetadataOverride();
+    this.ruleSetOverride = request.getRuleSetOverride();
   }
 
   @Schema(description = "Compatibility Level",

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Config.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Config.java
@@ -29,8 +29,8 @@ public class Config {
 
   private String compatibilityLevel;
   private String compatibilityGroup;
-  private Metadata defaultMetadata;
-  private RuleSet defaultRuleSet;
+  private Metadata metadataOverride;
+  private RuleSet ruleSetOverride;
 
   public Config(@JsonProperty("compatibilityLevel") String compatibilityLevel) {
     this.compatibilityLevel = compatibilityLevel;
@@ -64,24 +64,24 @@ public class Config {
     this.compatibilityGroup = compatibilityGroup;
   }
 
-  @JsonProperty("defaultMetadata")
-  public Metadata getDefaultMetadata() {
-    return this.defaultMetadata;
+  @JsonProperty("metadataOverride")
+  public Metadata getMetadataOverride() {
+    return this.metadataOverride;
   }
 
-  @JsonProperty("defaultMetadata")
-  public void setDefaultMetadata(Metadata defaultMetadata) {
-    this.defaultMetadata = defaultMetadata;
+  @JsonProperty("metadataOverride")
+  public void setMetadataOverride(Metadata metadataOverride) {
+    this.metadataOverride = metadataOverride;
   }
 
-  @JsonProperty("defaultRuleSet")
-  public RuleSet getDefaultRuleSet() {
-    return this.defaultRuleSet;
+  @JsonProperty("ruleSetOverride")
+  public RuleSet getRuleSetOverride() {
+    return this.ruleSetOverride;
   }
 
-  @JsonProperty("defaultRuleSet")
-  public void setDefaultRuleSet(RuleSet defaultRuleSet) {
-    this.defaultRuleSet = defaultRuleSet;
+  @JsonProperty("ruleSetOverride")
+  public void setRuleSetOverride(RuleSet ruleSetOverride) {
+    this.ruleSetOverride = ruleSetOverride;
   }
 
   @Override
@@ -95,13 +95,13 @@ public class Config {
     Config config = (Config) o;
     return Objects.equals(compatibilityLevel, config.compatibilityLevel)
         && Objects.equals(compatibilityGroup, config.compatibilityGroup)
-        && Objects.equals(defaultMetadata, config.defaultMetadata)
-        && Objects.equals(defaultRuleSet, config.defaultRuleSet);
+        && Objects.equals(metadataOverride, config.metadataOverride)
+        && Objects.equals(ruleSetOverride, config.ruleSetOverride);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(compatibilityLevel, compatibilityGroup, defaultMetadata, defaultRuleSet);
+    return Objects.hash(compatibilityLevel, compatibilityGroup, metadataOverride, ruleSetOverride);
   }
 
   @Override
@@ -109,8 +109,8 @@ public class Config {
     return "Config{" +
         "compatibilityLevel='" + compatibilityLevel + '\'' +
         ", compatibilityGroup='" + compatibilityGroup + '\'' +
-        ", defaultMetadata=" + defaultMetadata +
-        ", defaultRuleSet=" + defaultRuleSet +
+        ", metadataOverride=" + metadataOverride +
+        ", ruleSetOverride=" + ruleSetOverride +
         '}';
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Config.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Config.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -27,6 +28,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public class Config {
 
   private String compatibilityLevel;
+  private String compatibilityGroup;
+  private Metadata defaultMetadata;
+  private RuleSet defaultRuleSet;
 
   public Config(@JsonProperty("compatibilityLevel") String compatibilityLevel) {
     this.compatibilityLevel = compatibilityLevel;
@@ -50,6 +54,36 @@ public class Config {
     this.compatibilityLevel = compatibilityLevel;
   }
 
+  @JsonProperty("compatibilityGroup")
+  public String getCompatibilityGroup() {
+    return this.compatibilityGroup;
+  }
+
+  @JsonProperty("compatibilityGroup")
+  public void setCompatibilityGroup(String compatibilityGroup) {
+    this.compatibilityGroup = compatibilityGroup;
+  }
+
+  @JsonProperty("defaultMetadata")
+  public Metadata getDefaultMetadata() {
+    return this.defaultMetadata;
+  }
+
+  @JsonProperty("defaultMetadata")
+  public void setDefaultMetadata(Metadata defaultMetadata) {
+    this.defaultMetadata = defaultMetadata;
+  }
+
+  @JsonProperty("defaultRuleSet")
+  public RuleSet getDefaultRuleSet() {
+    return this.defaultRuleSet;
+  }
+
+  @JsonProperty("defaultRuleSet")
+  public void setDefaultRuleSet(RuleSet defaultRuleSet) {
+    this.defaultRuleSet = defaultRuleSet;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -58,19 +92,25 @@ public class Config {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
-    Config that = (Config) o;
-
-    return this.compatibilityLevel.equals(that.compatibilityLevel);
+    Config config = (Config) o;
+    return Objects.equals(compatibilityLevel, config.compatibilityLevel)
+        && Objects.equals(compatibilityGroup, config.compatibilityGroup)
+        && Objects.equals(defaultMetadata, config.defaultMetadata)
+        && Objects.equals(defaultRuleSet, config.defaultRuleSet);
   }
 
   @Override
   public int hashCode() {
-    return 31 * compatibilityLevel.hashCode();
+    return Objects.hash(compatibilityLevel, compatibilityGroup, defaultMetadata, defaultRuleSet);
   }
 
   @Override
   public String toString() {
-    return "{compatibilityLevel=" + this.compatibilityLevel + "}";
+    return "Config{" +
+        "compatibilityLevel='" + compatibilityLevel + '\'' +
+        ", compatibilityGroup='" + compatibilityGroup + '\'' +
+        ", defaultMetadata=" + defaultMetadata +
+        ", defaultRuleSet=" + defaultRuleSet +
+        '}';
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/ConfigUpdateRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/ConfigUpdateRequest.java
@@ -35,8 +35,10 @@ public class ConfigUpdateRequest {
 
   private String compatibilityLevel;
   private String compatibilityGroup;
-  private Metadata metadataOverride;
-  private RuleSet ruleSetOverride;
+  private Metadata initialMetadata;
+  private Metadata finalMetadata;
+  private RuleSet initialRuleSet;
+  private RuleSet finalRuleSet;
 
   public ConfigUpdateRequest() {
   }
@@ -44,8 +46,10 @@ public class ConfigUpdateRequest {
   public ConfigUpdateRequest(Config config) {
     this.compatibilityLevel = config.getCompatibilityLevel();
     this.compatibilityGroup = config.getCompatibilityGroup();
-    this.metadataOverride = config.getMetadataOverride();
-    this.ruleSetOverride = config.getRuleSetOverride();
+    this.initialMetadata = config.getInitialMetadata();
+    this.finalMetadata = config.getFinalMetadata();
+    this.initialRuleSet = config.getInitialRuleSet();
+    this.finalRuleSet = config.getFinalRuleSet();
   }
 
   public static ConfigUpdateRequest fromJson(String json) throws IOException {
@@ -76,24 +80,44 @@ public class ConfigUpdateRequest {
     this.compatibilityGroup = compatibilityGroup;
   }
 
-  @JsonProperty("metadataOverride")
-  public Metadata getMetadataOverride() {
-    return this.metadataOverride;
+  @JsonProperty("initialMetadata")
+  public Metadata getInitialMetadata() {
+    return this.initialMetadata;
   }
 
-  @JsonProperty("metadataOverride")
-  public void setMetadataOverride(Metadata metadataOverride) {
-    this.metadataOverride = metadataOverride;
+  @JsonProperty("initialMetadata")
+  public void setInitialMetadata(Metadata initialMetadata) {
+    this.initialMetadata = initialMetadata;
   }
 
-  @JsonProperty("ruleSetOverride")
-  public RuleSet getRuleSetOverride() {
-    return this.ruleSetOverride;
+  @JsonProperty("finalMetadata")
+  public Metadata getFinalMetadata() {
+    return this.finalMetadata;
   }
 
-  @JsonProperty("ruleSetOverride")
-  public void setRuleSetOverride(RuleSet ruleSetOverride) {
-    this.ruleSetOverride = ruleSetOverride;
+  @JsonProperty("finalMetadata")
+  public void setFinalMetadata(Metadata finalMetadata) {
+    this.finalMetadata = finalMetadata;
+  }
+
+  @JsonProperty("initialRuleSet")
+  public RuleSet getInitialRuleSet() {
+    return this.initialRuleSet;
+  }
+
+  @JsonProperty("initialRuleSet")
+  public void setInitialRuleSet(RuleSet initialRuleSet) {
+    this.initialRuleSet = initialRuleSet;
+  }
+
+  @JsonProperty("finalRuleSet")
+  public RuleSet getFinalRuleSet() {
+    return this.finalRuleSet;
+  }
+
+  @JsonProperty("finalRuleSet")
+  public void setFinalRuleSet(RuleSet finalRuleSet) {
+    this.finalRuleSet = finalRuleSet;
   }
 
   public String toJson() throws IOException {
@@ -111,12 +135,15 @@ public class ConfigUpdateRequest {
     ConfigUpdateRequest that = (ConfigUpdateRequest) o;
     return Objects.equals(compatibilityLevel, that.compatibilityLevel)
         && Objects.equals(compatibilityGroup, that.compatibilityGroup)
-        && Objects.equals(metadataOverride, that.metadataOverride)
-        && Objects.equals(ruleSetOverride, that.ruleSetOverride);
+        && Objects.equals(initialMetadata, that.initialMetadata)
+        && Objects.equals(finalMetadata, that.finalMetadata)
+        && Objects.equals(initialRuleSet, that.initialRuleSet)
+        && Objects.equals(finalRuleSet, that.finalRuleSet);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(compatibilityLevel, compatibilityGroup, metadataOverride, ruleSetOverride);
+    return Objects.hash(compatibilityLevel, compatibilityGroup,
+        initialMetadata, finalMetadata, initialRuleSet, finalRuleSet);
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/ConfigUpdateRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/ConfigUpdateRequest.java
@@ -19,6 +19,8 @@ package io.confluent.kafka.schemaregistry.client.rest.entities.requests;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
+import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet;
 import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -31,6 +33,9 @@ import java.util.Objects;
 public class ConfigUpdateRequest {
 
   private String compatibilityLevel;
+  private String compatibilityGroup;
+  private Metadata defaultMetadata;
+  private RuleSet defaultRuleSet;
 
   public static ConfigUpdateRequest fromJson(String json) throws IOException {
     return JacksonMapper.INSTANCE.readValue(json, ConfigUpdateRequest.class);
@@ -50,6 +55,36 @@ public class ConfigUpdateRequest {
     this.compatibilityLevel = compatibilityLevel;
   }
 
+  @JsonProperty("compatibilityGroup")
+  public String getCompatibilityGroup() {
+    return this.compatibilityGroup;
+  }
+
+  @JsonProperty("compatibilityGroup")
+  public void setCompatibilityGroup(String compatibilityGroup) {
+    this.compatibilityGroup = compatibilityGroup;
+  }
+
+  @JsonProperty("defaultMetadata")
+  public Metadata getDefaultMetadata() {
+    return this.defaultMetadata;
+  }
+
+  @JsonProperty("defaultMetadata")
+  public void setDefaultMetadata(Metadata defaultMetadata) {
+    this.defaultMetadata = defaultMetadata;
+  }
+
+  @JsonProperty("defaultRuleSet")
+  public RuleSet getDefaultRuleSet() {
+    return this.defaultRuleSet;
+  }
+
+  @JsonProperty("defaultRuleSet")
+  public void setDefaultRuleSet(RuleSet defaultRuleSet) {
+    this.defaultRuleSet = defaultRuleSet;
+  }
+
   public String toJson() throws IOException {
     return JacksonMapper.INSTANCE.writeValueAsString(this);
   }
@@ -63,11 +98,14 @@ public class ConfigUpdateRequest {
       return false;
     }
     ConfigUpdateRequest that = (ConfigUpdateRequest) o;
-    return Objects.equals(compatibilityLevel, that.compatibilityLevel);
+    return Objects.equals(compatibilityLevel, that.compatibilityLevel)
+        && Objects.equals(compatibilityGroup, that.compatibilityGroup)
+        && Objects.equals(defaultMetadata, that.defaultMetadata)
+        && Objects.equals(defaultRuleSet, that.defaultRuleSet);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(compatibilityLevel);
+    return Objects.hash(compatibilityLevel, compatibilityGroup, defaultMetadata, defaultRuleSet);
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/ConfigUpdateRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/ConfigUpdateRequest.java
@@ -34,8 +34,8 @@ public class ConfigUpdateRequest {
 
   private String compatibilityLevel;
   private String compatibilityGroup;
-  private Metadata defaultMetadata;
-  private RuleSet defaultRuleSet;
+  private Metadata metadataOverride;
+  private RuleSet ruleSetOverride;
 
   public static ConfigUpdateRequest fromJson(String json) throws IOException {
     return JacksonMapper.INSTANCE.readValue(json, ConfigUpdateRequest.class);
@@ -65,24 +65,24 @@ public class ConfigUpdateRequest {
     this.compatibilityGroup = compatibilityGroup;
   }
 
-  @JsonProperty("defaultMetadata")
-  public Metadata getDefaultMetadata() {
-    return this.defaultMetadata;
+  @JsonProperty("metadataOverride")
+  public Metadata getMetadataOverride() {
+    return this.metadataOverride;
   }
 
-  @JsonProperty("defaultMetadata")
-  public void setDefaultMetadata(Metadata defaultMetadata) {
-    this.defaultMetadata = defaultMetadata;
+  @JsonProperty("metadataOverride")
+  public void setMetadataOverride(Metadata metadataOverride) {
+    this.metadataOverride = metadataOverride;
   }
 
-  @JsonProperty("defaultRuleSet")
-  public RuleSet getDefaultRuleSet() {
-    return this.defaultRuleSet;
+  @JsonProperty("ruleSetOverride")
+  public RuleSet getRuleSetOverride() {
+    return this.ruleSetOverride;
   }
 
-  @JsonProperty("defaultRuleSet")
-  public void setDefaultRuleSet(RuleSet defaultRuleSet) {
-    this.defaultRuleSet = defaultRuleSet;
+  @JsonProperty("ruleSetOverride")
+  public void setRuleSetOverride(RuleSet ruleSetOverride) {
+    this.ruleSetOverride = ruleSetOverride;
   }
 
   public String toJson() throws IOException {
@@ -100,12 +100,12 @@ public class ConfigUpdateRequest {
     ConfigUpdateRequest that = (ConfigUpdateRequest) o;
     return Objects.equals(compatibilityLevel, that.compatibilityLevel)
         && Objects.equals(compatibilityGroup, that.compatibilityGroup)
-        && Objects.equals(defaultMetadata, that.defaultMetadata)
-        && Objects.equals(defaultRuleSet, that.defaultRuleSet);
+        && Objects.equals(metadataOverride, that.metadataOverride)
+        && Objects.equals(ruleSetOverride, that.ruleSetOverride);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(compatibilityLevel, compatibilityGroup, defaultMetadata, defaultRuleSet);
+    return Objects.hash(compatibilityLevel, compatibilityGroup, metadataOverride, ruleSetOverride);
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/ConfigUpdateRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/ConfigUpdateRequest.java
@@ -19,6 +19,7 @@ package io.confluent.kafka.schemaregistry.client.rest.entities.requests;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Config;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet;
 import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
@@ -36,6 +37,16 @@ public class ConfigUpdateRequest {
   private String compatibilityGroup;
   private Metadata metadataOverride;
   private RuleSet ruleSetOverride;
+
+  public ConfigUpdateRequest() {
+  }
+
+  public ConfigUpdateRequest(Config config) {
+    this.compatibilityLevel = config.getCompatibilityLevel();
+    this.compatibilityGroup = config.getCompatibilityGroup();
+    this.metadataOverride = config.getMetadataOverride();
+    this.ruleSetOverride = config.getRuleSetOverride();
+  }
 
   public static ConfigUpdateRequest fromJson(String json) throws IOException {
     return JacksonMapper.INSTANCE.readValue(json, ConfigUpdateRequest.class);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
@@ -145,7 +145,7 @@ public class ConfigValue extends SubjectValue {
     );
   }
 
-  public static ConfigValue merge(ConfigValue oldConfig, ConfigValue newConfig) {
+  public static ConfigValue update(ConfigValue oldConfig, ConfigValue newConfig) {
     if (oldConfig == null) {
       return newConfig;
     }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
@@ -30,31 +30,43 @@ public class ConfigValue extends SubjectValue {
 
   private CompatibilityLevel compatibilityLevel;
   private String compatibilityGroup;
-  private Metadata metadataOverride;
-  private RuleSet ruleSetOverride;
+  private Metadata initialMetadata;
+  private Metadata finalMetadata;
+  private RuleSet initialRuleSet;
+  private RuleSet finalRuleSet;
 
   public ConfigValue(@JsonProperty("subject") String subject,
                      @JsonProperty("compatibilityLevel") CompatibilityLevel compatibilityLevel,
                      @JsonProperty("compatibilityGroup") String compatibilityGroup,
-                     @JsonProperty("metadataOverride") Metadata metadataOverride,
-                     @JsonProperty("ruleSetOverride") RuleSet ruleSetOverride) {
+                     @JsonProperty("initialMetadata") Metadata initialMetadata,
+                     @JsonProperty("finalMetadata") Metadata finalMetadata,
+                     @JsonProperty("initialRuleSet") RuleSet initialRuleSet,
+                     @JsonProperty("finalRuleSet") RuleSet finalRuleSet) {
     super(subject);
     this.compatibilityLevel = compatibilityLevel;
     this.compatibilityGroup = compatibilityGroup;
-    this.metadataOverride = metadataOverride;
-    this.ruleSetOverride = ruleSetOverride;
+    this.initialMetadata = initialMetadata;
+    this.finalMetadata = finalMetadata;
+    this.initialRuleSet = initialRuleSet;
+    this.finalRuleSet = finalRuleSet;
   }
 
   public ConfigValue(String subject, Config configEntity) {
     super(subject);
     this.compatibilityLevel = CompatibilityLevel.forName(configEntity.getCompatibilityLevel());
     this.compatibilityGroup = configEntity.getCompatibilityGroup();
-    io.confluent.kafka.schemaregistry.client.rest.entities.Metadata metadata =
-        configEntity.getMetadataOverride();
-    this.metadataOverride = metadata != null ? new Metadata(metadata) : null;
-    io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet ruleSet =
-        configEntity.getRuleSetOverride();
-    this.ruleSetOverride = ruleSet != null ? new RuleSet(ruleSet) : null;
+    io.confluent.kafka.schemaregistry.client.rest.entities.Metadata initialMetadata =
+        configEntity.getInitialMetadata();
+    this.initialMetadata = initialMetadata != null ? new Metadata(initialMetadata) : null;
+    io.confluent.kafka.schemaregistry.client.rest.entities.Metadata finalMetadata =
+        configEntity.getFinalMetadata();
+    this.finalMetadata = finalMetadata != null ? new Metadata(finalMetadata) : null;
+    io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet initialRuleSet =
+        configEntity.getInitialRuleSet();
+    this.initialRuleSet = initialRuleSet != null ? new RuleSet(initialRuleSet) : null;
+    io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet finalRuleSet =
+        configEntity.getFinalRuleSet();
+    this.finalRuleSet = finalRuleSet != null ? new RuleSet(finalRuleSet) : null;
   }
 
   @JsonProperty("compatibilityLevel")
@@ -77,24 +89,44 @@ public class ConfigValue extends SubjectValue {
     this.compatibilityGroup = compatibilityGroup;
   }
 
-  @JsonProperty("metadataOverride")
-  public Metadata getMetadataOverride() {
-    return this.metadataOverride;
+  @JsonProperty("initialMetadata")
+  public Metadata getInitialMetadata() {
+    return this.initialMetadata;
   }
 
-  @JsonProperty("metadataOverride")
-  public void setMetadataOverride(Metadata metadataOverride) {
-    this.metadataOverride = metadataOverride;
+  @JsonProperty("initialMetadata")
+  public void setInitialMetadata(Metadata initialMetadata) {
+    this.initialMetadata = initialMetadata;
   }
 
-  @JsonProperty("ruleSetOverride")
-  public RuleSet getRuleSetOverride() {
-    return this.ruleSetOverride;
+  @JsonProperty("finalMetadata")
+  public Metadata getFinalMetadata() {
+    return this.finalMetadata;
   }
 
-  @JsonProperty("ruleSetOverride")
-  public void setRuleSetOverride(RuleSet ruleSetOverride) {
-    this.ruleSetOverride = ruleSetOverride;
+  @JsonProperty("finalMetadata")
+  public void setFinalMetadata(Metadata finalMetadata) {
+    this.finalMetadata = finalMetadata;
+  }
+
+  @JsonProperty("initialRuleSet")
+  public RuleSet getInitialRuleSet() {
+    return this.initialRuleSet;
+  }
+
+  @JsonProperty("initialRuleSet")
+  public void setInitialRuleSet(RuleSet initialRuleSet) {
+    this.initialRuleSet = initialRuleSet;
+  }
+
+  @JsonProperty("finalRuleSet")
+  public RuleSet getfinalRuleSet() {
+    return this.finalRuleSet;
+  }
+
+  @JsonProperty("finalRuleSet")
+  public void setfinalRuleSet(RuleSet finalRuleSet) {
+    this.finalRuleSet = finalRuleSet;
   }
 
   @Override
@@ -111,14 +143,16 @@ public class ConfigValue extends SubjectValue {
     ConfigValue that = (ConfigValue) o;
     return compatibilityLevel == that.compatibilityLevel
         && Objects.equals(compatibilityGroup, that.compatibilityGroup)
-        && Objects.equals(metadataOverride, that.metadataOverride)
-        && Objects.equals(ruleSetOverride, that.ruleSetOverride);
+        && Objects.equals(initialMetadata, that.initialMetadata)
+        && Objects.equals(finalMetadata, that.finalMetadata)
+        && Objects.equals(initialRuleSet, that.initialRuleSet)
+        && Objects.equals(finalRuleSet, that.finalRuleSet);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), compatibilityLevel, compatibilityGroup, metadataOverride,
-        ruleSetOverride);
+    return Objects.hash(super.hashCode(), compatibilityLevel, compatibilityGroup,
+        initialMetadata, finalMetadata, initialRuleSet, finalRuleSet);
   }
 
   @Override
@@ -126,8 +160,10 @@ public class ConfigValue extends SubjectValue {
     return "ConfigValue{"
         + "compatibilityLevel=" + compatibilityLevel
         + ", compatibilityGroup='" + compatibilityGroup + '\''
-        + ", metadataOverride=" + metadataOverride
-        + ", ruleSetOverride=" + ruleSetOverride
+        + ", initialMetadata=" + initialMetadata
+        + ", finalMetadata=" + finalMetadata
+        + ", initialRuleSet=" + initialRuleSet
+        + ", finalRuleSet=" + finalRuleSet
         + '}';
   }
 
@@ -140,19 +176,19 @@ public class ConfigValue extends SubjectValue {
     return new Config(
         compatibilityLevel != null ? compatibilityLevel.name : null,
         compatibilityGroup,
-        metadataOverride != null ? metadataOverride.toMetadataEntity() : null,
-        ruleSetOverride != null ? ruleSetOverride.toRuleSetEntity() : null
+        initialMetadata != null ? initialMetadata.toMetadataEntity() : null,
+        finalMetadata != null ? finalMetadata.toMetadataEntity() : null,
+        initialRuleSet != null ? initialRuleSet.toRuleSetEntity() : null,
+        finalRuleSet != null ? finalRuleSet.toRuleSetEntity() : null
     );
   }
 
   public static ConfigValue update(ConfigValue oldConfig, ConfigValue newConfig) {
     if (oldConfig == null) {
       return newConfig;
-    }
-    else if (newConfig == null) {
+    } else if (newConfig == null) {
       return oldConfig;
-    }
-    else {
+    } else {
       return new ConfigValue(
           newConfig.getSubject() != null
               ? newConfig.getSubject() : oldConfig.getSubject(),
@@ -160,10 +196,14 @@ public class ConfigValue extends SubjectValue {
               ? newConfig.getCompatibilityLevel() : oldConfig.getCompatibilityLevel(),
           newConfig.getCompatibilityGroup() != null
               ? newConfig.getCompatibilityGroup() : oldConfig.getCompatibilityGroup(),
-          newConfig.getMetadataOverride() != null
-              ? newConfig.getMetadataOverride() : oldConfig.getMetadataOverride(),
-          newConfig.getRuleSetOverride() != null
-              ? newConfig.getRuleSetOverride() : oldConfig.getRuleSetOverride()
+          newConfig.getInitialMetadata() != null
+              ? newConfig.getInitialMetadata() : oldConfig.getInitialMetadata(),
+          newConfig.getFinalMetadata() != null
+              ? newConfig.getFinalMetadata() : oldConfig.getFinalMetadata(),
+          newConfig.getInitialRuleSet() != null
+              ? newConfig.getInitialRuleSet() : oldConfig.getInitialRuleSet(),
+          newConfig.getfinalRuleSet() != null
+              ? newConfig.getfinalRuleSet() : oldConfig.getfinalRuleSet()
       );
     }
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
@@ -146,17 +146,25 @@ public class ConfigValue extends SubjectValue {
   }
 
   public static ConfigValue merge(ConfigValue oldConfig, ConfigValue newConfig) {
-    return new ConfigValue(
-        newConfig.getSubject() != null
-            ? newConfig.getSubject() : oldConfig.getSubject(),
-        newConfig.getCompatibilityLevel() != null
-            ? newConfig.getCompatibilityLevel() : oldConfig.getCompatibilityLevel(),
-        newConfig.getCompatibilityGroup() != null
-            ? newConfig.getCompatibilityGroup() : oldConfig.getCompatibilityGroup(),
-        newConfig.getMetadataOverride() != null
-            ? newConfig.getMetadataOverride() : oldConfig.getMetadataOverride(),
-        newConfig.getRuleSetOverride() != null
-            ? newConfig.getRuleSetOverride() : oldConfig.getRuleSetOverride()
-    );
+    if (oldConfig == null) {
+      return newConfig;
+    }
+    else if (newConfig == null) {
+      return oldConfig;
+    }
+    else {
+      return new ConfigValue(
+          newConfig.getSubject() != null
+              ? newConfig.getSubject() : oldConfig.getSubject(),
+          newConfig.getCompatibilityLevel() != null
+              ? newConfig.getCompatibilityLevel() : oldConfig.getCompatibilityLevel(),
+          newConfig.getCompatibilityGroup() != null
+              ? newConfig.getCompatibilityGroup() : oldConfig.getCompatibilityGroup(),
+          newConfig.getMetadataOverride() != null
+              ? newConfig.getMetadataOverride() : oldConfig.getMetadataOverride(),
+          newConfig.getRuleSetOverride() != null
+              ? newConfig.getRuleSetOverride() : oldConfig.getRuleSetOverride()
+      );
+    }
   }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
@@ -69,6 +69,11 @@ public class ConfigValue extends SubjectValue {
     this.finalRuleSet = finalRuleSet != null ? new RuleSet(finalRuleSet) : null;
   }
 
+  public ConfigValue(String subject, CompatibilityLevel compatibilityLevel) {
+    super(subject);
+    this.compatibilityLevel = compatibilityLevel;
+  }
+
   @JsonProperty("compatibilityLevel")
   public CompatibilityLevel getCompatibilityLevel() {
     return compatibilityLevel;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
@@ -143,4 +143,19 @@ public class ConfigValue extends SubjectValue {
         ruleSetOverride != null ? ruleSetOverride.toRuleSetEntity() : null
     );
   }
+
+  public static ConfigValue merge(ConfigValue oldConfig, ConfigValue newConfig) {
+    return new ConfigValue(
+        newConfig.getSubject() != null
+            ? newConfig.getSubject() : oldConfig.getSubject(),
+        newConfig.getCompatibilityLevel() != null
+            ? newConfig.getCompatibilityLevel() : oldConfig.getCompatibilityLevel(),
+        newConfig.getCompatibilityGroup() != null
+            ? newConfig.getCompatibilityGroup() : oldConfig.getCompatibilityGroup(),
+        newConfig.getMetadataOverride() != null
+            ? newConfig.getMetadataOverride() : oldConfig.getMetadataOverride(),
+        newConfig.getRuleSetOverride() != null
+            ? newConfig.getRuleSetOverride() : oldConfig.getRuleSetOverride()
+    );
+  }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
@@ -45,9 +45,16 @@ public class ConfigValue extends SubjectValue {
     this.ruleSetOverride = ruleSetOverride;
   }
 
-  public ConfigValue() {
-    super(null);
-    compatibilityLevel = null;
+  public ConfigValue(String subject, Config configEntity) {
+    super(subject);
+    this.compatibilityLevel = CompatibilityLevel.forName(configEntity.getCompatibilityLevel());
+    this.compatibilityGroup = configEntity.getCompatibilityGroup();
+    io.confluent.kafka.schemaregistry.client.rest.entities.Metadata metadata =
+        configEntity.getMetadataOverride();
+    this.metadataOverride = metadata != null ? new Metadata(metadata) : null;
+    io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet ruleSet =
+        configEntity.getRuleSetOverride();
+    this.ruleSetOverride = ruleSet != null ? new RuleSet(ruleSet) : null;
   }
 
   @JsonProperty("compatibilityLevel")

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
@@ -21,17 +21,28 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.confluent.kafka.schemaregistry.CompatibilityLevel;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Config;
+import java.util.Objects;
 
 @JsonInclude(Include.NON_EMPTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ConfigValue extends SubjectValue {
 
   private CompatibilityLevel compatibilityLevel;
+  private String compatibilityGroup;
+  private Metadata metadataOverride;
+  private RuleSet ruleSetOverride;
 
   public ConfigValue(@JsonProperty("subject") String subject,
-                     @JsonProperty("compatibilityLevel") CompatibilityLevel compatibilityLevel) {
+                     @JsonProperty("compatibilityLevel") CompatibilityLevel compatibilityLevel,
+                     @JsonProperty("compatibilityGroup") String compatibilityGroup,
+                     @JsonProperty("metadataOverride") Metadata metadataOverride,
+                     @JsonProperty("ruleSetOverride") RuleSet ruleSetOverride) {
     super(subject);
     this.compatibilityLevel = compatibilityLevel;
+    this.compatibilityGroup = compatibilityGroup;
+    this.metadataOverride = metadataOverride;
+    this.ruleSetOverride = ruleSetOverride;
   }
 
   public ConfigValue() {
@@ -49,6 +60,36 @@ public class ConfigValue extends SubjectValue {
     this.compatibilityLevel = compatibilityLevel;
   }
 
+  @JsonProperty("compatibilityGroup")
+  public String getCompatibilityGroup() {
+    return this.compatibilityGroup;
+  }
+
+  @JsonProperty("compatibilityGroup")
+  public void setCompatibilityGroup(String compatibilityGroup) {
+    this.compatibilityGroup = compatibilityGroup;
+  }
+
+  @JsonProperty("metadataOverride")
+  public Metadata getMetadataOverride() {
+    return this.metadataOverride;
+  }
+
+  @JsonProperty("metadataOverride")
+  public void setMetadataOverride(Metadata metadataOverride) {
+    this.metadataOverride = metadataOverride;
+  }
+
+  @JsonProperty("ruleSetOverride")
+  public RuleSet getRuleSetOverride() {
+    return this.ruleSetOverride;
+  }
+
+  @JsonProperty("ruleSetOverride")
+  public void setRuleSetOverride(RuleSet ruleSetOverride) {
+    this.ruleSetOverride = ruleSetOverride;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -60,31 +101,39 @@ public class ConfigValue extends SubjectValue {
     if (!super.equals(o)) {
       return false;
     }
-
     ConfigValue that = (ConfigValue) o;
-
-    if (!this.compatibilityLevel.equals(that.compatibilityLevel)) {
-      return false;
-    }
-    return true;
+    return compatibilityLevel == that.compatibilityLevel && Objects.equals(
+        compatibilityGroup, that.compatibilityGroup) && Objects.equals(metadataOverride,
+        that.metadataOverride) && Objects.equals(ruleSetOverride, that.ruleSetOverride);
   }
 
   @Override
   public int hashCode() {
-    int result = super.hashCode();
-    result = 31 * result + compatibilityLevel.hashCode();
-    return result;
+    return Objects.hash(super.hashCode(), compatibilityLevel, compatibilityGroup, metadataOverride,
+        ruleSetOverride);
   }
 
   @Override
   public String toString() {
-    StringBuilder sb = new StringBuilder();
-    sb.append("{compatibilityLevel=" + this.compatibilityLevel + "}");
-    return sb.toString();
+    return "ConfigValue{"
+        + "compatibilityLevel=" + compatibilityLevel
+        + ", compatibilityGroup='" + compatibilityGroup + '\''
+        + ", metadataOverride=" + metadataOverride
+        + ", ruleSetOverride=" + ruleSetOverride
+        + '}';
   }
 
   @Override
   public ConfigKey toKey() {
     return new ConfigKey(getSubject());
+  }
+
+  public Config toConfigEntity() {
+    return new Config(
+        compatibilityLevel != null ? compatibilityLevel.name : null,
+        compatibilityGroup,
+        metadataOverride != null ? metadataOverride.toMetadataEntity() : null,
+        ruleSetOverride != null ? ruleSetOverride.toRuleSetEntity() : null
+    );
   }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
@@ -109,9 +109,10 @@ public class ConfigValue extends SubjectValue {
       return false;
     }
     ConfigValue that = (ConfigValue) o;
-    return compatibilityLevel == that.compatibilityLevel && Objects.equals(
-        compatibilityGroup, that.compatibilityGroup) && Objects.equals(metadataOverride,
-        that.metadataOverride) && Objects.equals(ruleSetOverride, that.ruleSetOverride);
+    return compatibilityLevel == that.compatibilityLevel
+        && Objects.equals(compatibilityGroup, that.compatibilityGroup)
+        && Objects.equals(metadataOverride, that.metadataOverride)
+        && Objects.equals(ruleSetOverride, that.ruleSetOverride);
   }
 
   @Override

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
@@ -15,8 +15,8 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
-import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Config;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreInitializationException;
@@ -238,9 +238,9 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
 
   @Override
   @SuppressWarnings("unchecked")
-  public CompatibilityLevel compatibilityLevel(String subject,
-                                               boolean returnTopLevelIfNotFound,
-                                               CompatibilityLevel defaultForTopLevel
+  public Config config(String subject,
+                       boolean returnTopLevelIfNotFound,
+                       Config defaultForTopLevel
   ) throws StoreException {
     ConfigKey subjectConfigKey = new ConfigKey(subject);
     ConfigValue config = (ConfigValue) get((K) subjectConfigKey);
@@ -248,7 +248,7 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
       return defaultForTopLevel;
     }
     if (config != null) {
-      return config.getCompatibilityLevel();
+      return config.toConfigEntity();
     } else if (returnTopLevelIfNotFound) {
       QualifiedSubject qs = QualifiedSubject.create(tenant(), subject);
       if (qs != null && !DEFAULT_CONTEXT.equals(qs.getContext())) {
@@ -256,7 +256,7 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
       } else {
         config = (ConfigValue) get((K) new ConfigKey(null));
       }
-      return config != null ? config.getCompatibilityLevel() : defaultForTopLevel;
+      return config != null ? config.toConfigEntity() : defaultForTopLevel;
     } else {
       return null;
     }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -1505,7 +1505,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       kafkaStore.waitUntilKafkaReaderReachesLastOffset(subject, kafkaStoreTimeoutMs);
       ConfigValue oldConfig = (ConfigValue) kafkaStore.get(configKey);
       ConfigValue newConfig = new ConfigValue(subject, config);
-      kafkaStore.put(configKey, ConfigValue.merge(oldConfig, newConfig));
+      kafkaStore.put(configKey, ConfigValue.update(oldConfig, newConfig));
       log.debug("Wrote new config : " + config + " to the Kafka data store with key " + configKey);
     } catch (StoreException e) {
       throw new SchemaRegistryStoreException("Failed to write new config value to the store",

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -684,8 +684,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
           if (getMode(subject) != null) {
             deleteMode(subject);
           }
-          if (getCompatibilityLevel(subject) != null) {
-            deleteCompatibility(subject);
+          if (getConfig(subject) != null) {
+            deleteConfig(subject);
           }
         }
       } else {
@@ -758,8 +758,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
         if (getMode(subject) != null) {
           deleteMode(subject);
         }
-        if (getCompatibilityLevel(subject) != null) {
-          deleteCompatibility(subject);
+        if (getConfig(subject) != null) {
+          deleteConfig(subject);
         }
       } else {
         for (Integer version : deletedVersions) {
@@ -933,14 +933,13 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     }
   }
 
-  private void forwardUpdateCompatibilityLevelRequestToLeader(
-      String subject, CompatibilityLevel compatibilityLevel,
+  private void forwardUpdateConfigRequestToLeader(
+      String subject, Config config,
       Map<String, String> headerProperties)
       throws SchemaRegistryRequestForwardingException {
     UrlList baseUrl = leaderRestService.getBaseUrls();
 
-    ConfigUpdateRequest configUpdateRequest = new ConfigUpdateRequest();
-    configUpdateRequest.setCompatibilityLevel(compatibilityLevel.name);
+    ConfigUpdateRequest configUpdateRequest = new ConfigUpdateRequest(config);
     log.debug(String.format("Forwarding update config request %s to %s",
                             configUpdateRequest, baseUrl));
     try {
@@ -997,7 +996,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     }
   }
 
-  private void forwardDeleteCompatibilityConfigToLeader(
+  private void forwardDeleteConfigToLeader(
       Map<String, String> requestProperties,
       String subject
   ) throws SchemaRegistryRequestForwardingException {
@@ -1500,7 +1499,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     }
   }
 
-  public void updateCompatibilityLevel(String subject, CompatibilityLevel newCompatibilityLevel)
+  public void updateConfig(String subject, Config config)
       throws SchemaRegistryStoreException, OperationNotPermittedException, UnknownLeaderException {
     if (isReadOnlyMode(subject)) {
       throw new OperationNotPermittedException("Subject " + subject + " is in read-only mode");
@@ -1508,35 +1507,38 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     ConfigKey configKey = new ConfigKey(subject);
     try {
       kafkaStore.waitUntilKafkaReaderReachesLastOffset(subject, kafkaStoreTimeoutMs);
-      ConfigValue configValue = (ConfigValue) kafkaStore.get(configKey);
+      ConfigValue oldConfig = (ConfigValue) kafkaStore.get(configKey);
+      ConfigValue newConfig = new ConfigValue(subject, config);
       kafkaStore.put(configKey, new ConfigValue(
           subject,
-          newCompatibilityLevel,
-          configValue.getCompatibilityGroup(),
-          configValue.getMetadataOverride(),
-          configValue.getRuleSetOverride())
-      );
-      log.debug("Wrote new compatibility level: " + newCompatibilityLevel.name + " to the"
-                + " Kafka data store with key " + configKey.toString());
+          newConfig.getCompatibilityLevel() != null
+              ? newConfig.getCompatibilityLevel() : oldConfig.getCompatibilityLevel(),
+          newConfig.getCompatibilityGroup() != null
+              ? newConfig.getCompatibilityGroup() : oldConfig.getCompatibilityGroup(),
+          newConfig.getMetadataOverride() != null
+              ? newConfig.getMetadataOverride() : oldConfig.getMetadataOverride(),
+          newConfig.getRuleSetOverride() != null
+              ? newConfig.getRuleSetOverride() : oldConfig.getRuleSetOverride()
+      ));
+      log.debug("Wrote new config : " + config + " to the Kafka data store with key " + configKey);
     } catch (StoreException e) {
       throw new SchemaRegistryStoreException("Failed to write new config value to the store",
                                              e);
     }
   }
 
-  public void updateConfigOrForward(String subject, CompatibilityLevel newCompatibilityLevel,
+  public void updateConfigOrForward(String subject, Config newConfig,
                                     Map<String, String> headerProperties)
       throws SchemaRegistryStoreException, SchemaRegistryRequestForwardingException,
       UnknownLeaderException, OperationNotPermittedException {
     kafkaStore.lockFor(subject).lock();
     try {
       if (isLeader()) {
-        updateCompatibilityLevel(subject, newCompatibilityLevel);
+        updateConfig(subject, newConfig);
       } else {
         // forward update config request to the leader
         if (leaderIdentity != null) {
-          forwardUpdateCompatibilityLevelRequestToLeader(subject, newCompatibilityLevel,
-                                                         headerProperties);
+          forwardUpdateConfigRequestToLeader(subject, newConfig, headerProperties);
         } else {
           throw new UnknownLeaderException("Update config request failed since leader is "
                                            + "unknown");
@@ -1547,32 +1549,32 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     }
   }
 
-  public void deleteCompatibilityConfig(String subject)
+  public void deleteSubjectConfig(String subject)
       throws SchemaRegistryStoreException, OperationNotPermittedException {
     if (isReadOnlyMode(subject)) {
       throw new OperationNotPermittedException("Subject " + subject + " is in read-only mode");
     }
     try {
       kafkaStore.waitUntilKafkaReaderReachesLastOffset(subject, kafkaStoreTimeoutMs);
-      deleteCompatibility(subject);
+      deleteConfig(subject);
     } catch (StoreException e) {
       throw new SchemaRegistryStoreException("Failed to delete subject config value from store",
           e);
     }
   }
 
-  public void deleteCompatibilityConfigOrForward(String subject,
-                                                        Map<String, String> headerProperties)
+  public void deleteConfigOrForward(String subject,
+                                    Map<String, String> headerProperties)
       throws SchemaRegistryStoreException, SchemaRegistryRequestForwardingException,
       OperationNotPermittedException, UnknownLeaderException {
     kafkaStore.lockFor(subject).lock();
     try {
       if (isLeader()) {
-        deleteCompatibilityConfig(subject);
+        deleteSubjectConfig(subject);
       } else {
         // forward delete subject config request to the leader
         if (leaderIdentity != null) {
-          forwardDeleteCompatibilityConfigToLeader(headerProperties, subject);
+          forwardDeleteConfigToLeader(headerProperties, subject);
         } else {
           throw new UnknownLeaderException("Delete config request failed since leader is "
               + "unknown");
@@ -1692,7 +1694,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     this.kafkaStore.delete(modeKey);
   }
 
-  private void deleteCompatibility(String subject) throws StoreException {
+  private void deleteConfig(String subject) throws StoreException {
     ConfigKey configKey = new ConfigKey(subject);
     this.kafkaStore.delete(configKey);
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -1090,11 +1090,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
           Schema schema,
           boolean isNew) throws InvalidSchemaException {
     try {
-      ParsedSchema s = schemaCache.get(new RawSchema(schema, isNew));
-      if (schema.getVersion() != null) {
-        s = s.copy(schema.getVersion());
-      }
-      return s;
+      return schemaCache.get(new RawSchema(schema, isNew));
     } catch (ExecutionException e) {
       Throwable cause = e.getCause();
       if (cause instanceof InvalidSchemaException) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -1090,7 +1090,11 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
           Schema schema,
           boolean isNew) throws InvalidSchemaException {
     try {
-      return schemaCache.get(new RawSchema(schema, isNew));
+      ParsedSchema s = schemaCache.get(new RawSchema(schema, isNew));
+      if (schema.getVersion() != null) {
+        s = s.copy(schema.getVersion());
+      }
+      return s;
     } catch (ExecutionException e) {
       Throwable cause = e.getCause();
       if (cause instanceof InvalidSchemaException) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -1509,17 +1509,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       kafkaStore.waitUntilKafkaReaderReachesLastOffset(subject, kafkaStoreTimeoutMs);
       ConfigValue oldConfig = (ConfigValue) kafkaStore.get(configKey);
       ConfigValue newConfig = new ConfigValue(subject, config);
-      kafkaStore.put(configKey, new ConfigValue(
-          subject,
-          newConfig.getCompatibilityLevel() != null
-              ? newConfig.getCompatibilityLevel() : oldConfig.getCompatibilityLevel(),
-          newConfig.getCompatibilityGroup() != null
-              ? newConfig.getCompatibilityGroup() : oldConfig.getCompatibilityGroup(),
-          newConfig.getMetadataOverride() != null
-              ? newConfig.getMetadataOverride() : oldConfig.getMetadataOverride(),
-          newConfig.getRuleSetOverride() != null
-              ? newConfig.getRuleSetOverride() : oldConfig.getRuleSetOverride()
-      ));
+      kafkaStore.put(configKey, ConfigValue.merge(oldConfig, newConfig));
       log.debug("Wrote new config : " + config + " to the Kafka data store with key " + configKey);
     } catch (StoreException e) {
       throw new SchemaRegistryStoreException("Failed to write new config value to the store",

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupCache.java
@@ -17,6 +17,7 @@ package io.confluent.kafka.schemaregistry.storage;
 
 import static io.confluent.kafka.schemaregistry.storage.SchemaRegistry.DEFAULT_TENANT;
 
+import io.confluent.kafka.schemaregistry.client.rest.entities.Config;
 import java.util.Map;
 import java.util.Set;
 
@@ -107,9 +108,25 @@ public interface LookupCache<K,V> extends Store<K,V> {
    * @param defaultForTopLevel default value for the top level scope
    * @return the compatibility level if found, otherwise null
    */
-  CompatibilityLevel compatibilityLevel(String subject,
-                                        boolean returnTopLevelIfNotFound,
-                                        CompatibilityLevel defaultForTopLevel)
+  default CompatibilityLevel compatibilityLevel(String subject,
+                                                boolean returnTopLevelIfNotFound,
+                                                CompatibilityLevel defaultForTopLevel)
+      throws StoreException {
+    Config config = config(subject, returnTopLevelIfNotFound, new Config(defaultForTopLevel.name));
+    return CompatibilityLevel.forName(config.getCompatibilityLevel());
+  }
+
+  /**
+   * Retrieves the config for a subject.
+   *
+   * @param subject the subject
+   * @param returnTopLevelIfNotFound whether to return the top level scope if not found
+   * @param defaultForTopLevel default value for the top level scope
+   * @return the compatibility level if found, otherwise null
+   */
+  Config config(String subject,
+                boolean returnTopLevelIfNotFound,
+                Config defaultForTopLevel)
       throws StoreException;
 
   /**


### PR DESCRIPTION
Adds the following to the Config entity:
- compatibilityGroup: will be used to group schemas for compatibility checks
- initial/finalMetadata: will be used to override metadata in schemas
- initial/finalRuleSet: will be used to override ruleSets in schemas