### PR TITLE
Fixing CVE-2023-2976 in guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
         <io.confluent.schema-registry.version>7.6.0-0</io.confluent.schema-registry.version>
         <commons.compress.version>1.21</commons.compress.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
+        <guava.version>32.0.1-jre</guava.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Guava 31.1-jre has CVE-2023-2976, upgrading to remove the CVE