### PR TITLE
DGS-7103 Optimize instantiation of lists of schemas

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -13,7 +13,7 @@
               files="(AbstractKafkaProtobufSerializer|DynamicSchema|MessageDefinition|ProtobufSchema|Rule|RuleContext|SchemaRegistryCoordinator).java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
-              files="(AzureKmsClient|AbstractKafkaAvroDeserializer|AbstractKafkaAvroSerializer|AbstractKafkaSchemaSerDe|CachedSchemaRegistryClient|RestService|Errors|SchemaRegistryRestApplication|Context|KafkaSchemaRegistry|KafkaStore|AvroConverter|AvroData|AvroSchemaUtils|KafkaGroupLeaderElector|ProtobufSchema|ProtobufData|JsonSchemaData|InMemoryCache|SchemaMessageReader|Jackson|JsonSchemaConverter|MetricsContainer|ProtobufSchema|ProtobufSchemaUtils|MetadataEncoderService|ProtoFileElementDeserializer).java"/>
+              files="(AzureKmsClient|AbstractKafkaAvroDeserializer|AbstractKafkaAvroSerializer|AbstractKafkaSchemaSerDe|CachedSchemaRegistryClient|MockSchemaRegistryClient|RestService|Errors|SchemaRegistryRestApplication|Context|KafkaSchemaRegistry|KafkaStore|AvroConverter|AvroData|AvroSchemaUtils|KafkaGroupLeaderElector|ProtobufSchema|ProtobufData|JsonSchemaData|InMemoryCache|SchemaMessageReader|Jackson|JsonSchemaConverter|MetricsContainer|ProtobufSchema|ProtobufSchemaUtils|MetadataEncoderService|ProtoFileElementDeserializer).java"/>
 
     <suppress checks="ClassFanOutComplexity"
               files="(RestService|KafkaSchemaRegistry|KafkaStore|KafkaStoreReaderThread|AvroData|KafkaGroupLeaderElector).java"/>
@@ -37,7 +37,7 @@
               files="(.*SchemaRegistryClient|JSON.*).java"/>
 
     <suppress checks="MethodLength"
-              files="(SchemaRegistryConfig|ProtobufData|JsonSchemaData).java"/>
+              files="(KafkaSchemaRegistry|SchemaRegistryConfig|ProtobufData|JsonSchemaData).java"/>
 
     <suppress checks="BooleanExpressionComplexity"
               files="(AvroData|JsonSchema|KafkaSchemaRegistry|ProtobufData|ProtobufSchema|CelExecutor|MetadataEncoderService).java"/>

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/CompatibilityChecker.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/CompatibilityChecker.java
@@ -19,6 +19,7 @@ package io.confluent.kafka.schemaregistry;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class CompatibilityChecker {
 
@@ -79,7 +80,15 @@ public class CompatibilityChecker {
   public List<String> isCompatible(
       ParsedSchema newSchema, List<? extends ParsedSchema> previousSchemas
   ) {
-    List<? extends ParsedSchema> previousSchemasCopy = new ArrayList<>(previousSchemas);
+    return isCompatibleWithHolders(newSchema, previousSchemas.stream()
+        .map(SimpleParsedSchemaHolder::new)
+        .collect(Collectors.toList()));
+  }
+
+  public List<String> isCompatibleWithHolders(
+      ParsedSchema newSchema, List<ParsedSchemaHolder> previousSchemas
+  ) {
+    List<ParsedSchemaHolder> previousSchemasCopy = new ArrayList<>(previousSchemas);
     // Validator checks in list order, but checks should occur in reverse chronological order
     Collections.reverse(previousSchemasCopy);
     return validator.validate(newSchema, previousSchemasCopy);

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
@@ -205,15 +205,8 @@ public interface ParsedSchema {
    *         the list of error messages
    */
   default List<String> isCompatible(
-      CompatibilityLevel level, List<? extends ParsedSchema> previousSchemas) {
-    if (level != CompatibilityLevel.NONE) {
-      for (ParsedSchema previousSchema : previousSchemas) {
-        if (!schemaType().equals(previousSchema.schemaType())) {
-          return Lists.newArrayList("Incompatible because of different schema type");
-        }
-      }
-    }
-    return CompatibilityChecker.checker(level).isCompatible(this, previousSchemas);
+      CompatibilityLevel level, List<ParsedSchemaHolder> previousSchemas) {
+    return CompatibilityChecker.checker(level).isCompatibleWithHolders(this, previousSchemas);
   }
 
   /**

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
@@ -16,7 +16,6 @@
 
 package io.confluent.kafka.schemaregistry;
 
-import com.google.common.collect.Lists;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchemaHolder.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchemaHolder.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Confluent Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry;
+
+public interface ParsedSchemaHolder {
+
+  /**
+   * Returns the schema.
+   *
+   * @return the schema
+   */
+  ParsedSchema schema();
+
+  /**
+   * Clears the schema if it can be lazily retrieved in the future.
+   */
+  void clear();
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidator.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaValidator.java
@@ -46,5 +46,5 @@ public interface SchemaValidator {
    *     applicable
    * @return List of error message, otherwise empty list
    */
-  List<String> validate(ParsedSchema toValidate, Iterable<? extends ParsedSchema> existing);
+  List<String> validate(ParsedSchema toValidate, Iterable<ParsedSchemaHolder> existing);
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SimpleParsedSchemaHolder.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SimpleParsedSchemaHolder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Confluent Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry;
+
+public class SimpleParsedSchemaHolder implements ParsedSchemaHolder {
+
+  private ParsedSchema schema;
+
+  public SimpleParsedSchemaHolder(ParsedSchema schema) {
+    this.schema = schema;
+  }
+
+  /**
+   * Returns the schema.
+   *
+   * @return the schema
+   */
+  @Override
+  public ParsedSchema schema() {
+    return schema;
+  }
+
+  /**
+   * Clears the schema if it can be lazily retrieved in the future.
+   */
+  @Override
+  public void clear() {
+  }
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -16,6 +16,8 @@
 
 package io.confluent.kafka.schemaregistry.client;
 
+import io.confluent.kafka.schemaregistry.ParsedSchemaHolder;
+import io.confluent.kafka.schemaregistry.SimpleParsedSchemaHolder;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Config;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
@@ -512,11 +514,11 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
       return false;
     }
 
-    List<ParsedSchema> schemaHistory = new ArrayList<>();
+    List<ParsedSchemaHolder> schemaHistory = new ArrayList<>();
     for (int version : allVersions(subject)) {
       SchemaMetadata schemaMetadata = getSchemaMetadata(subject, version);
-      schemaHistory.add(getSchemaBySubjectAndIdFromRegistry(subject,
-          schemaMetadata.getId()));
+      schemaHistory.add(new SimpleParsedSchemaHolder(getSchemaBySubjectAndIdFromRegistry(subject,
+          schemaMetadata.getId())));
     }
 
     return newSchema.isCompatible(compatibilityLevel, schemaHistory).isEmpty();
@@ -622,11 +624,11 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
       return Collections.singletonList("Compatibility level not specified.");
     }
 
-    List<ParsedSchema> schemaHistory = new ArrayList<>();
+    List<ParsedSchemaHolder> schemaHistory = new ArrayList<>();
     for (int version : allVersions(subject)) {
       SchemaMetadata schemaMetadata = getSchemaMetadata(subject, version);
-      schemaHistory.add(getSchemaBySubjectAndIdFromRegistry(subject,
-          schemaMetadata.getId()));
+      schemaHistory.add(new SimpleParsedSchemaHolder(getSchemaBySubjectAndIdFromRegistry(subject,
+          schemaMetadata.getId())));
     }
 
     return newSchema.isCompatible(compatibilityLevel, schemaHistory);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -183,6 +183,18 @@ public class SchemaRegistryConfig extends RestConfig {
   public static final String SCHEMA_CANONICALIZE_ON_CONSUME_CONFIG =
       "schema.canonicalize.on.consume";
 
+  /**
+   * <code>schema.search.default.limit</code>
+   */
+  public static final String SCHEMA_SEARCH_DEFAULT_LIMIT_CONFIG = "schema.search.default.limit";
+  public static final int SCHEMA_SEARCH_DEFAULT_LIMIT_DEFAULT = 1000;
+
+  /**
+   * <code>schema.search.max.limit</code>
+   */
+  public static final String SCHEMA_SEARCH_MAX_LIMIT_CONFIG = "schema.search.max.limit";
+  public static final int SCHEMA_SEARCH_MAX_LIMIT_DEFAULT = 1000;
+
   public static final String METADATA_ENCODER_SECRET_CONFIG = "metadata.encoder.secret";
   public static final String METADATA_ENCODER_OLD_SECRET_CONFIG = "metadata.encoder.old.secret";
 
@@ -322,6 +334,10 @@ public class SchemaRegistryConfig extends RestConfig {
       "The expiration in seconds for entries accessed in the cache.";
   protected static final String SCHEMA_CANONICALIZE_ON_CONSUME_DOC =
       "A list of schema types to canonicalize on consume, to be used if canonicalization changes.";
+  protected static final String SCHEMA_SEARCH_DEFAULT_LIMIT_DOC =
+      "The default limit for schema searches.";
+  protected static final String SCHEMA_SEARCH_MAX_LIMIT_DOC =
+      "The max limit for schema searches.";
   protected static final String METADATA_ENCODER_SECRET_DOC =
       "The secret used to encrypt and decrypt encoder keysets. "
       + "Use a random string with high entropy.";
@@ -512,6 +528,14 @@ public class SchemaRegistryConfig extends RestConfig {
     )
     .define(SCHEMA_CANONICALIZE_ON_CONSUME_CONFIG, ConfigDef.Type.LIST, "",
         ConfigDef.Importance.LOW, SCHEMA_CANONICALIZE_ON_CONSUME_DOC
+    )
+    .define(SCHEMA_SEARCH_DEFAULT_LIMIT_CONFIG, ConfigDef.Type.INT,
+        SCHEMA_SEARCH_DEFAULT_LIMIT_DEFAULT,
+        ConfigDef.Importance.LOW, SCHEMA_SEARCH_DEFAULT_LIMIT_DOC
+    )
+    .define(SCHEMA_SEARCH_MAX_LIMIT_CONFIG, ConfigDef.Type.INT,
+        SCHEMA_SEARCH_MAX_LIMIT_DEFAULT,
+        ConfigDef.Importance.LOW, SCHEMA_SEARCH_MAX_LIMIT_DOC
     )
     .define(METADATA_ENCODER_SECRET_CONFIG, ConfigDef.Type.PASSWORD, null,
         ConfigDef.Importance.HIGH, METADATA_ENCODER_SECRET_DOC

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/client/LocalSchemaRegistryClient.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/client/LocalSchemaRegistryClient.java
@@ -51,6 +51,7 @@ import io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidModeExceptio
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
 import io.confluent.kafka.schemaregistry.storage.LookupFilter;
 import io.confluent.kafka.schemaregistry.storage.Mode;
+import io.confluent.kafka.schemaregistry.storage.SchemaKey;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -128,7 +129,7 @@ public class LocalSchemaRegistryClient implements SchemaRegistryClient {
     if (!DEFAULT_TENANT.equals(schemaRegistry.tenant())) {
       subject = schemaRegistry.tenant() + TENANT_DELIMITER + subject;
     }
-    Iterator<Schema> allSchemasForThisTopic = null;
+    Iterator<SchemaKey> resultSchemas = null;
     List<Integer> allVersions = new ArrayList<>();
     String errorMessage = "Error while validating that subject "
         + subject
@@ -145,14 +146,14 @@ public class LocalSchemaRegistryClient implements SchemaRegistryClient {
     errorMessage = "Error while listing all versions for subject "
         + subject;
     try {
-      allSchemasForThisTopic = schemaRegistry.getAllVersions(subject, LookupFilter.DEFAULT);
+      resultSchemas = schemaRegistry.getAllVersions(subject, LookupFilter.DEFAULT);
     } catch (SchemaRegistryStoreException e) {
       throw Errors.storeException(errorMessage, e);
     } catch (SchemaRegistryException e) {
       throw Errors.schemaRegistryException(errorMessage, e);
     }
-    while (allSchemasForThisTopic.hasNext()) {
-      Schema schema = allSchemasForThisTopic.next();
+    while (resultSchemas.hasNext()) {
+      SchemaKey schema = resultSchemas.next();
       allVersions.add(schema.getVersion());
     }
     return allVersions;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -28,6 +28,7 @@ import io.confluent.kafka.schemaregistry.rest.VersionId;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
 import io.confluent.kafka.schemaregistry.storage.LookupFilter;
+import io.confluent.kafka.schemaregistry.storage.SchemaKey;
 import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
 import io.confluent.rest.annotations.PerformanceMetric;
 import io.swagger.v3.oas.annotations.Operation;
@@ -148,7 +149,8 @@ public class CompatibilityResource {
       errorMessages = schemaRegistry.isCompatible(
           subject, schema,
           schemaForSpecifiedVersion != null
-              ? Collections.singletonList(schemaForSpecifiedVersion)
+              ? Collections.singletonList(
+                  new SchemaKey(subject, schemaForSpecifiedVersion.getVersion()))
               : Collections.emptyList(),
           normalize
       );
@@ -218,7 +220,7 @@ public class CompatibilityResource {
 
     // returns true if posted schema is compatible with the specified subject.
     List<String> errorMessages;
-    List<Schema> previousSchemas = new ArrayList<>();
+    List<SchemaKey> previousSchemas = new ArrayList<>();
     try {
       //Don't check compatibility against deleted schema
       schemaRegistry.getAllVersions(subject, LookupFilter.DEFAULT)

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
@@ -104,7 +104,8 @@ public class SchemasResource {
     } catch (SchemaRegistryException e) {
       throw Errors.schemaRegistryException(errorMessage, e);
     }
-    int toIndex = limit > 0 ? offset + limit : Integer.MAX_VALUE;
+    limit = schemaRegistry.normalizeLimit(limit);
+    int toIndex = offset + limit;
     int index = 0;
     while (schemas.hasNext() && index < toIndex) {
       Schema schema = schemas.next();

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -39,6 +39,7 @@ import io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidRuleSetExcep
 import io.confluent.kafka.schemaregistry.rules.RuleException;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
 import io.confluent.kafka.schemaregistry.storage.LookupFilter;
+import io.confluent.kafka.schemaregistry.storage.SchemaKey;
 import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
 import io.confluent.rest.annotations.PerformanceMetric;
 import io.swagger.v3.oas.annotations.Operation;
@@ -293,7 +294,7 @@ public class SubjectVersionsResource {
     subject = QualifiedSubject.normalize(schemaRegistry.tenant(), subject);
 
     // check if subject exists. If not, throw 404
-    Iterator<Schema> resultSchemas;
+    Iterator<SchemaKey> resultSchemas;
     List<Integer> allVersions = new ArrayList<>();
     String errorMessage = "Error while validating that subject "
                           + subject
@@ -324,7 +325,7 @@ public class SubjectVersionsResource {
       throw Errors.schemaRegistryException(errorMessage, e);
     }
     while (resultSchemas.hasNext()) {
-      Schema schema = resultSchemas.next();
+      SchemaKey schema = resultSchemas.next();
       allVersions.add(schema.getVersion());
     }
     return allVersions;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -20,6 +20,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.ParsedSchemaHolder;
 import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
@@ -127,6 +128,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   private final int kafkaStoreTimeoutMs;
   private final int initTimeout;
   private final int kafkaStoreMaxRetries;
+  private final int searchDefaultLimit;
+  private final int searchMaxLimit;
   private final boolean isEligibleForLeaderElector;
   private final boolean delayLeaderElection;
   private final boolean allowModeChanges;
@@ -198,6 +201,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
             return loadSchema(s.getSchema(), s.isNew(), s.isNormalize());
           }
         });
+    this.searchDefaultLimit =
+        config.getInt(SchemaRegistryConfig.SCHEMA_SEARCH_DEFAULT_LIMIT_CONFIG);
+    this.searchMaxLimit = config.getInt(SchemaRegistryConfig.SCHEMA_SEARCH_MAX_LIMIT_CONFIG);
     this.lookupCache = lookupCache();
     this.idGenerator = identityGenerator(config);
     this.kafkaStore = kafkaStore(config);
@@ -515,6 +521,14 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     return providers.get(schemaType);
   }
 
+  public int normalizeLimit(int suppliedLimit) {
+    int limit = searchDefaultLimit;
+    if (suppliedLimit > 0 && suppliedLimit <= searchMaxLimit) {
+      limit = suppliedLimit;
+    }
+    return limit;
+  }
+
   @Override
   public int register(String subject,
                       Schema schema,
@@ -546,18 +560,21 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       }
 
       // determine the latest version of the schema in the subject
-      List<SchemaValue> allVersions = getAllSchemaValues(subject);
+      List<SchemaKey> allVersions = getAllSchemaKeys(subject);
       Collections.reverse(allVersions);
 
       List<SchemaValue> deletedVersions = new ArrayList<>();
-      List<ParsedSchema> undeletedVersions = new ArrayList<>();
+      List<ParsedSchemaHolder> undeletedVersions = new ArrayList<>();
       int newVersion = MIN_VERSION;
-      for (SchemaValue schemaValue : allVersions) {
+      // iterate from the latest to first
+      for (SchemaKey schemaKey : allVersions) {
+        LazyParsedSchemaHolder schemaHolder = new LazyParsedSchemaHolder(this, schemaKey);
+        SchemaValue schemaValue = schemaHolder.schemaValue();
         newVersion = Math.max(newVersion, schemaValue.getVersion() + 1);
         if (schemaValue.isDeleted()) {
           deletedVersions.add(schemaValue);
         } else {
-          ParsedSchema undeletedSchema = parseSchema(getSchemaEntityFromSchemaValue(schemaValue));
+          ParsedSchema undeletedSchema = schemaHolder.schema();
           if (parsedSchema != null
               && parsedSchema.references().isEmpty()
               && !undeletedSchema.references().isEmpty()
@@ -565,7 +582,11 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
             // This handles the case where a schema is sent with all references resolved
             return schemaValue.getId();
           }
-          undeletedVersions.add(undeletedSchema);
+          if (!undeletedVersions.isEmpty()) {
+            // minor optimization: clear the holder if it is not the latest
+            schemaHolder.clear();
+          }
+          undeletedVersions.add(schemaHolder);
         }
       }
 
@@ -574,6 +595,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
         parsedSchema = maybePopulateFromPrevious(config, schema, parsedSchema, undeletedVersions);
       }
 
+      // sort undeleted in ascending
       Collections.reverse(undeletedVersions);
       final List<String> compatibilityErrorLogs = isCompatibleWithPrevious(
               config, parsedSchema, undeletedVersions);
@@ -692,10 +714,11 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   }
 
   private ParsedSchema maybePopulateFromPrevious(
-      Config config, Schema schema, ParsedSchema parsedSchema, List<ParsedSchema> undeletedVersions)
+      Config config, Schema schema, ParsedSchema parsedSchema,
+      List<ParsedSchemaHolder> undeletedVersions)
       throws InvalidSchemaException {
     ParsedSchema previousSchema =
-        undeletedVersions.size() > 0 ? undeletedVersions.get(0) : null;
+        undeletedVersions.size() > 0 ? undeletedVersions.get(0).schema() : null;
     if (parsedSchema == null) {
       if (previousSchema != null) {
         parsedSchema = previousSchema.copy(schema.getMetadata(), schema.getRuleSet());
@@ -851,7 +874,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       kafkaStore.waitUntilKafkaReaderReachesLastOffset(subject, kafkaStoreTimeoutMs);
       List<Integer> deletedVersions = new ArrayList<>();
       int deleteWatermarkVersion = 0;
-      Iterator<Schema> schemasToBeDeleted = getAllVersions(subject,
+      Iterator<SchemaKey> schemasToBeDeleted = getAllVersions(subject,
           permanentDelete ? LookupFilter.INCLUDE_DELETED : LookupFilter.DEFAULT);
       while (schemasToBeDeleted.hasNext()) {
         deleteWatermarkVersion = schemasToBeDeleted.next().getVersion();
@@ -972,15 +995,15 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
         }
       }
 
-      List<SchemaValue> allVersions = getAllSchemaValues(subject);
+      List<SchemaKey> allVersions = getAllSchemaKeys(subject);
       Collections.reverse(allVersions);
 
-      for (SchemaValue schemaValue : allVersions) {
-        if ((lookupDeletedSchema || !schemaValue.isDeleted())
+      for (SchemaKey schemaKey : allVersions) {
+        Schema prev = get(schemaKey.getSubject(), schemaKey.getVersion(), lookupDeletedSchema);
+        if (prev != null
             && parsedSchema != null
             && parsedSchema.references().isEmpty()
-            && !schemaValue.getReferences().isEmpty()) {
-          Schema prev = getSchemaEntityFromSchemaValue(schemaValue);
+            && !prev.getReferences().isEmpty()) {
           ParsedSchema prevSchema = parseSchema(prev);
           if (parsedSchema.deepEquals(prevSchema)) {
             // This handles the case where a schema is sent with all references resolved
@@ -999,12 +1022,12 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   public Schema getLatestWithMetadata(
       String subject, Map<String, String> metadata, boolean lookupDeletedSchema)
       throws SchemaRegistryException {
-    List<SchemaValue> allVersions = getAllSchemaValues(subject);
+    List<SchemaKey> allVersions = getAllSchemaKeys(subject);
     Collections.reverse(allVersions);
 
-    for (SchemaValue schemaValue : allVersions) {
-      if (lookupDeletedSchema || !schemaValue.isDeleted()) {
-        Schema schema = getSchemaEntityFromSchemaValue(schemaValue);
+    for (SchemaKey schemaKey : allVersions) {
+      Schema schema = get(schemaKey.getSubject(), schemaKey.getVersion(), lookupDeletedSchema);
+      if (schema != null) {
         if (schema.getMetadata() != null) {
           Map<String, String> props = schema.getMetadata().getProperties();
           if (props != null && props.entrySet().containsAll(metadata.entrySet())) {
@@ -1303,20 +1326,12 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     if (versionId.isLatest()) {
       return getLatestVersion(subject);
     } else {
-      SchemaKey key = new SchemaKey(subject, version);
-      try {
-        SchemaValue schemaValue = (SchemaValue) kafkaStore.get(key);
-        metadataEncoder.decodeMetadata(schemaValue);
-        Schema schema = null;
-        if ((schemaValue != null && !schemaValue.isDeleted()) || returnDeletedSchema) {
-          schema = getSchemaEntityFromSchemaValue(schemaValue);
-        }
-        return schema;
-      } catch (StoreException e) {
-        throw new SchemaRegistryStoreException(
-            "Error while retrieving schema from the backend Kafka"
-            + " store", e);
+      SchemaValue schemaValue = getSchemaValue(new SchemaKey(subject, version));
+      Schema schema = null;
+      if (schemaValue != null && (!schemaValue.isDeleted() || returnDeletedSchema)) {
+        schema = schemaValue.toSchemaEntity();
       }
+      return schema;
     }
   }
 
@@ -1337,11 +1352,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       if (subjectVersionKey == null) {
         return null;
       }
-      schema = (SchemaValue) kafkaStore.get(subjectVersionKey);
-      if (schema == null) {
-        return null;
-      }
-      metadataEncoder.decodeMetadata(schema);
+      schema = getSchemaValue(subjectVersionKey);
     } catch (StoreException e) {
       throw new SchemaRegistryStoreException(
           "Error while retrieving schema with id "
@@ -1361,6 +1372,19 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       schemaString.setMaxId(idGenerator.getMaxId(schema));
     }
     return schemaString;
+  }
+
+  protected SchemaValue getSchemaValue(SchemaKey key)
+      throws SchemaRegistryException {
+    try {
+      SchemaValue schemaValue = (SchemaValue) kafkaStore.get(key);
+      metadataEncoder.decodeMetadata(schemaValue);
+      return schemaValue;
+    } catch (StoreException e) {
+      throw new SchemaRegistryStoreException(
+          "Error while retrieving schema from the backend Kafka"
+              + " store", e);
+    }
   }
 
   private SchemaKey getSchemaKeyUsingContexts(int id, String subject)
@@ -1477,7 +1501,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
         return null;
       }
 
-      return lookupCache.schemaIdAndSubjects(getSchemaEntityFromSchemaValue(schema))
+      return lookupCache.schemaIdAndSubjects(schema.toSchemaEntity())
           .allSubjectVersions()
           .entrySet()
           .stream()
@@ -1485,7 +1509,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
             try {
               SchemaValue schemaValue =
                   (SchemaValue) kafkaStore.get(new SchemaKey(e.getKey(), e.getValue()));
-              if ((schemaValue != null && !schemaValue.isDeleted()) || lookupDeleted) {
+              if (schemaValue != null && (!schemaValue.isDeleted() || lookupDeleted)) {
                 return Stream.of(new SubjectVersion(e.getKey(), e.getValue()));
               } else {
                 return Stream.empty();
@@ -1538,10 +1562,10 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   }
 
   @Override
-  public Iterator<Schema> getAllVersions(String subject, LookupFilter filter)
+  public Iterator<SchemaKey> getAllVersions(String subject, LookupFilter filter)
       throws SchemaRegistryException {
     try (CloseableIterator<SchemaRegistryValue> allVersions = allVersions(subject, false)) {
-      return sortSchemasByVersion(allVersions, filter).iterator();
+      return sortSchemaKeysByVersion(allVersions, filter).iterator();
     }
   }
 
@@ -1556,10 +1580,10 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     }
   }
 
-  private List<SchemaValue> getAllSchemaValues(String subject)
+  private List<SchemaKey> getAllSchemaKeys(String subject)
       throws SchemaRegistryException {
     try (CloseableIterator<SchemaRegistryValue> allVersions = allVersions(subject, false)) {
-      return sortSchemaValuesByVersion(allVersions);
+      return sortSchemaKeysByVersion(allVersions, LookupFilter.INCLUDE_DELETED);
     }
   }
 
@@ -1586,7 +1610,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       }
     }
 
-    return latestSchemaValue != null ? getSchemaEntityFromSchemaValue(latestSchemaValue) : null;
+    return latestSchemaValue != null ? latestSchemaValue.toSchemaEntity() : null;
   }
 
   private CloseableIterator<SchemaRegistryValue> allVersions(
@@ -1780,25 +1804,13 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     }
   }
 
-  @Override
-  public List<String> isCompatible(String subject,
-                                   Schema newSchema,
-                                   Schema latestSchema)
-      throws SchemaRegistryException {
-    if (latestSchema == null) {
-      log.error("Latest schema not provided");
-      throw new InvalidSchemaException("Latest schema not provided");
-    }
-    return isCompatible(subject, newSchema, Collections.singletonList(latestSchema), false);
-  }
-
   /**
    * @param previousSchemas Full schema history in chronological order
    */
   @Override
   public List<String> isCompatible(String subject,
                                    Schema newSchema,
-                                   List<Schema> previousSchemas,
+                                   List<SchemaKey> previousSchemas,
                                    boolean normalize)
       throws SchemaRegistryException {
 
@@ -1807,10 +1819,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       throw new InvalidSchemaException("Previous schema not provided");
     }
 
-    List<ParsedSchema> prevParsedSchemas = new ArrayList<>(previousSchemas.size());
-    for (Schema previousSchema : previousSchemas) {
-      ParsedSchema prevParsedSchema = parseSchema(previousSchema);
-      prevParsedSchemas.add(prevParsedSchema);
+    List<ParsedSchemaHolder> prevParsedSchemas = new ArrayList<>(previousSchemas.size());
+    for (SchemaKey previousSchema : previousSchemas) {
+      prevParsedSchemas.add(new LazyParsedSchemaHolder(this, previousSchema));
     }
 
     ParsedSchema parsedSchema = canonicalizeSchema(newSchema, true, normalize);
@@ -1824,7 +1835,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
 
   private List<String> isCompatibleWithPrevious(Config config,
                                                 ParsedSchema parsedSchema,
-                                                List<ParsedSchema> previousSchemas)
+                                                List<ParsedSchemaHolder> previousSchemas)
       throws SchemaRegistryException {
 
     CompatibilityLevel compatibility = CompatibilityLevel.forName(config.getCompatibilityLevel());
@@ -1834,7 +1845,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       if (groupValue != null) {
         // Only check compatibility against schemas with the same compatibility group value
         previousSchemas = previousSchemas.stream()
-            .filter(s -> groupValue.equals(getCompatibilityGroupValue(s, compatibilityGroup)))
+            .filter(s -> groupValue.equals(
+                getCompatibilityGroupValue(s.schema(), compatibilityGroup)))
             .collect(Collectors.toList());
       }
     }
@@ -1982,11 +1994,6 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   }
 
   private List<Schema> sortSchemasByVersion(CloseableIterator<SchemaRegistryValue> schemas,
-                                            LookupFilter filter) {
-    return sortSchemasByVersion(schemas, filter, false);
-  }
-
-  private List<Schema> sortSchemasByVersion(CloseableIterator<SchemaRegistryValue> schemas,
                                             LookupFilter filter,
                                             boolean returnLatestOnly) {
     List<Schema> schemaList = new ArrayList<>();
@@ -1997,7 +2004,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       if (!shouldInclude) {
         continue;
       }
-      Schema schema = getSchemaEntityFromSchemaValue(schemaValue);
+      Schema schema = schemaValue.toSchemaEntity();
       if (returnLatestOnly) {
         if (previousSchema != null && !schema.getSubject().equals(previousSchema.getSubject())) {
           schemaList.add(previousSchema);
@@ -2018,19 +2025,20 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     return schemaList;
   }
 
-  private List<SchemaValue> sortSchemaValuesByVersion(
-          CloseableIterator<SchemaRegistryValue> schemas) {
-    List<SchemaValue> schemaList = new ArrayList<>();
+  private List<SchemaKey> sortSchemaKeysByVersion(CloseableIterator<SchemaRegistryValue> schemas,
+      LookupFilter filter) {
+    List<SchemaKey> schemaList = new ArrayList<>();
     while (schemas.hasNext()) {
       SchemaValue schemaValue = (SchemaValue) schemas.next();
-      schemaList.add(schemaValue);
+      boolean shouldInclude = shouldInclude(schemaValue.isDeleted(), filter);
+      if (!shouldInclude) {
+        continue;
+      }
+      SchemaKey schemaKey = schemaValue.toKey();
+      schemaList.add(schemaKey);
     }
     Collections.sort(schemaList);
     return schemaList;
-  }
-
-  private Schema getSchemaEntityFromSchemaValue(SchemaValue schemaValue) {
-    return schemaValue != null ? schemaValue.toSchemaEntity() : null;
   }
 
   private boolean isSubjectVersionDeleted(String subject, int version)

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LazyParsedSchemaHolder.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LazyParsedSchemaHolder.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 Confluent Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.storage;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.ParsedSchemaHolder;
+import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
+import java.lang.ref.SoftReference;
+
+public class LazyParsedSchemaHolder implements ParsedSchemaHolder {
+
+  private KafkaSchemaRegistry schemaRegistry;
+  private SchemaKey schemaKey;
+  private SoftReference<SchemaValue> schemaValueRef;
+
+  public LazyParsedSchemaHolder(KafkaSchemaRegistry schemaRegistry, SchemaKey schemaKey) {
+    this.schemaRegistry = schemaRegistry;
+    this.schemaKey = schemaKey;
+    this.schemaValueRef = new SoftReference<>(null);
+  }
+
+  /**
+   * Returns the schema.
+   *
+   * @return the schema
+   */
+  @Override
+  public ParsedSchema schema() {
+    try {
+      return schemaRegistry.parseSchema(schemaValue().toSchemaEntity());
+    } catch (SchemaRegistryException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  public SchemaValue schemaValue() throws SchemaRegistryException {
+    SchemaValue schemaValue = schemaValueRef.get();
+    if (schemaValue == null) {
+      schemaValue = schemaRegistry.getSchemaValue(schemaKey);
+      schemaValueRef = new SoftReference<>(schemaValue);
+    }
+    return schemaValue;
+  }
+
+  /**
+   * Clears the schema if it can be lazily retrieved in the future.
+   */
+  @Override
+  public void clear() {
+    schemaValueRef.clear();
+  }
+}

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
@@ -64,7 +64,7 @@ public interface SchemaRegistry extends SchemaVersionFetcher {
   Set<String> listSubjectsForId(int id, String subject, boolean returnDeleted)
       throws SchemaRegistryException;
 
-  Iterator<Schema> getAllVersions(String subject, LookupFilter filter)
+  Iterator<SchemaKey> getAllVersions(String subject, LookupFilter filter)
       throws SchemaRegistryException;
 
   Iterator<Schema> getVersionsWithSubjectPrefix(
@@ -92,11 +92,7 @@ public interface SchemaRegistry extends SchemaVersionFetcher {
 
   List<String> isCompatible(String subject,
                             Schema newSchema,
-                            Schema targetSchema) throws SchemaRegistryException;
-
-  List<String> isCompatible(String subject,
-                            Schema newSchema,
-                            List<Schema> previousSchemas,
+                            List<SchemaKey> previousSchemas,
                             boolean normalize) throws SchemaRegistryException;
 
   void close();

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/TestSchemaValidation.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/TestSchemaValidation.java
@@ -16,6 +16,8 @@
 package io.confluent.kafka.schemaregistry.json;
 
 
+import io.confluent.kafka.schemaregistry.ParsedSchemaHolder;
+import io.confluent.kafka.schemaregistry.SimpleParsedSchemaHolder;
 import org.everit.json.schema.ArraySchema;
 import org.everit.json.schema.BooleanSchema;
 import org.everit.json.schema.CombinedSchema;
@@ -228,24 +230,24 @@ public class TestSchemaValidation {
       SchemaValidator validator = builder.canReadStrategy().validateAll();
       List<String> valid = validator.validate(
           new JsonSchema(reader),
-          Collections.singleton(new JsonSchema(writer))
+          Collections.singleton(new SimpleParsedSchemaHolder(new JsonSchema(writer)))
       );
       Assert.assertFalse(valid.isEmpty());
     }
   }
 
   private void testValidatorPasses(SchemaValidator validator, Schema schema, Schema... prev) {
-    ArrayList<JsonSchema> prior = new ArrayList<>();
+    ArrayList<ParsedSchemaHolder> prior = new ArrayList<>();
     for (int i = prev.length - 1; i >= 0; i--) {
-      prior.add(new JsonSchema(prev[i]));
+      prior.add(new SimpleParsedSchemaHolder(new JsonSchema(prev[i])));
     }
     validator.validate(new JsonSchema(schema), prior);
   }
 
   private void testValidatorFails(SchemaValidator validator, Schema schemaFails, Schema... prev) {
-    ArrayList<JsonSchema> prior = new ArrayList<>();
+    ArrayList<ParsedSchemaHolder> prior = new ArrayList<>();
     for (int i = prev.length - 1; i >= 0; i--) {
-      prior.add(new JsonSchema(prev[i]));
+      prior.add(new SimpleParsedSchemaHolder(new JsonSchema(prev[i])));
     }
     List<String> valid = validator.validate(new JsonSchema(schemaFails), prior);
     Assert.assertFalse(valid.isEmpty());

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -30,6 +30,7 @@ import com.squareup.wire.schema.internal.parser.ProtoFileElement;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.SchemaEntity;
 import io.confluent.kafka.schemaregistry.SchemaProvider;
+import io.confluent.kafka.schemaregistry.SimpleParsedSchemaHolder;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
@@ -1421,7 +1422,8 @@ public class ProtobufSchemaTest {
     ProtobufSchema schema2 = new ProtobufSchema(desc);
 
     assertTrue(schema.isCompatible(
-        CompatibilityLevel.BACKWARD, Collections.singletonList(schema2)).isEmpty());
+        CompatibilityLevel.BACKWARD,
+        Collections.singletonList(new SimpleParsedSchemaHolder(schema2))).isEmpty());
     assertEquals(schema.canonicalString(), schema2.canonicalString());
   }
 
@@ -1444,7 +1446,8 @@ public class ProtobufSchemaTest {
     ProtobufSchema schema2 = new ProtobufSchema(desc);
 
     assertTrue(schema.isCompatible(
-            CompatibilityLevel.BACKWARD, Collections.singletonList(schema2)).isEmpty());
+            CompatibilityLevel.BACKWARD,
+        Collections.singletonList(new SimpleParsedSchemaHolder(schema2))).isEmpty());
     assertEquals(schema.canonicalString(), schema2.canonicalString());
   }
 
@@ -1458,11 +1461,13 @@ public class ProtobufSchemaTest {
     String fileProto = schema.formattedString(Format.SERIALIZED.symbol());
     ProtobufSchema schema2 = new ProtobufSchema(fileProto);
     assertTrue(schema.isCompatible(
-        CompatibilityLevel.BACKWARD, Collections.singletonList(schema2)).isEmpty());
+        CompatibilityLevel.BACKWARD,
+        Collections.singletonList(new SimpleParsedSchemaHolder(schema2))).isEmpty());
     fileProto = schema2.formattedString(Format.SERIALIZED.symbol());
     ProtobufSchema schema3 = new ProtobufSchema(fileProto);
     assertTrue(schema2.isCompatible(
-        CompatibilityLevel.BACKWARD, Collections.singletonList(schema3)).isEmpty());
+        CompatibilityLevel.BACKWARD,
+        Collections.singletonList(new SimpleParsedSchemaHolder(schema3))).isEmpty());
     assertEquals(schema2, schema3);
 
     original = resourceLoader.readObj("NestedTestProto.proto");
@@ -1470,11 +1475,13 @@ public class ProtobufSchemaTest {
     fileProto = schema.formattedString(Format.SERIALIZED.symbol());
     schema2 = new ProtobufSchema(fileProto);
     assertTrue(schema.isCompatible(
-        CompatibilityLevel.BACKWARD, Collections.singletonList(schema2)).isEmpty());
+        CompatibilityLevel.BACKWARD,
+        Collections.singletonList(new SimpleParsedSchemaHolder(schema2))).isEmpty());
     fileProto = schema2.formattedString(Format.SERIALIZED.symbol());
     schema3 = new ProtobufSchema(fileProto);
     assertTrue(schema2.isCompatible(
-        CompatibilityLevel.BACKWARD, Collections.singletonList(schema3)).isEmpty());
+        CompatibilityLevel.BACKWARD,
+        Collections.singletonList(new SimpleParsedSchemaHolder(schema3))).isEmpty());
     assertEquals(schema2, schema3);
   }
 


### PR DESCRIPTION
Various memory optimizations:
- For compatibility checks, use `List<ParsedSchemaHolder>` instead of `List<ParsedSchema>`.  This is to allow the schema to be parsed lazily.
- For retrieval methods, use `List<SchemaKey>` instead of `List<Schema>` or `List<SchemaValue>`, since keys use less memory
- For the `/schemas` endpoint, add config params for `schema.search.default.limit` and `schema.search.max.limit` to limit number of schemas retrieved in memory