### PR TITLE
DGS-6929 Ignore invalid Avro defaults for source connectors

### DIFF
--- a/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -26,6 +26,7 @@ import io.confluent.kafka.schemaregistry.utils.BoundedConcurrentHashMap;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.regex.Pattern;
+import org.apache.avro.AvroTypeException;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericEnumSymbol;
@@ -1177,11 +1178,20 @@ public class AvroData {
     } else if (fieldSchema.isOptional()) {
       defaultVal = JsonProperties.NULL_VALUE;
     }
-    org.apache.avro.Schema.Field field = new org.apache.avro.Schema.Field(
-        fieldName,
-        fromConnectSchema(fieldSchema, fromConnectContext, false),
-        discardTypeDocDefault ? fieldSchema.doc() : fieldDoc,
-        defaultVal);
+    org.apache.avro.Schema.Field field;
+    try {
+      field = new org.apache.avro.Schema.Field(
+          fieldName,
+          fromConnectSchema(fieldSchema, fromConnectContext, false),
+          discardTypeDocDefault ? fieldSchema.doc() : fieldDoc,
+          defaultVal);
+    } catch (AvroTypeException e) {
+      field = new org.apache.avro.Schema.Field(
+          fieldName,
+          fromConnectSchema(fieldSchema, fromConnectContext, false),
+          discardTypeDocDefault ? fieldSchema.doc() : fieldDoc);
+      log.warn("Ignoring invalid default for field " + fieldName, e);
+    }
     fields.add(field);
   }
 

--- a/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -1179,16 +1179,17 @@ public class AvroData {
       defaultVal = JsonProperties.NULL_VALUE;
     }
     org.apache.avro.Schema.Field field;
+    org.apache.avro.Schema schema = fromConnectSchema(fieldSchema, fromConnectContext, false);
     try {
       field = new org.apache.avro.Schema.Field(
           fieldName,
-          fromConnectSchema(fieldSchema, fromConnectContext, false),
+          schema,
           discardTypeDocDefault ? fieldSchema.doc() : fieldDoc,
           defaultVal);
     } catch (AvroTypeException e) {
       field = new org.apache.avro.Schema.Field(
           fieldName,
-          fromConnectSchema(fieldSchema, fromConnectContext, false),
+          schema,
           discardTypeDocDefault ? fieldSchema.doc() : fieldDoc);
       log.warn("Ignoring invalid default for field " + fieldName, e);
     }


### PR DESCRIPTION
Previous fixes ignored invalid defaults for sink connectors.  This is corresponding behavior for source connectors.