### PR TITLE
DGS-7412 Fix for registering references in non-default context

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaProvider.java
@@ -50,7 +50,7 @@ public class AvroSchemaProvider extends AbstractSchemaProvider {
       return new AvroSchema(
           schema.getSchema(),
           schema.getReferences(),
-          resolveReferences(schema.getReferences()),
+          resolveReferences(schema),
           null,
           (validateDefaults || normalize) && isNew
       );

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
@@ -159,6 +159,22 @@ public class QualifiedSubject implements Comparable<QualifiedSubject> {
     return qs != null ? qs.toQualifiedContext() : "";
   }
 
+  public static String qualifySubjectWithParent(String tenant, String parent, String subject) {
+    QualifiedSubject qualifiedSubject = QualifiedSubject.create(tenant, subject);
+    boolean isQualified = qualifiedSubject != null
+        && !DEFAULT_CONTEXT.equals(qualifiedSubject.getContext());
+    if (!isQualified) {
+      QualifiedSubject qualifiedParent = QualifiedSubject.create(tenant, parent);
+      boolean isParentQualified = qualifiedParent != null
+          && !DEFAULT_CONTEXT.equals(qualifiedParent.getContext());
+      if (isParentQualified) {
+        subject = new QualifiedSubject(tenant, qualifiedParent.getContext(), subject)
+            .toQualifiedSubject();
+      }
+    }
+    return subject;
+  }
+
   /**
    * Normalizes the given qualified subject name.
    *

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
@@ -173,7 +173,8 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
     // compaction when the previous non-deleted schemaValue will not get registered
     addToSchemaHashToGuid(schemaKey, schemaValue);
     for (SchemaReference ref : schemaValue.getReferences()) {
-      SchemaKey refKey = new SchemaKey(ref.getSubject(), ref.getVersion());
+      String refSubject = getReferenceSubject(schemaKey.getSubject(), ref);
+      SchemaKey refKey = new SchemaKey(refSubject, ref.getVersion());
       Map<String, Map<SchemaKey, Set<Integer>>> ctxRefBy =
           referencedBy.getOrDefault(tenant(), Collections.emptyMap());
       Map<SchemaKey, Set<Integer>> refBy = ctxRefBy.getOrDefault(ctx, Collections.emptyMap());
@@ -222,7 +223,8 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
     subjectVersions.put(schemaKey.getSubject(), schemaKey.getVersion());
     addToSchemaHashToGuid(schemaKey, schemaValue);
     for (SchemaReference ref : schemaValue.getReferences()) {
-      SchemaKey refKey = new SchemaKey(ref.getSubject(), ref.getVersion());
+      String refSubject = getReferenceSubject(schemaKey.getSubject(), ref);
+      SchemaKey refKey = new SchemaKey(refSubject, ref.getVersion());
       Map<String, Map<SchemaKey, Set<Integer>>> ctxRefBy =
           referencedBy.computeIfAbsent(tenant(), k -> new ConcurrentHashMap<>());
       Map<SchemaKey, Set<Integer>> refBy =
@@ -240,6 +242,24 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
         hashToGuid.computeIfAbsent(tenant(), k -> new ConcurrentHashMap<>());
     Map<MD5, Integer> hashes = ctxHashes.computeIfAbsent(ctx, k -> new ConcurrentHashMap<>());
     hashes.put(md5, schemaValue.getId());
+  }
+
+  private String getReferenceSubject(String subject, SchemaReference reference) {
+    String refSubject = reference.getSubject();
+    QualifiedSubject qualifiedRefSubject =
+        QualifiedSubject.create(tenant(), reference.getSubject());
+    boolean isRefQualified = qualifiedRefSubject != null
+        && !DEFAULT_CONTEXT.equals(qualifiedRefSubject.getContext());
+    if (!isRefQualified) {
+      QualifiedSubject qualifiedSubject = QualifiedSubject.create(tenant(), subject);
+      boolean isSchemaQualified = qualifiedSubject != null
+          && !DEFAULT_CONTEXT.equals(qualifiedSubject.getContext());
+      if (isSchemaQualified) {
+        refSubject = new QualifiedSubject(
+            tenant(), qualifiedSubject.getContext(), refSubject).toQualifiedSubject();
+      }
+    }
+    return refSubject;
   }
 
   @Override

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/utils/TestUtils.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/utils/TestUtils.java
@@ -117,7 +117,7 @@ public class TestUtils {
     // the newly registered schema should be immediately readable on the leader
     assertEquals("Registered schema should be found",
             schemaString,
-            restService.getId(expectedId).getSchemaString());
+            restService.getId(expectedId, subject).getSchemaString());
   }
 
   public static void registerAndVerifySchema(RestService restService, String schemaString,

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaProvider.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaProvider.java
@@ -37,7 +37,7 @@ public class JsonSchemaProvider extends AbstractSchemaProvider {
       return new JsonSchema(
               schema.getSchema(),
               schema.getReferences(),
-              resolveReferences(schema.getReferences()),
+              resolveReferences(schema),
               null
       );
     } catch (Exception e) {

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaProvider.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaProvider.java
@@ -38,7 +38,7 @@ public class ProtobufSchemaProvider extends AbstractSchemaProvider {
       return new ProtobufSchema(
               schema.getSchema(),
               schema.getReferences(),
-              resolveReferences(schema.getReferences()),
+              resolveReferences(schema),
               null,
               null
       );


### PR DESCRIPTION
Fix for registering references in non-default context.  We ensure the reference is qualified with the correct context.

Much of this PR is backported from 7.4.x.  The main change is a new call to qualify referenced subjects with the context of their parent schema.