### PR TITLE
DGS-5624  SR Oauth client config : Make Identity pool and logical cluster id as optional

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/OauthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/OauthCredentialProvider.java
@@ -68,9 +68,9 @@ public class OauthCredentialProvider implements BearerAuthCredentialProvider {
     ConfigurationUtils cu = new ConfigurationUtils(map);
 
     targetSchemaRegistry = cu.validateString(
-        SchemaRegistryClientConfig.BEARER_AUTH_LOGICAL_CLUSTER);
+        SchemaRegistryClientConfig.BEARER_AUTH_LOGICAL_CLUSTER, false);
     targetIdentityPoolId = cu.validateString(
-        SchemaRegistryClientConfig.BEARER_AUTH_IDENTITY_POOL_ID);
+        SchemaRegistryClientConfig.BEARER_AUTH_IDENTITY_POOL_ID, false);
 
     tokenRetriever = new CachedOauthTokenRetriever();
     tokenRetriever.configure(getTokenRetriever(cu), getTokenValidator(map),

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/OauthCredentialProviderTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/OauthCredentialProviderTest.java
@@ -69,7 +69,9 @@ public class OauthCredentialProviderTest {
   public void TestConfigureInsufficientConfigs() {
     List<String> optionalConfigs = Arrays.asList(SchemaRegistryClientConfig.BEARER_AUTH_SCOPE,
         SchemaRegistryClientConfig.BEARER_AUTH_SCOPE_CLAIM_NAME,
-        SchemaRegistryClientConfig.BEARER_AUTH_SUB_CLAIM_NAME);
+        SchemaRegistryClientConfig.BEARER_AUTH_SUB_CLAIM_NAME,
+        SchemaRegistryClientConfig.BEARER_AUTH_IDENTITY_POOL_ID,
+        SchemaRegistryClientConfig.BEARER_AUTH_LOGICAL_CLUSTER);
     for (String missingKey : CONFIG_MAP.keySet()) {
       // ignoring optional keys
       if (optionalConfigs.contains(missingKey)) {


### PR DESCRIPTION
This PR makes the Identity pool and logical cluster id as optional to make the open-source experience better.