### PR TITLE
[DGS-6267] - Changing logs to debug in SR

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -263,7 +263,7 @@ public class ConfigResource {
   public void deleteTopLevelConfig(
       final @Suspended AsyncResponse asyncResponse,
       @Context HttpHeaders headers) {
-    log.info("Deleting Global compatibility setting and reverting back to default");
+    log.debug("Deleting Global compatibility setting and reverting back to default");
 
     Config deletedConfig;
     try {
@@ -308,7 +308,7 @@ public class ConfigResource {
       @Context HttpHeaders headers,
       @Parameter(description = "Name of the subject", required = true)
       @PathParam("subject") String subject) {
-    log.info("Deleting compatibility setting for subject {}", subject);
+    log.debug("Deleting compatibility setting for subject {}", subject);
 
     subject = QualifiedSubject.normalize(schemaRegistry.tenant(), subject);
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
@@ -245,7 +245,7 @@ public class ModeResource {
       @Context HttpHeaders headers,
       @Parameter(description = "Name of the subject", required = true)
       @PathParam("subject") String subject) {
-    log.info("Deleting mode for subject {}", subject);
+    log.debug("Deleting mode for subject {}", subject);
 
     subject = QualifiedSubject.normalize(schemaRegistry.tenant(), subject);
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -469,7 +469,7 @@ public class SubjectVersionsResource {
       @PathParam("version") String version,
       @Parameter(description = "Whether to perform a permanent delete")
       @QueryParam("permanent") boolean permanentDelete) {
-    log.info("Deleting schema version {} from subject {}", version, subject);
+    log.debug("Deleting schema version {} from subject {}", version, subject);
 
     subject = QualifiedSubject.normalize(schemaRegistry.tenant(), subject);
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -110,7 +110,7 @@ public class SubjectsResource {
       @QueryParam("deleted") boolean lookupDeletedSchema,
       @Parameter(description = "Schema", required = true)
       @NotNull RegisterSchemaRequest request) {
-    log.info("Schema lookup under subject {}, deleted {}, type {}",
+    log.debug("Schema lookup under subject {}, deleted {}, type {}",
              subject, lookupDeletedSchema, request.getSchemaType());
 
     subject = QualifiedSubject.normalize(schemaRegistry.tenant(), subject);
@@ -211,7 +211,7 @@ public class SubjectsResource {
       @PathParam("subject") String subject,
       @Parameter(description = "Whether to perform a permanent delete")
       @QueryParam("permanent") boolean permanentDelete) {
-    log.info("Deleting subject {}", subject);
+    log.debug("Deleting subject {}", subject);
 
     subject = QualifiedSubject.normalize(schemaRegistry.tenant(), subject);
 


### PR DESCRIPTION
What
------
1. Changing log.info to log.debug for log statements with redundant information.

Why
--------
1. We are reducing the number of logs by removing redundant logs. For eg,
Requests parameters that can be obtained from the HTTP Log will be moved to debug statement.
    For eg, log statement for HTTP Request
    ```
    154.217.101.184 - - [17/Feb/2023:00:01:30 +0000] 
    "DELETE /subjects/test-subject?permanent=true HTTP/2.0" 
    3200 3 "-" "Go-http-client/2.0" 9 
    ```
    Log statement by resource file: 
    ```
    Deleting subject test-subject
    ```
    The second statement isn’t lending any new information and hence we’ll change to log.debug. 
    
    
References
------------
1. Ticket - https://confluentinc.atlassian.net/browse/DGS-5341