### PR TITLE
MINOR pass DekRegistry to cache update handlers

### DIFF
--- a/dek-registry/src/main/java/io/confluent/dekregistry/storage/DekCacheUpdateHandler.java
+++ b/dek-registry/src/main/java/io/confluent/dekregistry/storage/DekCacheUpdateHandler.java
@@ -18,4 +18,6 @@ package io.confluent.dekregistry.storage;
 import io.kcache.CacheUpdateHandler;
 
 public interface DekCacheUpdateHandler extends CacheUpdateHandler<EncryptionKeyId, EncryptionKey> {
+
+  String DEK_REGISTRY = "dekRegistry";
 }

--- a/dek-registry/src/main/java/io/confluent/dekregistry/storage/DekRegistry.java
+++ b/dek-registry/src/main/java/io/confluent/dekregistry/storage/DekRegistry.java
@@ -185,6 +185,7 @@ public class DekRegistry implements Closeable {
       DekRegistryConfig config) {
     Map<String, Object> handlerConfigs =
         config.originalsWithPrefix(DekRegistryConfig.DEK_REGISTRY_UPDATE_HANDLERS_CONFIG + ".");
+    handlerConfigs.put(DekCacheUpdateHandler.DEK_REGISTRY, this);
     List<DekCacheUpdateHandler> customCacheHandlers =
         config.getConfiguredInstances(DekRegistryConfig.DEK_REGISTRY_UPDATE_HANDLERS_CONFIG,
         DekCacheUpdateHandler.class,


### PR DESCRIPTION
This will be used later when exporting deks for Schema Linking