### PR TITLE
DGS-7861: make BearerAuthCredentialProvider extend Closeable

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageFormatter.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageFormatter.java
@@ -132,5 +132,13 @@ public class AvroMessageFormatter extends SchemaMessageFormatter<Object> {
     public Object deserialize(String topic, byte[] payload) throws SerializationException {
       return super.deserialize(topic, isKey, payload, null);
     }
+
+    @Override
+    public void close() {
+      if (keyDeserializer != null) {
+        keyDeserializer.close();
+      }
+      super.close();
+    }
   }
 }

--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageFormatter.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageFormatter.java
@@ -134,7 +134,7 @@ public class AvroMessageFormatter extends SchemaMessageFormatter<Object> {
     }
 
     @Override
-    public void close() {
+    public void close() throws IOException {
       if (keyDeserializer != null) {
         keyDeserializer.close();
       }

--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
@@ -171,5 +171,13 @@ public class AvroMessageReader extends SchemaMessageReader<Object> {
     ) {
       return super.serializeImpl(subject, object, (AvroSchema) schema);
     }
+
+    @Override
+    public void close() {
+      if (keySerializer != null) {
+        keySerializer.close();
+      }
+      super.close();
+    }
   }
 }

--- a/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/formatter/AvroMessageReader.java
@@ -173,7 +173,7 @@ public class AvroMessageReader extends SchemaMessageReader<Object> {
     }
 
     @Override
-    public void close() {
+    public void close() throws IOException {
       if (keySerializer != null) {
         keySerializer.close();
       }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
@@ -19,6 +19,7 @@ package io.confluent.kafka.serializers;
 import org.apache.avro.Schema;
 import org.apache.kafka.common.serialization.Deserializer;
 
+import java.io.IOException;
 import java.util.Map;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -62,6 +63,10 @@ public class KafkaAvroDeserializer extends AbstractKafkaAvroDeserializer
 
   @Override
   public void close() {
-    super.close();
+    try {
+      super.close();
+    } catch (IOException e) {
+      throw new RuntimeException("Exception while closing deserializer", e);
+    }
   }
 }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
@@ -62,6 +62,6 @@ public class KafkaAvroDeserializer extends AbstractKafkaAvroDeserializer
 
   @Override
   public void close() {
-
+    super.close();
   }
 }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
@@ -18,6 +18,7 @@ package io.confluent.kafka.serializers;
 
 import org.apache.kafka.common.serialization.Serializer;
 
+import java.io.IOException;
 import java.util.Map;
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
@@ -64,6 +65,10 @@ public class KafkaAvroSerializer extends AbstractKafkaAvroSerializer implements 
 
   @Override
   public void close() {
-    super.close();
+    try {
+      super.close();
+    } catch (IOException e) {
+      throw new RuntimeException("Exception while closing serializer", e);
+    }
   }
 }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java
@@ -64,6 +64,6 @@ public class KafkaAvroSerializer extends AbstractKafkaAvroSerializer implements 
 
   @Override
   public void close() {
-
+    super.close();
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -683,7 +683,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   @Override
-  public void close() {
+  public void close() throws IOException {
     if (restService != null) {
       restService.close();
     }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -682,6 +682,13 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
     missingIdCache.invalidateAll();
   }
 
+  @Override
+  public void close() {
+    if (restService != null) {
+      restService.close();
+    }
+  }
+
   private void checkMissingSchemaCache(String subject, ParsedSchema schema, boolean normalize)
       throws RestClientException {
     if (missingSchemaCache.getIfPresent(

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -16,6 +16,7 @@
 
 package io.confluent.kafka.schemaregistry.client;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
@@ -29,7 +30,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 
-public interface SchemaRegistryClient extends SchemaVersionFetcher {
+public interface SchemaRegistryClient extends Closeable,SchemaVersionFetcher {
 
   public Optional<ParsedSchema> parseSchema(
       String schemaType,
@@ -266,4 +267,7 @@ public interface SchemaRegistryClient extends SchemaVersionFetcher {
   }
 
   public void reset();
+
+  @Override
+  default void close() {}
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -269,5 +269,5 @@ public interface SchemaRegistryClient extends Closeable, SchemaVersionFetcher {
   public void reset();
 
   @Override
-  default void close() {}
+  default void close() throws IOException {}
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -30,7 +30,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 
-public interface SchemaRegistryClient extends Closeable,SchemaVersionFetcher {
+public interface SchemaRegistryClient extends Closeable, SchemaVersionFetcher {
 
   public Optional<ParsedSchema> parseSchema(
       String schemaType,

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -35,14 +35,15 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
 import io.confluent.kafka.schemaregistry.client.security.basicauth.BasicAuthCredentialProviderFactory;
 import io.confluent.kafka.schemaregistry.client.security.bearerauth.BearerAuthCredentialProvider;
 
-import java.io.InputStreamReader;
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.config.ConfigException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
@@ -74,7 +75,7 @@ import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 /**
  * Rest access layer for sending requests to the schema registry.
  */
-public class RestService implements Configurable {
+public class RestService implements Closeable, Configurable {
 
   private static final Logger log = LoggerFactory.getLogger(RestService.class);
   private static final TypeReference<RegisterSchemaResponse> REGISTER_RESPONSE_TYPE =
@@ -1251,5 +1252,12 @@ public class RestService implements Configurable {
 
   public void setProxy(String proxyHost, int proxyPort) {
     this.proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
+  }
+
+  @Override
+  public void close() {
+    if (bearerAuthCredentialProvider != null) {
+      bearerAuthCredentialProvider.close();
+    }
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -1255,7 +1255,7 @@ public class RestService implements Closeable, Configurable {
   }
 
   @Override
-  public void close() {
+  public void close() throws IOException {
     if (bearerAuthCredentialProvider != null) {
       bearerAuthCredentialProvider.close();
     }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProvider.java
@@ -18,10 +18,14 @@ package io.confluent.kafka.schemaregistry.client.security.bearerauth;
 
 import org.apache.kafka.common.Configurable;
 
+import java.io.Closeable;
 import java.net.URL;
 
-public interface BearerAuthCredentialProvider extends Configurable {
+public interface BearerAuthCredentialProvider extends Closeable, Configurable {
   String alias();
 
   String getBearerToken(URL url);
+
+  @Override
+  default void close() {}
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProvider.java
@@ -27,5 +27,5 @@ public interface BearerAuthCredentialProvider extends Closeable, Configurable {
   String getBearerToken(URL url);
 
   @Override
-  default void close() {}
+  default void close() throws IOException {}
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProvider.java
@@ -19,6 +19,7 @@ package io.confluent.kafka.schemaregistry.client.security.bearerauth;
 import org.apache.kafka.common.Configurable;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.net.URL;
 
 public interface BearerAuthCredentialProvider extends Closeable, Configurable {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
@@ -141,7 +141,11 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
   public void onShutdown() {
 
     if (schemaRegistry != null) {
-      schemaRegistry.close();
+      try {
+        schemaRegistry.close();
+      } catch (IOException e) {
+        log.error("Error closing schema registry", e);
+      }
     }
 
     if (schemaRegistryResourceExtensions != null) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -1522,6 +1522,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     if (leaderElector != null) {
       leaderElector.close();
     }
+    if (leaderRestService != null) {
+      leaderRestService.close();
+    }
   }
 
   public void updateCompatibilityLevel(String subject, CompatibilityLevel newCompatibilityLevel)

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -1516,7 +1516,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   }
 
   @Override
-  public void close() {
+  public void close() throws IOException {
     log.info("Shutting down schema registry");
     kafkaStore.close();
     if (leaderElector != null) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -91,7 +92,7 @@ public interface SchemaRegistry extends SchemaVersionFetcher {
                             Schema newSchema,
                             List<Schema> previousSchemas) throws SchemaRegistryException;
 
-  void close();
+  void close() throws IOException;
 
   void deleteSchemaVersion(String subject, Schema schema,
                            boolean permanentDelete) throws SchemaRegistryException;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/tools/SchemaRegistryClientPerformance.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/tools/SchemaRegistryClientPerformance.java
@@ -85,7 +85,7 @@ public class SchemaRegistryClientPerformance extends SchemaRegistryPerformance {
   }
 
   @Override
-  protected void close() {
+  protected void close() throws IOException {
     if (client != null) {
       client.close();
     }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/tools/SchemaRegistryClientPerformance.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/tools/SchemaRegistryClientPerformance.java
@@ -83,5 +83,13 @@ public class SchemaRegistryClientPerformance extends SchemaRegistryPerformance {
     registeredSchemas++;
     cb.onCompletion(1, 0);
   }
+
+  @Override
+  protected void close() {
+    if (client != null) {
+      client.close();
+    }
+    super.close();
+  }
 }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/tools/SchemaRegistryPerformance.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/tools/SchemaRegistryPerformance.java
@@ -143,7 +143,7 @@ public class SchemaRegistryPerformance extends AbstractPerformanceTest {
     cb.onCompletion(1, 0);
   }
 
-  protected void close() {
+  protected void close() throws IOException {
     // We can see some failures due to things like timeouts, but we want it to be obvious
     // if there are too many failures (indicating a real underlying problem). 1% is an arbitrarily
     // chosen limit.

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/tools/SchemaRegistryPerformance.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/tools/SchemaRegistryPerformance.java
@@ -153,6 +153,9 @@ public class SchemaRegistryPerformance extends AbstractPerformanceTest {
                                  + " registered successfully out of " + targetRegisteredSchemas
                                  + " attempted");
     }
+    if (restService != null) {
+      restService.close();
+    }
   }
 
   @Override

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
@@ -79,7 +79,10 @@ public class RestApp {
   }
 
   public void stop() throws Exception {
-    restClient = null;
+    if (restClient != null) {
+      restClient.close();
+      restClient = null;
+    }
     if (restServer != null) {
       restServer.stop();
       restServer.join();

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageFormatter.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageFormatter.java
@@ -129,5 +129,13 @@ public class JsonSchemaMessageFormatter extends SchemaMessageFormatter<JsonNode>
     public JsonNode deserialize(String topic, byte[] payload) throws SerializationException {
       return (JsonNode) super.deserialize(false, topic, isKey, payload);
     }
+
+    @Override
+    public void close() {
+      if (keyDeserializer != null) {
+        keyDeserializer.close();
+      }
+      super.close();
+    }
   }
 }

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageFormatter.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageFormatter.java
@@ -131,7 +131,7 @@ public class JsonSchemaMessageFormatter extends SchemaMessageFormatter<JsonNode>
     }
 
     @Override
-    public void close() {
+    public void close() throws IOException {
       if (keyDeserializer != null) {
         keyDeserializer.close();
       }

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageReader.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageReader.java
@@ -170,7 +170,7 @@ public class JsonSchemaMessageReader extends SchemaMessageReader<JsonNode>
     }
 
     @Override
-    public void close() {
+    public void close() throws IOException {
       if (keySerializer != null) {
         keySerializer.close();
       }

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageReader.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/formatter/json/JsonSchemaMessageReader.java
@@ -168,5 +168,13 @@ public class JsonSchemaMessageReader extends SchemaMessageReader<JsonNode>
     ) {
       return super.serializeImpl(subject, object, (JsonSchema) schema);
     }
+
+    @Override
+    public void close() {
+      if (keySerializer != null) {
+        keySerializer.close();
+      }
+      super.close();
+    }
   }
 }

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaDeserializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaDeserializer.java
@@ -19,6 +19,7 @@ package io.confluent.kafka.serializers.json;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.kafka.common.serialization.Deserializer;
 
+import java.io.IOException;
 import java.util.Map;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -81,6 +82,10 @@ public class KafkaJsonSchemaDeserializer<T> extends AbstractKafkaJsonSchemaDeser
 
   @Override
   public void close() {
-    super.close();
+    try {
+      super.close();
+    } catch (IOException e) {
+      throw new RuntimeException("Exception while closing deserializer", e);
+    }
   }
 }

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaDeserializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaDeserializer.java
@@ -81,6 +81,6 @@ public class KafkaJsonSchemaDeserializer<T> extends AbstractKafkaJsonSchemaDeser
 
   @Override
   public void close() {
-
+    super.close();
   }
 }

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializer.java
@@ -90,6 +90,10 @@ public class KafkaJsonSchemaSerializer<T> extends AbstractKafkaJsonSchemaSeriali
 
   @Override
   public void close() {
-    super.close();
+    try {
+      super.close();
+    } catch (IOException e) {
+      throw new RuntimeException("Exception while closing serializer", e);
+    }
   }
 }

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializer.java
@@ -90,5 +90,6 @@ public class KafkaJsonSchemaSerializer<T> extends AbstractKafkaJsonSchemaSeriali
 
   @Override
   public void close() {
+    super.close();
   }
 }

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/DownloadSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/DownloadSchemaRegistryMojo.java
@@ -29,6 +29,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -175,7 +176,11 @@ public class DownloadSchemaRegistryMojo extends SchemaRegistryMojo {
         );
       }
     }
-    close();
+    try {
+      close();
+    } catch (IOException e) {
+      throw new MojoExecutionException("Exception while closing schema registry client", e);
+    }
   }
 
   private String getExtension(ParsedSchema parsedSchema) {

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/DownloadSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/DownloadSchemaRegistryMojo.java
@@ -175,6 +175,7 @@ public class DownloadSchemaRegistryMojo extends SchemaRegistryMojo {
         );
       }
     }
+    close();
   }
 
   private String getExtension(ParsedSchema parsedSchema) {

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
@@ -21,6 +21,7 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -101,7 +102,7 @@ public abstract class SchemaRegistryMojo extends AbstractMojo implements Closeab
   }
 
   @Override
-  public void close() {
+  public void close() throws IOException {
     if (client != null) {
       client.close();
     }

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/SchemaRegistryMojo.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.utils.Utils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -35,7 +36,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
 import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 
-public abstract class SchemaRegistryMojo extends AbstractMojo {
+public abstract class SchemaRegistryMojo extends AbstractMojo implements Closeable {
 
   @Parameter(required = true)
   List<String> schemaRegistryUrls;
@@ -97,5 +98,12 @@ public abstract class SchemaRegistryMojo extends AbstractMojo {
     return Arrays.asList(
         new AvroSchemaProvider(), new JsonSchemaProvider(), new ProtobufSchemaProvider()
     );
+  }
+
+  @Override
+  public void close() {
+    if (client != null) {
+      client.close();
+    }
   }
 }

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/UploadSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/UploadSchemaRegistryMojo.java
@@ -123,6 +123,7 @@ public abstract class UploadSchemaRegistryMojo extends SchemaRegistryMojo {
       if (!success) {
         failures++;
       }
+      close();
     } catch (Exception ex) {
       getLog().error("Exception thrown while processing " + key, ex);
       errors++;

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/formatter/protobuf/ProtobufMessageFormatter.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/formatter/protobuf/ProtobufMessageFormatter.java
@@ -147,5 +147,13 @@ public class ProtobufMessageFormatter extends SchemaMessageFormatter<Message> {
     public Message deserialize(String topic, byte[] payload) throws SerializationException {
       return (Message) super.deserialize(false, topic, isKey, payload);
     }
+
+    @Override
+    public void close() {
+      if (keyDeserializer != null) {
+        keyDeserializer.close();
+      }
+      super.close();
+    }
   }
 }

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/formatter/protobuf/ProtobufMessageFormatter.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/formatter/protobuf/ProtobufMessageFormatter.java
@@ -149,7 +149,7 @@ public class ProtobufMessageFormatter extends SchemaMessageFormatter<Message> {
     }
 
     @Override
-    public void close() {
+    public void close() throws IOException {
       if (keyDeserializer != null) {
         keyDeserializer.close();
       }

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/formatter/protobuf/ProtobufMessageReader.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/formatter/protobuf/ProtobufMessageReader.java
@@ -17,6 +17,8 @@ package io.confluent.kafka.formatter.protobuf;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
+
+import java.io.IOException;
 import java.util.Properties;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Serializer;
@@ -158,7 +160,7 @@ public class ProtobufMessageReader extends SchemaMessageReader<Message> {
     }
 
     @Override
-    public void close() {
+    public void close() throws IOException {
       if (keySerializer != null) {
         keySerializer.close();
       }

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/formatter/protobuf/ProtobufMessageReader.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/formatter/protobuf/ProtobufMessageReader.java
@@ -156,5 +156,13 @@ public class ProtobufMessageReader extends SchemaMessageReader<Message> {
     ) {
       return super.serializeImpl(subject, topic, isKey, object, (ProtobufSchema) schema);
     }
+
+    @Override
+    public void close() {
+      if (keySerializer != null) {
+        keySerializer.close();
+      }
+      super.close();
+    }
   }
 }

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufDeserializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufDeserializer.java
@@ -78,6 +78,6 @@ public class KafkaProtobufDeserializer<T extends Message>
 
   @Override
   public void close() {
-
+    super.close();
   }
 }

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufDeserializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufDeserializer.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Message;
 import org.apache.kafka.common.serialization.Deserializer;
 
+import java.io.IOException;
 import java.util.Map;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
@@ -78,6 +79,10 @@ public class KafkaProtobufDeserializer<T extends Message>
 
   @Override
   public void close() {
-    super.close();
+    try {
+      super.close();
+    } catch (IOException e) {
+      throw new RuntimeException("Exception while closing deserializer", e);
+    }
   }
 }

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufSerializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufSerializer.java
@@ -103,6 +103,10 @@ public class KafkaProtobufSerializer<T extends Message>
 
   @Override
   public void close() {
-    super.close();
+    try {
+      super.close();
+    } catch (IOException e) {
+      throw new RuntimeException("Exception while closing serializer", e);
+    }
   }
 }

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufSerializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufSerializer.java
@@ -103,5 +103,6 @@ public class KafkaProtobufSerializer<T extends Message>
 
   @Override
   public void close() {
+    super.close();
   }
 }

--- a/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageDeserializer.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageDeserializer.java
@@ -20,6 +20,7 @@ import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Deserializer;
 
 import java.io.Closeable;
+import java.io.IOException;
 
 public interface SchemaMessageDeserializer<T> extends Closeable {
 

--- a/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageDeserializer.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageDeserializer.java
@@ -19,11 +19,16 @@ package io.confluent.kafka.formatter;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Deserializer;
 
-public interface SchemaMessageDeserializer<T> {
+import java.io.Closeable;
+
+public interface SchemaMessageDeserializer<T> extends Closeable {
 
   Deserializer getKeyDeserializer();
 
   Object deserializeKey(String topic, byte[] payload);
 
   T deserialize(String topic, byte[] payload) throws SerializationException;
+
+  @Override
+  default void close() {}
 }

--- a/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageDeserializer.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageDeserializer.java
@@ -30,5 +30,5 @@ public interface SchemaMessageDeserializer<T> extends Closeable {
   T deserialize(String topic, byte[] payload) throws SerializationException;
 
   @Override
-  default void close() {}
+  default void close() throws IOException {}
 }

--- a/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageFormatter.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageFormatter.java
@@ -198,7 +198,9 @@ public abstract class SchemaMessageFormatter<T> implements MessageFormatter {
 
   @Override
   public void close() {
-    // nothing to do
+    if (deserializer != null) {
+      deserializer.close();
+    }
   }
 
   private static final int MAGIC_BYTE = 0x0;

--- a/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageFormatter.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageFormatter.java
@@ -199,7 +199,11 @@ public abstract class SchemaMessageFormatter<T> implements MessageFormatter {
   @Override
   public void close() {
     if (deserializer != null) {
-      deserializer.close();
+      try {
+        deserializer.close();
+      } catch (IOException e) {
+        throw new RuntimeException("Exception while closing deserializer", e);
+      }
     }
   }
 

--- a/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageReader.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageReader.java
@@ -383,7 +383,11 @@ public abstract class SchemaMessageReader<T> implements MessageReader {
   @Override
   public void close() {
     if (serializer != null) {
-      serializer.close();
+      try {
+        serializer.close();
+      } catch (IOException e) {
+        throw new RuntimeException("Exception while closing serializer", e);
+      }
     }
   }
 }

--- a/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageReader.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageReader.java
@@ -382,6 +382,8 @@ public abstract class SchemaMessageReader<T> implements MessageReader {
 
   @Override
   public void close() {
-    // nothing to do
+    if (serializer != null) {
+      serializer.close();
+    }
   }
 }

--- a/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageSerializer.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageSerializer.java
@@ -20,7 +20,9 @@ import org.apache.kafka.common.serialization.Serializer;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 
-public interface SchemaMessageSerializer<T> {
+import java.io.Closeable;
+
+public interface SchemaMessageSerializer<T> extends Closeable {
 
   Serializer getKeySerializer();
 
@@ -33,4 +35,7 @@ public interface SchemaMessageSerializer<T> {
       T object,
       ParsedSchema schema
   );
+
+  @Override
+  default void close() {}
 }

--- a/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageSerializer.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageSerializer.java
@@ -21,6 +21,7 @@ import org.apache.kafka.common.serialization.Serializer;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 
 import java.io.Closeable;
+import java.io.IOException;
 
 public interface SchemaMessageSerializer<T> extends Closeable {
 

--- a/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageSerializer.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageSerializer.java
@@ -37,5 +37,5 @@ public interface SchemaMessageSerializer<T> extends Closeable {
   );
 
   @Override
-  default void close() {}
+  default void close() throws IOException {}
 }

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -18,6 +18,8 @@ package io.confluent.kafka.serializers;
 
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.utils.BoundedConcurrentHashMap;
+
+import java.io.Closeable;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -48,7 +50,7 @@ import io.confluent.kafka.serializers.subject.TopicNameStrategy;
 /**
  * Common fields and helper methods for both the serializer and the deserializer.
  */
-public abstract class AbstractKafkaSchemaSerDe {
+public abstract class AbstractKafkaSchemaSerDe implements Closeable {
 
   protected static final byte MAGIC_BYTE = 0x0;
   protected static final int idSize = 4;
@@ -259,6 +261,13 @@ public abstract class AbstractKafkaSchemaSerDe {
       return new InvalidConfigurationException(e.getMessage());
     } else {
       return new SerializationException(errorMessage, e);
+    }
+  }
+
+  @Override
+  public void close() {
+    if (schemaRegistry != null) {
+      schemaRegistry.close();
     }
   }
 

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -265,7 +265,7 @@ public abstract class AbstractKafkaSchemaSerDe implements Closeable {
   }
 
   @Override
-  public void close() {
+  public void close() throws IOException {
     if (schemaRegistry != null) {
       schemaRegistry.close();
     }


### PR DESCRIPTION
This is a partial fix for the memory leak caused by `MdsBearerAuthProvider`. 
This change does not include the Converters which requires a KIP.