### PR TITLE
DGS-6075 : Add explicit definition of snakeyaml.

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -23,6 +23,10 @@
     <name>kafka-schema-registry-client</name>
 
     <dependencies>
+         <dependency>
+             <groupId>org.yaml</groupId>
+             <artifactId>snakeyaml</artifactId>
+         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>


### PR DESCRIPTION
This is to make sure all client consumers use the version of snakeyaml from client instead of jackson databind dep.