### PR TITLE
Local schema cache weighted invalidation based on schema size 

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/metrics/MetricsContainer.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/metrics/MetricsContainer.java
@@ -66,6 +66,9 @@ public class MetricsContainer {
   public static final String METRIC_NAME_JSON_SCHEMAS_DELETED = "json-schemas-deleted";
   public static final String METRIC_NAME_PB_SCHEMAS_CREATED = "protobuf-schemas-created";
   public static final String METRIC_NAME_PB_SCHEMAS_DELETED = "protobuf-schemas-deleted";
+  public static final String METRIC_NAME_SCHEMA_CACHE_SIZE = "schema-cache-size";
+  public static final String METRIC_NAME_SCHEMA_CACHE_HIT = "schema-cache-hit";
+  public static final String METRIC_NAME_SCHEMA_CACHE_MISS = "schema-cache-miss";
 
   private final Metrics metrics;
   private final Map<String, String> configuredTags;
@@ -86,6 +89,9 @@ public class MetricsContainer {
   private final SchemaRegistryMetric avroSchemasDeleted;
   private final SchemaRegistryMetric jsonSchemasDeleted;
   private final SchemaRegistryMetric protobufSchemasDeleted;
+  private final SchemaRegistryMetric schemaCacheHit;
+  private final SchemaRegistryMetric schemaCacheMiss;
+  private final SchemaRegistryMetric schemaCacheSize;
 
   private final MetricsContext metricsContext;
 
@@ -146,6 +152,12 @@ public class MetricsContainer {
 
     this.protobufSchemasDeleted = createMetric(METRIC_NAME_PB_SCHEMAS_DELETED,
             "Number of deleted Protobuf schemas", new CumulativeCount());
+
+    this.schemaCacheHit = createMetric("schema-cache-hit", "Number of times the local schema cache has been hit");
+
+    this.schemaCacheMiss = createMetric("schema-cache-miss", "Number of times the local schema cache has been missed");
+
+    this.schemaCacheSize = createMetric("schema-cache-size", "Size of the local schema cache");
   }
 
   public Metrics getMetrics() {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -166,6 +166,18 @@ public class SchemaRegistryConfig extends RestConfig {
   public static final String SCHEMA_COMPATIBILITY_CONFIG = "schema.compatibility.level";
 
   /**
+   * <code>schema.cache.maximum.weight</code>
+   */
+  public static final String SCHEMA_CACHE_MAXIMUM_WEIGHT_CONFIG = "schema.cache.maximum.weight";
+  public static final int SCHEMA_CACHE_MAXIMUM_WEIGHT_DEFAULT = 1000000;
+
+  /**
+   * <code>schema.cache.use.weight</code>
+   */
+  public static final String SCHEMA_CACHE_USE_WEIGHT_CONFIG = "schema.cache.use.weight";
+  public static final int SCHEMA_CACHE_USE_WEIGHT_DEFAULT = false;
+
+  /**
    * <code>schema.cache.size</code>
    */
   public static final String SCHEMA_CACHE_SIZE_CONFIG = "schema.cache.size";
@@ -322,6 +334,10 @@ public class SchemaRegistryConfig extends RestConfig {
       "The expiration in seconds for entries accessed in the cache.";
   protected static final String SCHEMA_CANONICALIZE_ON_CONSUME_DOC =
       "A list of schema types to canonicalize on consume, to be used if canonicalization changes.";
+  protected static final String SCHEMA_CACHE_MAXIMUM_WEIGHT_DOC =
+          "The maximum weight of the schema cache.";
+  protected static final String SCHEMA_CACHE_USE_WEIGHT_DOC =
+          "Whether to use weight or size based local schema cache.";
   protected static final String METADATA_ENCODER_SECRET_DOC =
       "The secret used to encrypt and decrypt encoder keysets. "
       + "Use a random string with high entropy.";
@@ -512,6 +528,14 @@ public class SchemaRegistryConfig extends RestConfig {
     )
     .define(SCHEMA_CANONICALIZE_ON_CONSUME_CONFIG, ConfigDef.Type.LIST, "",
         ConfigDef.Importance.LOW, SCHEMA_CANONICALIZE_ON_CONSUME_DOC
+    )
+    .define(SCHEMA_CACHE_MAXIMUM_WEIGHT_CONFIG,
+        ConfigDef.Type.INT, SCHEMA_CACHE_MAXIMUM_WEIGHT_DEFAULT,
+        ConfigDef.Importance.LOW, SCHEMA_CACHE_MAXIMUM_WEIGHT_DOC
+    )
+    .define(SCHEMA_CACHE_USE_WEIGHT_CONFIG,
+            ConfigDef.Type.BOOLEAN, SCHEMA_CACHE_USE_WEIGHT_DEFAULT,
+            ConfigDef.Importance.LOW, SCHEMA_CACHE_USE_WEIGHT_DOC
     )
     .define(METADATA_ENCODER_SECRET_CONFIG, ConfigDef.Type.PASSWORD, null,
         ConfigDef.Importance.HIGH, METADATA_ENCODER_SECRET_DOC

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -66,6 +66,7 @@ import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
 import io.confluent.rest.RestConfig;
 import io.confluent.rest.exceptions.RestException;
 import io.confluent.rest.NamedURI;
+import com.google.common.cache.Weigher;
 
 import java.util.Map;
 import java.util.List;
@@ -188,21 +189,36 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     this.groupId = config.getString(SchemaRegistryConfig.SCHEMAREGISTRY_GROUP_ID_CONFIG);
     this.metricsContainer = new MetricsContainer(config, this.kafkaClusterId);
     this.providers = initProviders(config);
-    this.schemaCache = CacheBuilder.newBuilder()
-        .maximumSize(config.getInt(SchemaRegistryConfig.SCHEMA_CACHE_SIZE_CONFIG))
-        .expireAfterAccess(
-            config.getInt(SchemaRegistryConfig.SCHEMA_CACHE_EXPIRY_SECS_CONFIG), TimeUnit.SECONDS)
+    this.schemaCache = this.buildLocalSchemaCache();
+    this.lookupCache = lookupCache();
+    this.idGenerator = identityGenerator(config);
+    this.kafkaStore = kafkaStore(config);
+    this.metadataEncoder = new MetadataEncoderService(this);
+    this.ruleSetHandler = new RuleSetHandler();
+  }
+
+  private Cache buildLocalSchemaCache() {
+    if (config.getBoolean(SchemaRegistryConfig.SCHEMA_CACHE_USE_WEIGHT_CONFIG)) {
+      return CacheBuilder.newBuilder()
+        .maximumWeight(config.getInt(SchemaRegistryConfig.SCHEMA_CACHE_MAXIMUM_WEIGHT_CONFIG))
+        .weigher((Weigher<RawSchema, ParsedSchema>) (k, v) -> v.canonicalString().length())
+        .expireAfterAccess(config.getInt(SchemaRegistryConfig.SCHEMA_CACHE_EXPIRY_SECS_CONFIG), TimeUnit.SECONDS)
         .build(new CacheLoader<RawSchema, ParsedSchema>() {
           @Override
           public ParsedSchema load(RawSchema s) throws Exception {
             return loadSchema(s.getSchema(), s.isNew(), s.isNormalize());
           }
         });
-    this.lookupCache = lookupCache();
-    this.idGenerator = identityGenerator(config);
-    this.kafkaStore = kafkaStore(config);
-    this.metadataEncoder = new MetadataEncoderService(this);
-    this.ruleSetHandler = new RuleSetHandler();
+    }
+    return CacheBuilder.newBuilder()
+      .maximumSize(config.getInt(SchemaRegistryConfig.SCHEMA_CACHE_SIZE_CONFIG))
+      .expireAfterAccess(config.getInt(SchemaRegistryConfig.SCHEMA_CACHE_EXPIRY_SECS_CONFIG), TimeUnit.SECONDS)
+      .build(new CacheLoader<RawSchema, ParsedSchema>() {
+        @Override
+        public ParsedSchema load(RawSchema s) throws Exception {
+          return loadSchema(s.getSchema(), s.isNew(), s.isNormalize());
+        }
+      });
   }
 
   private Map<String, SchemaProvider> initProviders(SchemaRegistryConfig config) {


### PR DESCRIPTION
### Summary
<!-- What does the code do? What have you changed? -->
- While running schema registry we have observed scenarios where large schemas that contain many versions do not get invalidated quickly enough from the local schema cache. (Similar to large objects in an avalanche rising to the surface, large schemas with many references stay in the cache for max time period.)
- Rather than increase the total heap space of our schema registry nodes or decrease the total size of the cache we've solved this issue with weight based local schema cache invalidation. Our schemas vary greatly in size and some of them are very large. It’s not efficient for us to size heap to accommodate a full cache of very large schemas without OOMing.
- No performance degradation has been observed in our schema registry instance, but would love to work through mainline benchmark strategies as needed. Our hypothesis for this reasoning is that our cache hit % has stayed constant between sized based cache and weight based cache.
- Included in this pr is metrics to track the local schema cache in both size and hits + misses.
- By default this feature is not enabled.

### Motivation
<!-- Why are you making this change? This can be a link to a Jira task. -->
- We have observed scenarios operating the schema registry where during periods of heavy write traffic the leader node will OOM based on the local cache becoming too large. This write traffic is extremely spiky and contains large schemas that contain many versions (important for checking compatibility).
- This change hopefully serves to provide operational clarity into managing the local schema cache + provide a fix for this failure scenario.