### PR TITLE
DGS-5514 Implementation for new config parameters

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Metadata.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Metadata.java
@@ -140,4 +140,46 @@ public class Metadata {
       sensitive.forEach(s -> md.update(s.getBytes(StandardCharsets.UTF_8)));
     }
   }
+
+  public static Metadata mergeMetadata(Metadata oldMetadata, Metadata newMetadata) {
+    if (oldMetadata == null) {
+      return newMetadata;
+    } else if (newMetadata == null) {
+      return oldMetadata;
+    } else {
+      return new Metadata(
+          merge(oldMetadata.annotations, newMetadata.annotations),
+          merge(oldMetadata.properties, newMetadata.properties),
+          merge(oldMetadata.sensitive, newMetadata.sensitive)
+      );
+    }
+  }
+
+  private static <T> SortedMap<String, T> merge(
+      SortedMap<String, T> oldMap,
+      SortedMap<String, T> newMap) {
+    if (oldMap == null || oldMap.isEmpty()) {
+      return newMap;
+    } else if (newMap == null || newMap.isEmpty()) {
+      return oldMap;
+    } else {
+      SortedMap<String, T> map = new TreeMap<>(oldMap);
+      map.putAll(newMap);
+      return map;
+    }
+  }
+
+  private static SortedSet<String> merge(
+      SortedSet<String> oldSet,
+      SortedSet<String> newSet) {
+    if (oldSet == null || oldSet.isEmpty()) {
+      return newSet;
+    } else if (newSet == null || newSet.isEmpty()) {
+      return oldSet;
+    } else {
+      SortedSet<String> set = new TreeSet<>(oldSet);
+      set.addAll(newSet);
+      return set;
+    }
+  }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Metadata.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Metadata.java
@@ -148,7 +148,7 @@ public class Metadata {
       return oldMetadata;
     } else {
       return new Metadata(
-          merge(oldMetadata.annotations, newMetadata.annotations),
+          merge(oldMetadata.paths, newMetadata.paths),
           merge(oldMetadata.properties, newMetadata.properties),
           merge(oldMetadata.sensitive, newMetadata.sensitive)
       );

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/entities/MergeEntitiesTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/entities/MergeEntitiesTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.confluent.kafka.schemaregistry.client.rest.entities;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+
+public class MergeEntitiesTest {
+
+  @Test
+  public void mergeMetadatas() throws Exception {
+    Map<String, Set<String>> paths = new HashMap<>();
+    paths.put("**.ssn", Collections.singleton("PII"));
+    Map<String, String> properties = new HashMap<>();
+    properties.put("key1", "value1");
+    Set<String> sensitive = new HashSet<>();
+    sensitive.add("key1");
+    Metadata m1 = new Metadata(paths, properties, sensitive);
+    Metadata m2 = new Metadata(Collections.emptyMap(), Collections.emptyMap(), null);
+
+    Metadata m3 = Metadata.mergeMetadata(m1, m2);
+    assertEquals(m3.getPaths().get("**.ssn"), Collections.singleton("PII"));
+    assertEquals(m3.getProperties().get("key1"), "value1");
+    assertTrue(m3.getSensitive().contains("key1"));
+
+    paths = new HashMap<>();
+    paths.put("**.ssn", Collections.singleton("PRIVATE"));
+    properties = new HashMap<>();
+    properties.put("key2", "value2");
+    sensitive = new HashSet<>();
+    sensitive.add("key2");
+    m2 = new Metadata(paths, properties, sensitive);
+
+    Metadata m4 = Metadata.mergeMetadata(m1, m2);
+    assertEquals(m4.getPaths().get("**.ssn"), Collections.singleton("PRIVATE"));
+    assertEquals(m4.getProperties().get("key1"), "value1");
+    assertEquals(m4.getProperties().get("key2"), "value2");
+    assertTrue(m4.getSensitive().contains("key1"));
+    assertTrue(m4.getSensitive().contains("key2"));
+  }
+
+  @Test
+  public void mergeRuleSets() throws Exception {
+    Rule r1 = new Rule("hi", null, null, null, null, null, null, null, false);
+    Rule r2 = new Rule("bye", null, null, null, null, null, null, null, false);
+    List<Rule> rules1 = ImmutableList.of(r1, r2);
+    RuleSet rs1 = new RuleSet(rules1, null);
+    List<Rule> rules2 = ImmutableList.of(r2, r1);
+    RuleSet rs2 = new RuleSet(rules2, null);
+
+    RuleSet rs3 = RuleSet.mergeRuleSets(rs1, rs2);
+    assertEquals(rs3.getMigrationRules(), rules2);
+
+    rs3 = RuleSet.mergeRuleSets(rs2, rs1);
+    assertEquals(rs3.getMigrationRules(), rules1);
+  }
+}

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -164,7 +164,7 @@ public class CompatibilityResource {
     }
 
     CompatibilityCheckResponse compatibilityCheckResponse =
-            createCompatiblityCheckResponse(errorMessages, verbose);
+            createCompatibilityCheckResponse(errorMessages, verbose);
     asyncResponse.resume(compatibilityCheckResponse);
   }
 
@@ -240,11 +240,11 @@ public class CompatibilityResource {
     }
 
     CompatibilityCheckResponse compatibilityCheckResponse =
-        createCompatiblityCheckResponse(errorMessages, verbose);
+        createCompatibilityCheckResponse(errorMessages, verbose);
     asyncResponse.resume(compatibilityCheckResponse);
   }
 
-  private static CompatibilityCheckResponse createCompatiblityCheckResponse(
+  private static CompatibilityCheckResponse createCompatibilityCheckResponse(
           List<String> errorMessages,
           boolean verbose) {
     CompatibilityCheckResponse compatibilityCheckResponse = new CompatibilityCheckResponse();

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
@@ -243,23 +243,26 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
                        Config defaultForTopLevel
   ) throws StoreException {
     ConfigKey subjectConfigKey = new ConfigKey(subject);
-    ConfigValue config = (ConfigValue) get((K) subjectConfigKey);
-    if (config == null && subject == null) {
+    ConfigValue configValue = (ConfigValue) get((K) subjectConfigKey);
+    if (configValue == null && subject == null) {
       return defaultForTopLevel;
     }
-    if (config != null) {
-      return config.toConfigEntity();
+    Config config = null;
+    if (configValue != null) {
+      config = configValue.toConfigEntity();
     } else if (returnTopLevelIfNotFound) {
       QualifiedSubject qs = QualifiedSubject.create(tenant(), subject);
       if (qs != null && !DEFAULT_CONTEXT.equals(qs.getContext())) {
-        config = (ConfigValue) get((K) new ConfigKey(qs.toQualifiedContext()));
+        configValue = (ConfigValue) get((K) new ConfigKey(qs.toQualifiedContext()));
       } else {
-        config = (ConfigValue) get((K) new ConfigKey(null));
+        configValue = (ConfigValue) get((K) new ConfigKey(null));
       }
-      return config != null ? config.toConfigEntity() : defaultForTopLevel;
-    } else {
-      return null;
+      config = configValue != null ? configValue.toConfigEntity() : defaultForTopLevel;
     }
+    if (config != null && config.getCompatibilityLevel() == null) {
+      config.setCompatibilityLevel(defaultForTopLevel.getCompatibilityLevel());
+    }
+    return config;
   }
 
   @Override

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -95,6 +95,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+import static io.confluent.kafka.schemaregistry.client.rest.entities.Metadata.mergeMetadata;
+import static io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet.mergeRuleSets;
 import static io.confluent.kafka.schemaregistry.utils.QualifiedSubject.CONTEXT_DELIMITER;
 import static io.confluent.kafka.schemaregistry.utils.QualifiedSubject.CONTEXT_PREFIX;
 import static io.confluent.kafka.schemaregistry.utils.QualifiedSubject.CONTEXT_WILDCARD;
@@ -519,8 +521,11 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       }
       Collections.reverse(undeletedVersions);
 
+      Config config = getConfigInScope(subject);
+      parsedSchema = maybeSetMetadataRuleSet(config, parsedSchema, undeletedVersions);
+
       final List<String> compatibilityErrorLogs = isCompatibleWithPrevious(
-              subject, parsedSchema, undeletedVersions);
+              config, parsedSchema, undeletedVersions);
       final boolean isCompatible = compatibilityErrorLogs.isEmpty();
 
       try {
@@ -622,6 +627,40 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   private boolean isReadOnlyMode(String subject) throws SchemaRegistryStoreException {
     Mode subjectMode = getModeInScope(subject);
     return subjectMode == Mode.READONLY || subjectMode == Mode.READONLY_OVERRIDE;
+  }
+
+  private ParsedSchema maybeSetMetadataRuleSet(
+      Config config, ParsedSchema schema, List<ParsedSchema> previousSchemas) {
+    ParsedSchema previousSchema = previousSchemas.size() > 0 ? previousSchemas.get(0) : null;
+    io.confluent.kafka.schemaregistry.client.rest.entities.Metadata specificMetadata = null;
+    if (schema.metadata() != null) {
+      specificMetadata = schema.metadata();
+    } else if (previousSchema != null) {
+      specificMetadata = previousSchema.metadata();
+    }
+    io.confluent.kafka.schemaregistry.client.rest.entities.Metadata mergedMetadata;
+    io.confluent.kafka.schemaregistry.client.rest.entities.Metadata initialMetadata;
+    io.confluent.kafka.schemaregistry.client.rest.entities.Metadata finalMetadata;
+    initialMetadata = config.getInitialMetadata();
+    finalMetadata = config.getFinalMetadata();
+    mergedMetadata =
+        mergeMetadata(mergeMetadata(initialMetadata, specificMetadata), finalMetadata);
+    io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet specificRuleSet = null;
+    if (schema.ruleSet() != null) {
+      specificRuleSet = schema.ruleSet();
+    } else if (previousSchema != null) {
+      specificRuleSet = previousSchema.ruleSet();
+    }
+    io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet mergedRuleSet;
+    io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet initialRuleSet;
+    io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet finalRuleSet;
+    initialRuleSet = config.getInitialRuleSet();
+    finalRuleSet = config.getFinalRuleSet();
+    mergedRuleSet = mergeRuleSets(mergeRuleSets(initialRuleSet, specificRuleSet), finalRuleSet);
+    if (mergedMetadata != null || mergedRuleSet != null) {
+      schema = schema.copy(mergedMetadata, mergedRuleSet);
+    }
+    return schema;
   }
 
   public int registerOrForward(String subject,
@@ -1622,24 +1661,6 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     return groupId;
   }
 
-  public CompatibilityLevel getCompatibilityLevel(String subject)
-      throws SchemaRegistryStoreException {
-    try {
-      return lookupCache.compatibilityLevel(subject, false, defaultCompatibilityLevel);
-    } catch (StoreException e) {
-      throw new SchemaRegistryStoreException("Failed to write new config value to the store", e);
-    }
-  }
-
-  public CompatibilityLevel getCompatibilityLevelInScope(String subject)
-      throws SchemaRegistryStoreException {
-    try {
-      return lookupCache.compatibilityLevel(subject, true, defaultCompatibilityLevel);
-    } catch (StoreException e) {
-      throw new SchemaRegistryStoreException("Failed to write new config value to the store", e);
-    }
-  }
-
   public Config getConfig(String subject)
       throws SchemaRegistryStoreException {
     try {
@@ -1691,16 +1712,35 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     }
 
     ParsedSchema parsedSchema = canonicalizeSchema(newSchema, true, false);
-    return isCompatibleWithPrevious(subject, parsedSchema, prevParsedSchemas);
+    Config config = getConfigInScope(subject);
+    return isCompatibleWithPrevious(config, parsedSchema, prevParsedSchemas);
   }
 
-  private List<String> isCompatibleWithPrevious(String subject,
+  private List<String> isCompatibleWithPrevious(Config config,
                                                 ParsedSchema parsedSchema,
                                                 List<ParsedSchema> previousSchemas)
       throws SchemaRegistryException {
 
-    CompatibilityLevel compatibility = getCompatibilityLevelInScope(subject);
+    CompatibilityLevel compatibility = CompatibilityLevel.forName(config.getCompatibilityLevel());
+    String compatibilityGroup = config.getCompatibilityGroup();
+    if (compatibilityGroup != null) {
+      String groupValue = getCompatibilityGroupValue(parsedSchema, compatibilityGroup);
+      if (groupValue != null) {
+        // Only check compatibility against schemas with the same compatibility group value
+        previousSchemas = previousSchemas.stream()
+            .filter(s -> groupValue.equals(getCompatibilityGroupValue(s, compatibilityGroup)))
+            .collect(Collectors.toList());
+      }
+    }
     return parsedSchema.isCompatible(compatibility, previousSchemas);
+  }
+
+  private static String getCompatibilityGroupValue(
+      ParsedSchema parsedSchema, String compatibilityGroup) {
+    if (parsedSchema.metadata() != null && parsedSchema.metadata().getProperties() != null) {
+      return parsedSchema.metadata().getProperties().get(compatibilityGroup);
+    }
+    return null;
   }
 
   private void deleteMode(String subject) throws StoreException {


### PR DESCRIPTION
When registering a schema, the metadata/rules are initially set to the initialMetadata/RuleSet, then the passed in metadata/rules are merged on top of the initial values, then the finalMetadata/RuleSet are merged on top of the value from the previous step.

The compatibilityGroup designates a metadata key whose value is used to group schemas.  For example, if the compatibiltyGroup is `application.version`, then only the schemas with the same metadata value for `application.version` will be checked for compatibility.  This allows you to skip the compatibility check when changing the `application.version`, such as for a major version bump.