### PR TITLE
DGS-6319 Handle field encryption rules that apply to the same tags

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -10,7 +10,7 @@
               files="ErrorMessage.java"/>
 
     <suppress checks="ParameterNumber"
-              files="(AbstractKafkaProtobufSerializer|DynamicSchema|MessageDefinition|ProtobufSchema|Rule|SchemaRegistryCoordinator).java"/>
+              files="(AbstractKafkaProtobufSerializer|DynamicSchema|MessageDefinition|ProtobufSchema|Rule|RuleContext|SchemaRegistryCoordinator).java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
               files="(AzureKmsClient|AbstractKafkaAvroDeserializer|AbstractKafkaAvroSerializer|AbstractKafkaSchemaSerDe|CachedSchemaRegistryClient|RestService|Errors|SchemaRegistryRestApplication|Context|KafkaSchemaRegistry|KafkaStore|AvroConverter|AvroData|AvroSchemaUtils|KafkaGroupLeaderElector|ProtobufSchema|ProtobufData|JsonSchemaData|InMemoryCache|SchemaMessageReader|Jackson|JsonSchemaConverter|MetricsContainer|ProtobufSchema|ProtobufSchemaUtils|MetadataEncoderService|ProtoFileElementDeserializer).java"/>

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/rules/FieldRuleExecutor.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/rules/FieldRuleExecutor.java
@@ -25,7 +25,11 @@ public interface FieldRuleExecutor extends RuleExecutor {
 
   default Object transform(RuleContext ctx, Object message) throws RuleException {
     try (FieldTransform transform = newTransform(ctx)) {
-      return ctx.target().transformMessage(ctx, transform, message);
+      if (transform != null) {
+        return ctx.target().transformMessage(ctx, transform, message);
+      } else {
+        return message;
+      }
     }
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/rules/RuleContext.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/rules/RuleContext.java
@@ -24,6 +24,7 @@ import io.confluent.kafka.schemaregistry.utils.WildcardMatcher;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -46,6 +47,8 @@ public class RuleContext {
   private final boolean isKey;
   private final RuleMode ruleMode;
   private final Rule rule;
+  private final int index;
+  private final List<Rule> rules;
   private final Map<Object, Object> customData = new ConcurrentHashMap<>();
   private final Deque<FieldContext> fieldContexts;
 
@@ -59,7 +62,9 @@ public class RuleContext {
       Object originalValue,
       boolean isKey,
       RuleMode ruleMode,
-      Rule rule) {
+      Rule rule,
+      int index,
+      List<Rule> rules) {
     this.source = source;
     this.target = target;
     this.subject = subject;
@@ -70,6 +75,8 @@ public class RuleContext {
     this.isKey = isKey;
     this.ruleMode = ruleMode;
     this.rule = rule;
+    this.index = index;
+    this.rules = rules;
     this.fieldContexts = new ArrayDeque<>();
   }
 
@@ -111,6 +118,14 @@ public class RuleContext {
 
   public Rule rule() {
     return rule;
+  }
+
+  public int index() {
+    return index;
+  }
+
+  public List<Rule> rules() {
+    return rules;
   }
 
   public Map<Object, Object> customData() {

--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -93,6 +93,11 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
     </Match>
 
     <Match>
+        <Class name="io.confluent.kafka.schemaregistry.rules.FieldRuleExecutor"/>
+        <Bug pattern="NP_LOAD_OF_KNOWN_NULL_VALUE"/>
+    </Match>
+
+    <Match>
         <Class name="io.confluent.kafka.schemaregistry.utils.AppInfoParser"/>
         <Bug pattern="NP_LOAD_OF_KNOWN_NULL_VALUE"/>
     </Match>

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -593,7 +593,8 @@ public abstract class AbstractKafkaSchemaSerDe {
         }
       }
     }
-    for (Rule rule : rules) {
+    for (int i = 0; i < rules.size(); i++) {
+      Rule rule = rules.get(i);
       if (rule.isDisabled()) {
         continue;
       }
@@ -609,7 +610,7 @@ public abstract class AbstractKafkaSchemaSerDe {
         continue;
       }
       RuleContext ctx = new RuleContext(source, target,
-          subject, topic, headers, key(), isKey ? null : original, isKey, ruleMode, rule);
+          subject, topic, headers, key(), isKey ? null : original, isKey, ruleMode, rule, i, rules);
       RuleExecutor ruleExecutor = getRuleExecutor(ctx);
       if (ruleExecutor != null) {
         try {


### PR DESCRIPTION
Handle field level encryption rules that apply to the same tags.  On encryption the later rules with the same tags should override the earlier ones, whereas on decryption, the earlier rules should override the later ones.