### PR TITLE
DGS-6698: Remove SnakeYaml from the dependencyManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,6 @@
         <swagger.version>1.6.2</swagger.version>
         <spotbugs.plugin.version>4.0.0</spotbugs.plugin.version>
         <commons.compress.version>1.21</commons.compress.version>
-        <snake.yaml.version>1.32</snake.yaml.version>
     </properties>
 
     <repositories>
@@ -205,11 +204,6 @@
                         <artifactId>guava</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>${snake.yaml.version}</version>
             </dependency>
 
             <!--children-->


### PR DESCRIPTION
Remove SnakeYaml from the dependencyManagement to pull the latest version defined in common. See: https://github.com/confluentinc/common/pull/514