### PR TITLE
DGS-6331 Handle javaType for oneOfs during JSON deserialization

### DIFF
--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -261,6 +261,11 @@ public class JsonSchema implements ParsedSchema {
   }
 
   public void validate(Object value) throws JsonProcessingException, ValidationException {
+    validate(rawSchema(), value);
+  }
+
+  public static void validate(Schema schema, Object value)
+      throws JsonProcessingException, ValidationException {
     Object primitiveValue = NONE_MARKER;
     if (isPrimitive(value)) {
       primitiveValue = value;
@@ -276,7 +281,7 @@ public class JsonSchema implements ParsedSchema {
       primitiveValue = ((TextNode) value).asText();
     }
     if (primitiveValue != NONE_MARKER) {
-      rawSchema().validate(primitiveValue);
+      schema.validate(primitiveValue);
     } else {
       Object jsonObject;
       if (value instanceof ArrayNode) {
@@ -288,7 +293,7 @@ public class JsonSchema implements ParsedSchema {
       } else {
         jsonObject = objectMapper.convertValue(value, JSONObject.class);
       }
-      rawSchema().validate(jsonObject);
+      schema.validate(jsonObject);
     }
   }
 

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
@@ -24,6 +24,9 @@ import kafka.utils.VerifiableProperties;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.errors.SerializationException;
+import org.everit.json.schema.CombinedSchema;
+import org.everit.json.schema.ReferenceSchema;
+import org.everit.json.schema.Schema;
 import org.everit.json.schema.ValidationException;
 
 import java.io.ByteArrayInputStream;
@@ -115,8 +118,6 @@ public abstract class AbstractKafkaJsonSchemaDeserializer<T> extends AbstractKaf
       int length = buffer.limit() - 1 - idSize;
       int start = buffer.position() + buffer.arrayOffset();
 
-      String typeName = schema.getString(typeProperty);
-
       JsonNode jsonNode = null;
       if (validate) {
         try {
@@ -135,19 +136,30 @@ public abstract class AbstractKafkaJsonSchemaDeserializer<T> extends AbstractKaf
         value = jsonNode != null
             ? objectMapper.convertValue(jsonNode, type)
             : objectMapper.readValue(buffer.array(), start, length, type);
-      } else if (typeName != null) {
-        value = jsonNode != null
-            ? deriveType(jsonNode, typeName)
-            : deriveType(buffer, length, start, typeName);
-      } else if (Object.class.equals(type)) {
-        value = jsonNode != null
-            ? objectMapper.convertValue(jsonNode, type)
-            : objectMapper.readValue(buffer.array(), start, length, type);
       } else {
-        // Return JsonNode if type is null
-        value = jsonNode != null
-            ? jsonNode
-            : objectMapper.readTree(new ByteArrayInputStream(buffer.array(), start, length));
+        String typeName;
+        if (schema.rawSchema() instanceof CombinedSchema) {
+          if (jsonNode == null) {
+            jsonNode = objectMapper.readValue(buffer.array(), start, length, JsonNode.class);
+          }
+          typeName = getTypeName(schema.rawSchema(), jsonNode);
+        } else {
+          typeName = schema.getString(typeProperty);
+        }
+        if (typeName != null) {
+          value = jsonNode != null
+              ? deriveType(jsonNode, typeName)
+              : deriveType(buffer, length, start, typeName);
+        } else if (Object.class.equals(type)) {
+          value = jsonNode != null
+              ? objectMapper.convertValue(jsonNode, type)
+              : objectMapper.readValue(buffer.array(), start, length, type);
+        } else {
+          // Return JsonNode if type is null
+          value = jsonNode != null
+              ? jsonNode
+              : objectMapper.readTree(new ByteArrayInputStream(buffer.array(), start, length));
+        }
       }
 
       if (includeSchemaAndVersion) {
@@ -171,6 +183,26 @@ public abstract class AbstractKafkaJsonSchemaDeserializer<T> extends AbstractKaf
     } catch (RestClientException e) {
       throw toKafkaException(e, "Error retrieving JSON schema for id " + id);
     }
+  }
+
+  private String getTypeName(Schema schema, JsonNode jsonNode) {
+    if (schema instanceof CombinedSchema) {
+      for (Schema subschema : ((CombinedSchema) schema).getSubschemas()) {
+        boolean valid = false;
+        try {
+          JsonSchema.validate(subschema, jsonNode);
+          valid = true;
+        } catch (Exception e) {
+          // noop
+        }
+        if (valid) {
+          return getTypeName(subschema, jsonNode);
+        }
+      }
+    } else if (schema instanceof ReferenceSchema) {
+      return getTypeName(((ReferenceSchema)schema).getReferredSchema(), jsonNode);
+    }
+    return (String) schema.getUnprocessedProperties().get(typeProperty);
   }
 
   private Object deriveType(


### PR DESCRIPTION
When using a javaType with a oneOf, look for the javaType on the subschemas instead of the root oneOf.