### PR TITLE
DGS-6065: Use HOST_NAME config for host even if inter.instance.listener.name is set

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -297,8 +297,7 @@ public class SchemaRegistryConfig extends RestConfig {
   protected static final String HOST_DOC =
       "The host name. Make sure to set this if running SchemaRegistry "
       + "with multiple nodes. This name is also used in the endpoint for inter instance "
-      + "communication if inter.instance.listener.name is not specified or does not match "
-      + "any listener ";
+      + "communication";
   protected static final String SCHEMA_PROVIDERS_DOC =
       "  A list of classes to use as SchemaProvider. Implementing the interface "
           + "<code>SchemaProvider</code> allows you to add custom schema types to Schema Registry.";

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -166,13 +166,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     log.info("Found internal listener: " + internalListener.toString());
     SchemeAndPort schemeAndPort = new SchemeAndPort(internalListener.getUri().getScheme(),
         internalListener.getUri().getPort());
-    // Use listener endpoint for identity when a matching named inter instance listener was found.
-    // Default to existing behavior of using host name config and listener port otherwise.
-    String internalListenerName = internalListener.getName();
-    String host =   (internalListenerName != null
-                      && internalListenerName.equals(interInstanceListenerNameConfig))
-                    ? internalListener.getUri().getHost()
-                    : config.getString(SchemaRegistryConfig.HOST_NAME_CONFIG);
+    String host = config.getString(SchemaRegistryConfig.HOST_NAME_CONFIG);
     this.myIdentity = new SchemaRegistryIdentity(host, schemeAndPort.port,
         isEligibleForLeaderElector, schemeAndPort.scheme);
     log.info("Setting my identity to " + myIdentity.toString());


### PR DESCRIPTION
Re-applying the changes in the original [PR](https://github.com/confluentinc/schema-registry/pull/2536) for 7.4.x to master as the changes from the pint merge got subsequently overwritten.