### PR TITLE
DGS-xxxx: update Msal4j dependency to bring in latest json-smart

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,8 @@
                 <artifactId>azure-core</artifactId>
                 <version>1.33.0</version>
             </dependency>
+            <!-- after updating azure-identity (when new version is available)
+                 please check if teh pin of msal4j can be removed -->
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-identity</artifactId>
@@ -249,6 +251,13 @@
                 <groupId>com.azure</groupId>
                 <artifactId>azure-security-keyvault-keys</artifactId>
                 <version>4.5.1</version>
+            </dependency>
+            <!-- subdependncy of azure-identity, security hygiene fix for CVE-2023-1370
+                 updated mslal4j brings updated nimbus that does not ship vulnderable json-smart -->
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>msal4j</artifactId>
+                <version>1.13.8</version>
             </dependency>
             <dependency>
                 <groupId>com.bettercloud</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -240,12 +240,14 @@
                 <artifactId>azure-core</artifactId>
                 <version>1.33.0</version>
             </dependency>
-            <!-- after updating azure-identity (when new version is available)
-                 please check if teh pin of msal4j can be removed -->
+            <!-- Updating azure-identity from 1.7.3. to 1.8.2 per rayokota suggestion
+                 this does not resolve CVE-2023-1370, and pin of msal4j is still required
+                 after updating azure-identity (when new version is available)
+                 please check if the pin of msal4j can be removed -->
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-identity</artifactId>
-                <version>1.7.3</version>
+                <version>1.8.2</version>
             </dependency>
             <dependency>
                 <groupId>com.azure</groupId>


### PR DESCRIPTION
Update msal4j used in serde to bring in updated json-smart dependency to address security hygiene cleanup of: CVE-2023-1370
commit / branch needs renaming after engineering ticket gets created from https://confluentinc.atlassian.net/browse/CVE-356