### PR TITLE
DGS-3076: Skip logging large schemas during schema incompatibility check

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidatorBuilder.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidatorBuilder.java
@@ -33,6 +33,7 @@ public final class SchemaValidatorBuilder {
   private SchemaValidationStrategy strategy;
   private static final String NEW_PREFIX = "new";
   private static final String OLD_PREFIX = "old";
+  private static int MAX_SCHEMA_SIZE_FOR_LOGGING = 10 * 1024;
 
   /**
    * Use a strategy that validates that a schema can be used to read existing
@@ -111,7 +112,12 @@ public final class SchemaValidatorBuilder {
         if (existing.version() != null) {
           messages.add("{oldSchemaVersion: " + existing.version() + "}");
         }
-        messages.add("{oldSchema: '" + existing + "'}");
+        if (existing.toString().length() <= MAX_SCHEMA_SIZE_FOR_LOGGING) {
+          messages.add("{oldSchema: '" + existing + "'}");
+        } else {
+          messages.add("{oldSchema: <truncated to " + MAX_SCHEMA_SIZE_FOR_LOGGING + " characters> '"
+                         + existing.toString().substring(0, MAX_SCHEMA_SIZE_FOR_LOGGING) + "'}");
+        }
       }
     }
     return messages;


### PR DESCRIPTION
Fix to truncate schemas larger than 10K in the API response and log.