### PR TITLE
DGS-7289 Adding CustomBearerAuthCredentialProvider

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClientConfig.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClientConfig.java
@@ -65,9 +65,9 @@ public class SchemaRegistryClientConfig {
       "bearer.auth.cache.expiry.buffer.seconds";
   public static final short BEARER_AUTH_CACHE_EXPIRY_BUFFER_SECONDS_DEFAULT = 300;
 
-  //Custom Token Related
-  public static final String BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS =
-      "bearer.auth.custom.token.provider.class";
+  //Custom bearer Auth related
+  public static final String BEARER_AUTH_CUSTOM_PROVIDER_CLASS =
+      "bearer.auth.custom.provider.class";
 
 
   public static void withClientSslSupport(ConfigDef configDef, String namespace) {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClientConfig.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClientConfig.java
@@ -65,6 +65,10 @@ public class SchemaRegistryClientConfig {
       "bearer.auth.cache.expiry.buffer.seconds";
   public static final short BEARER_AUTH_CACHE_EXPIRY_BUFFER_SECONDS_DEFAULT = 300;
 
+  //Custom Token Related
+  public static final String BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS =
+      "bearer.auth.custom.token.provider.class";
+
 
   public static void withClientSslSupport(ConfigDef configDef, String namespace) {
     org.apache.kafka.common.config.ConfigDef sslConfigDef = new org.apache.kafka.common.config

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProvider.java
@@ -22,8 +22,9 @@ import org.apache.kafka.common.Configurable;
 public interface BearerAuthCredentialProvider extends Configurable {
 
   /*
-  Making alias() default method as custom implementation loaded using CustomTokenProvider don't
-  need to Implement it.
+  Making alias() default method as custom implementation loaded using
+  CustomBearerAuthCredentialProvider via config bearer.auth.custom.provider.class don't need to
+  Implement it.
   */
   default String alias() {
     return null;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProvider.java
@@ -21,8 +21,18 @@ import org.apache.kafka.common.Configurable;
 
 public interface BearerAuthCredentialProvider extends Configurable {
 
-  String alias();
+  /*
+  Making alias() default method as custom implementation loaded using CustomTokenProvider don't
+  need to Implement it.
+  */
+  default String alias() {
+    return null;
+  }
 
+  /*
+   This getBearerToken method should Ideally return a token from a cache. The cache should be
+   responsible for refreshing the token.
+  */
   String getBearerToken(URL url);
 
   default String getTargetSchemaRegistry() {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/CustomBearerAuthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/CustomBearerAuthCredentialProvider.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.client.security.bearerauth;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
+import java.net.URL;
+import java.util.Map;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.security.oauthbearer.secured.ConfigurationUtils;
+
+public class CustomBearerAuthCredentialProvider implements BearerAuthCredentialProvider {
+
+  BearerAuthCredentialProvider customTokenCredentialProvider;
+  private String targetSchemaRegistry;
+  private String targetIdentityPoolId;
+
+  @Override
+  public String alias() {
+    return "CUSTOM";
+  }
+
+  @Override
+  public String getBearerToken(URL url) {
+    return this.customTokenCredentialProvider.getBearerToken(url);
+  }
+
+  @Override
+  public String getTargetSchemaRegistry() {
+    return this.customTokenCredentialProvider.getTargetSchemaRegistry() != null
+        ? this.customTokenCredentialProvider.getTargetSchemaRegistry() : this.targetSchemaRegistry;
+  }
+
+  @Override
+  public String getTargetIdentityPoolId() {
+    return this.customTokenCredentialProvider.getTargetIdentityPoolId() != null
+        ? this.customTokenCredentialProvider.getTargetIdentityPoolId() : this.targetIdentityPoolId;
+  }
+
+  @Override
+  public void configure(Map<String, ?> map) {
+    ConfigurationUtils cu = new ConfigurationUtils(map);
+    String className = cu.validateString(
+        SchemaRegistryClientConfig.BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS);
+
+    try {
+      this.customTokenCredentialProvider = (BearerAuthCredentialProvider) Class.forName(className)
+          .getDeclaredConstructor()
+          .newInstance();
+    } catch (Exception e) {
+      throw new ConfigException(String.format(
+          "Unable to instantiate an object of class %s, failed with exception: ",
+          SchemaRegistryClientConfig.BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS
+      ) + e.getMessage());
+    }
+    targetSchemaRegistry = cu.validateString(
+        SchemaRegistryClientConfig.BEARER_AUTH_LOGICAL_CLUSTER, false);
+    targetIdentityPoolId = cu.validateString(
+        SchemaRegistryClientConfig.BEARER_AUTH_IDENTITY_POOL_ID, false);
+    this.customTokenCredentialProvider.configure(map);
+  }
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/CustomBearerAuthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/CustomBearerAuthCredentialProvider.java
@@ -56,8 +56,7 @@ public class CustomBearerAuthCredentialProvider implements BearerAuthCredentialP
   public void configure(Map<String, ?> map) {
     ConfigurationUtils cu = new ConfigurationUtils(map);
     String className = cu.validateString(
-        SchemaRegistryClientConfig.BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS);
-
+        SchemaRegistryClientConfig.BEARER_AUTH_CUSTOM_PROVIDER_CLASS);
     try {
       this.customBearerAuthCredentialProvider =
           (BearerAuthCredentialProvider) Class.forName(className)
@@ -66,7 +65,7 @@ public class CustomBearerAuthCredentialProvider implements BearerAuthCredentialP
     } catch (Exception e) {
       throw new ConfigException(String.format(
           "Unable to instantiate an object of class %s, failed with exception: ",
-          SchemaRegistryClientConfig.BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS
+          SchemaRegistryClientConfig.BEARER_AUTH_CUSTOM_PROVIDER_CLASS
       ) + e.getMessage());
     }
     targetSchemaRegistry = cu.validateString(

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/CustomBearerAuthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/CustomBearerAuthCredentialProvider.java
@@ -41,13 +41,15 @@ public class CustomBearerAuthCredentialProvider implements BearerAuthCredentialP
   @Override
   public String getTargetSchemaRegistry() {
     return this.customBearerAuthCredentialProvider.getTargetSchemaRegistry() != null
-        ? this.customBearerAuthCredentialProvider.getTargetSchemaRegistry() : this.targetSchemaRegistry;
+        ? this.customBearerAuthCredentialProvider.getTargetSchemaRegistry()
+        : this.targetSchemaRegistry;
   }
 
   @Override
   public String getTargetIdentityPoolId() {
     return this.customBearerAuthCredentialProvider.getTargetIdentityPoolId() != null
-        ? this.customBearerAuthCredentialProvider.getTargetIdentityPoolId() : this.targetIdentityPoolId;
+        ? this.customBearerAuthCredentialProvider.getTargetIdentityPoolId()
+        : this.targetIdentityPoolId;
   }
 
   @Override
@@ -57,7 +59,8 @@ public class CustomBearerAuthCredentialProvider implements BearerAuthCredentialP
         SchemaRegistryClientConfig.BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS);
 
     try {
-      this.customBearerAuthCredentialProvider = (BearerAuthCredentialProvider) Class.forName(className)
+      this.customBearerAuthCredentialProvider =
+          (BearerAuthCredentialProvider) Class.forName(className)
           .getDeclaredConstructor()
           .newInstance();
     } catch (Exception e) {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/CustomBearerAuthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/CustomBearerAuthCredentialProvider.java
@@ -24,7 +24,7 @@ import org.apache.kafka.common.security.oauthbearer.secured.ConfigurationUtils;
 
 public class CustomBearerAuthCredentialProvider implements BearerAuthCredentialProvider {
 
-  BearerAuthCredentialProvider customTokenCredentialProvider;
+  BearerAuthCredentialProvider customBearerAuthCredentialProvider;
   private String targetSchemaRegistry;
   private String targetIdentityPoolId;
 
@@ -35,19 +35,19 @@ public class CustomBearerAuthCredentialProvider implements BearerAuthCredentialP
 
   @Override
   public String getBearerToken(URL url) {
-    return this.customTokenCredentialProvider.getBearerToken(url);
+    return this.customBearerAuthCredentialProvider.getBearerToken(url);
   }
 
   @Override
   public String getTargetSchemaRegistry() {
-    return this.customTokenCredentialProvider.getTargetSchemaRegistry() != null
-        ? this.customTokenCredentialProvider.getTargetSchemaRegistry() : this.targetSchemaRegistry;
+    return this.customBearerAuthCredentialProvider.getTargetSchemaRegistry() != null
+        ? this.customBearerAuthCredentialProvider.getTargetSchemaRegistry() : this.targetSchemaRegistry;
   }
 
   @Override
   public String getTargetIdentityPoolId() {
-    return this.customTokenCredentialProvider.getTargetIdentityPoolId() != null
-        ? this.customTokenCredentialProvider.getTargetIdentityPoolId() : this.targetIdentityPoolId;
+    return this.customBearerAuthCredentialProvider.getTargetIdentityPoolId() != null
+        ? this.customBearerAuthCredentialProvider.getTargetIdentityPoolId() : this.targetIdentityPoolId;
   }
 
   @Override
@@ -57,7 +57,7 @@ public class CustomBearerAuthCredentialProvider implements BearerAuthCredentialP
         SchemaRegistryClientConfig.BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS);
 
     try {
-      this.customTokenCredentialProvider = (BearerAuthCredentialProvider) Class.forName(className)
+      this.customBearerAuthCredentialProvider = (BearerAuthCredentialProvider) Class.forName(className)
           .getDeclaredConstructor()
           .newInstance();
     } catch (Exception e) {
@@ -70,6 +70,6 @@ public class CustomBearerAuthCredentialProvider implements BearerAuthCredentialP
         SchemaRegistryClientConfig.BEARER_AUTH_LOGICAL_CLUSTER, false);
     targetIdentityPoolId = cu.validateString(
         SchemaRegistryClientConfig.BEARER_AUTH_IDENTITY_POOL_ID, false);
-    this.customTokenCredentialProvider.configure(map);
+    this.customBearerAuthCredentialProvider.configure(map);
   }
 }

--- a/client/src/main/resources/META-INF/services/io.confluent.kafka.schemaregistry.client.security.bearerauth.BearerAuthCredentialProvider
+++ b/client/src/main/resources/META-INF/services/io.confluent.kafka.schemaregistry.client.security.bearerauth.BearerAuthCredentialProvider
@@ -1,3 +1,4 @@
 io.confluent.kafka.schemaregistry.client.security.bearerauth.StaticTokenCredentialProvider
 io.confluent.kafka.schemaregistry.client.security.bearerauth.oauth.OauthCredentialProvider
 io.confluent.kafka.schemaregistry.client.security.bearerauth.oauth.SaslOauthCredentialProvider
+io.confluent.kafka.schemaregistry.client.security.bearerauth.CustomBearerAuthCredentialProvider

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProviderFactoryTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProviderFactoryTest.java
@@ -57,6 +57,19 @@ public class BearerAuthCredentialProviderFactoryTest {
   }
 
   @Test
+  public void testCustomBearerAuthCredentialProvider() {
+    Map<String, String> CONFIG_MAP = new HashMap<>();
+    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_LOGICAL_CLUSTER, "lsrc-dummy");
+    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_IDENTITY_POOL_ID, "my-pool-id");
+    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS,
+        StaticTokenCredentialProvider.class.getName());
+    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_TOKEN_CONFIG, "custom-token");
+
+    assertInstance(BearerAuthCredentialProviderFactory.getBearerAuthCredentialProvider(
+        "CUSTOM", CONFIG_MAP), CustomBearerAuthCredentialProvider.class);
+  }
+
+  @Test
   public void testUnknownProvider() {
     Assert.assertNull(BearerAuthCredentialProviderFactory.getBearerAuthCredentialProvider(
         "UNKNOWN", CONFIG_MAP));

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProviderFactoryTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProviderFactoryTest.java
@@ -61,7 +61,7 @@ public class BearerAuthCredentialProviderFactoryTest {
     Map<String, String> CONFIG_MAP = new HashMap<>();
     CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_LOGICAL_CLUSTER, "lsrc-dummy");
     CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_IDENTITY_POOL_ID, "my-pool-id");
-    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS,
+    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_CUSTOM_PROVIDER_CLASS,
         StaticTokenCredentialProvider.class.getName());
     CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_TOKEN_CONFIG, "custom-token");
 

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/CustomBearerAuthCredentialProviderTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/CustomBearerAuthCredentialProviderTest.java
@@ -46,7 +46,7 @@ public class CustomBearerAuthCredentialProviderTest {
     CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_IDENTITY_POOL_ID, POOL_ID);
     CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_ISSUER_ENDPOINT_URL, tempFile.toString());
     CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS,
-        MyFileTokenProvider.class.getName());
+        "io.confluent.kafka.schemaregistry.client.security.bearerauth.Resources.MyFileTokenProvider");
 
     BearerAuthCredentialProvider provider = new CustomBearerAuthCredentialProvider();
     provider.configure(CONFIG_MAP);

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/CustomBearerAuthCredentialProviderTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/CustomBearerAuthCredentialProviderTest.java
@@ -1,0 +1,61 @@
+package io.confluent.kafka.schemaregistry.client.security.bearerauth;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
+import io.confluent.kafka.schemaregistry.client.security.bearerauth.Resources.MyFileTokenProvider;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class CustomBearerAuthCredentialProviderTest {
+
+  private final String LSRC_ID = "lsrc-dummy";
+  private final String POOL_ID = "my-pool-id";
+
+  @Test
+  public void testWithStaticTokenProvider() throws MalformedURLException {
+    Map<String, String> CONFIG_MAP = new HashMap<>();
+    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_LOGICAL_CLUSTER, LSRC_ID);
+    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_IDENTITY_POOL_ID, POOL_ID);
+    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS,
+        StaticTokenCredentialProvider.class.getName());
+    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_TOKEN_CONFIG, "custom-token");
+
+    BearerAuthCredentialProvider provider = new CustomBearerAuthCredentialProvider();
+    provider.configure(CONFIG_MAP);
+    Assert.assertEquals("custom-token", provider.getBearerToken(new URL("http://dummy")));
+    Assert.assertEquals(LSRC_ID, provider.getTargetSchemaRegistry());
+    Assert.assertEquals(POOL_ID, provider.getTargetIdentityPoolId());
+  }
+
+  @Test
+  public void testWithMyFileTokenProvider() throws IOException {
+    String token = "my_custom_file_token";
+    Path tempFile = Files.createTempFile("MyTokenFile", "txt");
+    Files.write(tempFile, token.getBytes(StandardCharsets.UTF_8));
+
+    Map<String, String> CONFIG_MAP = new HashMap<>();
+    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_LOGICAL_CLUSTER, LSRC_ID);
+    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_IDENTITY_POOL_ID, POOL_ID);
+    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_ISSUER_ENDPOINT_URL, tempFile.toString());
+    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS,
+        MyFileTokenProvider.class.getName());
+
+    BearerAuthCredentialProvider provider = new CustomBearerAuthCredentialProvider();
+    provider.configure(CONFIG_MAP);
+
+    Assert.assertEquals(token, provider.getBearerToken(new URL("http://dummy")));
+    Assert.assertEquals(LSRC_ID, provider.getTargetSchemaRegistry());
+    Assert.assertEquals(POOL_ID, provider.getTargetIdentityPoolId());
+
+  }
+
+
+}

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/CustomBearerAuthCredentialProviderTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/CustomBearerAuthCredentialProviderTest.java
@@ -1,7 +1,6 @@
 package io.confluent.kafka.schemaregistry.client.security.bearerauth;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
-import io.confluent.kafka.schemaregistry.client.security.bearerauth.Resources.MyFileTokenProvider;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -24,7 +23,7 @@ public class CustomBearerAuthCredentialProviderTest {
     Map<String, String> CONFIG_MAP = new HashMap<>();
     CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_LOGICAL_CLUSTER, LSRC_ID);
     CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_IDENTITY_POOL_ID, POOL_ID);
-    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS,
+    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_CUSTOM_PROVIDER_CLASS,
         StaticTokenCredentialProvider.class.getName());
     CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_TOKEN_CONFIG, "custom-token");
 
@@ -45,7 +44,7 @@ public class CustomBearerAuthCredentialProviderTest {
     CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_LOGICAL_CLUSTER, LSRC_ID);
     CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_IDENTITY_POOL_ID, POOL_ID);
     CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_ISSUER_ENDPOINT_URL, tempFile.toString());
-    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS,
+    CONFIG_MAP.put(SchemaRegistryClientConfig.BEARER_AUTH_CUSTOM_PROVIDER_CLASS,
         "io.confluent.kafka.schemaregistry.client.security.bearerauth.Resources.MyFileTokenProvider");
 
     BearerAuthCredentialProvider provider = new CustomBearerAuthCredentialProvider();

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/Resources/MyFileTokenProvider.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/Resources/MyFileTokenProvider.java
@@ -1,0 +1,45 @@
+package io.confluent.kafka.schemaregistry.client.security.bearerauth.Resources;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
+import io.confluent.kafka.schemaregistry.client.security.bearerauth.BearerAuthCredentialProvider;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.config.ConfigException;
+
+/**
+ * <code>MyFileTokenProvider</code> is a <code>BearerAuthCredentialProvider</code>
+ * Indented only for testing purpose. The <code>MyFileTokenProvider</code> can loaded using
+ * <code>CustomTokenCredentialProvider<code/>
+ */
+public class MyFileTokenProvider implements BearerAuthCredentialProvider {
+
+  private String token;
+
+  @Override
+  public String getBearerToken(URL url) {
+    // Ideally this might be fetching a cache. And cache should hold the mechanism to refresh.
+    return this.token;
+  }
+
+  @Override
+  public void configure(Map<String, ?> map) {
+    Path path = Paths.get(
+        (String) map.get(SchemaRegistryClientConfig.BEARER_AUTH_ISSUER_ENDPOINT_URL));
+    try {
+      this.token = Files
+          .lines(path, StandardCharsets.UTF_8)
+          .collect(Collectors.joining(System.lineSeparator()));
+    } catch (IOException e) {
+      throw new ConfigException(String.format(
+          "Not to read file at given location %s", path.toString()
+      ));
+    }
+  }
+
+}

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDeConfig.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDeConfig.java
@@ -187,9 +187,9 @@ public class AbstractKafkaSchemaSerDeConfig extends AbstractConfig {
       + "if no value is specified. This value is ignored if it exceeds the remaining lifetime "
       + "of a token from the moment it is retrieved into schema registry.";
 
-  public static final String BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS = SchemaRegistryClientConfig
-      .BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS;
-  public static final String BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS_D0C =
+  public static final String BEARER_AUTH_CUSTOM_PROVIDER_CLASS = SchemaRegistryClientConfig
+      .BEARER_AUTH_CUSTOM_PROVIDER_CLASS;
+  public static final String BEARER_AUTH_CUSTOM_PROVIDER_CLASS_D0C =
       "Custom class which will provide the token credential. Needs to implement io.confluent.kafka"
           + ".schemaregistry.client.security.bearerauth.BearerAuthCredentialProvider interface";
 
@@ -280,8 +280,8 @@ public class AbstractKafkaSchemaSerDeConfig extends AbstractConfig {
                 Type.SHORT, BEARER_AUTH_CACHE_EXPIRY_BUFFER_SECONDS_DEFAULT, Range.between(0, 3600),
                 Importance.LOW,
                 BEARER_AUTH_CACHE_EXPIRY_BUFFER_SECONDS_DOC)
-        .define(BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS, Type.STRING,null, Importance.MEDIUM,
-            BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS_D0C)
+        .define(BEARER_AUTH_CUSTOM_PROVIDER_CLASS, Type.STRING,null, Importance.MEDIUM,
+            BEARER_AUTH_CUSTOM_PROVIDER_CLASS_D0C)
         .define(CONTEXT_NAME_STRATEGY, Type.CLASS, CONTEXT_NAME_STRATEGY_DEFAULT,
                 Importance.MEDIUM, CONTEXT_NAME_STRATEGY_DOC)
         .define(KEY_SUBJECT_NAME_STRATEGY, Type.CLASS, KEY_SUBJECT_NAME_STRATEGY_DEFAULT,

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDeConfig.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDeConfig.java
@@ -187,6 +187,12 @@ public class AbstractKafkaSchemaSerDeConfig extends AbstractConfig {
       + "if no value is specified. This value is ignored if it exceeds the remaining lifetime "
       + "of a token from the moment it is retrieved into schema registry.";
 
+  public static final String BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS = SchemaRegistryClientConfig
+      .BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS;
+  public static final String BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS_D0C =
+      "Custom class which will provide the token credential. Needs to implement io.confluent.kafka"
+          + ".schemaregistry.client.security.bearerauth.BearerAuthCredentialProvider interface";
+
   public static final String CONTEXT_NAME_STRATEGY = "context.name.strategy";
   public static final String CONTEXT_NAME_STRATEGY_DEFAULT =
       NullContextNameStrategy.class.getName();
@@ -274,6 +280,8 @@ public class AbstractKafkaSchemaSerDeConfig extends AbstractConfig {
                 Type.SHORT, BEARER_AUTH_CACHE_EXPIRY_BUFFER_SECONDS_DEFAULT, Range.between(0, 3600),
                 Importance.LOW,
                 BEARER_AUTH_CACHE_EXPIRY_BUFFER_SECONDS_DOC)
+        .define(BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS, Type.STRING,null, Importance.MEDIUM,
+            BEARER_AUTH_CUSTOM_TOKEN_PROVIDER_CLASS_D0C)
         .define(CONTEXT_NAME_STRATEGY, Type.CLASS, CONTEXT_NAME_STRATEGY_DEFAULT,
                 Importance.MEDIUM, CONTEXT_NAME_STRATEGY_DOC)
         .define(KEY_SUBJECT_NAME_STRATEGY, Type.CLASS, KEY_SUBJECT_NAME_STRATEGY_DEFAULT,


### PR DESCRIPTION
Introducing CustomBearerAuthCredentialProvider to make SR client extensible for custom token provider implementation. 
Users can implement their own concrete Implementation of the BearerAuthCredentialProvider Interface and plug into sr using this provider.
The user would have to give the following configs. 
```
bearer.auth.credentials.source=CUSTOM
bearer.auth.custom.token.provider.class=<Fully Qualified class name of custom Implementation>
bearer.auth.logical.cluster=<lsrc-xxxxx> #optional, needed for Confluent cloud SR
bearer.auth.identity.pool.id=<pood Id> #optional, needed for Confluent cloud SR
```