### PR TITLE
DGS-3254: Support for separate internal and external certs

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -269,7 +269,9 @@ public class SchemaRegistryConfig extends RestConfig {
           + "<code>StoreUpdateHandler</code> allows you to handle Kafka store update events.";
   protected static final String HOST_DOC =
       "The host name. Make sure to set this if running SchemaRegistry "
-      + "with multiple nodes.";
+      + "with multiple nodes. This name is also used in the endpoint for inter instance "
+      + "communication if inter.instance.listener.name is not specified or does not match "
+      + "any listener ";
   protected static final String SCHEMA_PROVIDERS_DOC =
       "  A list of classes to use as SchemaProvider. Implementing the interface "
           + "<code>SchemaProvider</code> allows you to add custom schema types to Schema Registry.";
@@ -362,17 +364,17 @@ public class SchemaRegistryConfig extends RestConfig {
       "The protocol used while making calls between the instances of schema registry. The follower "
       + "to leader node calls for writes and deletes will use the specified protocol. The default "
       + "value would be `http`. When `https` is set, `ssl.keystore.` and "
-      + "`ssl.truststore.` configs are used while making the call. The "
+      + "`ssl.truststore.` configs are used while making the call. If this config and "
+      + " inter.instance.listener.name are both set, inter.instance.listener.name takes precedence."
       + "schema.registry.inter.instance.protocol name is deprecated; prefer using "
       + "inter.instance.protocol instead.";
   protected static final String INTER_INSTANCE_HEADERS_WHITELIST_DOC
       = "A list of ``http`` headers to forward from follower to leader, "
       + "in addition to ``Content-Type``, ``Accept``, ``Authorization``.";
   protected static final String INTER_INSTANCE_LISTENER_NAME_DOC
-      = "Name of listener used for communication between schema registry instances. If this "
-      + "is unset, the listener name is defined by inter.instance.protocol. If both properties "
+      = "Name of listener used for communication between schema registry instances. If this value "
+      + "is unset, the listener used is defined by inter.instance.protocol. If both properties "
       + "are set at the same time, inter.instance.listener.name takes precedence.";
-
   private static final String COMPATIBILITY_DEFAULT = "backward";
   private static final String METRICS_JMX_PREFIX_DEFAULT_OVERRIDE = "kafka.schema.registry";
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -220,6 +220,8 @@ public class SchemaRegistryConfig extends RestConfig {
       "inter.instance.protocol";
   public static final String INTER_INSTANCE_HEADERS_WHITELIST_CONFIG =
       "inter.instance.headers.whitelist";
+  public static final String INTER_INSTANCE_LISTENER_NAME_CONFIG =
+      "inter.instance.listener.name";
 
   protected static final String SCHEMAREGISTRY_GROUP_ID_DOC =
       "Use this setting to override the group.id for the Kafka group used when Kafka is used for "
@@ -366,6 +368,10 @@ public class SchemaRegistryConfig extends RestConfig {
   protected static final String INTER_INSTANCE_HEADERS_WHITELIST_DOC
       = "A list of ``http`` headers to forward from follower to leader, "
       + "in addition to ``Content-Type``, ``Accept``, ``Authorization``.";
+  protected static final String INTER_INSTANCE_LISTENER_NAME_DOC
+      = "Name of listener used for communication between schema registry instances. If this "
+      + "is unset, the listener name is defined by inter.instance.protocol. If both properties "
+      + "are set at the same time, inter.instance.listener.name takes precedence.";
 
   private static final String COMPATIBILITY_DEFAULT = "backward";
   private static final String METRICS_JMX_PREFIX_DEFAULT_OVERRIDE = "kafka.schema.registry";
@@ -568,7 +574,10 @@ public class SchemaRegistryConfig extends RestConfig {
     .define(SCHEMAREGISTRY_INTER_INSTANCE_PROTOCOL_CONFIG, ConfigDef.Type.STRING, "",
             ConfigDef.Importance.LOW, SCHEMAREGISTRY_INTER_INSTANCE_PROTOCOL_DOC)
     .define(INTER_INSTANCE_PROTOCOL_CONFIG, ConfigDef.Type.STRING, HTTP,
-            ConfigDef.Importance.LOW, SCHEMAREGISTRY_INTER_INSTANCE_PROTOCOL_DOC);
+            ConfigDef.Importance.LOW, SCHEMAREGISTRY_INTER_INSTANCE_PROTOCOL_DOC)
+    .define(INTER_INSTANCE_LISTENER_NAME_CONFIG, ConfigDef.Type.STRING, "",
+      ConfigDef.Importance.LOW, INTER_INSTANCE_LISTENER_NAME_DOC);
+
   }
 
   private final CompatibilityLevel compatibilityType;
@@ -722,6 +731,14 @@ public class SchemaRegistryConfig extends RestConfig {
       return deprecatedValue;
     }
     return getString(INTER_INSTANCE_PROTOCOL_CONFIG);
+  }
+
+  /**
+   * Gets the inter.instance.protocol setting, handling the deprecated
+   * schema.registry.inter.instance.protocol setting.
+   */
+  public String interInstanceListenerName() {
+    return getString(INTER_INSTANCE_LISTENER_NAME_CONFIG);
   }
 
   public List<String> whitelistHeaders() {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -734,8 +734,7 @@ public class SchemaRegistryConfig extends RestConfig {
   }
 
   /**
-   * Gets the inter.instance.protocol setting, handling the deprecated
-   * schema.registry.inter.instance.protocol setting.
+   * Gets the inter.instance.listener.name setting.
    */
   public String interInstanceListenerName() {
     return getString(INTER_INSTANCE_LISTENER_NAME_CONFIG);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -158,16 +158,18 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     NamedURI internalListener = getInternalListener(config.getListeners(),
         interInstanceListenerNameConfig,
         config.interInstanceProtocol());
+    log.info("Found internal listener: " + internalListener.toString());
     String internalListenerName = Optional.ofNullable(internalListener.getName()).orElse("");
     SchemeAndPort schemeAndPort = new SchemeAndPort(internalListener.getUri().getScheme(),
         internalListener.getUri().getPort());
-    // Use listener endpoint for internal communication and identity when a named internal listener
-    // is present. Default to existing behaviour of using host name config and port, otherwise.
+    // Use listener endpoint for identity when a matching named internal listener was found.
+    // Default to existing behavior of using host name config and port otherwise.
     String host =   internalListenerName.equals(interInstanceListenerNameConfig)
                     ? internalListener.getUri().getHost()
                     : config.getString(SchemaRegistryConfig.HOST_NAME_CONFIG);
     this.myIdentity = new SchemaRegistryIdentity(host, schemeAndPort.port,
         isEligibleForLeaderElector, schemeAndPort.scheme);
+    log.info("Setting my identity to " + myIdentity.toString());
     Map<String, Object> sslConfig = config.getOverriddenSslConfigs(internalListener);
     this.sslFactory =
         new SslFactory(ConfigDef.convertToStringMapWithPasswordValues(sslConfig));

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -54,7 +54,6 @@ import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreInitializationException;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreTimeoutException;
 import io.confluent.kafka.schemaregistry.storage.serialization.Serializer;
-import io.confluent.rest.RestConfig;
 
 public class KafkaStore<K, V> implements Store<K, V> {
 
@@ -90,11 +89,9 @@ public class KafkaStore<K, V> implements Store<K, V> {
     this.topic = config.getString(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG);
     this.desiredReplicationFactor =
         config.getInt(SchemaRegistryConfig.KAFKASTORE_TOPIC_REPLICATION_FACTOR_CONFIG);
-    int port = KafkaSchemaRegistry.getSchemeAndPortForIdentity(
-        config.getInt(SchemaRegistryConfig.PORT_CONFIG),
-        config.getList(RestConfig.LISTENERS_CONFIG),
-        config.interInstanceProtocol()
-    ).port;
+    this.config = config;
+    int port = KafkaSchemaRegistry.getInternalListener(config.getListeners(),
+        config.interInstanceProtocol()).getUri().getPort();
     this.groupId = config.getString(SchemaRegistryConfig.KAFKASTORE_GROUP_ID_CONFIG).isEmpty()
                    ? String.format("schema-registry-%s-%d",
                         config.getString(SchemaRegistryConfig.HOST_NAME_CONFIG), port)
@@ -105,7 +102,6 @@ public class KafkaStore<K, V> implements Store<K, V> {
     this.serializer = serializer;
     this.localStore = localStore;
     this.noopKey = noopKey;
-    this.config = config;
     this.bootstrapBrokers = config.bootstrapBrokers();
     this.skipSchemaTopicValidation =
         config.getBoolean(SchemaRegistryConfig.KAFKASTORE_TOPIC_SKIP_VALIDATION_CONFIG);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -91,6 +91,7 @@ public class KafkaStore<K, V> implements Store<K, V> {
         config.getInt(SchemaRegistryConfig.KAFKASTORE_TOPIC_REPLICATION_FACTOR_CONFIG);
     this.config = config;
     int port = KafkaSchemaRegistry.getInternalListener(config.getListeners(),
+        config.interInstanceListenerName(),
         config.interInstanceProtocol()).getUri().getPort();
     this.groupId = config.getString(SchemaRegistryConfig.KAFKASTORE_GROUP_ID_CONFIG).isEmpty()
                    ? String.format("schema-registry-%s-%d",

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -90,7 +90,7 @@ public class KafkaStore<K, V> implements Store<K, V> {
     this.desiredReplicationFactor =
         config.getInt(SchemaRegistryConfig.KAFKASTORE_TOPIC_REPLICATION_FACTOR_CONFIG);
     this.config = config;
-    int port = KafkaSchemaRegistry.getInternalListener(config.getListeners(),
+    int port = KafkaSchemaRegistry.getInterInstanceListener(config.getListeners(),
         config.interInstanceListenerName(),
         config.interInstanceProtocol()).getUri().getPort();
     this.groupId = config.getString(SchemaRegistryConfig.KAFKASTORE_GROUP_ID_CONFIG).isEmpty()

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfigTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfigTest.java
@@ -206,7 +206,7 @@ public class SchemaRegistryConfigTest {
     props.setProperty("listener.name.alice." + RestConfig.SSL_KEYSTORE_LOCATION_CONFIG , "/mnt/keystore/internal/keystore.jks");
     SchemaRegistryConfig config = new SchemaRegistryConfig(props);
 
-    NamedURI internalListener = KafkaSchemaRegistry.getInternalListener(config.getListeners(),
+    NamedURI internalListener = KafkaSchemaRegistry.getInterInstanceListener(config.getListeners(),
       config.getString(SchemaRegistryConfig.INTER_INSTANCE_LISTENER_NAME_CONFIG),
       SchemaRegistryConfig.HTTPS);
     Map<String, Object> overrides = config.getOverriddenSslConfigs(internalListener);

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistryTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistryTest.java
@@ -14,59 +14,101 @@
  */
 package io.confluent.kafka.schemaregistry.storage;
 
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.rest.NamedURI;
+import io.confluent.rest.RestConfig;
+import io.confluent.rest.RestConfigException;
+import kafka.Kafka;
+import org.checkerframework.checker.units.qual.K;
 import org.junit.Test;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Properties;
 import java.util.LinkedList;
 import java.util.List;
 
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
+import scala.sys.Prop;
 
 import static org.junit.Assert.assertEquals;
 
 public class KafkaSchemaRegistryTest {
 
   @Test
-  public void testGetPortForIdentityPrecedence() throws SchemaRegistryException {
-    List<String> listeners = new LinkedList<String>();
-    listeners.add("http://localhost:456");
+  public void testGetPortForIdentityPrecedence() throws SchemaRegistryException, RestConfigException {
+    String listeners = "http://localhost:456";
+    Properties props = new Properties();
+    props.setProperty(RestConfig.PORT_CONFIG, "123");
+    props.setProperty(RestConfig.LISTENERS_CONFIG, listeners);
+    SchemaRegistryConfig config = new SchemaRegistryConfig(props);
 
     KafkaSchemaRegistry.SchemeAndPort schemeAndPort =
-        KafkaSchemaRegistry.getSchemeAndPortForIdentity(123, listeners, SchemaRegistryConfig.HTTP);
+        KafkaSchemaRegistry.getSchemeAndPortForIdentity(config.getListeners(), SchemaRegistryConfig.HTTP);
     assertEquals("Expected listeners to take precedence over port.", 456, schemeAndPort.port);
     assertEquals("Expected Scheme match", SchemaRegistryConfig.HTTP, schemeAndPort.scheme);
   }
 
   @Test
-  public void testGetPortForIdentityNoListeners() throws SchemaRegistryException {
-    List<String> listeners = new LinkedList<String>();
+  public void testGetPortForIdentityNoListeners() throws SchemaRegistryException, RestConfigException {
+    String listeners = "";
+    Properties props = new Properties();
+    props.setProperty(RestConfig.PORT_CONFIG, "123");
+    props.setProperty(RestConfig.LISTENERS_CONFIG, listeners);
+    SchemaRegistryConfig config = new SchemaRegistryConfig(props);
+
     KafkaSchemaRegistry.SchemeAndPort schemeAndPort =
-        KafkaSchemaRegistry.getSchemeAndPortForIdentity(123, listeners, SchemaRegistryConfig.HTTP);
+        KafkaSchemaRegistry.getSchemeAndPortForIdentity(config.getListeners(), SchemaRegistryConfig.HTTP);
     assertEquals("Expected port to take the configured port value", 123, schemeAndPort.port);
     assertEquals("Expected Scheme match", SchemaRegistryConfig.HTTP, schemeAndPort.scheme);
   }
 
   @Test
-  public void testGetPortForIdentityMultipleListenersWithHttps() throws SchemaRegistryException {
-    List<String> listeners = new LinkedList<String>();
-    listeners.add("http://localhost:123");
-    listeners.add("https://localhost:456");
+  public void testGetPortForIdentityMultipleListenersWithHttps() throws SchemaRegistryException, RestConfigException {
+    String listeners = "http://localhost:123, https://localhost:456";
+    Properties props = new Properties();
+    props.setProperty(RestConfig.PORT_CONFIG, "-1");
+    props.setProperty(RestConfig.LISTENERS_CONFIG, listeners);
+    SchemaRegistryConfig config = new SchemaRegistryConfig(props);
+
 
     KafkaSchemaRegistry.SchemeAndPort schemeAndPort =
-        KafkaSchemaRegistry.getSchemeAndPortForIdentity(-1, listeners, SchemaRegistryConfig.HTTPS);
+        KafkaSchemaRegistry.getSchemeAndPortForIdentity(config.getListeners(), SchemaRegistryConfig.HTTPS);
     assertEquals("Expected HTTPS listener's port to be returned", 456, schemeAndPort.port);
     assertEquals("Expected Scheme match", SchemaRegistryConfig.HTTPS, schemeAndPort.scheme);
   }
 
   @Test
-  public void testGetPortForIdentityMultipleListeners() throws SchemaRegistryException {
-    List<String> listeners = new LinkedList<String>();
-    listeners.add("http://localhost:123");
-    listeners.add("http://localhost:456");
+  public void testGetPortForIdentityMultipleListeners() throws SchemaRegistryException, RestConfigException {
+    String listeners = "http://localhost:123, http://localhost:456";
+    Properties props = new Properties();
+    props.setProperty(RestConfig.PORT_CONFIG, "-1");
+    props.setProperty(RestConfig.LISTENERS_CONFIG, listeners);
+    SchemaRegistryConfig config = new SchemaRegistryConfig(props);
+
 
     KafkaSchemaRegistry.SchemeAndPort schemeAndPort =
-        KafkaSchemaRegistry.getSchemeAndPortForIdentity(-1, listeners, SchemaRegistryConfig.HTTP);
-    assertEquals("Expected first listener's port to be returned", 123, schemeAndPort.port);
+        KafkaSchemaRegistry.getSchemeAndPortForIdentity(config.getListeners(), SchemaRegistryConfig.HTTP);
+    assertEquals("Expected last listener's port to be returned", 456, schemeAndPort.port);
     assertEquals("Expected Scheme match", SchemaRegistryConfig.HTTP, schemeAndPort.scheme);
   }
+
+  @Test
+  public void testGetNamedInternalListener() throws SchemaRegistryException, RestConfigException {
+    String listeners = "http://localhost:456, internal://localhost:123";
+    String listenerProtocolMap = "internal:http";
+    Properties props = new Properties();
+    props.setProperty(RestConfig.PORT_CONFIG, "-1");
+    props.setProperty(RestConfig.LISTENERS_CONFIG, listeners);
+    props.setProperty(RestConfig.LISTENER_PROTOCOL_MAP_CONFIG, listenerProtocolMap);
+    SchemaRegistryConfig config = new SchemaRegistryConfig(props);
+
+    NamedURI listener =
+      KafkaSchemaRegistry.getInternalListener(config.getListeners(), SchemaRegistryConfig.HTTP);
+    assertEquals("Expected internal listener's port to be returned", 123, listener.getUri().getPort());
+    assertEquals("Expected internal listener's name to be returned", "internal", listener.getName());
+    assertEquals("Expected Scheme match", SchemaRegistryConfig.HTTP, listener.getUri().getScheme());
+  }
+
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistryTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistryTest.java
@@ -44,10 +44,10 @@ public class KafkaSchemaRegistryTest {
     props.setProperty(RestConfig.LISTENERS_CONFIG, listeners);
     SchemaRegistryConfig config = new SchemaRegistryConfig(props);
 
-    KafkaSchemaRegistry.SchemeAndPort schemeAndPort =
-        KafkaSchemaRegistry.getSchemeAndPortForIdentity(config.getListeners(), SchemaRegistryConfig.HTTP);
-    assertEquals("Expected listeners to take precedence over port.", 456, schemeAndPort.port);
-    assertEquals("Expected Scheme match", SchemaRegistryConfig.HTTP, schemeAndPort.scheme);
+    NamedURI listener =
+        KafkaSchemaRegistry.getInternalListener(config.getListeners(), "", SchemaRegistryConfig.HTTP);
+    assertEquals("Expected listeners to take precedence over port.", 456, listener.getUri().getPort());
+    assertEquals("Expected Scheme match", SchemaRegistryConfig.HTTP, listener.getUri().getScheme());
   }
 
   @Test
@@ -58,10 +58,10 @@ public class KafkaSchemaRegistryTest {
     props.setProperty(RestConfig.LISTENERS_CONFIG, listeners);
     SchemaRegistryConfig config = new SchemaRegistryConfig(props);
 
-    KafkaSchemaRegistry.SchemeAndPort schemeAndPort =
-        KafkaSchemaRegistry.getSchemeAndPortForIdentity(config.getListeners(), SchemaRegistryConfig.HTTP);
-    assertEquals("Expected port to take the configured port value", 123, schemeAndPort.port);
-    assertEquals("Expected Scheme match", SchemaRegistryConfig.HTTP, schemeAndPort.scheme);
+    NamedURI listener =
+        KafkaSchemaRegistry.getInternalListener(config.getListeners(), "", SchemaRegistryConfig.HTTP);
+    assertEquals("Expected port to take the configured port value", 123, listener.getUri().getPort());
+    assertEquals("Expected Scheme match", SchemaRegistryConfig.HTTP, listener.getUri().getScheme());
   }
 
   @Test
@@ -72,11 +72,10 @@ public class KafkaSchemaRegistryTest {
     props.setProperty(RestConfig.LISTENERS_CONFIG, listeners);
     SchemaRegistryConfig config = new SchemaRegistryConfig(props);
 
-
-    KafkaSchemaRegistry.SchemeAndPort schemeAndPort =
-        KafkaSchemaRegistry.getSchemeAndPortForIdentity(config.getListeners(), SchemaRegistryConfig.HTTPS);
-    assertEquals("Expected HTTPS listener's port to be returned", 456, schemeAndPort.port);
-    assertEquals("Expected Scheme match", SchemaRegistryConfig.HTTPS, schemeAndPort.scheme);
+    NamedURI listener =
+        KafkaSchemaRegistry.getInternalListener(config.getListeners(), "", SchemaRegistryConfig.HTTPS);
+    assertEquals("Expected HTTPS listener's port to be returned", 456, listener.getUri().getPort());
+    assertEquals("Expected Scheme match", SchemaRegistryConfig.HTTPS, listener.getUri().getScheme());
   }
 
   @Test
@@ -88,27 +87,27 @@ public class KafkaSchemaRegistryTest {
     SchemaRegistryConfig config = new SchemaRegistryConfig(props);
 
 
-    KafkaSchemaRegistry.SchemeAndPort schemeAndPort =
-        KafkaSchemaRegistry.getSchemeAndPortForIdentity(config.getListeners(), SchemaRegistryConfig.HTTP);
-    assertEquals("Expected last listener's port to be returned", 456, schemeAndPort.port);
-    assertEquals("Expected Scheme match", SchemaRegistryConfig.HTTP, schemeAndPort.scheme);
+    NamedURI listener =
+        KafkaSchemaRegistry.getInternalListener(config.getListeners(), "", SchemaRegistryConfig.HTTP);
+    assertEquals("Expected last listener's port to be returned", 456, listener.getUri().getPort());
+    assertEquals("Expected Scheme match", SchemaRegistryConfig.HTTP, listener.getUri().getScheme());
   }
 
   @Test
   public void testGetNamedInternalListener() throws SchemaRegistryException, RestConfigException {
-    String listeners = "http://localhost:456, internal://localhost:123";
-    String listenerProtocolMap = "internal:http";
+    String listeners = "http://localhost:456, bob://localhost:123";
+    String listenerProtocolMap = "bob:http";
     Properties props = new Properties();
     props.setProperty(RestConfig.PORT_CONFIG, "-1");
     props.setProperty(RestConfig.LISTENERS_CONFIG, listeners);
     props.setProperty(RestConfig.LISTENER_PROTOCOL_MAP_CONFIG, listenerProtocolMap);
+    props.setProperty(SchemaRegistryConfig.INTER_INSTANCE_LISTENER_NAME_CONFIG, "bob");
     SchemaRegistryConfig config = new SchemaRegistryConfig(props);
 
     NamedURI listener =
-      KafkaSchemaRegistry.getInternalListener(config.getListeners(), SchemaRegistryConfig.HTTP);
+      KafkaSchemaRegistry.getInternalListener(config.getListeners(), config.interInstanceListenerName(), SchemaRegistryConfig.HTTP);
     assertEquals("Expected internal listener's port to be returned", 123, listener.getUri().getPort());
-    assertEquals("Expected internal listener's name to be returned", "internal", listener.getName());
+    assertEquals("Expected internal listener's name to be returned", "bob", listener.getName());
     assertEquals("Expected Scheme match", SchemaRegistryConfig.HTTP, listener.getUri().getScheme());
   }
-
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistryTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistryTest.java
@@ -14,23 +14,15 @@
  */
 package io.confluent.kafka.schemaregistry.storage;
 
-import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.rest.NamedURI;
 import io.confluent.rest.RestConfig;
 import io.confluent.rest.RestConfigException;
-import kafka.Kafka;
-import org.checkerframework.checker.units.qual.K;
 import org.junit.Test;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Properties;
-import java.util.LinkedList;
-import java.util.List;
 
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
-import scala.sys.Prop;
 
 import static org.junit.Assert.assertEquals;
 
@@ -45,7 +37,7 @@ public class KafkaSchemaRegistryTest {
     SchemaRegistryConfig config = new SchemaRegistryConfig(props);
 
     NamedURI listener =
-        KafkaSchemaRegistry.getInternalListener(config.getListeners(), "", SchemaRegistryConfig.HTTP);
+        KafkaSchemaRegistry.getInterInstanceListener(config.getListeners(), "", SchemaRegistryConfig.HTTP);
     assertEquals("Expected listeners to take precedence over port.", 456, listener.getUri().getPort());
     assertEquals("Expected Scheme match", SchemaRegistryConfig.HTTP, listener.getUri().getScheme());
   }
@@ -59,7 +51,7 @@ public class KafkaSchemaRegistryTest {
     SchemaRegistryConfig config = new SchemaRegistryConfig(props);
 
     NamedURI listener =
-        KafkaSchemaRegistry.getInternalListener(config.getListeners(), "", SchemaRegistryConfig.HTTP);
+        KafkaSchemaRegistry.getInterInstanceListener(config.getListeners(), "", SchemaRegistryConfig.HTTP);
     assertEquals("Expected port to take the configured port value", 123, listener.getUri().getPort());
     assertEquals("Expected Scheme match", SchemaRegistryConfig.HTTP, listener.getUri().getScheme());
   }
@@ -73,7 +65,7 @@ public class KafkaSchemaRegistryTest {
     SchemaRegistryConfig config = new SchemaRegistryConfig(props);
 
     NamedURI listener =
-        KafkaSchemaRegistry.getInternalListener(config.getListeners(), "", SchemaRegistryConfig.HTTPS);
+        KafkaSchemaRegistry.getInterInstanceListener(config.getListeners(), "", SchemaRegistryConfig.HTTPS);
     assertEquals("Expected HTTPS listener's port to be returned", 456, listener.getUri().getPort());
     assertEquals("Expected Scheme match", SchemaRegistryConfig.HTTPS, listener.getUri().getScheme());
   }
@@ -88,14 +80,14 @@ public class KafkaSchemaRegistryTest {
 
 
     NamedURI listener =
-        KafkaSchemaRegistry.getInternalListener(config.getListeners(), "", SchemaRegistryConfig.HTTP);
+        KafkaSchemaRegistry.getInterInstanceListener(config.getListeners(), "", SchemaRegistryConfig.HTTP);
     assertEquals("Expected last listener's port to be returned", 456, listener.getUri().getPort());
     assertEquals("Expected Scheme match", SchemaRegistryConfig.HTTP, listener.getUri().getScheme());
   }
 
   @Test
   public void testGetNamedInternalListener() throws SchemaRegistryException, RestConfigException {
-    String listeners = "http://localhost:456, bob://localhost:123";
+    String listeners = "bob://localhost:123, http://localhost:456";
     String listenerProtocolMap = "bob:http";
     Properties props = new Properties();
     props.setProperty(RestConfig.PORT_CONFIG, "-1");
@@ -105,7 +97,7 @@ public class KafkaSchemaRegistryTest {
     SchemaRegistryConfig config = new SchemaRegistryConfig(props);
 
     NamedURI listener =
-      KafkaSchemaRegistry.getInternalListener(config.getListeners(), config.interInstanceListenerName(), SchemaRegistryConfig.HTTP);
+      KafkaSchemaRegistry.getInterInstanceListener(config.getListeners(), config.interInstanceListenerName(), SchemaRegistryConfig.HTTP);
     assertEquals("Expected internal listener's port to be returned", 123, listener.getUri().getPort());
     assertEquals("Expected internal listener's name to be returned", "bob", listener.getName());
     assertEquals("Expected Scheme match", SchemaRegistryConfig.HTTP, listener.getUri().getScheme());


### PR DESCRIPTION
The PR includes the following changes -
- Support external and internal listeners in SR config. The listener to be used for internal traffic can be specified using the new config `inter.instance.listener.name`. 
- Support specifying separate certs for internal and external listeners.
`schema-registry.properties` can now include named listeners and separate certs for each. For example, `listener.name.internal` specifies the SSL configs to be used for the internal listener.
```
listeners=internal://localhost:1000,external://mydomain.com:2000
listener.protocol.map=internal:https,external:https

listener.name.internal.ssl.key.password=${file:/mnt/sslcerts/jksPassword.txt:jksPassword}
listener.name.internal.ssl.keystore.location=/opt/confluentinc/etc/internal/keystore.jks
listener.name.internal.ssl.keystore.password=${file:/mnt/sslcerts/jksPassword.txt:jksPassword}
listener.name.internal.ssl.truststore.location=/opt/confluentinc/etc/internal/truststore.jks
listener.name.internal.ssl.truststore.password=${file:/mnt/sslcerts/jksPassword.txt:jksPassword}

ssl.key.password=${file:/mnt/sslcerts/jksPassword.txt:jksPassword}
ssl.keystore.location=/mnt/sslcerts/keystore.jks
ssl.keystore.password=${file:/mnt/sslcerts/jksPassword.txt:jksPassword}
ssl.truststore.location=/mnt/sslcerts/truststore.jks
ssl.truststore.password=${file:/mnt/sslcerts/jksPassword.txt:jksPassword
```
- For inter-instance communication,`KafkaSchemaRegistry::SslFactory` will be instantiated with overridden SSL configs if an internal listener is specified.
- Schema registry instance identity (used for leader election and also for inter-instance communication) will use the internal listener's host and port if an internal listener was specified. Else, this will default to current behaviour that uses the HOST_NAME config.

Expected behaviour for SSL config: 
If both `listener.name.internal.ssl.*` and `ssl.*` are provided, `listener.name.internal.ssl.*` properties are applied to internal listeners with the capability to leverage internal certs and `ssl.*` properties are applied for external listeners. If only, `ssl.*` are supplied, the behavior is the same as today. If only `listener.name.internal.ssl.*` are supplied, only the internal listener is exposed and no external traffic will be allowed.
