### PR TITLE
Enhancements to DlqAction

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -445,7 +445,6 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
     }
 
     Object read(AvroSchema writerAvroSchema, AvroSchema readerAvroSchema) {
-      preOp(payload);
       try {
         List<Migration> migrations = Collections.emptyList();
         if (readerAvroSchema == null) {
@@ -518,7 +517,7 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
         throw new SerializationException("Error deserializing Avro message for id "
             + schemaId, e);
       } finally {
-        postOp();
+        postOp(payload);
       }
     }
   }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -106,7 +106,6 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
       return null;
     }
     String restClientErrorMsg = "";
-    preOp(object);
     try {
       int id;
       if (autoRegisterSchema) {
@@ -161,7 +160,7 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
     } catch (RestClientException e) {
       throw toKafkaException(e, restClientErrorMsg + schema);
     } finally {
-      postOp();
+      postOp(object);
     }
   }
 

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
@@ -120,6 +120,6 @@ public class KafkaAvroDeserializer extends AbstractKafkaAvroDeserializer
 
   @Override
   public void close() {
-
+    super.close();
   }
 }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
@@ -70,6 +70,6 @@ public class KafkaAvroSerializer extends AbstractKafkaAvroSerializer implements 
 
   @Override
   public void close() {
-
+    super.close();
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/rules/RuleBase.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/rules/RuleBase.java
@@ -22,10 +22,13 @@ import org.apache.kafka.common.Configurable;
 /**
  * Base type for rule interfaces.
  */
-public interface RuleBase extends Configurable {
+public interface RuleBase extends AutoCloseable, Configurable {
 
   default void configure(Map<String, ?> configs) {
   }
 
   String type();
+
+  default void close() {
+  }
 }

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
@@ -123,7 +123,6 @@ public abstract class AbstractKafkaJsonSchemaDeserializer<T> extends AbstractKaf
     }
 
     int id = -1;
-    preOp(payload);
     try {
       ByteBuffer buffer = getByteBuffer(payload);
       id = buffer.getInt();
@@ -234,7 +233,7 @@ public abstract class AbstractKafkaJsonSchemaDeserializer<T> extends AbstractKaf
     } catch (RestClientException e) {
       throw toKafkaException(e, "Error retrieving JSON schema for id " + id);
     } finally {
-      postOp();
+      postOp(payload);
     }
   }
 

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaSerializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaSerializer.java
@@ -114,7 +114,6 @@ public abstract class AbstractKafkaJsonSchemaSerializer<T> extends AbstractKafka
       return null;
     }
     String restClientErrorMsg = "";
-    preOp(object);
     try {
       int id;
       if (autoRegisterSchema) {
@@ -153,7 +152,7 @@ public abstract class AbstractKafkaJsonSchemaSerializer<T> extends AbstractKafka
     } catch (RestClientException e) {
       throw toKafkaException(e, restClientErrorMsg + schema);
     } finally {
-      postOp();
+      postOp(object);
     }
   }
 

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaDeserializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaDeserializer.java
@@ -89,6 +89,6 @@ public class KafkaJsonSchemaDeserializer<T> extends AbstractKafkaJsonSchemaDeser
 
   @Override
   public void close() {
-
+    super.close();
   }
 }

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializer.java
@@ -99,5 +99,6 @@ public class KafkaJsonSchemaSerializer<T> extends AbstractKafkaJsonSchemaSeriali
 
   @Override
   public void close() {
+    super.close();
   }
 }

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufDeserializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufDeserializer.java
@@ -127,7 +127,6 @@ public abstract class AbstractKafkaProtobufDeserializer<T extends Message>
     }
 
     int id = -1;
-    preOp(payload);
     try {
       ByteBuffer buffer = getByteBuffer(payload);
       id = buffer.getInt();
@@ -226,7 +225,7 @@ public abstract class AbstractKafkaProtobufDeserializer<T extends Message>
     } catch (RestClientException e) {
       throw toKafkaException(e, "Error retrieving Protobuf schema for id " + id);
     } finally {
-      postOp();
+      postOp(payload);
     }
   }
 

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufSerializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufSerializer.java
@@ -100,7 +100,6 @@ public abstract class AbstractKafkaProtobufSerializer<T extends Message>
       return null;
     }
     String restClientErrorMsg = "";
-    preOp(object);
     try {
       boolean autoRegisterForDeps = autoRegisterSchema && !onlyLookupReferencesBySchema;
       boolean useLatestForDeps = useLatestVersion && !onlyLookupReferencesBySchema;
@@ -152,7 +151,7 @@ public abstract class AbstractKafkaProtobufSerializer<T extends Message>
     } catch (RestClientException e) {
       throw toKafkaException(e, restClientErrorMsg + schema);
     } finally {
-      postOp();
+      postOp(object);
     }
   }
 

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufDeserializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufDeserializer.java
@@ -86,6 +86,6 @@ public class KafkaProtobufDeserializer<T extends Message>
 
   @Override
   public void close() {
-
+    super.close();
   }
 }

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufSerializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufSerializer.java
@@ -106,5 +106,6 @@ public class KafkaProtobufSerializer<T extends Message>
 
   @Override
   public void close() {
+    super.close();
   }
 }

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/WrapperKeyDeserializer.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/WrapperKeyDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Confluent Inc.
+ * Copyright 2023 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/WrapperKeyDeserializer.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/WrapperKeyDeserializer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+
+package io.confluent.kafka.serializers;
+
+import java.util.Map;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Deserializer;
+
+public class WrapperKeyDeserializer<T> implements Deserializer<T> {
+
+  private Deserializer<T> inner;
+
+  /**
+   * Constructor used by Kafka consumer.
+   */
+  public WrapperKeyDeserializer() {
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    configure(new WrapperKeyDeserializerConfig(configs), isKey);
+  }
+
+  @SuppressWarnings("unchecked")
+  protected void configure(WrapperKeyDeserializerConfig config, boolean isKey) {
+    if (!isKey) {
+      throw new IllegalArgumentException("WrapperKeyDeserializer is only for keys");
+    }
+    this.inner = config.getConfiguredInstance(
+        WrapperKeyDeserializerConfig.WRAPPED_KEY_DESERIALIZER, Deserializer.class);
+  }
+
+  @Override
+  public T deserialize(String topic, byte[] bytes) {
+    return deserialize(topic, null, bytes);
+  }
+
+  @Override
+  public T deserialize(String topic, Headers headers, byte[] bytes) {
+    try {
+      return inner.deserialize(topic, headers, bytes);
+    } finally {
+      AbstractKafkaSchemaSerDe.setKey(bytes);
+    }
+  }
+
+  @Override
+  public void close() {
+    inner.close();
+  }
+}

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/WrapperKeyDeserializerConfig.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/WrapperKeyDeserializerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Confluent Inc.
+ * Copyright 2023 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/WrapperKeyDeserializerConfig.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/WrapperKeyDeserializerConfig.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+
+package io.confluent.kafka.serializers;
+
+import java.util.Map;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+public class WrapperKeyDeserializerConfig extends AbstractConfig {
+
+  public static final String WRAPPED_KEY_DESERIALIZER = "wrapper.key.deserializer";
+  public static final String WRAPPED_KEY_DESERIALIZER_DOC =
+      "Deserializer class to which calls will be delegated";
+
+  private static final ConfigDef config;
+
+  static {
+    config = new ConfigDef().define(
+        WRAPPED_KEY_DESERIALIZER,
+        ConfigDef.Type.CLASS,
+        Object.class,
+        ConfigDef.Importance.HIGH,
+        WRAPPED_KEY_DESERIALIZER_DOC
+    );
+  }
+
+  public WrapperKeyDeserializerConfig(Map<?, ?> props) {
+    super(config, props);
+  }
+}

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/WrapperKeySerializer.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/WrapperKeySerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Confluent Inc.
+ * Copyright 2023 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/WrapperKeySerializer.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/WrapperKeySerializer.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+
+package io.confluent.kafka.serializers;
+
+import java.util.Map;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Serializer;
+
+public class WrapperKeySerializer<T> implements Serializer<T> {
+
+  private Serializer<T> inner;
+
+  /**
+   * Constructor used by Kafka producer.
+   */
+  public WrapperKeySerializer() {
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    configure(new WrapperKeySerializerConfig(configs), isKey);
+  }
+
+  @SuppressWarnings("unchecked")
+  protected void configure(WrapperKeySerializerConfig config, boolean isKey) {
+    if (!isKey) {
+      throw new IllegalArgumentException("WrapperKeySerializer is only for keys");
+    }
+    this.inner = config.getConfiguredInstance(
+        WrapperKeySerializerConfig.WRAPPED_KEY_SERIALIZER, Serializer.class);
+  }
+
+  @Override
+  public byte[] serialize(String topic, T data) {
+    return serialize(topic, null, data);
+  }
+
+  @Override
+  public byte[] serialize(String topic, Headers headers, T data) {
+    try {
+      return inner.serialize(topic, headers, data);
+    } finally {
+      AbstractKafkaSchemaSerDe.setKey(data);
+    }
+  }
+
+  @Override
+  public void close() {
+    inner.close();
+  }
+}

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/WrapperKeySerializerConfig.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/WrapperKeySerializerConfig.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+
+package io.confluent.kafka.serializers;
+
+import java.util.Map;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+public class WrapperKeySerializerConfig extends AbstractConfig {
+
+  public static final String WRAPPED_KEY_SERIALIZER = "wrapped.key.serializer";
+  public static final String WRAPPED_KEY_SERIALIZER_DOC =
+      "Serializer class to which calls will be delegated";
+
+  private static final ConfigDef config;
+
+  static {
+    config = new ConfigDef().define(
+        WRAPPED_KEY_SERIALIZER,
+        ConfigDef.Type.CLASS,
+        Object.class,
+        ConfigDef.Importance.HIGH,
+        WRAPPED_KEY_SERIALIZER_DOC
+    );
+  }
+
+  public WrapperKeySerializerConfig(Map<?, ?> props) {
+    super(config, props);
+  }
+}

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/WrapperKeySerializerConfig.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/WrapperKeySerializerConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Confluent Inc.
+ * Copyright 2023 Confluent Inc.
  *
  * Licensed under the Confluent Community License (the "License"); you may not use
  * this file except in compliance with the License.  You may obtain a copy of the


### PR DESCRIPTION
- Simplify capture of key by removing preOp
- Make rule executors/actions AutoCloseable
- Ensure rule executors/actions are closed, including producer in DlqAction
- Set default configs for producer in DlqAction
- Also add some Wrapper serdes to be used for keys that can capture the key value.