### PR TITLE
DGS-7797: Added host.port to augment host.name

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -156,6 +156,8 @@ public class SchemaRegistryConfig extends RestConfig {
    */
   public static final String HOST_NAME_CONFIG = "host.name";
 
+  public static final String HOST_PORT_CONFIG = "host.port";
+
   public static final String SCHEMA_PROVIDERS_CONFIG = "schema.providers";
 
   /**
@@ -315,6 +317,8 @@ public class SchemaRegistryConfig extends RestConfig {
       "The host name. Make sure to set this if running SchemaRegistry "
       + "with multiple nodes. This name is also used in the endpoint for inter instance "
       + "communication";
+  protected static final String HOST_PORT_DOC =
+      "The host port. This port is used in the endpoint for inter instance communication";
   protected static final String SCHEMA_PROVIDERS_DOC =
       "  A list of classes to use as SchemaProvider. Implementing the interface "
           + "<code>SchemaProvider</code> allows you to add custom schema types to Schema Registry.";
@@ -510,6 +514,9 @@ public class SchemaRegistryConfig extends RestConfig {
     )
     .define(HOST_NAME_CONFIG, ConfigDef.Type.STRING, getDefaultHost(),
         ConfigDef.Importance.HIGH, HOST_DOC
+    )
+    .define(HOST_PORT_CONFIG, ConfigDef.Type.INT, SCHEMAREGISTRY_PORT_DEFAULT,
+        ConfigDef.Importance.MEDIUM, HOST_PORT_DOC
     )
     .define(SCHEMA_PROVIDERS_CONFIG, ConfigDef.Type.LIST, "",
         ConfigDef.Importance.LOW, SCHEMA_PROVIDERS_DOC

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistryTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistryTest.java
@@ -102,4 +102,43 @@ public class KafkaSchemaRegistryTest {
     assertEquals("Expected internal listener's name to be returned", "bob", listener.getName());
     assertEquals("Expected Scheme match", SchemaRegistryConfig.HTTP, listener.getUri().getScheme());
   }
+
+  @Test
+  public void testMyIdentityWithoutPortOverride() throws RestConfigException, SchemaRegistryException {
+    String listeners = "bob://localhost:123, http://localhost:456";
+    String listenerProtocolMap = "bob:https";
+    Properties props = new Properties();
+    props.setProperty(SchemaRegistryConfig.HOST_NAME_CONFIG, "schema.registry-0.example.com");
+    props.setProperty(RestConfig.LISTENERS_CONFIG, listeners);
+    props.setProperty(RestConfig.LISTENER_PROTOCOL_MAP_CONFIG, listenerProtocolMap);
+    props.setProperty(SchemaRegistryConfig.INTER_INSTANCE_LISTENER_NAME_CONFIG, "bob");
+    SchemaRegistryConfig config = new SchemaRegistryConfig(props);
+    SchemaRegistryIdentity schemaRegistryIdentity = new
+        SchemaRegistryIdentity("schema.registry-0.example.com", 123, true, "https");
+    NamedURI internalListener = KafkaSchemaRegistry.getInterInstanceListener(config.getListeners(),
+        config.interInstanceListenerName(), SchemaRegistryConfig.HTTP);
+
+    assertEquals(schemaRegistryIdentity,
+        KafkaSchemaRegistry.getMyIdentity(internalListener, true, config));
+  }
+
+  @Test
+  public void testMyIdentityWithPortOverride() throws RestConfigException, SchemaRegistryException {
+    String listeners = "bob://localhost:123, http://localhost:456";
+    String listenerProtocolMap = "bob:https";
+    Properties props = new Properties();
+    props.setProperty(SchemaRegistryConfig.HOST_NAME_CONFIG, "schema.registry-0.example.com");
+    props.setProperty(SchemaRegistryConfig.HOST_PORT_CONFIG, "443");
+    props.setProperty(RestConfig.LISTENERS_CONFIG, listeners);
+    props.setProperty(RestConfig.LISTENER_PROTOCOL_MAP_CONFIG, listenerProtocolMap);
+    props.setProperty(SchemaRegistryConfig.INTER_INSTANCE_LISTENER_NAME_CONFIG, "bob");
+    SchemaRegistryConfig config = new SchemaRegistryConfig(props);
+    SchemaRegistryIdentity schemaRegistryIdentity = new
+        SchemaRegistryIdentity("schema.registry-0.example.com", 443, true, "https");
+    NamedURI internalListener = KafkaSchemaRegistry.getInterInstanceListener(config.getListeners(),
+        config.interInstanceListenerName(), SchemaRegistryConfig.HTTP);
+
+    assertEquals(schemaRegistryIdentity,
+        KafkaSchemaRegistry.getMyIdentity(internalListener, true, config));
+  }
 }


### PR DESCRIPTION
https://confluentinc.atlassian.net/browse/DGS-7797

Customers using a stretched or active-passive deployment of SR clusters need a way to specify port information for inter instance communication between DCs. We're introducing a new config `host.port` specifically for such cases where the inter instance communication happens on external network and cannot use the internal 8081 port. For eg. one common deployment we see is the usage of Openshift Routes where the port is 443. 