### PR TITLE
DGS-7564 When registering, return schema if changed on server

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -18,16 +18,19 @@ package io.confluent.kafka.serializers;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleMode;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.nio.ByteBuffer;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import org.apache.avro.Schema;
@@ -112,7 +115,16 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
       int id;
       if (autoRegisterSchema) {
         restClientErrorMsg = "Error registering Avro schema";
-        id = schemaRegistry.register(subject, schema, normalizeSchema);
+        io.confluent.kafka.schemaregistry.client.rest.entities.Schema s =
+            registerWithResponse(subject, schema, normalizeSchema);
+        if (s.getSchema() != null) {
+          Optional<ParsedSchema> optSchema = schemaRegistry.parseSchema(s);
+          if (optSchema.isPresent()) {
+            schema = (AvroSchema) optSchema.get();
+            schema = schema.copy(s.getVersion());
+          }
+        }
+        id = s.getId();
       } else if (useSchemaId >= 0) {
         restClientErrorMsg = "Error retrieving schema ID";
         schema = (AvroSchema)

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -23,7 +23,6 @@ import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleMode;
-import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -28,7 +28,7 @@
               files="(AvroData|ConfigResource|DownloadSchemaRegistryMojo|KafkaSchemaRegistry|KafkaStore|KafkaStoreReaderThread|MessageDefinition|Schema|SchemaValue|SchemaDiff|MessageSchemaDiff|AbstractKafkaSchemaSerDe|AbstractKafkaAvroSerializer|AbstractKafkaAvroDeserializer|AbstractKafkaJsonSchemaDeserializer|AbstractKafkaProtobufDeserializer|ProtobufData|ProtobufSchemaUtils|JsonSchemaData|SchemaMessageFormatter|SchemaMessageReader|ContextFilter|QualifiedSubject|SubjectVersionsResource|Rule|WildcardMatcher|JsonSchemaComparator|LocalSchemaRegistryClient).java"/>
 
     <suppress checks="JavaNCSS"
-              files="(AbstractKafkaAvroSerializer|AbstractKafkaJsonSchemaDeserializer|AbstractKafkaProtobufSerializer|AbstractKafkaProtobufDeserializer|AvroData|AvroSchema|AvroSchemaUtils|ProtobufData|SchemaDiff|NumberSchemaDiff|JsonSchema|JsonSchemaData|KafkaSchemaRegistry|KafkaStoreReaderThread|ProtobufSchema|ProtobufSchemaUtils|JsonSchemaComparator|SchemaMessageFormatter|SchemaMessageReader).java"/>
+              files="(AbstractKafkaAvroSerializer|AbstractKafkaJsonSchemaSerializer|AbstractKafkaJsonSchemaDeserializer|AbstractKafkaProtobufSerializer|AbstractKafkaProtobufDeserializer|AvroData|AvroSchema|AvroSchemaUtils|ProtobufData|SchemaDiff|NumberSchemaDiff|JsonSchema|JsonSchemaData|KafkaSchemaRegistry|KafkaStoreReaderThread|ProtobufSchema|ProtobufSchemaUtils|JsonSchemaComparator|SchemaMessageFormatter|SchemaMessageReader).java"/>
 
     <suppress checks="MethodLength"
               files="(AvroData|ProtobufSchema|ProtobufSchemaUtils).java"/>

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SimpleParsedSchemaHolder.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SimpleParsedSchemaHolder.java
@@ -38,6 +38,10 @@ public class SimpleParsedSchemaHolder implements ParsedSchemaHolder {
     return schema;
   }
 
+  public void setSchema(ParsedSchema schema) {
+    this.schema = schema;
+  }
+
   /**
    * Clears the schema if it can be lazily retrieved in the future.
    */

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -67,6 +67,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
 
   private final RestService restService;
   private final int cacheCapacity;
+  private final Map<String, Map<ParsedSchema, RegisterSchemaResponse>> schemaToResponseCache;
   private final Map<String, Map<ParsedSchema, Integer>> schemaToIdCache;
   private final Map<String, Map<Integer, ParsedSchema>> idToSchemaCache;
   private final Map<String, Map<ParsedSchema, Integer>> schemaToVersionCache;
@@ -188,6 +189,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
       Map<String, String> httpHeaders,
       Ticker ticker) {
     this.cacheCapacity = cacheCapacity;
+    this.schemaToResponseCache = new BoundedConcurrentHashMap<>(cacheCapacity);
     this.schemaToIdCache = new BoundedConcurrentHashMap<>(cacheCapacity);
     this.idToSchemaCache = new BoundedConcurrentHashMap<>(cacheCapacity);
     this.schemaToVersionCache = new BoundedConcurrentHashMap<>(cacheCapacity);
@@ -386,40 +388,49 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   @Override
   public int register(String subject, ParsedSchema schema, boolean normalize)
       throws IOException, RestClientException {
-    return register(subject, schema, 0, -1, normalize);
+    return registerWithResponse(subject, schema, 0, -1, normalize).getId();
   }
 
   @Override
   public int register(String subject, ParsedSchema schema, int version, int id)
       throws IOException, RestClientException {
-    return register(subject, schema, version, id, false);
+    return registerWithResponse(subject, schema, version, id, false).getId();
   }
 
-  private int register(String subject, ParsedSchema schema, int version, int id, boolean normalize)
+  @Override
+  public RegisterSchemaResponse registerWithResponse(
+      String subject, ParsedSchema schema, boolean normalize)
       throws IOException, RestClientException {
-    final Map<ParsedSchema, Integer> schemaIdMap = schemaToIdCache.computeIfAbsent(
-        subject, k -> new BoundedConcurrentHashMap<>(cacheCapacity));
+    return registerWithResponse(subject, schema, 0, -1, normalize);
+  }
 
-    Integer cachedId = schemaIdMap.get(schema);
-    if (cachedId != null && (id < 0 || id == cachedId)) {
-      return cachedId;
+  private RegisterSchemaResponse registerWithResponse(
+      String subject, ParsedSchema schema, int version, int id, boolean normalize)
+      throws IOException, RestClientException {
+    final Map<ParsedSchema, RegisterSchemaResponse> schemaResponseMap =
+        schemaToResponseCache.computeIfAbsent(
+            subject, k -> new BoundedConcurrentHashMap<>(cacheCapacity));
+
+    RegisterSchemaResponse cachedResponse = schemaResponseMap.get(schema);
+    if (cachedResponse != null && (id < 0 || id == cachedResponse.getId())) {
+      return cachedResponse;
     }
 
     synchronized (this) {
-      cachedId = schemaIdMap.get(schema);
-      if (cachedId != null && (id < 0 || id == cachedId)) {
-        return cachedId;
+      cachedResponse = schemaResponseMap.get(schema);
+      if (cachedResponse != null && (id < 0 || id == cachedResponse.getId())) {
+        return cachedResponse;
       }
 
-      final int retrievedId = id >= 0
-          ? registerAndGetId(subject, schema, version, id, normalize).getId()
-          : registerAndGetId(subject, schema, normalize).getId();
-      schemaIdMap.put(schema, retrievedId);
+      final RegisterSchemaResponse retrievedResponse = id >= 0
+          ? registerAndGetId(subject, schema, version, id, normalize)
+          : registerAndGetId(subject, schema, normalize);
+      schemaResponseMap.put(schema, retrievedResponse);
       String context = toQualifiedContext(subject);
       final Map<Integer, ParsedSchema> idSchemaMap = idToSchemaCache.computeIfAbsent(
           context, k -> new BoundedConcurrentHashMap<>(cacheCapacity));
-      idSchemaMap.put(retrievedId, schema);
-      return retrievedId;
+      idSchemaMap.put(retrievedResponse.getId(), schema);
+      return retrievedResponse;
     }
   }
 
@@ -663,6 +674,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
     }
     idToSchemaCache.remove(subject);
     schemaToIdCache.remove(subject);
+    schemaToResponseCache.remove(subject);
     return restService.deleteSubject(requestProperties, subject, isPermanent);
   }
 
@@ -788,6 +800,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
 
   @Override
   public synchronized void reset() {
+    schemaToResponseCache.clear();
     schemaToIdCache.clear();
     idToSchemaCache.clear();
     schemaToVersionCache.clear();

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -20,6 +20,7 @@ import com.google.common.base.Ticker;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
 import org.apache.kafka.common.config.SslConfigs;
 import org.slf4j.Logger;
@@ -301,13 +302,14 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
     return providers;
   }
 
-  private int registerAndGetId(String subject, ParsedSchema schema, boolean normalize)
+  private RegisterSchemaResponse registerAndGetId(
+      String subject, ParsedSchema schema, boolean normalize)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest(schema);
     return restService.registerSchema(request, subject, normalize);
   }
 
-  private int registerAndGetId(
+  private RegisterSchemaResponse registerAndGetId(
       String subject, ParsedSchema schema, int version, int id, boolean normalize)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest(schema);
@@ -410,8 +412,8 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
       }
 
       final int retrievedId = id >= 0
-          ? registerAndGetId(subject, schema, version, id, normalize)
-          : registerAndGetId(subject, schema, normalize);
+          ? registerAndGetId(subject, schema, version, id, normalize).getId()
+          : registerAndGetId(subject, schema, normalize).getId();
       schemaIdMap.put(schema, retrievedId);
       String context = toQualifiedContext(subject);
       final Map<Integer, ParsedSchema> idSchemaMap = idToSchemaCache.computeIfAbsent(

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -20,6 +20,7 @@ import com.google.common.base.Ticker;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Config;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
@@ -76,6 +77,7 @@ public interface SchemaRegistryClient extends SchemaVersionFetcher {
 
   public int register(String subject, ParsedSchema schema) throws IOException, RestClientException;
 
+
   default int register(String subject, ParsedSchema schema, boolean normalize)
       throws IOException, RestClientException {
     throw new UnsupportedOperationException();
@@ -95,6 +97,12 @@ public interface SchemaRegistryClient extends SchemaVersionFetcher {
 
   public int register(String subject, ParsedSchema schema, int version, int id) throws IOException,
       RestClientException;
+
+  default RegisterSchemaResponse registerWithResponse(
+      String subject, ParsedSchema schema, boolean normalize)
+      throws IOException, RestClientException {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * @deprecated use {@link #getSchemaById(int)} instead

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -503,24 +503,26 @@ public class RestService implements Configurable {
   // Visible for testing
   public int registerSchema(String schemaString, String subject)
       throws IOException, RestClientException {
-    return registerSchema(schemaString, subject, false);
+    return registerSchema(schemaString, subject, false).getId();
   }
 
-  public int registerSchema(String schemaString, String subject, boolean normalize)
+  public RegisterSchemaResponse registerSchema(String schemaString, String subject,
+                                               boolean normalize)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
     return registerSchema(request, subject, normalize);
   }
 
-  public int registerSchema(String schemaString, String schemaType,
-                            List<SchemaReference> references, String subject)
+  public RegisterSchemaResponse registerSchema(String schemaString, String schemaType,
+                                               List<SchemaReference> references, String subject)
       throws IOException, RestClientException {
     return registerSchema(schemaString, schemaType, references, subject, false);
   }
 
-  public int registerSchema(String schemaString, String schemaType,
-                            List<SchemaReference> references, String subject, boolean normalize)
+  public RegisterSchemaResponse registerSchema(String schemaString, String schemaType,
+                                               List<SchemaReference> references,
+                                               String subject, boolean normalize)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
@@ -532,11 +534,11 @@ public class RestService implements Configurable {
   // Visible for testing
   public int registerSchema(String schemaString, String subject, int version, int id)
       throws IOException, RestClientException {
-    return registerSchema(schemaString, subject, version, id, false);
+    return registerSchema(schemaString, subject, version, id, false).getId();
   }
 
-  public int registerSchema(String schemaString, String subject,
-                            int version, int id, boolean normalize)
+  public RegisterSchemaResponse registerSchema(String schemaString, String subject,
+                                               int version, int id, boolean normalize)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
@@ -545,15 +547,16 @@ public class RestService implements Configurable {
     return registerSchema(request, subject, normalize);
   }
 
-  public int registerSchema(String schemaString, String schemaType,
-                            List<SchemaReference> references, String subject, int version, int id)
+  public RegisterSchemaResponse registerSchema(String schemaString, String schemaType,
+                                               List<SchemaReference> references, String subject,
+                                               int version, int id)
       throws IOException, RestClientException {
     return registerSchema(schemaString, schemaType, references, subject, version, id, false);
   }
 
-  public int registerSchema(String schemaString, String schemaType,
-                            List<SchemaReference> references, String subject, int version, int id,
-                            boolean normalize)
+  public RegisterSchemaResponse registerSchema(String schemaString, String schemaType,
+                                               List<SchemaReference> references, String subject,
+                                               int version, int id, boolean normalize)
                             throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
@@ -564,17 +567,17 @@ public class RestService implements Configurable {
     return registerSchema(request, subject, normalize);
   }
 
-  public int registerSchema(RegisterSchemaRequest registerSchemaRequest,
-                            String subject,
-                            boolean normalize)
+  public RegisterSchemaResponse registerSchema(RegisterSchemaRequest registerSchemaRequest,
+                                               String subject,
+                                               boolean normalize)
       throws IOException, RestClientException {
     return registerSchema(DEFAULT_REQUEST_PROPERTIES, registerSchemaRequest, subject, normalize);
   }
 
-  public int registerSchema(Map<String, String> requestProperties,
-                            RegisterSchemaRequest registerSchemaRequest,
-                            String subject,
-                            boolean normalize)
+  public RegisterSchemaResponse registerSchema(Map<String, String> requestProperties,
+                                               RegisterSchemaRequest registerSchemaRequest,
+                                               String subject,
+                                               boolean normalize)
       throws IOException, RestClientException {
     UriBuilder builder = UriBuilder.fromPath("/subjects/{subject}/versions")
         .queryParam("normalize", normalize);
@@ -586,7 +589,7 @@ public class RestService implements Configurable {
         requestProperties,
         REGISTER_RESPONSE_TYPE);
 
-    return response.getId();
+    return response;
   }
 
   public List<String> testCompatibility(String schemaString, String subject, boolean verbose)

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Config.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Config.java
@@ -70,7 +70,7 @@ public class Config {
     this.compatibilityLevel = request.getCompatibilityLevel();
     this.compatibilityGroup = request.getCompatibilityGroup();
     this.defaultMetadata = request.getDefaultMetadata();
-    this.overrideMetadata = request.getDefaultMetadata();
+    this.overrideMetadata = request.getOverrideMetadata();
     this.defaultRuleSet = request.getDefaultRuleSet();
     this.overrideRuleSet = request.getOverrideRuleSet();
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Config.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Config.java
@@ -17,6 +17,7 @@
 package io.confluent.kafka.schemaregistry.client.rest.entities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -157,6 +158,14 @@ public class Config {
   @JsonProperty("overrideRuleSet")
   public void setOverrideRuleSet(RuleSet overrideRuleSet) {
     this.overrideRuleSet = overrideRuleSet;
+  }
+
+  @JsonIgnore
+  public boolean hasDefaultsOrOverrides() {
+    return defaultMetadata != null
+        || overrideMetadata != null
+        || defaultRuleSet != null
+        || overrideRuleSet != null;
   }
 
   @Override

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
@@ -140,6 +140,12 @@ public class Schema implements Comparable<Schema> {
     this.schema = schema.canonicalString();
   }
 
+  public Schema(String subject, Integer version, Integer id) {
+    this.subject = subject;
+    this.version = version;
+    this.id = id;
+  }
+
   public Schema(String subject, Integer id) {
     this.subject = subject;
     this.id = id;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
@@ -26,6 +26,7 @@ import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Collections;
@@ -150,6 +151,19 @@ public class Schema implements Comparable<Schema> {
     this.metadata = request.getMetadata();
     this.ruleSet = request.getRuleSet();
     this.schema = request.getSchema();
+  }
+
+  public Schema(String subject, RegisterSchemaResponse response) {
+    this.subject = subject;
+    this.version = response.getVersion() != null ? response.getVersion() : 0;
+    this.id = response.getId();
+    this.schemaType = response.getSchemaType() != null
+        ? response.getSchemaType() : AvroSchema.TYPE;
+    this.references = response.getReferences() != null
+        ? response.getReferences() : Collections.emptyList();
+    this.metadata = response.getMetadata();
+    this.ruleSet = response.getRuleSet();
+    this.schema = response.getSchema();
   }
 
   public Schema copy() {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
@@ -140,6 +140,11 @@ public class Schema implements Comparable<Schema> {
     this.schema = schema.canonicalString();
   }
 
+  public Schema(String subject, Integer id) {
+    this.subject = subject;
+    this.id = id;
+  }
+
   public Schema(String subject, RegisterSchemaRequest request) {
     this.subject = subject;
     this.version = request.getVersion() != null ? request.getVersion() : 0;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
@@ -181,6 +181,10 @@ public class Schema implements Comparable<Schema> {
     return new Schema(subject, version, id, schemaType, references, metadata, ruleSet, schema);
   }
 
+  public Schema copy(Integer version, Integer id) {
+    return new Schema(subject, version, id, schemaType, references, metadata, ruleSet, schema);
+  }
+
   @io.swagger.v3.oas.annotations.media.Schema(description = SUBJECT_DESC, example = SUBJECT_EXAMPLE)
   @JsonProperty("subject")
   public String getSubject() {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaRequest.java
@@ -182,10 +182,10 @@ public class RegisterSchemaRequest {
     if (id != null) {
       buf.append("id=").append(id).append(", ");
     }
-    buf.append("schemaType=").append(this.schemaType).append(",");
-    buf.append("references=").append(this.references).append(",");
-    buf.append("metadata=").append(this.metadata).append(",");
-    buf.append("ruleSet=").append(this.ruleSet).append(",");
+    buf.append("schemaType=").append(this.schemaType).append(", ");
+    buf.append("references=").append(this.references).append(", ");
+    buf.append("metadata=").append(this.metadata).append("," );
+    buf.append("ruleSet=").append(this.ruleSet).append(", ");
     buf.append("schema=").append(schema).append("}");
     return buf.toString();
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaRequest.java
@@ -184,7 +184,7 @@ public class RegisterSchemaRequest {
     }
     buf.append("schemaType=").append(this.schemaType).append(", ");
     buf.append("references=").append(this.references).append(", ");
-    buf.append("metadata=").append(this.metadata).append("," );
+    buf.append("metadata=").append(this.metadata).append(", ");
     buf.append("ruleSet=").append(this.ruleSet).append(", ");
     buf.append("schema=").append(schema).append("}");
     return buf.toString();

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaResponse.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaResponse.java
@@ -177,10 +177,10 @@ public class RegisterSchemaResponse {
       buf.append("version=").append(version).append(", ");
     }
     buf.append("id=").append(id).append(", ");
-    buf.append("schemaType=").append(this.schemaType).append(",");
-    buf.append("references=").append(this.references).append(",");
-    buf.append("metadata=").append(this.metadata).append(",");
-    buf.append("ruleSet=").append(this.ruleSet).append(",");
+    buf.append("schemaType=").append(this.schemaType).append(", ");
+    buf.append("references=").append(this.references).append(", ");
+    buf.append("metadata=").append(this.metadata).append("," );
+    buf.append("ruleSet=").append(this.ruleSet).append(", ");
     buf.append("schema=").append(schema).append("}");
     return buf.toString();
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaResponse.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaResponse.java
@@ -179,7 +179,7 @@ public class RegisterSchemaResponse {
     buf.append("id=").append(id).append(", ");
     buf.append("schemaType=").append(this.schemaType).append(", ");
     buf.append("references=").append(this.references).append(", ");
-    buf.append("metadata=").append(this.metadata).append("," );
+    buf.append("metadata=").append(this.metadata).append(", ");
     buf.append("ruleSet=").append(this.ruleSet).append(", ");
     buf.append("schema=").append(schema).append("}");
     return buf.toString();

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaResponse.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/RegisterSchemaResponse.java
@@ -20,11 +20,17 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
+import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaTypeConverter;
 import java.io.IOException;
 
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 
+import java.util.List;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -33,6 +39,29 @@ import java.util.Objects;
 public class RegisterSchemaResponse {
 
   private int id;
+  private Integer version;
+  private String schemaType;
+  private List<SchemaReference> references = null;
+  private Metadata metadata = null;
+  private RuleSet ruleSet = null;
+  private String schema;
+
+  public RegisterSchemaResponse() {
+  }
+
+  public RegisterSchemaResponse(int id) {
+    this.id = id;
+  }
+
+  public RegisterSchemaResponse(Schema schema) {
+    this.version = schema.getVersion();
+    this.id = schema.getId();
+    this.schemaType = schema.getSchemaType();
+    this.references = schema.getReferences();
+    this.metadata = schema.getMetadata();
+    this.ruleSet = schema.getRuleSet();
+    this.schema = schema.getSchema();
+  }
 
   public static RegisterSchemaResponse fromJson(String json) throws IOException {
     return JacksonMapper.INSTANCE.readValue(json, RegisterSchemaResponse.class);
@@ -50,8 +79,71 @@ public class RegisterSchemaResponse {
     this.id = id;
   }
 
-  public String toJson() throws IOException {
-    return JacksonMapper.INSTANCE.writeValueAsString(this);
+  @io.swagger.v3.oas.annotations.media.Schema(description = Schema.VERSION_DESC)
+  @JsonProperty("version")
+  public Integer getVersion() {
+    return this.version;
+  }
+
+  @JsonProperty("version")
+  public void setVersion(Integer version) {
+    this.version = version;
+  }
+
+  @io.swagger.v3.oas.annotations.media.Schema(description = Schema.TYPE_DESC)
+  @JsonProperty("schemaType")
+  @JsonSerialize(converter = SchemaTypeConverter.class)
+  public String getSchemaType() {
+    return this.schemaType;
+  }
+
+  @JsonProperty("schemaType")
+  public void setSchemaType(String schemaType) {
+    this.schemaType = schemaType;
+  }
+
+  @io.swagger.v3.oas.annotations.media.Schema(description = Schema.REFERENCES_DESC)
+  @JsonProperty("references")
+  public List<SchemaReference> getReferences() {
+    return this.references;
+  }
+
+  @JsonProperty("references")
+  public void setReferences(List<SchemaReference> references) {
+    this.references = references;
+  }
+
+  @io.swagger.v3.oas.annotations.media.Schema(description = Schema.METADATA_DESC)
+  @JsonProperty("metadata")
+  public Metadata getMetadata() {
+    return this.metadata;
+  }
+
+  @JsonProperty("metadata")
+  public void setMetadata(Metadata metadata) {
+    this.metadata = metadata;
+  }
+
+  @io.swagger.v3.oas.annotations.media.Schema(description = Schema.RULESET_DESC)
+  @JsonProperty("ruleSet")
+  public RuleSet getRuleSet() {
+    return this.ruleSet;
+  }
+
+  @JsonProperty("ruleSet")
+  public void setRuleSet(RuleSet ruleSet) {
+    this.ruleSet = ruleSet;
+  }
+
+  @io.swagger.v3.oas.annotations.media.Schema(description = Schema.SCHEMA_DESC)
+  @JsonProperty("schema")
+  public String getSchema() {
+    return this.schema;
+  }
+
+  @JsonProperty("schema")
+  public void setSchema(String schema) {
+    this.schema = schema;
   }
 
   @Override
@@ -63,11 +155,38 @@ public class RegisterSchemaResponse {
       return false;
     }
     RegisterSchemaResponse that = (RegisterSchemaResponse) o;
-    return id == that.id;
+    return Objects.equals(version, that.version)
+        && id == that.id
+        && Objects.equals(schemaType, that.schemaType)
+        && Objects.equals(references, that.references)
+        && Objects.equals(metadata, that.metadata)
+        && Objects.equals(ruleSet, that.ruleSet)
+        && Objects.equals(schema, that.schema);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id);
+    return Objects.hash(schemaType, references, metadata, ruleSet, version, id, schema);
   }
+
+  @Override
+  public String toString() {
+    StringBuilder buf = new StringBuilder();
+    buf.append("{");
+    if (version != null) {
+      buf.append("version=").append(version).append(", ");
+    }
+    buf.append("id=").append(id).append(", ");
+    buf.append("schemaType=").append(this.schemaType).append(",");
+    buf.append("references=").append(this.references).append(",");
+    buf.append("metadata=").append(this.metadata).append(",");
+    buf.append("ruleSet=").append(this.ruleSet).append(",");
+    buf.append("schema=").append(schema).append("}");
+    return buf.toString();
+  }
+
+  public String toJson() throws IOException {
+    return JacksonMapper.INSTANCE.writeValueAsString(this);
+  }
+
 }

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
@@ -169,8 +169,8 @@ public class CachedSchemaRegistryClientTest {
 
     replay(restService);
 
-    assertEquals(new RegisterSchemaResponse(ID_25), client.register(SUBJECT_0, AVRO_SCHEMA_0));
-    assertEquals(new RegisterSchemaResponse(ID_25), client.register(SUBJECT_0, AVRO_SCHEMA_0)); // hit the cache
+    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0));
+    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0)); // hit the cache
 
     verify(restService);
   }
@@ -185,8 +185,8 @@ public class CachedSchemaRegistryClientTest {
 
     replay(restService);
 
-    assertEquals(new RegisterSchemaResponse(ID_25), client.register(SUBJECT_0, AVRO_SCHEMA_0, VERSION_1, ID_25));
-    assertEquals(new RegisterSchemaResponse(ID_25), client.register(SUBJECT_0, AVRO_SCHEMA_0, VERSION_1, ID_25)); // hit the cache
+    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0, VERSION_1, ID_25));
+    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0, VERSION_1, ID_25)); // hit the cache
 
     verify(restService);
   }
@@ -204,7 +204,7 @@ public class CachedSchemaRegistryClientTest {
 
     replay(restService);
 
-    assertEquals(new RegisterSchemaResponse(ID_25), client.register(SUBJECT_0, SCHEMA_WITH_DECIMAL, VERSION_1, ID_25));
+    assertEquals(ID_25, client.register(SUBJECT_0, SCHEMA_WITH_DECIMAL, VERSION_1, ID_25));
     assertEquals(ID_50, client.register(SUBJECT_0, SCHEMA_WITH_DECIMAL2, VERSION_2, ID_50));
 
     verify(restService);
@@ -218,7 +218,8 @@ public class CachedSchemaRegistryClientTest {
         .andReturn(new RegisterSchemaResponse(26))
         .andReturn(new RegisterSchemaResponse(27))
         .andReturn(new RegisterSchemaResponse(28))
-        .andReturn(new RegisterSchemaResponse(29));
+        .andReturn(new RegisterSchemaResponse(29))
+        .andReturn(new RegisterSchemaResponse(30));
 
     replay(restService);
 
@@ -245,7 +246,7 @@ public class CachedSchemaRegistryClientTest {
 
     replay(restService);
 
-    assertEquals(new RegisterSchemaResponse(ID_25), client.register(SUBJECT_0, AVRO_SCHEMA_0));
+    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0));
     assertEquals(
         AVRO_SCHEMA_0.rawSchema(),
         ((AvroSchema) client.getSchemaBySubjectAndId(SUBJECT_0, ID_25)).rawSchema()
@@ -276,7 +277,7 @@ public class CachedSchemaRegistryClientTest {
 
     replay(restService);
 
-    assertEquals(new RegisterSchemaResponse(ID_25), client.register(SUBJECT_0, AVRO_SCHEMA_0));
+    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0));
     assertEquals(version, client.getVersion(SUBJECT_0, AVRO_SCHEMA_0));
     assertEquals(version, client.getVersion(SUBJECT_0, AVRO_SCHEMA_0)); // hit the cache
 
@@ -306,8 +307,8 @@ public class CachedSchemaRegistryClientTest {
     replay(restService);
 
     // Make sure they still get the same ID
-    assertEquals(new RegisterSchemaResponse(ID_25), client.register(subjectOne, AVRO_SCHEMA_0));
-    assertEquals(new RegisterSchemaResponse(ID_25), client.register(subjectTwo, AVRO_SCHEMA_0));
+    assertEquals(ID_25, client.register(subjectOne, AVRO_SCHEMA_0));
+    assertEquals(ID_25, client.register(subjectTwo, AVRO_SCHEMA_0));
     // Neither of these two schemas should be cached yet
     assertEquals(
         AVRO_SCHEMA_0.rawSchema(),
@@ -345,8 +346,8 @@ public class CachedSchemaRegistryClientTest {
 
     replay(restService);
 
-    assertEquals(new RegisterSchemaResponse(ID_25), client.register(SUBJECT_0, AVRO_SCHEMA_0));
-    assertEquals(new RegisterSchemaResponse(ID_25), client.register(SUBJECT_0, AVRO_SCHEMA_0)); // hit the cache
+    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0));
+    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0)); // hit the cache
 
     assertEquals(Arrays.asList(0), client.deleteSubject(SUBJECT_0));
     assertEquals(Arrays.asList(1), client.deleteSubject(SUBJECT_0, true));
@@ -379,7 +380,7 @@ public class CachedSchemaRegistryClientTest {
 
     replay(restService);
 
-    assertEquals(new RegisterSchemaResponse(ID_25), client.register(SUBJECT_0, AVRO_SCHEMA_0));
+    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0));
     assertEquals(version, client.getVersion(SUBJECT_0, AVRO_SCHEMA_0));
     assertEquals(version, client.getVersion(SUBJECT_0, AVRO_SCHEMA_0)); // hit the cache
 

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
@@ -17,6 +17,7 @@ package io.confluent.kafka.schemaregistry.client;
 
 import com.google.common.testing.FakeTicker;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -163,13 +164,13 @@ public class CachedSchemaRegistryClientTest {
     // Expect one call to register schema
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
         eq(SUBJECT_0), anyBoolean()))
-        .andReturn(ID_25)
+        .andReturn(new RegisterSchemaResponse(ID_25))
         .once();
 
     replay(restService);
 
-    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0));
-    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0)); // hit the cache
+    assertEquals(new RegisterSchemaResponse(ID_25), client.register(SUBJECT_0, AVRO_SCHEMA_0));
+    assertEquals(new RegisterSchemaResponse(ID_25), client.register(SUBJECT_0, AVRO_SCHEMA_0)); // hit the cache
 
     verify(restService);
   }
@@ -179,13 +180,13 @@ public class CachedSchemaRegistryClientTest {
     // Expect one call to register schema
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
         eq(SUBJECT_0), anyBoolean()))
-        .andReturn(ID_25)
+        .andReturn(new RegisterSchemaResponse(ID_25))
         .once();
 
     replay(restService);
 
-    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0, VERSION_1, ID_25));
-    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0, VERSION_1, ID_25)); // hit the cache
+    assertEquals(new RegisterSchemaResponse(ID_25), client.register(SUBJECT_0, AVRO_SCHEMA_0, VERSION_1, ID_25));
+    assertEquals(new RegisterSchemaResponse(ID_25), client.register(SUBJECT_0, AVRO_SCHEMA_0, VERSION_1, ID_25)); // hit the cache
 
     verify(restService);
   }
@@ -194,16 +195,16 @@ public class CachedSchemaRegistryClientTest {
   public void testRegisterEquivalentSchemaDifferentid() throws Exception {
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
         eq(SUBJECT_0), anyBoolean()))
-        .andReturn(ID_25)
+        .andReturn(new RegisterSchemaResponse(ID_25))
         .once();
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
         eq(SUBJECT_0), anyBoolean()))
-        .andReturn(ID_50)
+        .andReturn(new RegisterSchemaResponse(ID_50))
         .once();
 
     replay(restService);
 
-    assertEquals(ID_25, client.register(SUBJECT_0, SCHEMA_WITH_DECIMAL, VERSION_1, ID_25));
+    assertEquals(new RegisterSchemaResponse(ID_25), client.register(SUBJECT_0, SCHEMA_WITH_DECIMAL, VERSION_1, ID_25));
     assertEquals(ID_50, client.register(SUBJECT_0, SCHEMA_WITH_DECIMAL2, VERSION_2, ID_50));
 
     verify(restService);
@@ -213,11 +214,11 @@ public class CachedSchemaRegistryClientTest {
   public void testRegisterOverCapacity() throws Exception {
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
         anyString(), anyBoolean()))
-        .andReturn(ID_25)
-        .andReturn(26)
-        .andReturn(27)
-        .andReturn(28)
-        .andReturn(29);
+        .andReturn(new RegisterSchemaResponse(ID_25))
+        .andReturn(new RegisterSchemaResponse(26))
+        .andReturn(new RegisterSchemaResponse(27))
+        .andReturn(new RegisterSchemaResponse(28))
+        .andReturn(new RegisterSchemaResponse(29));
 
     replay(restService);
 
@@ -236,7 +237,7 @@ public class CachedSchemaRegistryClientTest {
   public void testIdCache() throws Exception {
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
         eq(SUBJECT_0), anyBoolean()))
-        .andReturn(ID_25);
+        .andReturn(new RegisterSchemaResponse(ID_25));
 
     // Expect only one call to getId (the rest should hit the cache)
     expect(restService.getId(ID_25, SUBJECT_0))
@@ -244,7 +245,7 @@ public class CachedSchemaRegistryClientTest {
 
     replay(restService);
 
-    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0));
+    assertEquals(new RegisterSchemaResponse(ID_25), client.register(SUBJECT_0, AVRO_SCHEMA_0));
     assertEquals(
         AVRO_SCHEMA_0.rawSchema(),
         ((AvroSchema) client.getSchemaBySubjectAndId(SUBJECT_0, ID_25)).rawSchema()
@@ -263,7 +264,7 @@ public class CachedSchemaRegistryClientTest {
 
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
         eq(SUBJECT_0), anyBoolean()))
-        .andReturn(ID_25);
+        .andReturn(new RegisterSchemaResponse(ID_25));
 
     // Expect only one call to lookup the subject (the rest should hit the cache)
     expect(restService.lookUpSubjectVersion(anyObject(RegisterSchemaRequest.class),
@@ -275,7 +276,7 @@ public class CachedSchemaRegistryClientTest {
 
     replay(restService);
 
-    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0));
+    assertEquals(new RegisterSchemaResponse(ID_25), client.register(SUBJECT_0, AVRO_SCHEMA_0));
     assertEquals(version, client.getVersion(SUBJECT_0, AVRO_SCHEMA_0));
     assertEquals(version, client.getVersion(SUBJECT_0, AVRO_SCHEMA_0)); // hit the cache
 
@@ -292,10 +293,10 @@ public class CachedSchemaRegistryClientTest {
 
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
         eq(subjectOne), anyBoolean()))
-        .andReturn(ID_25);
+        .andReturn(new RegisterSchemaResponse(ID_25));
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
         eq(subjectTwo), anyBoolean()))
-        .andReturn(ID_25);
+        .andReturn(new RegisterSchemaResponse(ID_25));
 
     expect(restService.getId(ID_25, subjectOne))
             .andReturn(schemaStringOne);
@@ -305,8 +306,8 @@ public class CachedSchemaRegistryClientTest {
     replay(restService);
 
     // Make sure they still get the same ID
-    assertEquals(ID_25, client.register(subjectOne, AVRO_SCHEMA_0));
-    assertEquals(ID_25, client.register(subjectTwo, AVRO_SCHEMA_0));
+    assertEquals(new RegisterSchemaResponse(ID_25), client.register(subjectOne, AVRO_SCHEMA_0));
+    assertEquals(new RegisterSchemaResponse(ID_25), client.register(subjectTwo, AVRO_SCHEMA_0));
     // Neither of these two schemas should be cached yet
     assertEquals(
         AVRO_SCHEMA_0.rawSchema(),
@@ -333,7 +334,7 @@ public class CachedSchemaRegistryClientTest {
   public void testDeleteSchemaCache() throws Exception {
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
         eq(SUBJECT_0), anyBoolean()))
-        .andReturn(ID_25)
+        .andReturn(new RegisterSchemaResponse(ID_25))
         .once();
 
     expect(restService.deleteSubject(RestService.DEFAULT_REQUEST_PROPERTIES, SUBJECT_0, false))
@@ -344,8 +345,8 @@ public class CachedSchemaRegistryClientTest {
 
     replay(restService);
 
-    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0));
-    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0)); // hit the cache
+    assertEquals(new RegisterSchemaResponse(ID_25), client.register(SUBJECT_0, AVRO_SCHEMA_0));
+    assertEquals(new RegisterSchemaResponse(ID_25), client.register(SUBJECT_0, AVRO_SCHEMA_0)); // hit the cache
 
     assertEquals(Arrays.asList(0), client.deleteSubject(SUBJECT_0));
     assertEquals(Arrays.asList(1), client.deleteSubject(SUBJECT_0, true));
@@ -359,7 +360,7 @@ public class CachedSchemaRegistryClientTest {
 
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
         eq(SUBJECT_0), anyBoolean()))
-        .andReturn(ID_25);
+        .andReturn(new RegisterSchemaResponse(ID_25));
 
     // Expect only one call to lookup the subject (the rest should hit the cache)
     expect(restService.lookUpSubjectVersion(anyObject(RegisterSchemaRequest.class),
@@ -378,7 +379,7 @@ public class CachedSchemaRegistryClientTest {
 
     replay(restService);
 
-    assertEquals(ID_25, client.register(SUBJECT_0, AVRO_SCHEMA_0));
+    assertEquals(new RegisterSchemaResponse(ID_25), client.register(SUBJECT_0, AVRO_SCHEMA_0));
     assertEquals(version, client.getVersion(SUBJECT_0, AVRO_SCHEMA_0));
     assertEquals(version, client.getVersion(SUBJECT_0, AVRO_SCHEMA_0)); // hit the cache
 
@@ -450,7 +451,7 @@ public class CachedSchemaRegistryClientTest {
   public void testThreadSafe() throws Exception {
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
         eq(SUBJECT_0), anyBoolean()))
-        .andReturn(ID_25)
+        .andReturn(new RegisterSchemaResponse(ID_25))
         .anyTimes();
 
     expect(restService.getId(ID_25, SUBJECT_0))
@@ -502,11 +503,11 @@ public class CachedSchemaRegistryClientTest {
   public void testGetSchemas() throws Exception {
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
         anyString(), anyBoolean()))
-            .andReturn(ID_25)
-            .andReturn(26)
-            .andReturn(27)
-            .andReturn(28)
-            .andReturn(29);
+            .andReturn(new RegisterSchemaResponse(ID_25))
+            .andReturn(new RegisterSchemaResponse(26))
+            .andReturn(new RegisterSchemaResponse(27))
+            .andReturn(new RegisterSchemaResponse(28))
+            .andReturn(new RegisterSchemaResponse(29));
 
     List<Schema> schemas = IntStream.range(0, 5)
         .mapToObj( idx -> new Schema(

--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -2207,6 +2207,10 @@ components:
           - FULL
           - FULL_TRANSITIVE
           - NONE
+        alias:
+          type: string
+        normalize:
+          type: boolean
         compatibilityGroup:
           type: string
         defaultMetadata:
@@ -2221,6 +2225,10 @@ components:
     ConfigUpdateRequest:
       type: object
       properties:
+        alias:
+          type: string
+        normalize:
+          type: boolean
         compatibility:
           type: string
           description: Compatibility Level
@@ -2363,6 +2371,25 @@ components:
           description: Globally unique identifier of the schema
           format: int32
           example: 100001
+        version:
+          type: integer
+          description: Version number
+          format: int32
+        schemaType:
+          type: string
+          description: Schema type
+        references:
+          type: array
+          description: References to other schemas
+          items:
+            $ref: '#/components/schemas/SchemaReference'
+        metadata:
+          $ref: '#/components/schemas/Metadata'
+        ruleSet:
+          $ref: '#/components/schemas/RuleSet'
+        schema:
+          type: string
+          description: Schema definition string
       description: Schema register response
     ErrorMessage:
       type: object

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/client/LocalSchemaRegistryClient.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/client/LocalSchemaRegistryClient.java
@@ -30,6 +30,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.exceptions.IdDoesNotMatchException;
 import io.confluent.kafka.schemaregistry.exceptions.IncompatibleSchemaException;
@@ -168,24 +169,31 @@ public class LocalSchemaRegistryClient implements SchemaRegistryClient {
   @Override
   public synchronized int register(String subject, ParsedSchema schema, boolean normalize)
       throws IOException, RestClientException {
-    return register(subject, schema, 0, -1, normalize);
+    return registerWithResponse(subject, schema, 0, -1, normalize).getId();
   }
 
   @Override
   public synchronized int register(String subject, ParsedSchema schema, int version, int id)
       throws IOException, RestClientException {
-    return register(subject, schema, version, id, false);
+    return registerWithResponse(subject, schema, version, id, false).getId();
   }
 
-  private synchronized int register(String subject, ParsedSchema schema,
-      int version, int id, boolean normalize)
+  @Override
+  public synchronized RegisterSchemaResponse registerWithResponse(
+      String subject, ParsedSchema schema, boolean normalize)
+      throws IOException, RestClientException {
+    return registerWithResponse(subject, schema, 0, -1, normalize);
+  }
+
+  private synchronized RegisterSchemaResponse registerWithResponse(
+      String subject, ParsedSchema schema, int version, int id, boolean normalize)
       throws IOException, RestClientException {
     if (!DEFAULT_TENANT.equals(schemaRegistry.tenant())) {
       subject = schemaRegistry.tenant() + TENANT_DELIMITER + subject;
     }
     Schema s = new Schema(subject, version, id, schema);
     try {
-      return schemaRegistry.register(subject, s, normalize).getId();
+      return schemaRegistry.register(subject, s, normalize);
     } catch (IdDoesNotMatchException e) {
       throw Errors.idDoesNotMatchException(e);
     } catch (InvalidSchemaException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/client/LocalSchemaRegistryClient.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/client/LocalSchemaRegistryClient.java
@@ -193,7 +193,7 @@ public class LocalSchemaRegistryClient implements SchemaRegistryClient {
     }
     Schema s = new Schema(subject, version, id, schema);
     try {
-      return schemaRegistry.register(subject, s, normalize);
+      return new RegisterSchemaResponse(schemaRegistry.register(subject, s, normalize));
     } catch (IdDoesNotMatchException e) {
       throw Errors.idDoesNotMatchException(e);
     } catch (InvalidSchemaException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/client/LocalSchemaRegistryClient.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/client/LocalSchemaRegistryClient.java
@@ -185,7 +185,7 @@ public class LocalSchemaRegistryClient implements SchemaRegistryClient {
     }
     Schema s = new Schema(subject, version, id, schema);
     try {
-      return schemaRegistry.register(subject, s, normalize);
+      return schemaRegistry.register(subject, s, normalize).getId();
     } catch (IdDoesNotMatchException e) {
       throw Errors.idDoesNotMatchException(e);
     } catch (InvalidSchemaException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -402,12 +402,13 @@ public class SubjectVersionsResource {
         headers, schemaRegistry.config().whitelistHeaders());
 
     Schema schema = new Schema(subjectName, request);
-    int id;
+    RegisterSchemaResponse registerSchemaResponse;
     try {
       if (!normalize) {
         normalize = Boolean.TRUE.equals(schemaRegistry.getConfigInScope(subjectName).isNormalize());
       }
-      id = schemaRegistry.registerOrForward(subjectName, schema, normalize, headerProperties);
+      registerSchemaResponse =
+          schemaRegistry.registerOrForward(subjectName, schema, normalize, headerProperties);
     } catch (IdDoesNotMatchException e) {
       throw Errors.idDoesNotMatchException(e);
     } catch (InvalidSchemaException e) {
@@ -433,8 +434,6 @@ public class SubjectVersionsResource {
     } catch (SchemaRegistryException e) {
       throw Errors.schemaRegistryException("Error while registering schema", e);
     }
-    RegisterSchemaResponse registerSchemaResponse = new RegisterSchemaResponse();
-    registerSchemaResponse.setId(id);
     asyncResponse.resume(registerSchemaResponse);
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -407,8 +407,9 @@ public class SubjectVersionsResource {
       if (!normalize) {
         normalize = Boolean.TRUE.equals(schemaRegistry.getConfigInScope(subjectName).isNormalize());
       }
-      registerSchemaResponse =
+      Schema result =
           schemaRegistry.registerOrForward(subjectName, schema, normalize, headerProperties);
+      registerSchemaResponse = new RegisterSchemaResponse(result);
     } catch (IdDoesNotMatchException e) {
       throw Errors.idDoesNotMatchException(e);
     } catch (InvalidSchemaException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -543,6 +543,18 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     return limit;
   }
 
+  /**
+   * Register the given schema under the given subject.
+   *
+   * If the schema already exists, it is returned.  During registration, the metadata and ruleSet
+   * may be populated by the config that is in scope.
+   *
+   * @param subject The subject
+   * @param schema The schema
+   * @param normalize Whether to normalize the schema before registration
+   * @return A schema containing the id.  If the schema is different from the input parameter,
+   * it is set in the return object.
+   */
   @Override
   public Schema register(String subject,
                          Schema schema,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -22,7 +22,6 @@ import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.ParsedSchemaHolder;
 import io.confluent.kafka.schemaregistry.SchemaProvider;
-import io.confluent.kafka.schemaregistry.SimpleParsedSchemaHolder;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
@@ -555,6 +554,37 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       // Ensure cache is up-to-date before any potential writes
       kafkaStore.waitUntilKafkaReaderReachesLastOffset(subject, kafkaStoreTimeoutMs);
 
+      // determine the latest version of the schema in the subject
+      List<SchemaKey> allVersions = getAllSchemaKeys(subject);
+      // sort versions in descending
+      Collections.reverse(allVersions);
+
+      List<Schema> deletedVersions = new ArrayList<>();
+      List<ParsedSchemaHolder> undeletedVersions = new ArrayList<>();
+      // iterate from the latest to first
+      for (SchemaKey schemaKey : allVersions) {
+        LazyParsedSchemaHolder schemaHolder = new LazyParsedSchemaHolder(this, schemaKey);
+        SchemaValue schemaValue = schemaHolder.schemaValue();
+        if (schemaValue.isDeleted()) {
+          deletedVersions.add(
+              new Schema(schemaValue.getSubject(), schemaValue.getVersion(), schemaValue.getId()));
+        } else {
+          if (!undeletedVersions.isEmpty()) {
+            // minor optimization: clear the holder if it is not the latest
+            schemaHolder.clear();
+          }
+          undeletedVersions.add(schemaHolder);
+        }
+      }
+
+      Config config = getConfigInScope(subject);
+      Mode mode = getModeInScope(subject);
+
+      boolean populatedMetadataRuleSet = false;
+      if (mode != Mode.IMPORT) {
+        populatedMetadataRuleSet = maybePopulateFromPrevious(config, schema, undeletedVersions);
+      }
+
       int schemaId = schema.getId();
       ParsedSchema parsedSchema = canonicalizeSchema(schema, schemaId < 0, normalize);
 
@@ -574,51 +604,25 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
         }
       }
 
-      // determine the latest version of the schema in the subject
-      List<SchemaKey> allVersions = getAllSchemaKeys(subject);
-      Collections.reverse(allVersions);
-
-      List<SchemaValue> deletedVersions = new ArrayList<>();
-      List<ParsedSchemaHolder> undeletedVersions = new ArrayList<>();
       int newVersion = MIN_VERSION;
       // iterate from the latest to first
-      for (SchemaKey schemaKey : allVersions) {
-        LazyParsedSchemaHolder schemaHolder = new LazyParsedSchemaHolder(this, schemaKey);
-        SchemaValue schemaValue = schemaHolder.schemaValue();
+      for (ParsedSchemaHolder schemaHolder : undeletedVersions) {
+        SchemaValue schemaValue = ((LazyParsedSchemaHolder) schemaHolder).schemaValue();
         newVersion = Math.max(newVersion, schemaValue.getVersion() + 1);
-        if (schemaValue.isDeleted()) {
-          deletedVersions.add(schemaValue);
-        } else {
-          ParsedSchema undeletedSchema = schemaHolder.schema();
-          if (parsedSchema != null
-              && parsedSchema.references().isEmpty()
-              && !undeletedSchema.references().isEmpty()
-              && parsedSchema.deepEquals(undeletedSchema)
-              && (schemaId < 0 || schemaId == schemaValue.getId())) {
-            // This handles the case where a schema is sent with all references resolved
-            return new Schema(subject, schemaValue.getId());
-          }
-          if (!undeletedVersions.isEmpty()) {
-            // minor optimization: clear the holder if it is not the latest
-            schemaHolder.clear();
-          }
-          undeletedVersions.add(schemaHolder);
+        ParsedSchema undeletedSchema = schemaHolder.schema();
+        if (parsedSchema != null
+            && parsedSchema.references().isEmpty()
+            && !undeletedSchema.references().isEmpty()
+            && parsedSchema.deepEquals(undeletedSchema)
+            && (schemaId < 0 || schemaId == schemaValue.getId())) {
+          // This handles the case where a schema is sent with all references resolved
+          return new Schema(subject, schemaValue.getId());
         }
       }
 
-      boolean populatedMetadataRuleSet = false;
-      Mode mode = getModeInScope(subject);
       boolean isCompatible = true;
       List<String> compatibilityErrorLogs = new ArrayList<>();
       if (mode != Mode.IMPORT) {
-        Config config = getConfigInScope(subject);
-        if (schemaId < 0) {
-          ParsedSchemaHolder parsedSchemaHolder = new SimpleParsedSchemaHolder(parsedSchema);
-          populatedMetadataRuleSet = maybePopulateFromPrevious(
-              config, schema, parsedSchemaHolder, undeletedVersions);
-          parsedSchema = parsedSchemaHolder.schema();
-        }
-
         // sort undeleted in ascending
         Collections.reverse(undeletedVersions);
         compatibilityErrorLogs = isCompatibleWithPrevious(
@@ -626,23 +630,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
         isCompatible = compatibilityErrorLogs.isEmpty();
       }
 
-      maybeValidateAndNormalizeSchema(parsedSchema, schema, false, normalize);
-
-      // see if the schema to be registered already exists, after population and re-normalization
-      SchemaIdAndSubjects schemaIdAndSubjects = this.lookupCache.schemaIdAndSubjects(schema);
-      if (schemaIdAndSubjects != null
-          && (schemaId < 0 || schemaId == schemaIdAndSubjects.getSchemaId())) {
-        if (schemaIdAndSubjects.hasSubject(subject)
-            && !isSubjectVersionDeleted(subject, schemaIdAndSubjects.getVersion(subject))) {
-          // return only if the schema was previously registered under the input subject
-          return new Schema(subject, schemaIdAndSubjects.getSchemaId());
-        } else {
-          // need to register schema under the input subject
-          schemaId = schemaIdAndSubjects.getSchemaId();
-        }
-      }
-
-      if (isCompatible || mode == Mode.IMPORT) {
+      if (isCompatible) {
         // save the context key
         QualifiedSubject qs = QualifiedSubject.create(tenant(), subject);
         if (qs != null && !DEFAULT_CONTEXT.equals(qs.getContext())) {
@@ -689,7 +677,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
                 + "to generating an ID that is already in use.");
           }
         }
-        for (SchemaValue deleted : deletedVersions) {
+        for (Schema deleted : deletedVersions) {
           if (deleted.getId().equals(schema.getId())
                   && deleted.getVersion().compareTo(schema.getVersion()) < 0) {
             // Tombstone previous version with the same ID
@@ -740,32 +728,34 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   }
 
   private boolean maybePopulateFromPrevious(
-      Config config, Schema schema, ParsedSchemaHolder parsedSchemaHolder,
-      List<ParsedSchemaHolder> undeletedVersions)
-      throws InvalidSchemaException {
-    ParsedSchema parsedSchema = parsedSchemaHolder.schema();
-    ParsedSchema previousSchema =
-        undeletedVersions.size() > 0 ? undeletedVersions.get(0).schema() : null;
-    if (parsedSchema == null) {
-      if (previousSchema != null) {
-        parsedSchema = previousSchema.copy(schema.getMetadata(), schema.getRuleSet());
-        ((SimpleParsedSchemaHolder) parsedSchemaHolder).setSchema(parsedSchema);
+      Config config, Schema schema, List<ParsedSchemaHolder> undeletedVersions)
+      throws SchemaRegistryException {
+    SchemaValue previousSchemaValue = undeletedVersions.size() > 0
+        ? ((LazyParsedSchemaHolder) undeletedVersions.get(0)).schemaValue()
+        : null;
+    Schema previousSchema = previousSchemaValue != null
+        ? previousSchemaValue.toSchemaEntity()
+        : null;
+    if (schema == null
+        || schema.getSchema() == null
+        || schema.getSchema().trim().isEmpty()) {
+      if (previousSchemaValue != null) {
+        schema.setSchema(previousSchema.getSchema());
+        schema.setSchemaType(previousSchema.getSchemaType());
+        schema.setReferences(previousSchema.getReferences());
       } else {
         throw new InvalidSchemaException("Empty schema");
       }
     }
-    return maybeSetMetadataRuleSet(config, schema, parsedSchemaHolder, previousSchema);
+    return maybeSetMetadataRuleSet(config, schema, previousSchema);
   }
 
-  private boolean maybeSetMetadataRuleSet(
-      Config config, Schema schema, ParsedSchemaHolder parsedSchemaHolder,
-      ParsedSchema previousSchema) {
-    ParsedSchema parsedSchema = parsedSchemaHolder.schema();
+  private boolean maybeSetMetadataRuleSet(Config config, Schema schema, Schema previousSchema) {
     io.confluent.kafka.schemaregistry.client.rest.entities.Metadata specificMetadata = null;
-    if (parsedSchema.metadata() != null) {
-      specificMetadata = parsedSchema.metadata();
+    if (schema.getMetadata() != null) {
+      specificMetadata = schema.getMetadata();
     } else if (previousSchema != null) {
-      specificMetadata = previousSchema.metadata();
+      specificMetadata = previousSchema.getMetadata();
     }
     io.confluent.kafka.schemaregistry.client.rest.entities.Metadata mergedMetadata;
     io.confluent.kafka.schemaregistry.client.rest.entities.Metadata defaultMetadata;
@@ -775,10 +765,10 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     mergedMetadata =
         mergeMetadata(mergeMetadata(defaultMetadata, specificMetadata), overrideMetadata);
     io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet specificRuleSet = null;
-    if (parsedSchema.ruleSet() != null) {
-      specificRuleSet = parsedSchema.ruleSet();
+    if (schema.getRuleSet() != null) {
+      specificRuleSet = schema.getRuleSet();
     } else if (previousSchema != null) {
-      specificRuleSet = previousSchema.ruleSet();
+      specificRuleSet = previousSchema.getRuleSet();
     }
     io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet mergedRuleSet;
     io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet defaultRuleSet;
@@ -787,10 +777,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     overrideRuleSet = config.getOverrideRuleSet();
     mergedRuleSet = mergeRuleSets(mergeRuleSets(defaultRuleSet, specificRuleSet), overrideRuleSet);
     if (mergedMetadata != null || mergedRuleSet != null) {
-      parsedSchema = parsedSchema.copy(mergedMetadata, mergedRuleSet);
-      ((SimpleParsedSchemaHolder) parsedSchemaHolder).setSchema(parsedSchema);
-      schema.setMetadata(parsedSchema.metadata());
-      schema.setRuleSet(parsedSchema.ruleSet());
+      schema.setMetadata(mergedMetadata);
+      schema.setRuleSet(mergedRuleSet);
       return true;
     }
     return false;
@@ -801,13 +789,16 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
                                   boolean normalize,
                                   Map<String, String> headerProperties)
       throws SchemaRegistryException {
-    Schema existingSchema = lookUpSchemaUnderSubject(subject, schema, normalize, false);
-    if (existingSchema != null) {
-      if (schema.getId() == null
-          || schema.getId() < 0
-          || schema.getId().equals(existingSchema.getId())
-      ) {
-        return new Schema(subject, existingSchema.getId());
+    Config config = getConfigInScope(subject);
+    if (!config.hasDefaultsOrOverrides()) {
+      Schema existingSchema = lookUpSchemaUnderSubject(subject, schema, normalize, false);
+      if (existingSchema != null) {
+        if (schema.getId() == null
+            || schema.getId() < 0
+            || schema.getId().equals(existingSchema.getId())
+        ) {
+          return new Schema(subject, existingSchema.getId());
+        }
       }
     }
 
@@ -2129,9 +2120,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   }
 
   private static class RawSchema {
-    private Schema schema;
-    private boolean isNew;
-    private boolean normalize;
+    private final Schema schema;
+    private final boolean isNew;
+    private final boolean normalize;
 
     public RawSchema(Schema schema, boolean isNew, boolean normalize) {
       this.schema = schema;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -559,12 +559,14 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       // sort versions in descending
       Collections.reverse(allVersions);
 
+      int newVersion = MIN_VERSION;
       List<Schema> deletedVersions = new ArrayList<>();
       List<ParsedSchemaHolder> undeletedVersions = new ArrayList<>();
       // iterate from the latest to first
       for (SchemaKey schemaKey : allVersions) {
         LazyParsedSchemaHolder schemaHolder = new LazyParsedSchemaHolder(this, schemaKey);
         SchemaValue schemaValue = schemaHolder.schemaValue();
+        newVersion = Math.max(newVersion, schemaValue.getVersion() + 1);
         if (schemaValue.isDeleted()) {
           deletedVersions.add(
               new Schema(schemaValue.getSubject(), schemaValue.getVersion(), schemaValue.getId()));
@@ -607,11 +609,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
         }
       }
 
-      int newVersion = MIN_VERSION;
       // iterate from the latest to first
       for (ParsedSchemaHolder schemaHolder : undeletedVersions) {
         SchemaValue schemaValue = ((LazyParsedSchemaHolder) schemaHolder).schemaValue();
-        newVersion = Math.max(newVersion, schemaValue.getVersion() + 1);
         ParsedSchema undeletedSchema = schemaHolder.schema();
         if (parsedSchema != null
             && parsedSchema.references().isEmpty()

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -553,7 +553,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
    * @param schema The schema
    * @param normalize Whether to normalize the schema before registration
    * @return A schema containing the id.  If the schema is different from the input parameter,
-   *    it is set in the return object.
+   *     it is set in the return object.
    */
   @Override
   public Schema register(String subject,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -559,9 +559,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       // sort versions in descending
       Collections.reverse(allVersions);
 
-      int newVersion = MIN_VERSION;
       List<Schema> deletedVersions = new ArrayList<>();
       List<ParsedSchemaHolder> undeletedVersions = new ArrayList<>();
+      int newVersion = MIN_VERSION;
       // iterate from the latest to first
       for (SchemaKey schemaKey : allVersions) {
         LazyParsedSchemaHolder schemaHolder = new LazyParsedSchemaHolder(this, schemaKey);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -546,14 +546,14 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   /**
    * Register the given schema under the given subject.
    *
-   * If the schema already exists, it is returned.  During registration, the metadata and ruleSet
-   * may be populated by the config that is in scope.
+   * <p>If the schema already exists, it is returned.  During registration, the metadata and ruleSet
+   * may be populated by the config that is in scope.</p>
    *
    * @param subject The subject
    * @param schema The schema
    * @param normalize Whether to normalize the schema before registration
    * @return A schema containing the id.  If the schema is different from the input parameter,
-   * it is set in the return object.
+   *    it is set in the return object.
    */
   @Override
   public Schema register(String subject,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -35,11 +36,13 @@ public interface SchemaRegistry extends SchemaVersionFetcher {
 
   Set<String> schemaTypes();
 
-  default int register(String subject, Schema schema) throws SchemaRegistryException {
+  default RegisterSchemaResponse register(String subject, Schema schema)
+      throws SchemaRegistryException {
     return register(subject, schema, false);
   }
 
-  int register(String subject, Schema schema, boolean normalize) throws SchemaRegistryException;
+  RegisterSchemaResponse register(String subject, Schema schema, boolean normalize)
+      throws SchemaRegistryException;
 
   default Schema getByVersion(String subject, int version, boolean returnDeletedSchema) {
     try {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
@@ -15,7 +15,6 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
-import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -36,12 +35,12 @@ public interface SchemaRegistry extends SchemaVersionFetcher {
 
   Set<String> schemaTypes();
 
-  default RegisterSchemaResponse register(String subject, Schema schema)
+  default Schema register(String subject, Schema schema)
       throws SchemaRegistryException {
     return register(subject, schema, false);
   }
 
-  RegisterSchemaResponse register(String subject, Schema schema, boolean normalize)
+  Schema register(String subject, Schema schema, boolean normalize)
       throws SchemaRegistryException;
 
   default Schema getByVersion(String subject, int version, boolean returnDeletedSchema) {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiCompatibilityTest.java
@@ -341,6 +341,9 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     assertEquals("Registering should succeed",
         expectedIdSchema1,
         response.getId());
+    Metadata metadata2 = response.getMetadata();
+    assertEquals("configValue", metadata2.getProperties().get("configKey"));
+    assertEquals("subjectValue", metadata2.getProperties().get("subjectKey"));
 
     assertEquals("Version should match",
         response.getVersion(),
@@ -377,6 +380,9 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     assertEquals("Registering should succeed",
         expectedIdSchema2,
         response.getId());
+    metadata2 = response.getMetadata();
+    assertEquals("configValue", metadata2.getProperties().get("configKey"));
+    assertEquals("subjectValue", metadata2.getProperties().get("subjectKey"));
 
     assertEquals("Version should match",
         response.getVersion(),
@@ -385,7 +391,16 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
                 new Schema(subject, response)), subject, false, false).getVersion());
 
     SchemaString schemaString = restApp.restClient.getId(expectedIdSchema2, subject);
-    Metadata metadata2 = schemaString.getMetadata();
+    metadata2 = schemaString.getMetadata();
+    assertEquals("configValue", metadata2.getProperties().get("configKey"));
+    assertEquals("subjectValue", metadata2.getProperties().get("subjectKey"));
+
+    // re-register
+    response = restApp.restClient.registerSchema(request2, subject, false);
+    assertEquals("Registering should succeed",
+        expectedIdSchema2,
+        response.getId());
+    metadata2 = response.getMetadata();
     assertEquals("configValue", metadata2.getProperties().get("configKey"));
     assertEquals("subjectValue", metadata2.getProperties().get("subjectKey"));
 
@@ -406,6 +421,10 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     assertEquals("Registering should succeed",
         expectedIdSchema3,
         response.getId());
+    Metadata metadata4 = response.getMetadata();
+    assertEquals("configValue", metadata4.getProperties().get("configKey"));
+    assertEquals(null, metadata4.getProperties().get("subjectKey"));
+    assertEquals("newSubjectValue", metadata4.getProperties().get("newSubjectKey"));
 
     assertEquals("Version should match",
         response.getVersion(),
@@ -414,10 +433,10 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
                 new Schema(subject, response)), subject, false, false).getVersion());
 
     schemaString = restApp.restClient.getId(expectedIdSchema3, subject);
-    metadata3 = schemaString.getMetadata();
-    assertEquals("configValue", metadata3.getProperties().get("configKey"));
-    assertEquals(null, metadata3.getProperties().get("subjectKey"));
-    assertEquals("newSubjectValue", metadata3.getProperties().get("newSubjectKey"));
+    metadata4 = schemaString.getMetadata();
+    assertEquals("configValue", metadata4.getProperties().get("configKey"));
+    assertEquals(null, metadata4.getProperties().get("subjectKey"));
+    assertEquals("newSubjectValue", metadata4.getProperties().get("newSubjectKey"));
   }
 
   @Test
@@ -449,6 +468,9 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     assertEquals("Registering should succeed",
         expectedIdSchema1,
         response.getId());
+    RuleSet ruleSet2 = response.getRuleSet();
+    assertEquals("foo", ruleSet2.getMigrationRules().get(0).getName());
+    assertEquals("bar", ruleSet2.getMigrationRules().get(1).getName());
 
     assertEquals("Version should match",
         response.getVersion(),
@@ -485,6 +507,9 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     assertEquals("Registering should succeed",
         expectedIdSchema2,
         response.getId());
+    ruleSet2 = response.getRuleSet();
+    assertEquals("foo", ruleSet2.getMigrationRules().get(0).getName());
+    assertEquals("bar", ruleSet2.getMigrationRules().get(1).getName());
 
     assertEquals("Version should match",
         response.getVersion(),
@@ -493,7 +518,16 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
                 new Schema(subject, response)), subject, false, false).getVersion());
 
     SchemaString schemaString = restApp.restClient.getId(expectedIdSchema2, subject);
-    RuleSet ruleSet2 = schemaString.getRuleSet();
+    ruleSet2 = schemaString.getRuleSet();
+    assertEquals("foo", ruleSet2.getMigrationRules().get(0).getName());
+    assertEquals("bar", ruleSet2.getMigrationRules().get(1).getName());
+
+    // re-register
+    response = restApp.restClient.registerSchema(request2, subject, false);
+    assertEquals("Registering should succeed",
+        expectedIdSchema2,
+        response.getId());
+    ruleSet2 = schemaString.getRuleSet();
     assertEquals("foo", ruleSet2.getMigrationRules().get(0).getName());
     assertEquals("bar", ruleSet2.getMigrationRules().get(1).getName());
 
@@ -514,6 +548,9 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     assertEquals("Registering should succeed",
         expectedIdSchema3,
         response.getId());
+    RuleSet ruleSet3 = response.getRuleSet();
+    assertEquals("foo", ruleSet3.getMigrationRules().get(0).getName());
+    assertEquals("zap", ruleSet3.getMigrationRules().get(1).getName());
 
     assertEquals("Version should match",
         response.getVersion(),
@@ -522,7 +559,7 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
                 new Schema(subject, response)), subject, false, false).getVersion());
 
     schemaString = restApp.restClient.getId(expectedIdSchema3, subject);
-    RuleSet ruleSet3 = schemaString.getRuleSet();
+    ruleSet3 = schemaString.getRuleSet();
     assertEquals("foo", ruleSet3.getMigrationRules().get(0).getName());
     assertEquals("zap", ruleSet3.getMigrationRules().get(1).getName());
   }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiCompatibilityTest.java
@@ -29,6 +29,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.ConfigUpdateRequest;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestIncompatibleSchemaException;
@@ -336,9 +337,17 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     RegisterSchemaRequest request1 = new RegisterSchemaRequest(schema1);
     request1.setMetadata(metadata1);
     int expectedIdSchema1 = 1;
+    RegisterSchemaResponse response = restApp.restClient.registerSchema(request1, subject, false);
     assertEquals("Registering should succeed",
         expectedIdSchema1,
-        restApp.restClient.registerSchema(request1, subject, false).getId());
+        response.getId());
+
+    assertEquals("Version should match",
+        response.getVersion(),
+        restApp.restClient.lookUpSubjectVersion(
+            new RegisterSchemaRequest(
+                new Schema(subject, response)), subject, false, false).getVersion());
+
     // verify that default compatibility level is backward
     assertEquals("Default compatibility level should be backward",
         CompatibilityLevel.BACKWARD.name,
@@ -364,9 +373,16 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + " {\"type\":\"string\",\"name\":\"f2\"}]}");
     RegisterSchemaRequest request2 = new RegisterSchemaRequest(schema2);
     int expectedIdSchema2 = 2;
+    response = restApp.restClient.registerSchema(request2, subject, false);
     assertEquals("Registering should succeed",
         expectedIdSchema2,
-        restApp.restClient.registerSchema(request2, subject, false).getId());
+        response.getId());
+
+    assertEquals("Version should match",
+        response.getVersion(),
+        restApp.restClient.lookUpSubjectVersion(
+            new RegisterSchemaRequest(
+                new Schema(subject, response)), subject, false, false).getVersion());
 
     SchemaString schemaString = restApp.restClient.getId(expectedIdSchema2, subject);
     Metadata metadata2 = schemaString.getMetadata();
@@ -386,9 +402,16 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     RegisterSchemaRequest request3 = new RegisterSchemaRequest(schema3);
     request3.setMetadata(metadata3);
     int expectedIdSchema3 = 3;
+    response = restApp.restClient.registerSchema(request3, subject, false);
     assertEquals("Registering should succeed",
         expectedIdSchema3,
-        restApp.restClient.registerSchema(request3, subject, false).getId());
+        response.getId());
+
+    assertEquals("Version should match",
+        response.getVersion(),
+        restApp.restClient.lookUpSubjectVersion(
+            new RegisterSchemaRequest(
+                new Schema(subject, response)), subject, false, false).getVersion());
 
     schemaString = restApp.restClient.getId(expectedIdSchema3, subject);
     metadata3 = schemaString.getMetadata();
@@ -422,9 +445,17 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     RegisterSchemaRequest request1 = new RegisterSchemaRequest(schema1);
     request1.setRuleSet(ruleSet);
     int expectedIdSchema1 = 1;
+    RegisterSchemaResponse response = restApp.restClient.registerSchema(request1, subject, false);
     assertEquals("Registering should succeed",
         expectedIdSchema1,
-        restApp.restClient.registerSchema(request1, subject, false).getId());
+        response.getId());
+
+    assertEquals("Version should match",
+        response.getVersion(),
+        restApp.restClient.lookUpSubjectVersion(
+            new RegisterSchemaRequest(
+                new Schema(subject, response)), subject, false, false).getVersion());
+
     // verify that default compatibility level is backward
     assertEquals("Default compatibility level should be backward",
         CompatibilityLevel.BACKWARD.name,
@@ -450,9 +481,16 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + " {\"type\":\"string\",\"name\":\"f2\"}]}");
     RegisterSchemaRequest request2 = new RegisterSchemaRequest(schema2);
     int expectedIdSchema2 = 2;
+    response = restApp.restClient.registerSchema(request2, subject, false);
     assertEquals("Registering should succeed",
         expectedIdSchema2,
-        restApp.restClient.registerSchema(request2, subject, false).getId());
+        response.getId());
+
+    assertEquals("Version should match",
+        response.getVersion(),
+        restApp.restClient.lookUpSubjectVersion(
+            new RegisterSchemaRequest(
+                new Schema(subject, response)), subject, false, false).getVersion());
 
     SchemaString schemaString = restApp.restClient.getId(expectedIdSchema2, subject);
     RuleSet ruleSet2 = schemaString.getRuleSet();
@@ -472,9 +510,16 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     RegisterSchemaRequest request3 = new RegisterSchemaRequest(schema3);
     request3.setRuleSet(ruleSet);
     int expectedIdSchema3 = 3;
+    response = restApp.restClient.registerSchema(request3, subject, false);
     assertEquals("Registering should succeed",
         expectedIdSchema3,
-        restApp.restClient.registerSchema(request3, subject, false).getId());
+        response.getId());
+
+    assertEquals("Version should match",
+        response.getVersion(),
+        restApp.restClient.lookUpSubjectVersion(
+            new RegisterSchemaRequest(
+                new Schema(subject, response)), subject, false, false).getVersion());
 
     schemaString = restApp.restClient.getId(expectedIdSchema3, subject);
     RuleSet ruleSet3 = schemaString.getRuleSet();

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiCompatibilityTest.java
@@ -277,7 +277,7 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     int expectedIdSchema1 = 1;
     assertEquals("Registering should succeed",
         expectedIdSchema1,
-        restApp.restClient.registerSchema(request1, subject, false));
+        restApp.restClient.registerSchema(request1, subject, false).getId());
     // verify that default compatibility level is backward
     assertEquals("Default compatibility level should be backward",
         CompatibilityLevel.BACKWARD.name,
@@ -308,7 +308,7 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     int expectedIdSchema2 = 2;
     assertEquals("Registering should succeed",
         expectedIdSchema2,
-        restApp.restClient.registerSchema(request2, subject, false));
+        restApp.restClient.registerSchema(request2, subject, false).getId());
   }
 
   @Test
@@ -338,7 +338,7 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     int expectedIdSchema1 = 1;
     assertEquals("Registering should succeed",
         expectedIdSchema1,
-        restApp.restClient.registerSchema(request1, subject, false));
+        restApp.restClient.registerSchema(request1, subject, false).getId());
     // verify that default compatibility level is backward
     assertEquals("Default compatibility level should be backward",
         CompatibilityLevel.BACKWARD.name,
@@ -366,7 +366,7 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     int expectedIdSchema2 = 2;
     assertEquals("Registering should succeed",
         expectedIdSchema2,
-        restApp.restClient.registerSchema(request2, subject, false));
+        restApp.restClient.registerSchema(request2, subject, false).getId());
 
     SchemaString schemaString = restApp.restClient.getId(expectedIdSchema2, subject);
     Metadata metadata2 = schemaString.getMetadata();
@@ -388,7 +388,7 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     int expectedIdSchema3 = 3;
     assertEquals("Registering should succeed",
         expectedIdSchema3,
-        restApp.restClient.registerSchema(request3, subject, false));
+        restApp.restClient.registerSchema(request3, subject, false).getId());
 
     schemaString = restApp.restClient.getId(expectedIdSchema3, subject);
     metadata3 = schemaString.getMetadata();
@@ -424,7 +424,7 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     int expectedIdSchema1 = 1;
     assertEquals("Registering should succeed",
         expectedIdSchema1,
-        restApp.restClient.registerSchema(request1, subject, false));
+        restApp.restClient.registerSchema(request1, subject, false).getId());
     // verify that default compatibility level is backward
     assertEquals("Default compatibility level should be backward",
         CompatibilityLevel.BACKWARD.name,
@@ -452,7 +452,7 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     int expectedIdSchema2 = 2;
     assertEquals("Registering should succeed",
         expectedIdSchema2,
-        restApp.restClient.registerSchema(request2, subject, false));
+        restApp.restClient.registerSchema(request2, subject, false).getId());
 
     SchemaString schemaString = restApp.restClient.getId(expectedIdSchema2, subject);
     RuleSet ruleSet2 = schemaString.getRuleSet();
@@ -474,7 +474,7 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     int expectedIdSchema3 = 3;
     assertEquals("Registering should succeed",
         expectedIdSchema3,
-        restApp.restClient.registerSchema(request3, subject, false));
+        restApp.restClient.registerSchema(request3, subject, false).getId());
 
     schemaString = restApp.restClient.getId(expectedIdSchema3, subject);
     RuleSet ruleSet3 = schemaString.getRuleSet();
@@ -495,7 +495,7 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     int expectedIdSchema1 = 1;
     assertEquals("Registering should succeed",
         expectedIdSchema1,
-        restApp.restClient.registerSchema(request1, subject, false));
+        restApp.restClient.registerSchema(request1, subject, false).getId());
 
     // register just metadata, schema should be inherited from version 1
     RegisterSchemaRequest request2 = new RegisterSchemaRequest();
@@ -506,7 +506,7 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     int expectedIdSchema2 = 2;
     assertEquals("Registering should succeed",
         expectedIdSchema2,
-        restApp.restClient.registerSchema(request2, subject, false));
+        restApp.restClient.registerSchema(request2, subject, false).getId());
 
     SchemaString schemaString = restApp.restClient.getId(expectedIdSchema2, subject);
     assertEquals(schema1.canonicalString(), schemaString.getSchemaString());
@@ -526,7 +526,7 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     int expectedIdSchema1 = 1;
     assertEquals("Registering should succeed",
         expectedIdSchema1,
-        restApp.restClient.registerSchema(request1, subject, false));
+        restApp.restClient.registerSchema(request1, subject, false).getId());
 
     // register just ruleSet, schema should be inherited from version 1
     RegisterSchemaRequest request2 = new RegisterSchemaRequest();
@@ -537,7 +537,7 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     int expectedIdSchema2 = 2;
     assertEquals("Registering should succeed",
         expectedIdSchema2,
-        restApp.restClient.registerSchema(request2, subject, false));
+        restApp.restClient.registerSchema(request2, subject, false).getId());
 
     SchemaString schemaString = restApp.restClient.getId(expectedIdSchema2, subject);
     assertEquals(schema1.canonicalString(), schemaString.getSchemaString());
@@ -581,7 +581,7 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     int expectedIdSchema2 = 2;
     assertEquals("Registering should succeed",
         expectedIdSchema2,
-        restApp.restClient.registerSchema(request2, subject, false));
+        restApp.restClient.registerSchema(request2, subject, false).getId());
   }
 
   @Test

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiMetadataEncoderTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiMetadataEncoderTest.java
@@ -55,7 +55,7 @@ public class RestApiMetadataEncoderTest extends ClusterTestHarness {
     int expectedIdSchema1 = 1;
     assertEquals("Registering without id should succeed",
         expectedIdSchema1,
-        restApp.restClient.registerSchema(request, subject, false));
+        restApp.restClient.registerSchema(request, subject, false).getId());
 
     SchemaString schemaString = restApp.restClient.getId(expectedIdSchema1);
     assertEquals(properties, schemaString.getMetadata().getProperties());

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -262,14 +262,14 @@ public class RestApiTest extends ClusterTestHarness {
     boolean isCompatible = restApp.restClient.testCompatibility(jsonSchema, "JSON", null, subject, "latest", false).isEmpty();
     assertTrue("Different schema type is allowed when compatibility is NONE", isCompatible);
 
-    int id2 = restApp.restClient.registerSchema(jsonSchema, "JSON", null, subject);
+    int id2 = restApp.restClient.registerSchema(jsonSchema, "JSON", null, subject).getId();
     assertEquals("2nd schema registered globally should have id 2", 2,
         id2);
 
     isCompatible = restApp.restClient.testCompatibility(protobufSchema, "PROTOBUF", null, subject, "latest", false).isEmpty();
     assertTrue("Different schema type is allowed when compatibility is NONE", isCompatible);
 
-    int id3 = restApp.restClient.registerSchema(protobufSchema, "PROTOBUF", null, subject);
+    int id3 = restApp.restClient.registerSchema(protobufSchema, "PROTOBUF", null, subject).getId();
     assertEquals("3rd schema registered globally should have id 3", 3,
         id3);
   }
@@ -778,7 +778,7 @@ public class RestApiTest extends ClusterTestHarness {
     SchemaReference ref = new SchemaReference("otherns.Subrecord", unqualifiedSubject, 1);
     request.setReferences(Collections.singletonList(ref));
     String subject2 = context + "referrer";
-    int registeredId = restApp.restClient.registerSchema(request, subject2, false);
+    int registeredId = restApp.restClient.registerSchema(request, subject2, false).getId();
     assertEquals("Registering a new schema should succeed", 2, registeredId);
 
     SchemaString schemaString = restApp.restClient.getId(2, subject2);
@@ -879,14 +879,14 @@ public class RestApiTest extends ClusterTestHarness {
     request.setSchema(ref1);
     SchemaReference ref = new SchemaReference("myavro.currencies.Currency", "shared", 1);
     request.setReferences(Collections.singletonList(ref));
-    int registeredId = restApp.restClient.registerSchema(request, "ref1", false);
+    int registeredId = restApp.restClient.registerSchema(request, "ref1", false).getId();
     assertEquals("Registering a new schema should succeed", 2, registeredId);
 
     request = new RegisterSchemaRequest();
     request.setSchema(ref2);
     ref = new SchemaReference("myavro.currencies.Currency", "shared", 1);
     request.setReferences(Collections.singletonList(ref));
-    registeredId = restApp.restClient.registerSchema(request, "ref2", false);
+    registeredId = restApp.restClient.registerSchema(request, "ref2", false).getId();
     assertEquals("Registering a new schema should succeed", 3, registeredId);
 
     request = new RegisterSchemaRequest();
@@ -894,7 +894,7 @@ public class RestApiTest extends ClusterTestHarness {
     SchemaReference r1 = new SchemaReference("myavro.BudgetDecreased", "ref1", 1);
     SchemaReference r2 = new SchemaReference("myavro.BudgetUpdated", "ref2", 1);
     request.setReferences(Arrays.asList(r1, r2));
-    registeredId = restApp.restClient.registerSchema(request, "root", false);
+    registeredId = restApp.restClient.registerSchema(request, "root", false).getId();
     assertEquals("Registering a new schema should succeed", 4, registeredId);
 
     SchemaString schemaString = restApp.restClient.getId(4);
@@ -962,7 +962,7 @@ public class RestApiTest extends ClusterTestHarness {
     registerRequest.setSchema(schemaString1);
     registerRequest.setReferences(Arrays.asList(ref1, ref2));
     int idOfRegisteredSchema1Subject1 =
-        restApp.restClient.registerSchema(registerRequest, subject1, true);
+        restApp.restClient.registerSchema(registerRequest, subject1, true).getId();
     RegisterSchemaRequest lookUpRequest = new RegisterSchemaRequest();
     lookUpRequest.setSchema(schemaString2);
     lookUpRequest.setReferences(Arrays.asList(ref2, ref1));
@@ -1974,10 +1974,10 @@ public class RestApiTest extends ClusterTestHarness {
     RegisterSchemaRequest request1 = new RegisterSchemaRequest(schema1);
     request1.setMetadata(metadata);
 
-    int id = restApp.restClient.registerSchema(request1, subject, false);
+    int id = restApp.restClient.registerSchema(request1, subject, false).getId();
 
     RegisterSchemaRequest request2 = new RegisterSchemaRequest(schema1);
-    int id2 = restApp.restClient.registerSchema(request2, subject, false);
+    int id2 = restApp.restClient.registerSchema(request2, subject, false).getId();
     assertEquals(id, id2);
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -1998,7 +1998,7 @@ public class RestApiTest extends ClusterTestHarness {
     int expectedIdSchema1 = 1;
     assertEquals("Registering should succeed",
         expectedIdSchema1,
-        restApp.restClient.registerSchema(request1, subject, false));
+        restApp.restClient.registerSchema(request1, subject, false).getId());
 
     SchemaString schemaString = restApp.restClient.getId(expectedIdSchema1, subject);
     assertNull(schemaString.getRuleSet());

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/json/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/json/RestApiTest.java
@@ -101,7 +101,7 @@ public class RestApiTest extends ClusterTestHarness {
           JsonSchema.TYPE,
           Collections.emptyList(),
           subject1
-      );
+      ).getId();
       assertEquals("Re-registering an existing schema should return the existing version",
           expectedId,
           foundId
@@ -148,7 +148,7 @@ public class RestApiTest extends ClusterTestHarness {
     request.setSchemaType(JsonSchema.TYPE);
     SchemaReference ref = new SchemaReference("ref.json", "reference", 1);
     request.setReferences(Collections.singletonList(ref));
-    int registeredId = restApp.restClient.registerSchema(request, "referrer", false);
+    int registeredId = restApp.restClient.registerSchema(request, "referrer", false).getId();
     assertEquals("Registering a new schema should succeed", 2, registeredId);
 
     SchemaString schemaString = restApp.restClient.getId(2);
@@ -259,7 +259,7 @@ public class RestApiTest extends ClusterTestHarness {
     registerRequest.setSchemaType(JsonSchema.TYPE);
     registerRequest.setReferences(Arrays.asList(ref1, ref2));
     int idOfRegisteredSchema1Subject1 =
-        restApp.restClient.registerSchema(registerRequest, subject1, true);
+        restApp.restClient.registerSchema(registerRequest, subject1, true).getId();
     RegisterSchemaRequest lookUpRequest = new RegisterSchemaRequest();
     lookUpRequest.setSchema(schemaString2);
     lookUpRequest.setSchemaType(JsonSchema.TYPE);
@@ -342,7 +342,7 @@ public class RestApiTest extends ClusterTestHarness {
 
     // test that compatibility check for incompatible schema returns false and the appropriate
     // error response from Avro
-    int idOfRegisteredSchema1Subject1 = restApp.restClient.registerSchema(registerRequest, subject, true);
+    int idOfRegisteredSchema1Subject1 = restApp.restClient.registerSchema(registerRequest, subject, true).getId();
 
     try {
       registerRequest.setSchema(schema2String);
@@ -391,7 +391,7 @@ public class RestApiTest extends ClusterTestHarness {
         JsonSchema.TYPE,
         references,
         subject
-    );
+    ).getId();
     Assert.assertEquals(
         "Registering a new schema should succeed",
         expectedId,

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/protobuf/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/protobuf/RestApiTest.java
@@ -100,7 +100,7 @@ public class RestApiTest extends ClusterTestHarness {
           ProtobufSchema.TYPE,
           Collections.emptyList(),
           subject1
-      );
+      ).getId();
       assertEquals("Re-registering an existing schema should return the existing version",
           expectedId,
           foundId
@@ -151,7 +151,7 @@ public class RestApiTest extends ClusterTestHarness {
     SchemaReference meta = new SchemaReference("confluent/meta.proto", "confluent/meta.proto", 1);
     List<SchemaReference> refs = Arrays.asList(ref, meta);
     request.setReferences(refs);
-    int registeredId = restApp.restClient.registerSchema(request, "referrer", false);
+    int registeredId = restApp.restClient.registerSchema(request, "referrer", false).getId();
     assertEquals("Registering a new schema should succeed", 3, registeredId);
 
     SchemaString schemaString = restApp.restClient.getId(3);
@@ -210,7 +210,7 @@ public class RestApiTest extends ClusterTestHarness {
     SchemaReference meta = new SchemaReference("pkg1/msg1.proto", "pkg1/msg1.proto", 1);
     List<SchemaReference> refs = Arrays.asList(meta);
     request.setReferences(refs);
-    int registeredId = restApp.restClient.registerSchema(request, subject, false);
+    int registeredId = restApp.restClient.registerSchema(request, subject, false).getId();
     assertEquals("Registering a new schema should succeed", 2, registeredId);
   }
 
@@ -256,7 +256,7 @@ public class RestApiTest extends ClusterTestHarness {
 
     // test that compatibility check for incompatible schema returns false and the appropriate
     // error response from Avro
-    int idOfRegisteredSchema1Subject1 = restApp.restClient.registerSchema(registerRequest, subject, true);
+    int idOfRegisteredSchema1Subject1 = restApp.restClient.registerSchema(registerRequest, subject, true).getId();
 
     try {
       registerRequest.setSchema(schema2String);
@@ -336,7 +336,7 @@ public class RestApiTest extends ClusterTestHarness {
     SchemaReference ref2 = new SchemaReference("pkg2/msg2.proto", "pkg2/msg2.proto", 1);
     List<SchemaReference> refs = Arrays.asList(ref1, ref2);
     request.setReferences(refs);
-    int registeredId = restApp.restClient.registerSchema(request, subject1, true);
+    int registeredId = restApp.restClient.registerSchema(request, subject1, true).getId();
     assertEquals("Registering a new schema should succeed", 3, registeredId);
 
     // Alternate version of same schema
@@ -462,7 +462,7 @@ public class RestApiTest extends ClusterTestHarness {
         ProtobufSchema.TYPE,
         references,
         subject
-    );
+    ).getId();
     Assert.assertEquals(
         "Registering a new schema should succeed",
         (long) expectedId,

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/utils/TestUtils.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/utils/TestUtils.java
@@ -128,7 +128,7 @@ public class TestUtils {
         AvroSchema.TYPE,
         references,
         subject
-    );
+    ).getId();
     assertEquals("Registering a new schema should succeed", expectedId, registeredId);
 
     // the newly registered schema should be immediately readable on the leader

--- a/protobuf-serializer/src/test/java/io/confluent/kafka/schemaregistry/protobuf/rest/RestApiSerializerTest.java
+++ b/protobuf-serializer/src/test/java/io/confluent/kafka/schemaregistry/protobuf/rest/RestApiSerializerTest.java
@@ -30,11 +30,16 @@ import com.google.protobuf.Timestamp;
 import io.confluent.connect.protobuf.test.DescriptorRef;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.ConfigUpdateRequest;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import io.confluent.kafka.serializers.protobuf.AbstractKafkaProtobufSerializer;
 import io.confluent.kafka.serializers.subject.DefaultReferenceSubjectNameStrategy;
 import io.confluent.kafka.serializers.subject.strategy.ReferenceSubjectNameStrategy;
 import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
@@ -71,6 +76,7 @@ import io.confluent.kafka.serializers.protobuf.test.TestMessageProtos.TestMessag
 
 import static io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializerTest.getField;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class RestApiSerializerTest extends ClusterTestHarness {
 
@@ -396,6 +402,42 @@ public class RestApiSerializerTest extends ClusterTestHarness {
     assertEquals(schema.normalize(), resolvedSchema.normalize());
 
     checkNormalization(schemaRegistry, "DescriptorRef.proto");
+  }
+
+  @Test
+  public void testSchemaReferencesConfigMetadata() throws Exception {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("configKey", "configValue");
+    Metadata metadata = new Metadata(null, properties, null);
+    ConfigUpdateRequest config = new ConfigUpdateRequest();
+    config.setDefaultMetadata(metadata);
+    // add config metadata
+    assertEquals("Adding config with initial metadata should succeed",
+        config,
+        restApp.restClient.updateConfig(config, null));
+
+    SchemaRegistryClient schemaRegistry = new CachedSchemaRegistryClient(restApp.restClient,
+        10,
+        Collections.singletonList(new ProtobufSchemaProvider()),
+        Collections.emptyMap(),
+        Collections.emptyMap());
+    ProtobufSchema schema = ProtobufSchemaUtils.getSchema(DEPENDENCY_MESSAGE);
+    schema = AbstractKafkaProtobufSerializer.resolveDependencies(
+        schemaRegistry, true, false, false, null,
+        new DefaultReferenceSubjectNameStrategy(), "referrer", false, schema);
+
+    RegisterSchemaRequest request = new RegisterSchemaRequest(schema);
+    int registeredId = restApp.restClient.registerSchema(request, "referrer", false).getId();
+    assertEquals("Registering a new schema should succeed", 4, registeredId);
+
+    SchemaString schemaString = restApp.restClient.getId(4);
+    // the newly registered schema should be immediately readable on the leader
+    assertNotNull("Registered schema should be found", schemaString);
+
+    assertEquals("Schema dependencies should be found",
+        2,
+        schemaString.getReferences().size()
+    );
   }
 
   @Test(expected = RestClientException.class)

--- a/protobuf-serializer/src/test/java/io/confluent/kafka/schemaregistry/protobuf/rest/RestApiSerializerTest.java
+++ b/protobuf-serializer/src/test/java/io/confluent/kafka/schemaregistry/protobuf/rest/RestApiSerializerTest.java
@@ -442,7 +442,7 @@ public class RestApiSerializerTest extends ClusterTestHarness {
         references,
         subject,
         normalize
-    );
+    ).getId();
     assertEquals(
         "Registering a new schema should succeed",
         (long) expectedId,

--- a/protobuf-types/src/main/java/io/confluent/protobuf/type/Decimal.java
+++ b/protobuf-types/src/main/java/io/confluent/protobuf/type/Decimal.java
@@ -31,58 +31,6 @@ private static final long serialVersionUID = 0L;
   getUnknownFields() {
     return this.unknownFields;
   }
-  private Decimal(
-      com.google.protobuf.CodedInputStream input,
-      com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-      throws com.google.protobuf.InvalidProtocolBufferException {
-    this();
-    if (extensionRegistry == null) {
-      throw new java.lang.NullPointerException();
-    }
-    com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-        com.google.protobuf.UnknownFieldSet.newBuilder();
-    try {
-      boolean done = false;
-      while (!done) {
-        int tag = input.readTag();
-        switch (tag) {
-          case 0:
-            done = true;
-            break;
-          case 10: {
-
-            value_ = input.readBytes();
-            break;
-          }
-          case 16: {
-
-            precision_ = input.readUInt32();
-            break;
-          }
-          case 24: {
-
-            scale_ = input.readInt32();
-            break;
-          }
-          default: {
-            if (!parseUnknownField(
-                input, unknownFields, extensionRegistry, tag)) {
-              done = true;
-            }
-            break;
-          }
-        }
-      }
-    } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-      throw e.setUnfinishedMessage(this);
-    } catch (java.io.IOException e) {
-      throw new com.google.protobuf.InvalidProtocolBufferException(
-          e).setUnfinishedMessage(this);
-    } finally {
-      this.unknownFields = unknownFields.build();
-      makeExtensionsImmutable();
-    }
-  }
   public static final com.google.protobuf.Descriptors.Descriptor
       getDescriptor() {
     return io.confluent.protobuf.type.DecimalProto.internal_static_confluent_type_Decimal_descriptor;
@@ -164,7 +112,7 @@ private static final long serialVersionUID = 0L;
     if (scale_ != 0) {
       output.writeInt32(3, scale_);
     }
-    unknownFields.writeTo(output);
+    getUnknownFields().writeTo(output);
   }
 
   @java.lang.Override
@@ -185,7 +133,7 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.CodedOutputStream
         .computeInt32Size(3, scale_);
     }
-    size += unknownFields.getSerializedSize();
+    size += getUnknownFields().getSerializedSize();
     memoizedSize = size;
     return size;
   }
@@ -206,7 +154,7 @@ private static final long serialVersionUID = 0L;
         != other.getPrecision()) return false;
     if (getScale()
         != other.getScale()) return false;
-    if (!unknownFields.equals(other.unknownFields)) return false;
+    if (!getUnknownFields().equals(other.getUnknownFields())) return false;
     return true;
   }
 
@@ -223,7 +171,7 @@ private static final long serialVersionUID = 0L;
     hash = (53 * hash) + getPrecision();
     hash = (37 * hash) + SCALE_FIELD_NUMBER;
     hash = (53 * hash) + getScale();
-    hash = (29 * hash) + unknownFields.hashCode();
+    hash = (29 * hash) + getUnknownFields().hashCode();
     memoizedHashCode = hash;
     return hash;
   }
@@ -340,18 +288,13 @@ private static final long serialVersionUID = 0L;
 
     // Construct using io.confluent.protobuf.type.Decimal.newBuilder()
     private Builder() {
-      maybeForceBuilderInitialization();
+
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-      maybeForceBuilderInitialization();
-    }
-    private void maybeForceBuilderInitialization() {
-      if (com.google.protobuf.GeneratedMessageV3
-              .alwaysUseFieldBuilders) {
-      }
+
     }
     @java.lang.Override
     public Builder clear() {
@@ -448,7 +391,7 @@ private static final long serialVersionUID = 0L;
       if (other.getScale() != 0) {
         setScale(other.getScale());
       }
-      this.mergeUnknownFields(other.unknownFields);
+      this.mergeUnknownFields(other.getUnknownFields());
       onChanged();
       return this;
     }
@@ -463,17 +406,45 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws java.io.IOException {
-      io.confluent.protobuf.type.Decimal parsedMessage = null;
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
       try {
-        parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              value_ = input.readBytes();
+
+              break;
+            } // case 10
+            case 16: {
+              precision_ = input.readUInt32();
+
+              break;
+            } // case 16
+            case 24: {
+              scale_ = input.readInt32();
+
+              break;
+            } // case 24
+            default: {
+              if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                done = true; // was an endgroup tag
+              }
+              break;
+            } // default:
+          } // switch (tag)
+        } // while (!done)
       } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        parsedMessage = (io.confluent.protobuf.type.Decimal) e.getUnfinishedMessage();
         throw e.unwrapIOException();
       } finally {
-        if (parsedMessage != null) {
-          mergeFrom(parsedMessage);
-        }
-      }
+        onChanged();
+      } // finally
       return this;
     }
 
@@ -641,7 +612,18 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.CodedInputStream input,
         com.google.protobuf.ExtensionRegistryLite extensionRegistry)
         throws com.google.protobuf.InvalidProtocolBufferException {
-      return new Decimal(input, extensionRegistry);
+      Builder builder = newBuilder();
+      try {
+        builder.mergeFrom(input, extensionRegistry);
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(builder.buildPartial());
+      } catch (com.google.protobuf.UninitializedMessageException e) {
+        throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(e)
+            .setUnfinishedMessage(builder.buildPartial());
+      }
+      return builder.buildPartial();
     }
   };
 

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -34,6 +34,8 @@ import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientFactory;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Rule;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleMode;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import io.confluent.kafka.schemaregistry.rules.DlqAction;
 import io.confluent.kafka.schemaregistry.rules.ErrorAction;
 import io.confluent.kafka.schemaregistry.rules.NoneAction;
@@ -62,7 +64,6 @@ import java.util.ServiceLoader;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.KafkaException;
@@ -485,7 +486,8 @@ public abstract class AbstractKafkaSchemaSerDe implements Closeable {
   }
 
   @Deprecated
-  public int register(String subject, Schema schema) throws IOException, RestClientException {
+  public int register(String subject, org.apache.avro.Schema schema)
+      throws IOException, RestClientException {
     return schemaRegistry.register(subject, schema);
   }
 
@@ -498,8 +500,15 @@ public abstract class AbstractKafkaSchemaSerDe implements Closeable {
     return schemaRegistry.register(subject, schema, normalize);
   }
 
+  protected Schema registerWithResponse(String subject, ParsedSchema schema, boolean normalize)
+      throws IOException, RestClientException {
+    RegisterSchemaResponse response =
+        schemaRegistry.registerWithResponse(subject, schema, normalize);
+    return new Schema(subject, response);
+  }
+
   @Deprecated
-  public Schema getById(int id) throws IOException, RestClientException {
+  public org.apache.avro.Schema getById(int id) throws IOException, RestClientException {
     return schemaRegistry.getById(id);
   }
 
@@ -508,7 +517,7 @@ public abstract class AbstractKafkaSchemaSerDe implements Closeable {
   }
 
   @Deprecated
-  public Schema getBySubjectAndId(String subject, int id)
+  public org.apache.avro.Schema getBySubjectAndId(String subject, int id)
       throws IOException, RestClientException {
     return schemaRegistry.getBySubjectAndId(subject, id);
   }


### PR DESCRIPTION
This augments `RegisterSchemaResponse` with additional info, such as the schema.  If the schema has changed on the server, it is included in the response.