### PR TITLE
DGS-6613 Ignore invalid Avro defaults in Avro Converter

### DIFF
--- a/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -1948,8 +1948,12 @@ public class AvroData {
       builder.parameter(AVRO_FIELD_DEFAULT_FLAG_PROP, "true");
     }
     if (fieldDefaultVal != null) {
-      builder.defaultValue(
-          defaultValueFromAvro(builder, schema, fieldDefaultVal, toConnectContext));
+      try {
+        builder.defaultValue(
+            defaultValueFromAvro(builder, schema, fieldDefaultVal, toConnectContext));
+      } catch (DataException e) {
+        log.warn("Ignoring invalid default for schema " + schema.getName(), e);
+      }
     }
 
     Object connectNameJson = schema.getObjectProp(CONNECT_NAME_PROP);

--- a/avro-data/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-data/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -2427,6 +2427,50 @@ public class AvroDataTest {
   }
 
   @Test
+  public void testNestedRecordWithInvalidDefault() {
+    final String fullSchema = "{"
+        + "  \"name\": \"RecordWithObjectDefault\","
+        + "  \"type\": \"record\","
+        + "  \"fields\": [{"
+        + "    \"name\": \"obj\","
+        + "      \"type\": {"
+        + "        \"name\": \"Object\","
+        + "        \"type\": \"record\","
+        + "        \"connect.default\": [1.23],"
+        + "        \"fields\": [{"
+        + "            \"name\": \"nullableString\","
+        + "            \"type\": [\"null\",\"string\"]}"
+        + "        ]}"
+        + "    }]"
+        + "}";
+
+    org.apache.avro.Schema avroSchema = new org.apache.avro.Schema.Parser()
+        .setValidateDefaults(false).parse(fullSchema);
+
+    org.apache.avro.Schema innerSchema = new org.apache.avro.Schema.Parser().parse("{"
+        + "        \"name\": \"Object\","
+        + "        \"type\": \"record\","
+        + "        \"fields\": [{"
+        + "            \"name\": \"nullableString\","
+        + "            \"type\": [\"null\",\"string\"]}"
+        + "        ]}");
+
+    AvroData avroData = new AvroData(0);
+
+    // test record:
+    // {"obj": {"nullableString": null}}
+    GenericRecord nestedRecord = new GenericRecordBuilder(avroSchema)
+        .set("obj", new GenericRecordBuilder(innerSchema).set("nullableString", null).build())
+        .build();
+
+    SchemaAndValue schemaAndValue = avroData.toConnectData(avroSchema, nestedRecord);
+    Struct value = (Struct)schemaAndValue.value();
+    assertNotNull(value.get("obj"));
+    Struct objFieldValue = (Struct)value.get("obj");
+    assertNull(objFieldValue.get("nullableString"));
+  }
+
+  @Test
   public void testArrayOfRecordWithNullNamespace() {
     org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.array().items()
             .record("item").fields()


### PR DESCRIPTION
This is a continuation of DGS-1595 to ignore invalid defaults in the Avro Converter.