### PR TITLE
DGS-5897 Support return Avro schemas with all refs resolved

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
@@ -174,7 +174,7 @@ public class AvroSchema implements ParsedSchema {
         return schemaObj.toString();
       default:
         // Don't throw an exception for forward compatibility of formats
-        log.error("Unsupported format {}", format);
+        log.warn("Unsupported format {}", format);
         return canonicalString();
     }
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
@@ -174,7 +174,7 @@ public class AvroSchema implements ParsedSchema {
         return schemaObj.toString();
       default:
         // Don't throw an exception for forward compatibility of formats
-        log.error("Unsupported format " + format);
+        log.error("Unsupported format {}", format);
         return canonicalString();
     }
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
@@ -173,7 +173,9 @@ public class AvroSchema implements ParsedSchema {
       case RESOLVED:
         return schemaObj.toString();
       default:
-        throw new IllegalArgumentException("Unsupported format " + format);
+        // Don't throw an exception for forward compatibility of formats
+        log.error("Unsupported format " + format);
+        return canonicalString();
     }
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
@@ -16,11 +16,13 @@
 
 package io.confluent.kafka.schemaregistry.avro;
 
+import com.google.common.collect.EnumHashBiMap;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 
 import java.util.HashMap;
 import java.util.IdentityHashMap;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaCompatibility;
@@ -157,6 +159,22 @@ public class AvroSchema implements ParsedSchema {
       canonicalString = schemaObj.toString(schemaRefs, false);
     }
     return canonicalString;
+  }
+
+  @Override
+  public String formattedString(String format) {
+    if (format == null || format.trim().isEmpty()) {
+      return canonicalString();
+    }
+    Format formatEnum = Format.get(format);
+    switch (formatEnum) {
+      case DEFAULT:
+        return canonicalString();
+      case RESOLVED:
+        return schemaObj.toString();
+      default:
+        throw new IllegalArgumentException("Unsupported format " + format);
+    }
   }
 
   public Integer version() {
@@ -403,6 +421,43 @@ public class AvroSchema implements ParsedSchema {
           + "key=" + key
           + ", value=" + value
           + '}';
+    }
+  }
+
+  public enum Format {
+    DEFAULT("default"),
+    RESOLVED("resolved");
+
+    private static final EnumHashBiMap<Format, String> lookup =
+        EnumHashBiMap.create(Format.class);
+
+    static {
+      for (Format type : Format.values()) {
+        lookup.put(type, type.symbol());
+      }
+    }
+
+    private final String symbol;
+
+    Format(String symbol) {
+      this.symbol = symbol;
+    }
+
+    public String symbol() {
+      return symbol;
+    }
+
+    public static Format get(String symbol) {
+      return lookup.inverse().get(symbol);
+    }
+
+    public static Set<String> symbols() {
+      return lookup.inverse().keySet();
+    }
+
+    @Override
+    public String toString() {
+      return symbol();
     }
   }
 }

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -1744,7 +1744,9 @@ public class ProtobufSchema implements ParsedSchema {
         FileDescriptorProto file = toDynamicSchema().getFileDescriptorProto();
         return base64Encoder.encodeToString(file.toByteArray());
       default:
-        throw new IllegalArgumentException("Unsupported format " + format);
+        // Don't throw an exception for forward compatibility of formats
+        log.error("Unsupported format " + format);
+        return canonicalString();
     }
   }
 

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -1745,7 +1745,7 @@ public class ProtobufSchema implements ParsedSchema {
         return base64Encoder.encodeToString(file.toByteArray());
       default:
         // Don't throw an exception for forward compatibility of formats
-        log.error("Unsupported format {}", format);
+        log.warn("Unsupported format {}", format);
         return canonicalString();
     }
   }

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -128,8 +128,6 @@ public class ProtobufSchema implements ParsedSchema {
 
   public static final String TYPE = "PROTOBUF";
 
-  public static final String SERIALIZED_FORMAT = "serialized";
-
   public static final String PROTO2 = "proto2";
   public static final String PROTO3 = "proto3";
 
@@ -1737,6 +1735,8 @@ public class ProtobufSchema implements ParsedSchema {
     }
     Format formatEnum = Format.get(format);
     switch (formatEnum) {
+      case DEFAULT:
+        return canonicalString();
       case IGNORE_EXTENSIONS:
         FormatContext ctx = new FormatContext(true, false);
         return ProtobufSchemaUtils.toFormattedString(ctx, this);
@@ -1975,6 +1975,7 @@ public class ProtobufSchema implements ParsedSchema {
   }
 
   public enum Format {
+    DEFAULT("default"),
     IGNORE_EXTENSIONS("ignore_extensions"),
     SERIALIZED("serialized");
 

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -1745,7 +1745,7 @@ public class ProtobufSchema implements ParsedSchema {
         return base64Encoder.encodeToString(file.toByteArray());
       default:
         // Don't throw an exception for forward compatibility of formats
-        log.error("Unsupported format " + format);
+        log.error("Unsupported format {}", format);
         return canonicalString();
     }
   }

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -33,8 +33,6 @@ import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema.Format;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils.FormatContext;
 import io.confluent.kafka.schemaregistry.protobuf.dynamic.DynamicSchema;
 import io.confluent.kafka.schemaregistry.protobuf.dynamic.MessageDefinition;
-import java.text.DecimalFormat;
-import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -808,11 +806,11 @@ public class ProtobufSchemaTest {
 
     ProtoFileElement original = resourceLoader.readObj("TestProto.proto");
     ProtobufSchema schema = new ProtobufSchema(original.toSchema());
-    String fileProto = schema.formattedString(ProtobufSchema.SERIALIZED_FORMAT);
+    String fileProto = schema.formattedString(Format.SERIALIZED.symbol());
     ProtobufSchema schema2 = new ProtobufSchema(fileProto);
     assertTrue(schema.isCompatible(
         CompatibilityLevel.BACKWARD, Collections.singletonList(schema2)).isEmpty());
-    fileProto = schema2.formattedString(ProtobufSchema.SERIALIZED_FORMAT);
+    fileProto = schema2.formattedString(Format.SERIALIZED.symbol());
     ProtobufSchema schema3 = new ProtobufSchema(fileProto);
     assertTrue(schema2.isCompatible(
         CompatibilityLevel.BACKWARD, Collections.singletonList(schema3)).isEmpty());
@@ -820,11 +818,11 @@ public class ProtobufSchemaTest {
 
     original = resourceLoader.readObj("NestedTestProto.proto");
     schema = new ProtobufSchema(original.toSchema());
-    fileProto = schema.formattedString(ProtobufSchema.SERIALIZED_FORMAT);
+    fileProto = schema.formattedString(Format.SERIALIZED.symbol());
     schema2 = new ProtobufSchema(fileProto);
     assertTrue(schema.isCompatible(
         CompatibilityLevel.BACKWARD, Collections.singletonList(schema2)).isEmpty());
-    fileProto = schema2.formattedString(ProtobufSchema.SERIALIZED_FORMAT);
+    fileProto = schema2.formattedString(Format.SERIALIZED.symbol());
     schema3 = new ProtobufSchema(fileProto);
     assertTrue(schema2.isCompatible(
         CompatibilityLevel.BACKWARD, Collections.singletonList(schema3)).isEmpty());


### PR DESCRIPTION
Support returning Avro schemas with all references resolved.

This will help non-Java clients to more easily resolve references for Avro.

This only applies to Avro since Protobuf and JSON Schema do not support transforming the schema text by replacing references inline, whereas Avro does.