### PR TITLE
Initiate leader election after resources have been set up

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryMain.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryMain.java
@@ -42,8 +42,8 @@ public class SchemaRegistryMain {
       SchemaRegistryRestApplication app = new SchemaRegistryRestApplication(config);
       Server server = app.createServer();
       server.start();
-      // Initiate leader election only after all resources and listeners have been set up.
-      app.initLeaderElection();
+      // Do any work required after server is started, such as leader election.
+      app.postServerStart();
       log.info("Schema Registry version: {} commitId: {}",
           AppInfoParser.getVersion(), AppInfoParser.getCommitId());
       log.info("Server started, listening for requests...");

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryMain.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryMain.java
@@ -42,6 +42,7 @@ public class SchemaRegistryMain {
       SchemaRegistryRestApplication app = new SchemaRegistryRestApplication(config);
       Server server = app.createServer();
       server.start();
+      // Initiate leader election only after all resources and listeners have been set up.
       app.initLeaderElection();
       log.info("Schema Registry version: {} commitId: {}",
           AppInfoParser.getVersion(), AppInfoParser.getCommitId());

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryMain.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryMain.java
@@ -42,6 +42,7 @@ public class SchemaRegistryMain {
       SchemaRegistryRestApplication app = new SchemaRegistryRestApplication(config);
       Server server = app.createServer();
       server.start();
+      app.initLeaderElection();
       log.info("Schema Registry version: {} commitId: {}",
           AppInfoParser.getVersion(), AppInfoParser.getCommitId());
       log.info("Server started, listening for requests...");

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryMain.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryMain.java
@@ -42,7 +42,7 @@ public class SchemaRegistryMain {
       SchemaRegistryRestApplication app = new SchemaRegistryRestApplication(config);
       Server server = app.createServer();
       server.start();
-      // Do any work required after server is started, such as leader election.
+      // Do any work required after server is started.
       app.postServerStart();
       log.info("Schema Registry version: {} commitId: {}",
           AppInfoParser.getVersion(), AppInfoParser.getCommitId());

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
@@ -81,9 +81,9 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
     return kafkaSchemaRegistry;
   }
 
-  public void initLeaderElection() {
+  public void postServerStart() {
     try {
-      schemaRegistry.initLeaderElection();
+      schemaRegistry.postInit();
     } catch (SchemaRegistryException e) {
       log.error("Error starting the schema registry", e);
       System.exit(1);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
@@ -82,7 +82,6 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
   }
 
   public void initLeaderElection() {
-    // Initiate leader election only after all resources and listeners have been set up.
     try {
       schemaRegistry.initLeaderElection();
     } catch (SchemaRegistryException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
@@ -122,6 +122,14 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
         System.exit(1);
       }
     }
+
+    // Initiate leader election only after all resources have been set up.
+    try {
+      schemaRegistry.initLeaderElection();
+    } catch (SchemaRegistryException e) {
+      log.error("Error starting the schema registry", e);
+      System.exit(1);
+    }
   }
 
   @Override

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
@@ -81,6 +81,16 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
     return kafkaSchemaRegistry;
   }
 
+  public void initLeaderElection() {
+    // Initiate leader election only after all resources and listeners have been set up.
+    try {
+      schemaRegistry.initLeaderElection();
+    } catch (SchemaRegistryException e) {
+      log.error("Error starting the schema registry", e);
+      System.exit(1);
+    }
+  }
+
   @Override
   public void configureBaseApplication(
       final Configurable<?> config,
@@ -121,14 +131,6 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
         log.error("Error starting the schema registry", e);
         System.exit(1);
       }
-    }
-
-    // Initiate leader election only after all resources have been set up.
-    try {
-      schemaRegistry.initLeaderElection();
-    } catch (SchemaRegistryException e) {
-      log.error("Error starting the schema registry", e);
-      System.exit(1);
     }
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -323,11 +323,11 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     }
 
     config.checkBootstrapServers();
-    leaderElector = new KafkaGroupLeaderElector(config, myIdentity, this);
   }
 
   public void postInit() throws SchemaRegistryException {
     log.info("Joining schema registry with Kafka-based coordination");
+    leaderElector = new KafkaGroupLeaderElector(config, myIdentity, this);
     try {
       leaderElector.init();
     } catch (SchemaRegistryStoreException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -323,11 +323,11 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     }
 
     config.checkBootstrapServers();
-    log.info("Joining schema registry with Kafka-based coordination");
     leaderElector = new KafkaGroupLeaderElector(config, myIdentity, this);
   }
 
   public void postInit() throws SchemaRegistryException {
+    log.info("Joining schema registry with Kafka-based coordination");
     try {
       leaderElector.init();
     } catch (SchemaRegistryStoreException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -322,10 +322,13 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
           "Error initializing kafka store while initializing schema registry", e);
     }
 
+    config.checkBootstrapServers();
+    log.info("Joining schema registry with Kafka-based coordination");
+    leaderElector = new KafkaGroupLeaderElector(config, myIdentity, this);
+  }
+
+  public void initLeaderElection() throws SchemaRegistryException {
     try {
-      config.checkBootstrapServers();
-      log.info("Joining schema registry with Kafka-based coordination");
-      leaderElector = new KafkaGroupLeaderElector(config, myIdentity, this);
       leaderElector.init();
     } catch (SchemaRegistryStoreException e) {
       throw new SchemaRegistryInitializationException(

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -327,7 +327,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     leaderElector = new KafkaGroupLeaderElector(config, myIdentity, this);
   }
 
-  public void initLeaderElection() throws SchemaRegistryException {
+  public void postInit() throws SchemaRegistryException {
     try {
       leaderElector.init();
     } catch (SchemaRegistryStoreException e) {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
@@ -72,6 +72,7 @@ public class RestApp {
     restApp = new SchemaRegistryRestApplication(prop);
     restServer = restApp.createServer();
     restServer.start();
+    restApp.postServerStart();
     restConnect = restServer.getURI().toString();
     if (restConnect.endsWith("/"))
       restConnect = restConnect.substring(0, restConnect.length()-1);


### PR DESCRIPTION
Currently leader election is initiated before all resources have been set up. In a multi-node setup, once leader election is completed other pods will start to forward requests to new leader even if the new leader is busy setting up the resources.
This PR moves leader election to be after resources and listeners have been prepared, so when the new node steps up as leader, it is ready to accept and process requests already.