### PR TITLE
DGS-7772: Impl POST /subjects/{subject}/versions/{version}/tags

### DIFF
--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/AvroSchemaTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/AvroSchemaTest.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
-import io.confluent.kafka.schemaregistry.SchemaEntity;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import java.util.Collections;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
@@ -19,6 +19,7 @@ package io.confluent.kafka.schemaregistry;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
 import io.confluent.kafka.schemaregistry.rules.FieldTransform;
 import io.confluent.kafka.schemaregistry.rules.RuleContext;
 import io.confluent.kafka.schemaregistry.rules.RuleException;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.EnumHashBiMap;
 import com.google.common.collect.Lists;
-import io.confluent.kafka.schemaregistry.SchemaEntity;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
 import io.confluent.kafka.schemaregistry.rules.FieldTransform;
 import io.confluent.kafka.schemaregistry.rules.RuleContext;
 import io.confluent.kafka.schemaregistry.rules.RuleContext.FieldContext;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
@@ -38,7 +38,6 @@ import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map.Entry;
@@ -685,7 +684,7 @@ public class AvroSchema implements ParsedSchema {
   private void modifySchemaTags(JsonNode node,
                                 Map<SchemaEntity, Set<String>> tagsToAddMap,
                                 Map<SchemaEntity, Set<String>> tagsToRemoveMap) {
-    Set<SchemaEntity> entityToModify = new HashSet<>(tagsToAddMap.keySet());
+    Set<SchemaEntity> entityToModify = new LinkedHashSet<>(tagsToAddMap.keySet());
     entityToModify.addAll(tagsToRemoveMap.keySet());
 
     for (SchemaEntity entity : entityToModify) {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaUtils.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaUtils.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.util.TokenBuffer;
-import io.confluent.kafka.schemaregistry.SchemaEntity;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
 import io.confluent.kafka.schemaregistry.utils.BoundedConcurrentHashMap;
 import java.math.BigDecimal;
 import java.math.BigInteger;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -593,10 +593,10 @@ public class RestService implements Configurable {
     return response;
   }
 
-  public RegisterSchemaResponse registerSchemaTags(Map<String, String> requestProperties,
-                                                   TagSchemaRequest tagSchemaRequest,
-                                                   String subject,
-                                                   String version)
+  public RegisterSchemaResponse modifySchemaTags(Map<String, String> requestProperties,
+                                                 TagSchemaRequest tagSchemaRequest,
+                                                 String subject,
+                                                 String version)
       throws IOException, RestClientException {
     UriBuilder builder = UriBuilder.fromPath("/subjects/{subject}/versions/{version}/tags");
     String path = builder.build(subject, version).toString();

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -32,6 +32,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
 import io.confluent.kafka.schemaregistry.client.rest.entities.ServerClusterId;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.TagSchemaRequest;
 import io.confluent.kafka.schemaregistry.client.security.basicauth.BasicAuthCredentialProviderFactory;
 import io.confluent.kafka.schemaregistry.client.security.bearerauth.BearerAuthCredentialProvider;
 
@@ -586,6 +587,24 @@ public class RestService implements Configurable {
     RegisterSchemaResponse response = httpRequest(
         path, "POST",
         registerSchemaRequest.toJson().getBytes(StandardCharsets.UTF_8),
+        requestProperties,
+        REGISTER_RESPONSE_TYPE);
+
+    return response;
+  }
+
+  public RegisterSchemaResponse registerSchemaTags(Map<String, String> requestProperties,
+                                                   TagSchemaRequest tagSchemaRequest,
+                                                   String subject,
+                                                   String version)
+      throws IOException, RestClientException {
+    UriBuilder builder = UriBuilder.fromPath("/subjects/{subject}/versions/{version}/tags");
+    String path = builder.build(subject, version).toString();
+    System.out.println(path);
+
+    RegisterSchemaResponse response = httpRequest(
+        path, "POST",
+        tagSchemaRequest.toJson().getBytes(StandardCharsets.UTF_8),
         requestProperties,
         REGISTER_RESPONSE_TYPE);
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -600,7 +600,6 @@ public class RestService implements Configurable {
       throws IOException, RestClientException {
     UriBuilder builder = UriBuilder.fromPath("/subjects/{subject}/versions/{version}/tags");
     String path = builder.build(subject, version).toString();
-    System.out.println(path);
 
     RegisterSchemaResponse response = httpRequest(
         path, "POST",

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaEntity.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaEntity.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.confluent.kafka.schemaregistry.client.rest.entities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaEntity.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaEntity.java
@@ -13,8 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package io.confluent.kafka.schemaregistry;
+package io.confluent.kafka.schemaregistry.client.rest.entities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaEntity.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaEntity.java
@@ -48,6 +48,14 @@ public class SchemaEntity {
     return entityType;
   }
 
+  public String getNormalizedPath() {
+    if (entityPath.startsWith(".")) {
+      return entityPath.substring(1);
+    } else {
+      return entityPath;
+    }
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -58,13 +66,13 @@ public class SchemaEntity {
     }
 
     SchemaEntity other = (SchemaEntity) o;
-    return Objects.equals(this.entityPath, other.getEntityPath())
+    return Objects.equals(this.getNormalizedPath(), other.getNormalizedPath())
       && Objects.equals(this.entityType, other.getEntityType());
   }
 
   @Override
   public int hashCode() {
-    int result = Objects.hashCode(entityPath);
+    int result = Objects.hashCode(getNormalizedPath());
     result = 31 * result + Objects.hashCode(entityType);
     return result;
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaEntity.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaEntity.java
@@ -30,12 +30,18 @@ public class SchemaEntity {
 
   private final String entityPath;
   private final EntityType entityType;
+  private final String normalizedPath;
 
   @JsonCreator
   public SchemaEntity(@JsonProperty("entityPath") String entityPath,
                       @JsonProperty("entityType") EntityType entityType) {
     this.entityPath = entityPath;
     this.entityType = entityType;
+    if (this.entityPath.startsWith(".")) {
+      this.normalizedPath = entityPath.substring(1);
+    } else {
+      this.normalizedPath = this.entityPath;
+    }
   }
 
   @JsonProperty("entityPath")
@@ -49,11 +55,7 @@ public class SchemaEntity {
   }
 
   public String getNormalizedPath() {
-    if (entityPath.startsWith(".")) {
-      return entityPath.substring(1);
-    } else {
-      return entityPath;
-    }
+    return normalizedPath;
   }
 
   @Override

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaEntity.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaEntity.java
@@ -17,6 +17,7 @@
 package io.confluent.kafka.schemaregistry.client.rest.entities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -54,6 +55,7 @@ public class SchemaEntity {
     return entityType;
   }
 
+  @JsonIgnore
   public String getNormalizedPath() {
     return normalizedPath;
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaTags.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaTags.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.client.rest.entities;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
+
+import java.util.List;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_ONLY;
+
+@JsonAutoDetect(getterVisibility = PUBLIC_ONLY, setterVisibility = PUBLIC_ONLY,
+    fieldVisibility = NONE)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SchemaTags {
+
+  private SchemaEntity schemaEntity;
+  private List<String> tags;
+
+  @JsonCreator
+  public SchemaTags(@JsonProperty("schemaEntity") SchemaEntity schemaEntity,
+                    @JsonProperty("tags") List<String> tags) {
+    this.schemaEntity = schemaEntity;
+    this.tags = tags;
+  }
+
+  @JsonProperty("schemaEntity")
+  public SchemaEntity getSchemaEntity() {
+    return schemaEntity;
+  }
+
+  @JsonProperty("schemaEntity")
+  public void setSchemaEntity(SchemaEntity schemaEntity) {
+    this.schemaEntity = schemaEntity;
+  }
+
+  @JsonProperty("tags")
+  public List<String> getTags() {
+    return tags;
+  }
+
+  @JsonProperty("tags")
+  public void setTags(List<String> tags) {
+    this.tags = tags;
+  }
+
+  public String toJson() throws JsonProcessingException {
+    return JacksonMapper.INSTANCE.writeValueAsString(this);
+  }
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaTags.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaTags.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 
 import java.util.List;
+import java.util.Objects;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.PUBLIC_ONLY;
@@ -67,5 +68,24 @@ public class SchemaTags {
 
   public String toJson() throws JsonProcessingException {
     return JacksonMapper.INSTANCE.writeValueAsString(this);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SchemaTags other = (SchemaTags) o;
+    return Objects.equals(this.schemaEntity, other.schemaEntity)
+        && Objects.equals(this.tags, other.tags);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(schemaEntity, tags);
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/TagSchemaRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/TagSchemaRequest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2023 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.client.rest.entities.requests;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
+import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaTags;
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@io.swagger.v3.oas.annotations.media.Schema(description = "Schema tags register request")
+public class TagSchemaRequest {
+
+  private Integer newVersion;
+  private List<SchemaTags> tagsToAdd;
+  private List<SchemaTags> tagsToRemove;
+  private Metadata metadata;
+  private RuleSet ruleSet;
+
+  public TagSchemaRequest() {
+  }
+
+  @io.swagger.v3.oas.annotations.media.Schema(description = "The new version")
+  @JsonProperty("newVersion")
+  public Integer getNewVersion() {
+    return newVersion;
+  }
+
+  @JsonProperty("newVersion")
+  public void setNewVersion(Integer newVersion) {
+    this.newVersion = newVersion;
+  }
+
+  @JsonProperty("tagsToAdd")
+  public List<SchemaTags> getTagsToAdd() {
+    return tagsToAdd;
+  }
+
+  @JsonProperty("tagsToAdd")
+  public void setTagsToAdd(List<SchemaTags> tagsToAdd) {
+    this.tagsToAdd = tagsToAdd;
+  }
+
+  @JsonProperty("tagsToRemove")
+  public List<SchemaTags> getTagsToRemove() {
+    return tagsToRemove;
+  }
+
+  @JsonProperty("tagsToRemove")
+  public void setTagsToRemove(List<SchemaTags> tagsToRemove) {
+    this.tagsToRemove = tagsToRemove;
+  }
+
+  @io.swagger.v3.oas.annotations.media.Schema(description = Schema.METADATA_DESC)
+  @JsonProperty("metadata")
+  public Metadata getMetadata() {
+    return metadata;
+  }
+
+  @JsonProperty("metadata")
+  public void setMetadata(Metadata metadata) {
+    this.metadata = metadata;
+  }
+
+  @io.swagger.v3.oas.annotations.media.Schema(description = Schema.RULESET_DESC)
+  @JsonProperty("ruleSet")
+  public RuleSet getRuleSet() {
+    return ruleSet;
+  }
+
+  @JsonProperty("ruleSet")
+  public void setRuleSet(RuleSet ruleSet) {
+    this.ruleSet = ruleSet;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    TagSchemaRequest tagSchemaRequest = (TagSchemaRequest) o;
+    return Objects.equals(newVersion, tagSchemaRequest.newVersion)
+        && Objects.equals(tagsToAdd, tagSchemaRequest.tagsToAdd)
+        && Objects.equals(tagsToRemove, tagSchemaRequest.tagsToRemove)
+        && Objects.equals(metadata, tagSchemaRequest.metadata)
+        && Objects.equals(ruleSet, tagSchemaRequest.ruleSet);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(newVersion, tagsToAdd, tagsToRemove, metadata, ruleSet);
+  }
+
+  public String toJson() throws IOException {
+    return JacksonMapper.INSTANCE.writeValueAsString(this);
+  }
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/TagSchemaRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/TagSchemaRequest.java
@@ -19,7 +19,6 @@ package io.confluent.kafka.schemaregistry.client.rest.entities.requests;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/TagSchemaRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/TagSchemaRequest.java
@@ -29,6 +29,7 @@ import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -140,7 +141,7 @@ public class TagSchemaRequest {
     return schemaTags
         .stream()
         .collect(Collectors.toMap(SchemaTags::getSchemaEntity,
-            entry -> new HashSet<>(entry.getTags()),
+            entry -> new LinkedHashSet<>(entry.getTags()),
             (v1, v2) -> {
               v1.addAll(v2);
               return v1;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/TagSchemaRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/TagSchemaRequest.java
@@ -28,7 +28,6 @@ import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/TagSchemaRequestTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/TagSchemaRequestTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.client.rest.entities.requests;
+
+import com.google.common.collect.ImmutableSet;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaTags;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TagSchemaRequestTest {
+
+  @Test
+  public void testMergeSchemaTags() {
+    SchemaEntity entity1 =
+        new SchemaEntity("SampleRecord.f1", SchemaEntity.EntityType.SR_FIELD);
+    SchemaEntity entity2 =
+        new SchemaEntity(".SampleRecord.f1", SchemaEntity.EntityType.SR_FIELD);
+    SchemaTags tag1 = new SchemaTags(entity1, Collections.singletonList("tag1"));
+    SchemaTags tag2 = new SchemaTags(entity2, Collections.singletonList("tag2"));
+
+    Map<SchemaEntity, Set<String>> result =
+        TagSchemaRequest.schemaTagsListToMap(Arrays.asList(tag1, tag2));
+    assertEquals(1, result.size());
+    assertTrue(result.containsKey(entity1));
+    assertTrue(result.containsKey(entity2));
+    assertEquals(ImmutableSet.of("tag1", "tag2"), result.get(entity1));
+  }
+}

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -558,28 +558,28 @@ public class SubjectVersionsResource {
   @DocumentedName("registerSchemaTags")
   @PerformanceMetric("subjects.versions.register.tags")
   @Operation(summary = "Create schema embedded tags for a subject version",
-      description = "Create new schema subject version with the provided field or record level " +
-          "schema tags embedded (or remove) in the schema string, as well as the given metadata " +
-          "and ruleset.",
+      description = "Create new schema subject version with the provided field or record level "
+          + "schema tags embedded (or remove) in the schema string, as well as the given metadata "
+          + "and ruleset.",
       responses = {
           @ApiResponse(responseCode = "200", description = "Schema tags successfully registered.",
-              content = @Content(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation =
-                  RegisterSchemaResponse.class))),
+              content = @Content(schema = @io.swagger.v3.oas.annotations.media.Schema(
+                  implementation = RegisterSchemaResponse.class))),
           @ApiResponse(responseCode = "409", description = "Conflict. Incompatible schema.",
-              content = @Content(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation =
-                  ErrorMessage.class))),
+              content = @Content(schema = @io.swagger.v3.oas.annotations.media.Schema(
+                  implementation = ErrorMessage.class))),
           @ApiResponse(responseCode = "422",
               description = "Unprocessable entity. "
                   + "Error code 42201 indicates an invalid schema or schema type. ",
-              content = @Content(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation =
-                  ErrorMessage.class))),
+              content = @Content(schema = @io.swagger.v3.oas.annotations.media.Schema(
+                  implementation = ErrorMessage.class))),
           @ApiResponse(responseCode = "500",
               description = "Internal Server Error. "
                   + "Error code 50001 indicates a failure in the backend data store."
                   + "Error code 50002 indicates operation timed out. "
                   + "Error code 50003 indicates a failure forwarding the request to the primary.",
-              content = @Content(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation =
-                  ErrorMessage.class)))})
+              content = @Content(schema = @io.swagger.v3.oas.annotations.media.Schema(
+                  implementation = ErrorMessage.class)))})
   @Tags(@Tag(name = apiTag))
   public void registerTags(
       final @Suspended AsyncResponse asyncResponse,
@@ -590,8 +590,8 @@ public class SubjectVersionsResource {
       @PathParam("version") String version,
       @Parameter(description = "Tag schema request", required = true)
       @NotNull TagSchemaRequest request) {
-    log.info("Registering schema tags: subject {}, version {}, newVersion {}, " +
-            "adding {} tags, removing {} tags",
+    log.info("Registering schema tags: subject {}, version {}, newVersion {}, "
+            + "adding {} tags, removing {} tags",
         subjectName, version, request.getNewVersion(),
         request.getTagsToAdd() == null ? 0 : request.getTagsToAdd().size(),
         request.getTagsToRemove() == null ? 0 : request.getTagsToRemove().size());
@@ -624,7 +624,8 @@ public class SubjectVersionsResource {
     RegisterSchemaResponse registerSchemaResponse;
     try {
       Schema result =
-          schemaRegistry.registerSchemaTagsOrForward(subjectName, versionId, request, headerProperties);
+          schemaRegistry.registerSchemaTagsOrForward(
+              subjectName, versionId, request, headerProperties);
       registerSchemaResponse = new RegisterSchemaResponse(result);
     } catch (InvalidSchemaException e) {
       throw Errors.invalidSchemaException(e);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -20,6 +20,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.ErrorMessage;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.TagSchemaRequest;
 import io.confluent.kafka.schemaregistry.exceptions.IdDoesNotMatchException;
 import io.confluent.kafka.schemaregistry.exceptions.IncompatibleSchemaException;
 import io.confluent.kafka.schemaregistry.exceptions.InvalidSchemaException;
@@ -550,5 +551,104 @@ public class SubjectVersionsResource {
     }
 
     asyncResponse.resume(schema.getVersion());
+  }
+
+  @POST
+  @Path("/{version}/tags")
+  @DocumentedName("registerSchemaTags")
+  @PerformanceMetric("subjects.versions.register.tags")
+  @Operation(summary = "Create schema embedded tags for a subject version",
+      description = "Create new schema subject version with the provided field or record level " +
+          "schema tags embedded (or remove) in the schema string, as well as the given metadata " +
+          "and ruleset.",
+      responses = {
+          @ApiResponse(responseCode = "200", description = "Schema tags successfully registered.",
+              content = @Content(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation =
+                  RegisterSchemaResponse.class))),
+          @ApiResponse(responseCode = "409", description = "Conflict. Incompatible schema.",
+              content = @Content(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation =
+                  ErrorMessage.class))),
+          @ApiResponse(responseCode = "422",
+              description = "Unprocessable entity. "
+                  + "Error code 42201 indicates an invalid schema or schema type. ",
+              content = @Content(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation =
+                  ErrorMessage.class))),
+          @ApiResponse(responseCode = "500",
+              description = "Internal Server Error. "
+                  + "Error code 50001 indicates a failure in the backend data store."
+                  + "Error code 50002 indicates operation timed out. "
+                  + "Error code 50003 indicates a failure forwarding the request to the primary.",
+              content = @Content(schema = @io.swagger.v3.oas.annotations.media.Schema(implementation =
+                  ErrorMessage.class)))})
+  @Tags(@Tag(name = apiTag))
+  public void registerTags(
+      final @Suspended AsyncResponse asyncResponse,
+      @Context HttpHeaders headers,
+      @Parameter(description = "Name of the subject", required = true)
+      @PathParam("subject") String subjectName,
+      @Parameter(description = VERSION_PARAM_DESC, required = true)
+      @PathParam("version") String version,
+      @Parameter(description = "Tag schema request", required = true)
+      @NotNull TagSchemaRequest request) {
+    log.info("Registering schema tags: subject {}, version {}, newVersion {}, " +
+            "adding {} tags, removing {} tags",
+        subjectName, version, request.getNewVersion(),
+        request.getTagsToAdd() == null ? 0 : request.getTagsToAdd().size(),
+        request.getTagsToRemove() == null ? 0 : request.getTagsToRemove().size());
+
+    schemaRegistry.getRuleSetHandler().handle(subjectName, request);
+
+    if (request.getRuleSet() != null) {
+      try {
+        request.getRuleSet().validate();
+      } catch (RuleException e) {
+        throw new RestInvalidRuleSetException(e.getMessage());
+      }
+    }
+    if (subjectName != null
+        && !QualifiedSubject.isValidSubject(schemaRegistry.tenant(), subjectName)) {
+      throw Errors.invalidSubjectException(subjectName);
+    }
+    VersionId versionId;
+    try {
+      versionId = new VersionId(version);
+    } catch (InvalidVersionException e) {
+      throw Errors.invalidVersionException(e.getMessage());
+    }
+
+    subjectName = QualifiedSubject.normalize(schemaRegistry.tenant(), subjectName);
+
+    Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
+        headers, schemaRegistry.config().whitelistHeaders());
+
+    RegisterSchemaResponse registerSchemaResponse;
+    try {
+      Schema result =
+          schemaRegistry.registerSchemaTagsOrForward(subjectName, versionId, request, headerProperties);
+      registerSchemaResponse = new RegisterSchemaResponse(result);
+    } catch (InvalidSchemaException e) {
+      throw Errors.invalidSchemaException(e);
+    } catch (SchemaTooLargeException e) {
+      throw Errors.schemaTooLargeException("Register operation failed because schema is too large");
+    } catch (OperationNotPermittedException e) {
+      throw Errors.operationNotPermittedException(e.getMessage());
+    } catch (SchemaRegistryTimeoutException e) {
+      throw Errors.operationTimeoutException("Register operation timed out", e);
+    } catch (SchemaRegistryStoreException e) {
+      throw Errors.storeException("Register schema operation failed while writing"
+          + " to the Kafka store", e);
+    } catch (SchemaRegistryRequestForwardingException e) {
+      throw Errors.requestForwardingFailedException("Error while forwarding register schema request"
+          + " to the leader", e);
+    } catch (IncompatibleSchemaException e) {
+      throw Errors.incompatibleSchemaException("Schema being registered is incompatible with"
+          + " an earlier schema for subject \"" + subjectName + "\", details: "
+          + e.getMessage(), e);
+    } catch (UnknownLeaderException e) {
+      throw Errors.unknownLeaderException("Leader not known.", e);
+    } catch (SchemaRegistryException e) {
+      throw Errors.schemaRegistryException("Error while registering schema", e);
+    }
+    asyncResponse.resume(registerSchemaResponse);
   }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -43,7 +43,6 @@ import io.confluent.kafka.schemaregistry.client.security.SslFactory;
 import io.confluent.kafka.schemaregistry.exceptions.IdGenerationException;
 import io.confluent.kafka.schemaregistry.exceptions.IncompatibleSchemaException;
 import io.confluent.kafka.schemaregistry.exceptions.InvalidSchemaException;
-import io.confluent.kafka.schemaregistry.exceptions.InvalidVersionException;
 import io.confluent.kafka.schemaregistry.exceptions.OperationNotPermittedException;
 import io.confluent.kafka.schemaregistry.exceptions.ReferenceExistsException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
@@ -101,7 +100,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.HostnameVerifier;
-import javax.ws.rs.core.UriBuilder;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -908,7 +906,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       } else {
         // forward registering request to the leader
         if (leaderIdentity != null) {
-          return forwardRegisterSchemaTagsRequestToLeader(subject, schema, request, headerProperties);
+          return forwardRegisterSchemaTagsRequestToLeader(
+              subject, schema, request, headerProperties);
         } else {
           throw new UnknownLeaderException("Request failed since leader is unknown");
         }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -842,7 +842,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     }
   }
 
-  public Schema registerSchemaTags(String subject, Schema schema, TagSchemaRequest request)
+  public Schema modifySchemaTags(String subject, Schema schema, TagSchemaRequest request)
       throws SchemaRegistryException {
     ParsedSchema parsedSchema = parseSchema(schema);
     int newVersion = request.getNewVersion() != null ? request.getNewVersion() : 0;
@@ -878,7 +878,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     kafkaStore.lockFor(subject).lock();
     try {
       if (isLeader()) {
-        return registerSchemaTags(subject, schema, request);
+        return modifySchemaTags(subject, schema, request);
       } else {
         // forward registering request to the leader
         if (leaderIdentity != null) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/RuleSetHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/RuleSetHandler.java
@@ -16,6 +16,7 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.ConfigUpdateRequest;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.TagSchemaRequest;
@@ -48,7 +49,7 @@ public class RuleSetHandler {
     }
   }
 
-  public void handle(String subject, TagSchemaRequest request) {
+  public void handle(Schema schema, TagSchemaRequest request) {
     if (request.getRuleSet() != null) {
       log.warn("RuleSets are only supported by Confluent Enterprise and Confluent Cloud");
       request.setRuleSet(null);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/RuleSetHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/RuleSetHandler.java
@@ -18,6 +18,7 @@ package io.confluent.kafka.schemaregistry.storage;
 
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.ConfigUpdateRequest;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.TagSchemaRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +42,13 @@ public class RuleSetHandler {
   }
 
   public void handle(String subject, boolean normalize, RegisterSchemaRequest request) {
+    if (request.getRuleSet() != null) {
+      log.warn("RuleSets are only supported by Confluent Enterprise and Confluent Cloud");
+      request.setRuleSet(null);
+    }
+  }
+
+  public void handle(String subject, TagSchemaRequest request) {
     if (request.getRuleSet() != null) {
       log.warn("RuleSets are only supported by Confluent Enterprise and Confluent Cloud");
       request.setRuleSet(null);

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiRegisterSchemaTagsTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiRegisterSchemaTagsTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2023 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package io.confluent.kafka.schemaregistry.rest;
+
+import io.confluent.kafka.schemaregistry.ClusterTestHarness;
+import io.confluent.kafka.schemaregistry.client.rest.RestService;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaTags;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.TagSchemaRequest;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
+import io.confluent.kafka.schemaregistry.utils.TestUtils;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+public class RestApiRegisterSchemaTagsTest extends ClusterTestHarness {
+
+  public final String schemaString = "{" +
+      "\"type\":\"record\"," +
+      "\"name\":\"myrecord\"," +
+      "\"fields\":[{\"name\":\"f1\",\"type\":\"string\"}]" +
+      "}";
+
+  public RestApiRegisterSchemaTagsTest() {
+    super(1, true);
+  }
+
+  @Test
+  public void testRegisterSchemaTagsBasic() throws Exception {
+    String subject = "test";
+    TestUtils.registerAndVerifySchema(restApp.restClient, schemaString, 1, subject);
+
+    TagSchemaRequest tagSchemaRequest = new TagSchemaRequest();
+    tagSchemaRequest.setNewVersion(2);
+    tagSchemaRequest.setTagsToAdd(Collections.singletonList(
+        new SchemaTags(new SchemaEntity("myrecord", SchemaEntity.EntityType.SR_RECORD),
+            Collections.singletonList("TAG1"))));
+
+    String expectedSchema = "{" +
+        "\"type\":\"record\"," +
+        "\"name\":\"myrecord\"," +
+        "\"fields\":[{\"name\":\"f1\",\"type\":\"string\"}]," +
+        "\"confluent:tags\":[\"TAG1\"]}";
+    RegisterSchemaResponse responses = restApp.restClient
+        .registerSchemaTags(RestService.DEFAULT_REQUEST_PROPERTIES, tagSchemaRequest, subject, "latest");
+    assertEquals(expectedSchema, responses.getSchema());
+    assertEquals((Integer) 2, responses.getVersion());
+    assertEquals(2, responses.getId());
+    assertEquals("2", responses.getMetadata().getProperties().get("confluent:version"));
+  }
+
+  @Test
+  public void testRegisterSchemaTagsWithInvalidSchema() throws Exception {
+    // subject doesn't exist
+    TagSchemaRequest tagSchemaRequest = new TagSchemaRequest();
+    tagSchemaRequest.setNewVersion(2);
+    tagSchemaRequest.setTagsToAdd(Collections.singletonList(
+        new SchemaTags(new SchemaEntity("myrecord", SchemaEntity.EntityType.SR_RECORD),
+            Collections.singletonList("TAG1"))));
+    try {
+      RegisterSchemaResponse responses = restApp.restClient
+          .registerSchemaTags(RestService.DEFAULT_REQUEST_PROPERTIES, tagSchemaRequest, "non-exist", "1");
+    } catch (RestClientException e) {
+      assertEquals(Errors.SUBJECT_NOT_FOUND_ERROR_CODE, e.getErrorCode());
+    }
+
+    String subject = "test";
+    TestUtils.registerAndVerifySchema(restApp.restClient, schemaString, 1, subject);
+
+    // version doesn't exist
+    try {
+      RegisterSchemaResponse responses = restApp.restClient
+          .registerSchemaTags(RestService.DEFAULT_REQUEST_PROPERTIES, tagSchemaRequest, subject, "2");
+    } catch (RestClientException e) {
+      assertEquals(Errors.VERSION_NOT_FOUND_ERROR_CODE, e.getErrorCode());
+    }
+
+    // invalid version
+    try {
+      RegisterSchemaResponse responses = restApp.restClient
+          .registerSchemaTags(RestService.DEFAULT_REQUEST_PROPERTIES, tagSchemaRequest, subject, "-1");
+    } catch (RestClientException e) {
+      assertEquals(Errors.INVALID_SCHEMA_ERROR_CODE, e.getErrorCode());
+    }
+
+    // create tag on existing subject version
+    tagSchemaRequest.setNewVersion(1);
+    try {
+      RegisterSchemaResponse responses = restApp.restClient
+          .registerSchemaTags(RestService.DEFAULT_REQUEST_PROPERTIES, tagSchemaRequest, subject, "1");
+    } catch (RestClientException e) {
+      assertEquals(Errors.INVALID_SCHEMA_ERROR_CODE, e.getErrorCode());
+    }
+  }
+
+  @Test
+  public void testRegisterSchemaTagsWithInvalidTags() throws Exception {
+    String subject = "test";
+    TestUtils.registerAndVerifySchema(restApp.restClient, schemaString, 1, subject);
+
+    // invalid path
+    TagSchemaRequest tagSchemaRequest = new TagSchemaRequest();
+    tagSchemaRequest.setNewVersion(2);
+    tagSchemaRequest.setTagsToAdd(Collections.singletonList(
+        new SchemaTags(new SchemaEntity("does.not.exist", SchemaEntity.EntityType.SR_FIELD),
+            Collections.singletonList("TAG1"))));
+    try {
+      RegisterSchemaResponse responses = restApp.restClient
+          .registerSchemaTags(RestService.DEFAULT_REQUEST_PROPERTIES, tagSchemaRequest, subject, "1");
+    } catch (RestClientException e) {
+      assertEquals(Errors.INVALID_SCHEMA_ERROR_CODE, e.getErrorCode());
+    }
+  }
+}

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/protobuf/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/protobuf/RestApiTest.java
@@ -17,7 +17,12 @@
 package io.confluent.kafka.schemaregistry.rest.protobuf;
 
 import io.confluent.kafka.schemaregistry.CompatibilityLevel;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaTags;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.TagSchemaRequest;
 import io.confluent.kafka.schemaregistry.utils.ResourceLoader;
+import io.confluent.kafka.schemaregistry.utils.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -45,6 +50,7 @@ import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.serializers.protobuf.test.Root;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.junit.Assert.assertTrue;
 
@@ -439,6 +445,74 @@ public class RestApiTest extends ClusterTestHarness {
         + "}\n";
 
     registerAndVerifySchema(restApp.restClient, enumOptionSchemaString, 1, subject);
+  }
+
+  @Test
+  public void testRegisterSchemaTagsBasic() throws Exception {
+    String subject = "test";
+    String schemaString = "syntax = \"proto3\";\n" +
+        "package com.example;\n" +
+        "\n" +
+        "message Message1 {\n" +
+        "  string f1 = 1;\n" +
+        "  string f2 = 2;\n" +
+        "}\n";
+    registerAndVerifySchema(restApp.restClient, schemaString, 1, subject);
+
+    TagSchemaRequest tagSchemaRequest = new TagSchemaRequest();
+    tagSchemaRequest.setTagsToAdd(Arrays.asList(
+        new SchemaTags(new SchemaEntity("Message1.f1", SchemaEntity.EntityType.SR_FIELD),
+            Arrays.asList("TAG1")),
+        new SchemaTags(new SchemaEntity(".Message1.f1", SchemaEntity.EntityType.SR_FIELD),
+            Arrays.asList("TAG2"))
+        ));
+
+    String expectedSchema = "syntax = \"proto3\";\n" +
+        "package com.example;\n" +
+        "\n" +
+        "message Message1 {\n" +
+        "  string f1 = 1 [(confluent.field_meta) = {\n" +
+        "    tags: [\n" +
+        "      \"TAG1\",\n" +
+        "      \"TAG2\"\n" +
+        "    ]\n" +
+        "  }];\n" +
+        "  string f2 = 2;\n" +
+        "}\n";
+    RegisterSchemaResponse responses = restApp.restClient
+        .modifySchemaTags(RestService.DEFAULT_REQUEST_PROPERTIES, tagSchemaRequest, subject, "latest");
+    assertEquals(2, responses.getId());
+
+    Schema result = restApp.restClient.getLatestVersion(subject);
+    assertEquals(expectedSchema, result.getSchema());
+    assertEquals((Integer) 2, result.getVersion());
+    assertNull(result.getMetadata());
+
+    tagSchemaRequest = new TagSchemaRequest();
+    tagSchemaRequest.setNewVersion(3);
+    tagSchemaRequest.setTagsToRemove(Collections.singletonList(
+        new SchemaTags(new SchemaEntity("Message1.f1", SchemaEntity.EntityType.SR_FIELD),
+            Arrays.asList("TAG2"))));
+
+    expectedSchema = "syntax = \"proto3\";\n" +
+        "package com.example;\n" +
+        "\n" +
+        "message Message1 {\n" +
+        "  string f1 = 1 [(confluent.field_meta) = {\n" +
+        "    tags: [\n" +
+        "      \"TAG1\"\n" +
+        "    ]\n" +
+        "  }];\n" +
+        "  string f2 = 2;\n" +
+        "}\n";
+    responses = restApp.restClient
+        .modifySchemaTags(RestService.DEFAULT_REQUEST_PROPERTIES, tagSchemaRequest, subject, "latest");
+    assertEquals(3, responses.getId());
+
+    result = restApp.restClient.getLatestVersion(subject);
+    assertEquals(expectedSchema, result.getSchema());
+    assertEquals((Integer) 3, result.getVersion());
+    assertEquals("3", responses.getMetadata().getProperties().get("confluent:version"));
   }
 
   public static void registerAndVerifySchema(

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -36,7 +36,7 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
 import com.fasterxml.jackson.databind.ser.PropertyWriter;
 import com.google.common.collect.Lists;
-import io.confluent.kafka.schemaregistry.SchemaEntity;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
 import io.confluent.kafka.schemaregistry.rules.FieldTransform;
 import io.confluent.kafka.schemaregistry.rules.RuleContext;
 import io.confluent.kafka.schemaregistry.rules.RuleContext.FieldContext;

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -49,7 +49,6 @@ import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -869,7 +868,7 @@ public class JsonSchema implements ParsedSchema {
   private void modifySchemaTags(JsonNode node,
                                 Map<SchemaEntity, Set<String>> tagsToAddMap,
                                 Map<SchemaEntity, Set<String>> tagsToRemoveMap) {
-    Set<SchemaEntity> entityToModify = new HashSet<>(tagsToAddMap.keySet());
+    Set<SchemaEntity> entityToModify = new LinkedHashSet<>(tagsToAddMap.keySet());
     entityToModify.addAll(tagsToRemoveMap.keySet());
 
     for (SchemaEntity entity : entityToModify) {

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaUtils.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaUtils.java
@@ -36,7 +36,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import io.confluent.kafka.schemaregistry.SchemaEntity;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
 import io.confluent.kafka.schemaregistry.annotations.Schema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.databind.node.NumericNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.google.common.collect.ImmutableSet;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
-import io.confluent.kafka.schemaregistry.SchemaEntity;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
 import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -95,7 +95,7 @@ import com.squareup.wire.schema.internal.parser.ReservedElement;
 import com.squareup.wire.schema.internal.parser.RpcElement;
 import com.squareup.wire.schema.internal.parser.ServiceElement;
 import com.squareup.wire.schema.internal.parser.TypeElement;
-import io.confluent.kafka.schemaregistry.SchemaEntity;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.rules.FieldTransform;
 import io.confluent.kafka.schemaregistry.rules.RuleContext;
@@ -113,6 +113,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -145,10 +146,10 @@ import io.confluent.kafka.schemaregistry.protobuf.dynamic.MessageDefinition;
 
 import static com.google.common.base.CaseFormat.LOWER_UNDERSCORE;
 import static com.google.common.base.CaseFormat.UPPER_CAMEL;
-import static io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils.findMatchingFieldElement;
-import static io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils.findMatchingMessageElement;
+import static io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils.findMatchingElement;
 import static io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils.findMatchingNode;
 import static io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils.jsonToFile;
+import static io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils.removeLeadingDot;
 
 public class ProtobufSchema implements ParsedSchema {
 
@@ -2426,6 +2427,14 @@ public class ProtobufSchema implements ParsedSchema {
         getInlineTagsRecursively(tags, (EnumElement) type);
       }
     }
+    for (OneOfElement oneOfElement: messageElem.getOneOfs()) {
+      for(FieldElement oneOfField : oneOfElement.getFields()) {
+        ProtobufMeta fieldMeta = findMeta(CONFLUENT_FIELD_META, oneOfField.getOptions());
+        if (fieldMeta != null && fieldMeta.getTags() != null) {
+          tags.addAll(fieldMeta.getTags());
+        }
+      }
+    }
   }
 
   private void getInlineTagsRecursively(Set<String> tags, EnumElement enumElem) {
@@ -2454,26 +2463,38 @@ public class ProtobufSchema implements ParsedSchema {
                                 Map<SchemaEntity, Set<String>> tagsToRemoveMap) {
     Set<SchemaEntity> entityToModify = new HashSet<>(tagsToAddMap.keySet());
     entityToModify.addAll(tagsToRemoveMap.keySet());
+    Map<Object, OptionElement> optionCache = new HashMap<>();
 
     for (SchemaEntity entity : entityToModify) {
-      String[] identifiers = entity.getEntityPath().split("\\.");
-      MessageElement messageElement;
-      List<OptionElement> allOptions;
+      String[] identifiers = removeLeadingDot(entity.getEntityPath()).split("\\.");
+      List<OptionElement> allOptions = new LinkedList<>();
       Map<String, OptionElement> mergedOptions;
       String metaName;
       JsonNode entityNode;
+      Object matchingElement;
 
       if (SchemaEntity.EntityType.SR_RECORD == entity.getEntityType()) {
-        messageElement = findMatchingMessageElement(original, identifiers, identifiers.length);
-        entityNode = findMatchingNode(node, identifiers, identifiers.length);
-        allOptions = new LinkedList<>(messageElement.getOptions());
         metaName = CONFLUENT_MESSAGE_META;
+        matchingElement = findMatchingElement(original, identifiers, false);
+        MessageElement messageElement = (MessageElement) matchingElement;
+        entityNode = findMatchingNode(node, identifiers, false);
+        OptionElement cachedOptionElement = optionCache.get(matchingElement);
+        if (cachedOptionElement != null) {
+          allOptions.add(cachedOptionElement);
+        } else {
+          allOptions.addAll(messageElement.getOptions());
+        }
       } else {
-        messageElement = findMatchingMessageElement(original, identifiers, identifiers.length - 1);
-        FieldElement fieldElement = findMatchingFieldElement(messageElement, identifiers);
-        entityNode = findMatchingNode(node, identifiers, identifiers.length - 1);
-        allOptions = new LinkedList<>(fieldElement.getOptions());
         metaName = CONFLUENT_FIELD_META;
+        matchingElement = findMatchingElement(original, identifiers, true);
+        FieldElement fieldElement = (FieldElement) matchingElement;
+        entityNode = findMatchingNode(node, identifiers, true);
+        OptionElement cachedOptionElement = optionCache.get(matchingElement);
+        if (cachedOptionElement != null) {
+          allOptions.add(cachedOptionElement);
+        } else {
+          allOptions.addAll(fieldElement.getOptions());
+        }
       }
 
       Set<String> tagsToAdd = tagsToAddMap.get(entity);
@@ -2516,6 +2537,7 @@ public class ProtobufSchema implements ParsedSchema {
           }
         }
       }
+      optionCache.put(matchingElement, mergedOptions.get(metaName));
       ((ObjectNode) entityNode).replace("options", jsonMapper.valueToTree(mergedOptions.values()));
     }
   }

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -113,7 +113,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -2428,7 +2427,7 @@ public class ProtobufSchema implements ParsedSchema {
       }
     }
     for (OneOfElement oneOfElement: messageElem.getOneOfs()) {
-      for(FieldElement oneOfField : oneOfElement.getFields()) {
+      for (FieldElement oneOfField : oneOfElement.getFields()) {
         ProtobufMeta fieldMeta = findMeta(CONFLUENT_FIELD_META, oneOfField.getOptions());
         if (fieldMeta != null && fieldMeta.getTags() != null) {
           tags.addAll(fieldMeta.getTags());

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -148,7 +148,6 @@ import static com.google.common.base.CaseFormat.UPPER_CAMEL;
 import static io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils.findMatchingElement;
 import static io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils.findMatchingNode;
 import static io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils.jsonToFile;
-import static io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils.removeLeadingDot;
 
 public class ProtobufSchema implements ParsedSchema {
 
@@ -2465,7 +2464,7 @@ public class ProtobufSchema implements ParsedSchema {
     Map<Object, OptionElement> optionCache = new HashMap<>();
 
     for (SchemaEntity entity : entityToModify) {
-      String[] identifiers = removeLeadingDot(entity.getEntityPath()).split("\\.");
+      String[] identifiers = entity.getNormalizedPath().split("\\.");
       List<OptionElement> allOptions = new LinkedList<>();
       Map<String, OptionElement> mergedOptions;
       String metaName;

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -2451,7 +2451,7 @@ public class ProtobufSchema implements ParsedSchema {
   private Set<String> getInlineTags(FieldDescriptor fd) {
     if (fd.getOptions().hasExtension(MetaProto.fieldMeta)) {
       Meta meta = fd.getOptions().getExtension(MetaProto.fieldMeta);
-      return new HashSet<>(meta.getTagsList());
+      return new LinkedHashSet<>(meta.getTagsList());
     }
     return Collections.emptySet();
   }
@@ -2459,7 +2459,7 @@ public class ProtobufSchema implements ParsedSchema {
   private void modifySchemaTags(ProtoFileElement original, JsonNode node,
                                 Map<SchemaEntity, Set<String>> tagsToAddMap,
                                 Map<SchemaEntity, Set<String>> tagsToRemoveMap) {
-    Set<SchemaEntity> entityToModify = new HashSet<>(tagsToAddMap.keySet());
+    Set<SchemaEntity> entityToModify = new LinkedHashSet<>(tagsToAddMap.keySet());
     entityToModify.addAll(tagsToRemoveMap.keySet());
     Map<Object, OptionElement> optionCache = new HashMap<>();
 

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaUtils.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaUtils.java
@@ -118,14 +118,6 @@ public class ProtobufSchemaUtils {
     return jsonString.getBytes(StandardCharsets.UTF_8);
   }
 
-  public static String removeLeadingDot(String path) {
-    if (path.startsWith(".")) {
-      return path.substring(1);
-    } else {
-      return path;
-    }
-  }
-
   public static ProtoFileElement jsonToFile(JsonNode node) throws JsonProcessingException {
     return mapperWithProtoFileDeserializer.convertValue(node, ProtoFileElement.class);
   }

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaUtils.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaUtils.java
@@ -142,7 +142,8 @@ public class ProtobufSchemaUtils {
     return null;
   }
 
-  public static JsonNode findMatchingNode(JsonNode node, String[] identifiers, boolean isFieldPath) {
+  public static JsonNode findMatchingNode(JsonNode node, String[] identifiers,
+                                          boolean isFieldPath) {
     JsonNode nodePtr = null;
     // the idx of last message identifier (exclusive)
     int end = isFieldPath ? identifiers.length - 1 : identifiers.length;

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -2875,23 +2875,33 @@ public class ProtobufSchemaTest {
 
     Map<SchemaEntity, Set<String>> tags = new HashMap<>();
     tags.put(new SchemaEntity("SampleRecord", SchemaEntity.EntityType.SR_FIELD), toAdd);
-    assertThrows(IllegalArgumentException.class, () -> origin.copy(tags, Collections.emptyMap()));
+    assertThrows("Missing field", IllegalArgumentException.class,
+        () -> origin.copy(tags, Collections.emptyMap()));
 
     Map<SchemaEntity, Set<String>> tags2 = new HashMap<>();
     tags2.put(new SchemaEntity("SampleRecord.bad_oneof.f1", SchemaEntity.EntityType.SR_FIELD), toAdd);
-    assertThrows(IllegalArgumentException.class, () -> origin.copy(tags2, Collections.emptyMap()));
+    assertThrows("Bad oneOf fieldName", IllegalArgumentException.class,
+        () -> origin.copy(tags2, Collections.emptyMap()));
 
     Map<SchemaEntity, Set<String>> tags3 = new HashMap<>();
     tags3.put(new SchemaEntity("SampleRecord.f3", SchemaEntity.EntityType.SR_FIELD), toAdd);
-    assertThrows(IllegalArgumentException.class, () -> origin.copy(tags3, Collections.emptyMap()));
+    assertThrows("Non-existing field", IllegalArgumentException.class,
+        () -> origin.copy(tags3, Collections.emptyMap()));
 
     Map<SchemaEntity, Set<String>> tags4 = new HashMap<>();
     tags4.put(new SchemaEntity("badRecord", SchemaEntity.EntityType.SR_RECORD), toAdd);
-    assertThrows(IllegalArgumentException.class, () -> origin.copy(tags4, Collections.emptyMap()));
+    assertThrows("Non-existing message", IllegalArgumentException.class,
+        () -> origin.copy(tags4, Collections.emptyMap()));
 
     Map<SchemaEntity, Set<String>> tags5 = new HashMap<>();
     tags5.put(new SchemaEntity("..SampleRecord", SchemaEntity.EntityType.SR_RECORD), toAdd);
-    assertThrows(IllegalArgumentException.class, () -> origin.copy(tags5, Collections.emptyMap()));
+    assertThrows("Invalid path", IllegalArgumentException.class,
+        () -> origin.copy(tags5, Collections.emptyMap()));
+
+    Map<SchemaEntity, Set<String>> tags6 = new HashMap<>();
+    tags6.put(new SchemaEntity(".SampleRecord.f1", SchemaEntity.EntityType.SR_RECORD), toAdd);
+    assertThrows("Missing oneOf fieldName", IllegalArgumentException.class,
+        () -> origin.copy(tags6, Collections.emptyMap()));
   }
 
   @Test

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -2832,8 +2832,8 @@ public class ProtobufSchemaTest {
         "  oneof test_oneof {\n" +
         "    string f1 = 1 [(confluent.field_meta) = {\n" +
         "      tags: [\n" +
-        "        \"TAG2\",\n" +
-        "        \"TAG1\"\n" +
+        "        \"TAG1\",\n" +
+        "        \"TAG2\"\n" +
         "      ]\n" +
         "    }];\n" +
         "    int32 f2 = 2 [(confluent.field_meta) = {\n" +

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -42,6 +42,7 @@ import io.confluent.kafka.schemaregistry.protobuf.dynamic.MessageDefinition;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.Test;
 
@@ -2845,7 +2846,7 @@ public class ProtobufSchemaTest {
         "  }\n" +
         "}\n";
 
-    Map<SchemaEntity, Set<String>> tags = new HashMap<>();
+    Map<SchemaEntity, Set<String>> tags = new LinkedHashMap<>();
     tags.put(new SchemaEntity(".SampleRecord.f1",
         SchemaEntity.EntityType.SR_FIELD), Collections.singleton("TAG1"));
     tags.put(new SchemaEntity(".SampleRecord.test_oneof.f1",


### PR DESCRIPTION
- Implement `POST /subjects/{subject}/versions/{version}/tags`, which will register a new schema version with the given tags embedded into the schema string
- some bug fixes in the modifySchemaTags
- made improvement Protobuf SchemaEntity Path 
  -  make oneOf fieldName optional
  - make the leading dot optional


