### PR TITLE
DGS-6698: Remove SnakeYaml from the dependencyManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,6 @@
         <protoc.jar.maven.plugin.version>3.11.4</protoc.jar.maven.plugin.version>
         <okio.version>3.0.0</okio.version>
         <wire.version>4.3.0</wire.version>
-        <snakeyaml.version>1.32</snakeyaml.version>
         <swagger.version>1.6.2</swagger.version>
         <io.confluent.schema-registry.version>7.0.10-0</io.confluent.schema-registry.version>
         <commons.compress.version>1.21</commons.compress.version>
@@ -132,11 +131,6 @@
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java-util</artifactId>
                 <version>${protobuf.version}</version>
-            </dependency>
-            <dependency>
-            <groupId>org.yaml</groupId>
-                <artifactId>snakeyaml</artifactId>
-                <version>${snakeyaml.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.api.grpc</groupId>


### PR DESCRIPTION
Follow up for identical commit for branches 5.5.x - 6.2.x 
https://github.com/confluentinc/schema-registry/pull/2592