### PR TITLE
Static token provider: adding optional lsrc-id and pool-id

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/StaticTokenCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/StaticTokenCredentialProvider.java
@@ -21,10 +21,13 @@ import org.apache.kafka.common.config.ConfigException;
 
 import java.net.URL;
 import java.util.Map;
+import org.apache.kafka.common.security.oauthbearer.secured.ConfigurationUtils;
 
 public class StaticTokenCredentialProvider implements BearerAuthCredentialProvider {
 
   private String bearerToken;
+  private String targetSchemaRegistry;
+  private String targetIdentityPoolId;
 
   @Override
   public String alias() {
@@ -32,7 +35,23 @@ public class StaticTokenCredentialProvider implements BearerAuthCredentialProvid
   }
 
   @Override
+  public String getTargetSchemaRegistry() {
+    return this.targetSchemaRegistry;
+  }
+
+  @Override
+  public String getTargetIdentityPoolId() {
+    return this.targetIdentityPoolId;
+  }
+
+  @Override
   public void configure(Map<String, ?> configs) {
+    ConfigurationUtils cu = new ConfigurationUtils(configs);
+    targetSchemaRegistry = cu.validateString(
+        SchemaRegistryClientConfig.BEARER_AUTH_LOGICAL_CLUSTER, false);
+    targetIdentityPoolId = cu.validateString(
+        SchemaRegistryClientConfig.BEARER_AUTH_IDENTITY_POOL_ID, false);
+
     bearerToken = (String) configs.get(SchemaRegistryClientConfig.BEARER_AUTH_TOKEN_CONFIG);
     if (bearerToken != null && !bearerToken.isEmpty()) {
       return;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/SaslOauthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/SaslOauthCredentialProvider.java
@@ -85,12 +85,12 @@ public class SaslOauthCredentialProvider implements BearerAuthCredentialProvider
     JaasOptionsUtils jou = new JaasOptionsUtils((Map<String, Object>) jaasconfig);
 
     targetSchemaRegistry = cu.validateString(
-        SchemaRegistryClientConfig.BEARER_AUTH_LOGICAL_CLUSTER);
+        SchemaRegistryClientConfig.BEARER_AUTH_LOGICAL_CLUSTER, false);
 
     // if the schema registry oauth configs are set it is given higher preference
     targetIdentityPoolId = cu.get(SchemaRegistryClientConfig.BEARER_AUTH_IDENTITY_POOL_ID) != null
         ? cu.validateString(SchemaRegistryClientConfig.BEARER_AUTH_IDENTITY_POOL_ID)
-        : jou.validateString(SASL_IDENTITY_POOL_CONFIG);
+        : jou.validateString(SASL_IDENTITY_POOL_CONFIG, false);
 
     tokenRetriever = new CachedOauthTokenRetriever();
     tokenRetriever.configure(getTokenRetriever(cu, jou), getTokenValidator(cu, configs),

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/StaticTokenCredentialProviderTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/StaticTokenCredentialProviderTest.java
@@ -34,9 +34,12 @@ public class StaticTokenCredentialProviderTest {
   public void testBearerToken() throws MalformedURLException {
     Map<String, Object> clientConfig = new HashMap<>();
     clientConfig.put(SchemaRegistryClientConfig.BEARER_AUTH_TOKEN_CONFIG, "auth-token");
+    clientConfig.put(SchemaRegistryClientConfig.BEARER_AUTH_LOGICAL_CLUSTER, "lsrc-xyz123");
     StaticTokenCredentialProvider provider = new StaticTokenCredentialProvider();
     provider.configure(clientConfig);
     Assert.assertEquals("auth-token", provider.getBearerToken(new URL("http://localhost")));
+    Assert.assertEquals("lsrc-xyz123", provider.getTargetSchemaRegistry());
+    Assert.assertNull(provider.getTargetIdentityPoolId());
   }
 
   @Test(expected = ConfigException.class)


### PR DESCRIPTION
Adding lsrc-id and pool-id values in static_token. Also making lsrc-id and pool-id optional in sasl_oauthbearer_inherit.