### PR TITLE
DGS-6065: Use HOST_NAME config for host even if inter.instance.listener.name is set

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -276,8 +276,7 @@ public class SchemaRegistryConfig extends RestConfig {
   protected static final String HOST_DOC =
       "The host name. Make sure to set this if running SchemaRegistry "
       + "with multiple nodes. This name is also used in the endpoint for inter instance "
-      + "communication if inter.instance.listener.name is not specified or does not match "
-      + "any listener ";
+      + "communication";
   protected static final String SCHEMA_PROVIDERS_DOC =
       "  A list of classes to use as SchemaProvider. Implementing the interface "
           + "<code>SchemaProvider</code> allows you to add custom schema types to Schema Registry.";

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -168,10 +168,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     // Use listener endpoint for identity when a matching named inter instance listener was found.
     // Default to existing behavior of using host name config and listener port otherwise.
     String internalListenerName = internalListener.getName();
-    String host =   (internalListenerName != null
-                      && internalListenerName.equalsIgnoreCase(interInstanceListenerNameConfig))
-                    ? internalListener.getUri().getHost()
-                    : config.getString(SchemaRegistryConfig.HOST_NAME_CONFIG);
+    String host = config.getString(SchemaRegistryConfig.HOST_NAME_CONFIG);
     this.myIdentity = new SchemaRegistryIdentity(host, schemeAndPort.port,
         isEligibleForLeaderElector, schemeAndPort.scheme);
     log.info("Setting my identity to " + myIdentity.toString());

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -165,9 +165,6 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     log.info("Found internal listener: " + internalListener.toString());
     SchemeAndPort schemeAndPort = new SchemeAndPort(internalListener.getUri().getScheme(),
         internalListener.getUri().getPort());
-    // Use listener endpoint for identity when a matching named inter instance listener was found.
-    // Default to existing behavior of using host name config and listener port otherwise.
-    String internalListenerName = internalListener.getName();
     String host = config.getString(SchemaRegistryConfig.HOST_NAME_CONFIG);
     this.myIdentity = new SchemaRegistryIdentity(host, schemeAndPort.port,
         isEligibleForLeaderElector, schemeAndPort.scheme);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -169,7 +169,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     // Default to existing behavior of using host name config and listener port otherwise.
     String internalListenerName = internalListener.getName();
     String host =   (internalListenerName != null
-                      && internalListenerName.equals(interInstanceListenerNameConfig))
+                      && internalListenerName.equalsIgnoreCase(interInstanceListenerNameConfig))
                     ? internalListener.getUri().getHost()
                     : config.getString(SchemaRegistryConfig.HOST_NAME_CONFIG);
     this.myIdentity = new SchemaRegistryIdentity(host, schemeAndPort.port,


### PR DESCRIPTION
As reported in the ticket -

> Sometimes the listeners config is set to INTERNAL://0.0.0.0:9999 where the hostname part will not be resolved to the correct host if the follower node tries to talk to leader node. 

This PR reverts back to the original behavior of using the HOST_NAME config for inter instance communication. The scheme, port and ssl config will continue to be picked based on the `inter.instance.listener.name` config, if it is set.