### PR TITLE
Use static ObjectMappers

### DIFF
--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
@@ -49,7 +49,7 @@ import io.confluent.kafka.schemaregistry.json.jackson.Jackson;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDe;
 
 public abstract class AbstractKafkaJsonSchemaDeserializer<T> extends AbstractKafkaSchemaSerDe {
-  protected ObjectMapper objectMapper = Jackson.newObjectMapper();
+  protected static final ObjectMapper objectMapper = Jackson.newObjectMapper();
   protected Class<T> type;
   protected String typeProperty;
   protected boolean validate;

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaSerializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaSerializer.java
@@ -49,7 +49,7 @@ public abstract class AbstractKafkaJsonSchemaSerializer<T> extends AbstractKafka
   protected int useSchemaId = -1;
   protected boolean idCompatStrict;
   protected boolean latestCompatStrict;
-  protected ObjectMapper objectMapper = Jackson.newObjectMapper();
+  protected static final ObjectMapper objectMapper = Jackson.newObjectMapper();
   protected SpecificationVersion specVersion;
   protected boolean oneofForNullables;
   protected boolean failUnknownProperties;


### PR DESCRIPTION
The creation of `ObjectMapper`s can be very expensive, can we have them `static` instead?

This profiling came from a Kafka REST instance with Avro messages produce load:
![image](https://github.com/confluentinc/schema-registry/assets/5933053/4b7ea1df-e146-46f3-9e9d-46ae188734a4)
