### PR TITLE
DGS-7432 Fix ClassCastException when getting params option

### DIFF
--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -1351,17 +1351,23 @@ public class ProtobufSchema implements ParsedSchema {
 
   @SuppressWarnings("unchecked")
   public static Map<String, String> findParams(Optional<OptionElement> meta) {
-    List<Map<String, String>> keyValues = (List<Map<String, String>>) findMeta(meta, PARAMS_FIELD);
-    if (keyValues == null) {
+    Object result = findMeta(meta, PARAMS_FIELD);
+    if (result == null) {
       return null;
+    } else if (result instanceof Map) {
+      return (Map<String, String>) result;
+    } else if (result instanceof List) {
+      List<Map<String, String>> keyValues = (List<Map<String, String>>) result;
+      Map<String, String> params = new LinkedHashMap<>();
+      for (Map<String, String> keyValue : keyValues) {
+        String key = keyValue.get(KEY_FIELD);
+        String value = keyValue.get(VALUE_FIELD);
+        params.put(key, value);
+      }
+      return params;
+    } else {
+      throw new IllegalStateException("Unrecognized params type " + result.getClass().getName());
     }
-    Map<String, String> params = new LinkedHashMap<>();
-    for (Map<String, String> keyValue : keyValues) {
-      String key = keyValue.get(KEY_FIELD);
-      String value = keyValue.get(VALUE_FIELD);
-      params.put(key, value);
-    }
-    return params;
   }
 
   @SuppressWarnings("unchecked")

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -934,6 +934,43 @@ public class ProtobufSchemaTest {
   }
 
   @Test
+  public void testParams() {
+    String schemaString = "syntax = \"proto3\";\n"
+        + "package com.acme;\n"
+        + "import \"confluent/type/decimal.proto\";\n"
+        + "import \"google/protobuf/timestamp.proto\";\n"
+        + "message MyMessage {\n"
+        + " .google.protobuf.Timestamp MIT_DATE = 1;\n"
+        + " int64 MIT_LOC_ID = 2;\n"
+        + " int64 MIT_MI_ID = 3;\n"
+        + " int64 MIT_R_ID = 4;\n"
+        + " int32 MIT_COUNT = 5;\n"
+        + " .confluent.type.Decimal MIT_PRICE = 6 [(confluent.field_meta) = {\n"
+        + "  params: {\n"
+        + "   key: \"scale\",\n"
+        + "   value: \"2\"\n"
+        + "  }\n"
+        + " }];\n"
+        + " int64 MIT_PC_ID = 7;\n"
+        + " .google.protobuf.Timestamp MIT_CREATE_DATE = 8;\n"
+        + " int64 MIT_CREATE_BY_USER_ID = 9;\n"
+        + " .google.protobuf.Timestamp MIT_MODIFY_DATE = 10;\n"
+        + " int64 MIT_MODIFY_BY_USER_ID = 11;\n"
+        + " int64 MIT_CONCEPT_ID = 12;\n"
+        + " .confluent.type.Decimal MIT_ACTUAL_PRICE = 13 [(confluent.field_meta) = {\n"
+        + "  params: {\n"
+        + "   key: \"scale\",\n"
+        + "   value: \"2\"\n"
+        + "  }\n"
+        + " }];\n"
+        + "}";
+    ProtobufSchema schema = new ProtobufSchema(schemaString);
+    // Ensure we can process params when creating a dynamic schema
+    assertNotNull(schema.toDynamicSchema());
+  }
+
+
+  @Test
   public void testNormalization() {
     String schemaString = "syntax = \"proto3\";\n"
         + "package my.package;\n"


### PR DESCRIPTION
The object returned from getMeta can be either a List of key-value pairs of a Map.  Previously the Map case was not handled.