### PR TITLE
DGS-7422 Optimization: omit compat check during IMPORT

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -40,7 +40,7 @@
               files="(SchemaRegistryConfig|ProtobufData|JsonSchemaData).java"/>
 
     <suppress checks="BooleanExpressionComplexity"
-              files="(AvroData|ProtobufData).java"/>
+              files="(AvroData|ProtobufData|KafkaSchemaRegistry).java"/>
 
     <suppress checks="MemberName"
               files="(DynamicSchema|EnumDefinition|MessageDefinition|ServiceDefinition).java"/>

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -487,7 +487,6 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
 
       Mode mode = getModeInScope(subject);
       boolean isCompatible = true;
-      List<String> compatibilityErrorLogs = new ArrayList<>();
       if (mode != Mode.IMPORT) {
         isCompatible = isCompatibleWithPrevious(subject, parsedSchema, undeletedVersions).isEmpty();
       }


### PR DESCRIPTION
Omit the compat check during IMPORT mode.  This avoids situations where Avro throws an AvroRuntimeException, which halts import.