### PR TITLE
DGS-6192 Include default ctx when using subjectPrefix w/wildcard ctx

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -1472,7 +1472,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
         String unqualifiedSubjectOrPrefix =
             subjectOrPrefix.substring(idx + CONTEXT_WILDCARD.length());
         if (!unqualifiedSubjectOrPrefix.isEmpty()) {
-          return allVersionsFromAllContexts(unqualifiedSubjectOrPrefix, isPrefix);
+          return allVersionsFromAllContexts(prefix, unqualifiedSubjectOrPrefix, isPrefix);
         }
         start = prefix + CONTEXT_PREFIX + CONTEXT_DELIMITER;
         end = prefix + CONTEXT_PREFIX + Character.MAX_VALUE + CONTEXT_DELIMITER;
@@ -1490,14 +1490,22 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   }
 
   private CloseableIterator<SchemaRegistryValue> allVersionsFromAllContexts(
-      String unqualifiedSubjectOrPrefix, boolean isPrefix) throws SchemaRegistryException {
+      String tenantPrefix, String unqualifiedSubjectOrPrefix, boolean isPrefix)
+      throws SchemaRegistryException {
+    List<SchemaRegistryValue> versions = new ArrayList<>();
+    // Add default versions from default context
+    try (CloseableIterator<SchemaRegistryValue> iter =
+        allVersions(tenantPrefix + unqualifiedSubjectOrPrefix, isPrefix)) {
+      while (iter.hasNext()) {
+        versions.add(iter.next());
+      }
+    }
     List<ContextValue> contexts = new ArrayList<>();
     try (CloseableIterator<SchemaRegistryValue> iter = allContexts()) {
       while (iter.hasNext()) {
         contexts.add((ContextValue) iter.next());
       }
     }
-    List<SchemaRegistryValue> versions = new ArrayList<>();
     for (ContextValue v : contexts) {
       QualifiedSubject qualSub =
           new QualifiedSubject(v.getTenant(), v.getContext(), unqualifiedSubjectOrPrefix);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -1493,7 +1493,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       String tenantPrefix, String unqualifiedSubjectOrPrefix, boolean isPrefix)
       throws SchemaRegistryException {
     List<SchemaRegistryValue> versions = new ArrayList<>();
-    // Add default versions from default context
+    // Add versions from default context
     try (CloseableIterator<SchemaRegistryValue> iter =
         allVersions(tenantPrefix + unqualifiedSubjectOrPrefix, isPrefix)) {
       while (iter.hasNext()) {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiContextTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiContextTest.java
@@ -42,6 +42,7 @@ public class RestApiContextTest extends ClusterTestHarness {
     String subject1 = ":.ctx1:testTopic1";
     String subject2 = ":.ctx2:testTopic2";
     String subject3 = ":.ctx3:testTopic1";
+    String subject4 = "testTopic1";
     int schemasInSubject1 = 10;
     List<Integer> allVersionsInSubject1 = new ArrayList<Integer>();
     List<String> allSchemasInSubject1 = TestUtils.getRandomCanonicalAvroString(schemasInSubject1);
@@ -50,7 +51,10 @@ public class RestApiContextTest extends ClusterTestHarness {
     List<String> allSchemasInSubject2 = TestUtils.getRandomCanonicalAvroString(schemasInSubject2);
     int schemasInSubject3 = 2;
     List<Integer> allVersionsInSubject3 = new ArrayList<Integer>();
-    List<String> allSchemasInSubject3 = TestUtils.getRandomCanonicalAvroString(schemasInSubject2);
+    List<String> allSchemasInSubject3 = TestUtils.getRandomCanonicalAvroString(schemasInSubject3);
+    int schemasInSubject4 = 1;
+    List<Integer> allVersionsInSubject4 = new ArrayList<Integer>();
+    List<String> allSchemasInSubject4 = TestUtils.getRandomCanonicalAvroString(schemasInSubject4);
 
     // test getAllVersions with no existing data
     try {
@@ -110,7 +114,7 @@ public class RestApiContextTest extends ClusterTestHarness {
     // reset the schema id counter due to a different context
     schemaIdCounter = 1;
 
-    // test registering schemas in subject2
+    // test registering schemas in subject3
     for (int i = 0; i < schemasInSubject3; i++) {
       String schema = allSchemasInSubject3.get(i);
       int expectedVersion = i + 1;
@@ -118,6 +122,19 @@ public class RestApiContextTest extends ClusterTestHarness {
           subject3);
       schemaIdCounter++;
       allVersionsInSubject3.add(expectedVersion);
+    }
+
+    // reset the schema id counter due to a different context
+    schemaIdCounter = 1;
+
+    // test registering schemas in subject4
+    for (int i = 0; i < schemasInSubject4; i++) {
+      String schema = allSchemasInSubject4.get(i);
+      int expectedVersion = i + 1;
+      registerAndVerifySchema(restApp.restClient, schema, schemaIdCounter,
+          subject4);
+      schemaIdCounter++;
+      allVersionsInSubject4.add(expectedVersion);
     }
 
     // test getAllVersions with existing data
@@ -144,23 +161,23 @@ public class RestApiContextTest extends ClusterTestHarness {
                  restApp.restClient.getAllSubjects(":.ctx2:", false));
 
     // test getAllSubjects with existing data
-    assertEquals("Getting all subjects should match no registered subjects",
-                 Collections.emptyList(),
+    assertEquals("Getting all subjects should match default subjects",
+                 Collections.singletonList(subject4),
                  restApp.restClient.getAllSubjects("", false));
 
     // test getAllSubjectsWithPrefix with context wildcard
     assertEquals("Getting all subjects should match all registered subjects",
-        ImmutableList.of(subject1, subject2, subject3),
+        ImmutableList.of(subject1, subject2, subject3, subject4),
         restApp.restClient.getAllSubjects(":*:", false));
 
     // test getSchemas with context wildcard
     assertEquals("Getting all schemas should match all registered subjects",
-        schemasInSubject1 + schemasInSubject2 + schemasInSubject3,
+        schemasInSubject1 + schemasInSubject2 + schemasInSubject3 + schemasInSubject4,
         restApp.restClient.getSchemas(":*:", false, false).size());
 
     // test getSchemas with context wildcard and subject
     assertEquals("Getting all schemas should match registered subjects",
-        schemasInSubject1 + schemasInSubject3,
+        schemasInSubject1 + schemasInSubject3 + schemasInSubject4,
         restApp.restClient.getSchemas(":*:testTopic1", false, false).size());
 
     // test getSchemas with context wildcard and subject
@@ -168,12 +185,12 @@ public class RestApiContextTest extends ClusterTestHarness {
         schemasInSubject2,
         restApp.restClient.getSchemas(":*:testTopic2", false, false).size());
 
-    Schema schema = restApp.restClient.getVersion("testTopic1", 1);
+    Schema schema = restApp.restClient.getVersion("testTopic2", 1);
     assertEquals("Getting schema by version w/o context should succeed",
         1,
         schema.getVersion().intValue());
 
-    schema = restApp.restClient.lookUpSubjectVersion(schema.getSchema(), "testTopic1");
+    schema = restApp.restClient.lookUpSubjectVersion(schema.getSchema(), "testTopic2");
     assertEquals("Getting schema by schema w/o context should succeed",
         1,
         schema.getVersion().intValue());


### PR DESCRIPTION
DGS-5400 added ability to pass a subjectPrefix with a wildcard context, but it only returned subjects that had an explicit context.  This fix will cause subjects from the default context to also be returned.