### PR TITLE
Refactor duplicate tag handling for field rule executors

### DIFF
--- a/client-encryption/src/main/java/io/confluent/kafka/schemaregistry/encryption/FieldEncryptionExecutor.java
+++ b/client-encryption/src/main/java/io/confluent/kafka/schemaregistry/encryption/FieldEncryptionExecutor.java
@@ -24,7 +24,6 @@ import com.google.crypto.tink.KmsClient;
 import com.google.crypto.tink.KmsClients;
 import com.google.crypto.tink.aead.AeadConfig;
 import com.google.crypto.tink.daead.DeterministicAeadConfig;
-import io.confluent.kafka.schemaregistry.client.rest.entities.Rule;
 import io.confluent.kafka.schemaregistry.rules.FieldRuleExecutor;
 import io.confluent.kafka.schemaregistry.rules.FieldTransform;
 import io.confluent.kafka.schemaregistry.rules.RuleContext;
@@ -189,36 +188,9 @@ public abstract class FieldEncryptionExecutor implements FieldRuleExecutor {
 
   @Override
   public FieldTransform newTransform(RuleContext ctx) throws RuleException {
-    switch (ctx.ruleMode()) {
-      case WRITE:
-        for (int i = ctx.index() + 1; i < ctx.rules().size(); i++) {
-          if (haveSameTags(ctx.rule(), ctx.rules().get(i))) {
-            // ignore this rule if a later one has the same tags
-            return null;
-          }
-        }
-        break;
-      case READ:
-        for (int i = 0; i < ctx.index(); i++) {
-          if (haveSameTags(ctx.rule(), ctx.rules().get(i))) {
-            // ignore this rule if an earlier one has the same tags
-            return null;
-          }
-        }
-        break;
-      default:
-        return null;
-    }
     FieldTransform transform = new FieldEncryptionExecutorTransform();
     transform.init(ctx);
     return transform;
-  }
-
-  private boolean haveSameTags(Rule rule1, Rule rule2) {
-    return rule1.getKind() == rule2.getKind()
-        && rule1.getMode() == rule2.getMode()
-        && Objects.equals(rule1.getType(), rule2.getType())
-        && Objects.equals(rule1.getTags(), rule2.getTags());
   }
 
   private Cryptor getCryptor(boolean isKey) {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/rules/FieldRuleExecutor.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/rules/FieldRuleExecutor.java
@@ -47,7 +47,7 @@ public interface FieldRuleExecutor extends RuleExecutor {
         }
         break;
       default:
-        return message;
+        throw new IllegalArgumentException("Unsupported rule mode " + ctx.ruleMode());
     }
 
     try (FieldTransform transform = newTransform(ctx)) {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/rules/FieldRuleExecutor.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/rules/FieldRuleExecutor.java
@@ -16,6 +16,9 @@
 
 package io.confluent.kafka.schemaregistry.rules;
 
+import io.confluent.kafka.schemaregistry.client.rest.entities.Rule;
+import java.util.Objects;
+
 /**
  * A field-level rule executor.
  */
@@ -24,6 +27,29 @@ public interface FieldRuleExecutor extends RuleExecutor {
   FieldTransform newTransform(RuleContext ctx) throws RuleException;
 
   default Object transform(RuleContext ctx, Object message) throws RuleException {
+    switch (ctx.ruleMode()) {
+      case WRITE:
+      case UPGRADE:
+        for (int i = ctx.index() + 1; i < ctx.rules().size(); i++) {
+          if (haveSameTags(ctx.rule(), ctx.rules().get(i))) {
+            // ignore this rule if a later one has the same tags
+            return message;
+          }
+        }
+        break;
+      case READ:
+      case DOWNGRADE:
+        for (int i = 0; i < ctx.index(); i++) {
+          if (haveSameTags(ctx.rule(), ctx.rules().get(i))) {
+            // ignore this rule if an earlier one has the same tags
+            return message;
+          }
+        }
+        break;
+      default:
+        return message;
+    }
+
     try (FieldTransform transform = newTransform(ctx)) {
       if (transform != null) {
         return ctx.target().transformMessage(ctx, transform, message);
@@ -31,5 +57,12 @@ public interface FieldRuleExecutor extends RuleExecutor {
         return message;
       }
     }
+  }
+
+  static boolean haveSameTags(Rule rule1, Rule rule2) {
+    return rule1.getKind() == rule2.getKind()
+        && rule1.getMode() == rule2.getMode()
+        && Objects.equals(rule1.getType(), rule2.getType())
+        && Objects.equals(rule1.getTags(), rule2.getTags());
   }
 }

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelExecutor.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelExecutor.java
@@ -81,7 +81,7 @@ public class CelExecutor implements RuleExecutor {
     }
   }
 
-  protected Object execute(
+  protected static Object execute(
       RuleContext ctx, Object obj, Map<String, Object> args)
       throws RuleException {
     String expr = ctx.rule().getExpr();
@@ -101,7 +101,7 @@ public class CelExecutor implements RuleExecutor {
     return execute(expr, obj, args);
   }
 
-  private Object execute(String rule, Object obj, Map<String, Object> args)
+  private static Object execute(String rule, Object obj, Map<String, Object> args)
       throws RuleException {
     try {
       boolean isAvro = false;

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelFieldExecutor.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelFieldExecutor.java
@@ -20,10 +20,9 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.rules.FieldTransform;
 import io.confluent.kafka.schemaregistry.rules.FieldRuleExecutor;
 import io.confluent.kafka.schemaregistry.rules.RuleContext;
-import io.confluent.kafka.schemaregistry.rules.RuleException;
 import java.util.ArrayList;
 
-public class CelFieldExecutor extends CelExecutor implements FieldRuleExecutor {
+public class CelFieldExecutor implements FieldRuleExecutor {
 
   public static final String TYPE = "CEL_FIELD";
 
@@ -32,16 +31,9 @@ public class CelFieldExecutor extends CelExecutor implements FieldRuleExecutor {
   }
 
   @Override
-  public Object transform(RuleContext ctx, Object message) throws RuleException {
-    try (FieldTransform transform = newTransform(ctx)) {
-      return ctx.target().transformMessage(ctx, transform, message);
-    }
-  }
-
-  @Override
   public FieldTransform newTransform(RuleContext ruleContext) {
     return (ctx, fieldCtx, fieldValue) ->
-        execute(ctx, fieldValue, ImmutableMap.<String, Object>builder()
+        CelExecutor.execute(ctx, fieldValue, ImmutableMap.<String, Object>builder()
             .put("value", fieldValue)
             .put("fullName", fieldCtx.getFullName())
             .put("name", fieldCtx.getName())


### PR DESCRIPTION
This refactors the handling of duplicate tags for field rule executors so that the CEL_FIELD rule handles
duplicate tags consistently with CSFLE.