### PR TITLE
DGS-6701 Fix getSchemaById to match subject if passed

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
@@ -149,6 +149,11 @@ public class QualifiedSubject implements Comparable<QualifiedSubject> {
     return qs != null ? qs.getContext() : DEFAULT_CONTEXT;
   }
 
+  public static String qualifiedContextFor(String tenant, String qualifiedSubject) {
+    QualifiedSubject qs = QualifiedSubject.create(tenant, qualifiedSubject);
+    return qs != null ? qs.toQualifiedContext() : "";
+  }
+
   /**
    * Normalizes the given qualified subject name.
    *

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -521,11 +521,12 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
           schema.setId(schemaId);
           kafkaStore.put(schemaKey, new SchemaValue(schema));
         } else {
+          String qctx = QualifiedSubject.qualifiedContextFor(tenant(), subject);
           int retries = 0;
           while (retries++ < kafkaStoreMaxRetries) {
             int newId = idGenerator.id(new SchemaValue(schema));
             // Verify id is not already in use
-            if (lookupCache.schemaKeyById(newId, subject) == null) {
+            if (lookupCache.schemaKeyById(newId, qctx) == null) {
               schema.setId(newId);
               if (retries > 1) {
                 log.warn(String.format("Retrying to register the schema with ID %s", newId));
@@ -849,7 +850,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
 
   public void checkIfSchemaWithIdExist(int id, Schema schema)
       throws SchemaRegistryException, StoreException {
-    SchemaKey existingKey = this.lookupCache.schemaKeyById(id, schema.getSubject());
+    String qctx = QualifiedSubject.qualifiedContextFor(tenant(), schema.getSubject());
+    SchemaKey existingKey = this.lookupCache.schemaKeyById(id, qctx);
     if (existingKey != null) {
       SchemaRegistryValue existingValue = this.lookupCache.get(existingKey);
       if (existingValue != null
@@ -1208,10 +1210,10 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     QualifiedSubject qs = QualifiedSubject.create(tenant(), subject);
     boolean isQualifiedSubject = qs != null && !DEFAULT_CONTEXT.equals(qs.getContext());
     SchemaKey subjectVersionKey = lookupCache.schemaKeyById(id, subject);
-    if (subject == null
-        || subject.isEmpty()
+    if (qs == null
+        || qs.getSubject().isEmpty()
         || isQualifiedSubject
-        || schemaKeyMatchesSubject(subjectVersionKey, qs)) {
+        || subjectVersionKey != null) {
       return subjectVersionKey;
     }
     // Try qualifying the subject with each known context
@@ -1221,25 +1223,14 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
         QualifiedSubject qualSub =
             new QualifiedSubject(v.getTenant(), v.getContext(), qs.getSubject());
         SchemaKey key = lookupCache.schemaKeyById(id, qualSub.toQualifiedSubject());
-        if (schemaKeyMatchesSubject(key, qualSub)) {
+        if (key != null) {
           return key;
         }
       }
     }
     // Could not find the id in subjects in other contexts,
-    // just return the id in the default context if found
-    return subjectVersionKey;
-  }
-
-  private boolean schemaKeyMatchesSubject(SchemaKey key, QualifiedSubject qs) {
-    if (key == null) {
-      return false;
-    } else if (qs == null) {
-      return true;
-    } else {
-      QualifiedSubject keyQs = QualifiedSubject.create(tenant(), key.getSubject());
-      return keyQs != null && qs.getSubject().equals(keyQs.getSubject());
-    }
+    // just return the id in the given context if found
+    return lookupCache.schemaKeyById(id, qs.toQualifiedContext());
   }
 
   private CloseableIterator<SchemaRegistryValue> allContexts() throws SchemaRegistryException {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -23,6 +23,7 @@ import io.confluent.kafka.schemaregistry.metrics.MetricsContainer;
 import io.confluent.kafka.schemaregistry.metrics.SchemaRegistryMetric;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
+import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
 import java.util.Collections;
 import java.util.List;
 import org.apache.kafka.common.TopicPartition;
@@ -74,7 +75,9 @@ public class KafkaStoreMessageHandler implements SchemaUpdateHandler {
         }
       }
       try {
-        SchemaKey oldKey = lookupCache.schemaKeyById(schemaObj.getId(), schemaObj.getSubject());
+        String qctx = QualifiedSubject.qualifiedContextFor(
+            schemaRegistry.tenant(), schemaObj.getSubject());
+        SchemaKey oldKey = lookupCache.schemaKeyById(schemaObj.getId(), qctx);
         if (oldKey != null) {
           SchemaValue oldSchema;
           oldSchema = (SchemaValue) lookupCache.get(oldKey);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LookupCache.java
@@ -64,7 +64,7 @@ public interface LookupCache<K,V> extends Store<K,V> {
    * Provides the {@link SchemaKey} for the provided schema id.
    *
    * @param id the schema id; never {@code null}
-   * @param subject the subject
+   * @param subject the qualified context or subject
    * @return the {@link SchemaKey} if found, otherwise null.
    */
   SchemaKey schemaKeyById(Integer id, String subject) throws StoreException;

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiContextTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiContextTest.java
@@ -204,7 +204,9 @@ public class RestApiContextTest extends ClusterTestHarness {
     RestService noCtxRestClient3 = new RestService(restApp.restConnect);
 
     String subject1 = "testTopic1";
-    String subject2 = "testTopic2";
+    String subject2A = "testTopic2A";
+    String subject2B = "testTopic2B";
+    String subject2C = "testTopic2C";
     String subject3 = "testTopic3";
     int schemasInSubject1 = 10;
     List<Integer> allVersionsInSubject1 = new ArrayList<Integer>();
@@ -251,12 +253,16 @@ public class RestApiContextTest extends ClusterTestHarness {
     // reset the schema id counter due to a different context
     schemaIdCounter = 1;
 
-    // test registering schemas in subject2
+    // test registering schemas in subject2A, subject2B, subject2C
     for (int i = 0; i < schemasInSubject2; i++) {
       String schema = allSchemasInSubject2.get(i);
       int expectedVersion = i + 1;
       registerAndVerifySchema(restClient2, schema, schemaIdCounter,
-          subject2);
+          subject2A);
+      registerAndVerifySchema(restClient2, schema, schemaIdCounter,
+          subject2B);
+      registerAndVerifySchema(restClient2, schema, schemaIdCounter,
+          subject2C);
       schemaIdCounter++;
       allVersionsInSubject2.add(expectedVersion);
     }
@@ -287,9 +293,9 @@ public class RestApiContextTest extends ClusterTestHarness {
     assertEquals("Getting all versions from subject1 should match all registered versions",
         allVersionsInSubject1,
         restClient1.getAllVersions(subject1));
-    assertEquals("Getting all versions from subject2 should match all registered versions",
+    assertEquals("Getting all versions from subject2A should match all registered versions",
         allVersionsInSubject2,
-        restClient2.getAllVersions(subject2));
+        restClient2.getAllVersions(subject2A));
     assertEquals("Getting all versions from subject3 should match all registered versions",
         allVersionsInSubject3,
         restClient3.getAllVersions(subject3));
@@ -312,7 +318,7 @@ public class RestApiContextTest extends ClusterTestHarness {
 
     // test getAllSubjects with existing data
     assertEquals("Getting all subjects should match all registered subjects",
-        Collections.singletonList(":.ctx2:" + subject2),
+        ImmutableList.of(":.ctx2:" + subject2A, ":.ctx2:" + subject2B, ":.ctx2:" + subject2C),
         restClient2.getAllSubjects());
 
     // test getAllSubjects with existing data
@@ -331,11 +337,11 @@ public class RestApiContextTest extends ClusterTestHarness {
         allSchemasInSubject3.get(0),
         noCtxRestClient3.getId(1, subject3).getSchemaString());
 
-    // Now ask for schema id 1 from subject2.
+    // Now ask for schema id 1 from subject2A.
     // This should NOT return schema id 1 from the default context
     assertEquals("Registered schema should be found",
         allSchemasInSubject2.get(0),
-        noCtxRestClient3.getId(1, subject2).getSchemaString());
+        noCtxRestClient3.getId(1, subject2A).getSchemaString());
   }
 
   static void registerAndVerifySchema(RestService restService, String schemaString,


### PR DESCRIPTION
We ensure the subject name is matched when calling `getSchemaById`.

For calls to `getSchemaById` that don't care about the subject name matching (but only the context), we pass a qualified context with no subject name.

This is a fix to https://github.com/confluentinc/schema-registry/pull/2443