### PR TITLE
DGS-5400 Support subjectPrefix containing wildcard context and subject

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/DelegatingIterator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/DelegatingIterator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.storage;
+
+import java.util.Iterator;
+
+class DelegatingIterator<T> implements CloseableIterator<T> {
+
+  private final Iterator<T> iterator;
+
+  public DelegatingIterator(Iterator<T> iterator) {
+    this.iterator = iterator;
+  }
+
+  @Override
+  public boolean hasNext() {
+    return iterator.hasNext();
+  }
+
+  @Override
+  public T next() {
+    return iterator.next();
+  }
+
+  @Override
+  public void remove() {
+    iterator.remove();
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
@@ -393,32 +393,4 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
       return false;
     };
   }
-
-  static class DelegatingIterator<T> implements CloseableIterator<T> {
-
-    private final Iterator<T> iterator;
-
-    public DelegatingIterator(Iterator<T> iterator) {
-      this.iterator = iterator;
-    }
-
-    @Override
-    public boolean hasNext() {
-      return iterator.hasNext();
-    }
-
-    @Override
-    public T next() {
-      return iterator.next();
-    }
-
-    @Override
-    public void remove() {
-      iterator.remove();
-    }
-
-    @Override
-    public void close() {
-    }
-  }
 }


### PR DESCRIPTION
This supports a subjectPrefix such as `:*:mytopic`, which will correspond to `mytopic` in all contexts