### PR TITLE
DGS-8112 Allow properties to be omitted during serialization

### DIFF
--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaSerializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaSerializer.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafka.serializers.json;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -69,6 +70,10 @@ public abstract class AbstractKafkaJsonSchemaSerializer<T> extends AbstractKafka
     this.specVersion = SpecificationVersion.get(
         config.getString(KafkaJsonSchemaSerializerConfig.SCHEMA_SPEC_VERSION));
     this.oneofForNullables = config.getBoolean(KafkaJsonSchemaSerializerConfig.ONEOF_FOR_NULLABLES);
+    String inclusion = config.getString(KafkaJsonSchemaSerializerConfig.DEFAULT_PROPERTY_INCLUSION);
+    if (inclusion != null) {
+      this.objectMapper.setDefaultPropertyInclusion(JsonInclude.Include.valueOf(inclusion));
+    }
     this.failUnknownProperties =
         config.getBoolean(KafkaJsonSchemaDeserializerConfig.FAIL_UNKNOWN_PROPERTIES);
     this.validate = config.getBoolean(KafkaJsonSchemaSerializerConfig.FAIL_INVALID_SCHEMA);

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializerConfig.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializerConfig.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafka.serializers.json;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.confluent.kafka.schemaregistry.json.SpecificationVersion;
 import io.confluent.kafka.schemaregistry.utils.EnumRecommender;
 import java.util.Locale;
@@ -51,6 +52,10 @@ public class KafkaJsonSchemaSerializerConfig extends AbstractKafkaSchemaSerDeCon
   public static final String ONEOF_FOR_NULLABLES_DOC = "Whether JSON schemas derived from objects "
       + "will use oneOf for nullable fields";
 
+  public static final String DEFAULT_PROPERTY_INCLUSION = "json.default.property.inclusion";
+  public static final String DEFAULT_PROPERTY_INCLUSION_DOC = "Controls the inclusion of "
+      + "properties during serialization";
+
   public static final String JSON_INDENT_OUTPUT = "json.indent.output";
   public static final boolean JSON_INDENT_OUTPUT_DEFAULT = false;
   public static final String JSON_INDENT_OUTPUT_DOC = "Whether JSON output should be indented "
@@ -85,6 +90,12 @@ public class KafkaJsonSchemaSerializerConfig extends AbstractKafkaSchemaSerDeCon
         ONEOF_FOR_NULLABLES_DEFAULT,
         ConfigDef.Importance.MEDIUM,
         ONEOF_FOR_NULLABLES_DOC
+    ).define(DEFAULT_PROPERTY_INCLUSION,
+        ConfigDef.Type.STRING,
+        null,
+        EnumRecommender.in(JsonInclude.Include.values()),
+        ConfigDef.Importance.MEDIUM,
+        DEFAULT_PROPERTY_INCLUSION_DOC
     ).define(JSON_INDENT_OUTPUT,
         ConfigDef.Type.BOOLEAN,
         JSON_INDENT_OUTPUT_DEFAULT,

--- a/json-schema-serializer/src/test/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializerTest.java
+++ b/json-schema-serializer/src/test/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializerTest.java
@@ -69,6 +69,7 @@ public class KafkaJsonSchemaSerializerTest {
     latestConfig.put(KafkaJsonSchemaSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "bogus");
     latestConfig.put(KafkaJsonSchemaSerializerConfig.USE_LATEST_VERSION, true);
     latestConfig.put(KafkaJsonSchemaSerializerConfig.LATEST_COMPATIBILITY_STRICT, false);
+    latestConfig.put(KafkaJsonSchemaSerializerConfig.DEFAULT_PROPERTY_INCLUSION, "NON_NULL");
     latestSerializer = new KafkaJsonSchemaSerializer<>(schemaRegistry, new HashMap(latestConfig));
     topic = "test";
   }
@@ -157,6 +158,17 @@ public class KafkaJsonSchemaSerializerTest {
     User user = new User("john", "doe", (short) -1, "jack", LocalDate.parse("2018-12-27"));
 
     byte[] bytes = serializer.serialize("foo", user);
+    Object deserialized = getDeserializer(User.class).deserialize(topic, bytes);
+    assertEquals(user, deserialized);
+  }
+
+  @Test
+  public void serializeUserIgnoreNulls() throws Exception {
+    User user = new User("john", "doe", (short) 50, "jack", null);
+    JsonSchema userSchema = JsonSchemaUtils.getSchema(user, null, false, null);
+    schemaRegistry.register(topic + "-value", userSchema);
+
+    byte[] bytes = latestSerializer.serialize(topic, user);
     Object deserialized = getDeserializer(User.class).deserialize(topic, bytes);
     assertEquals(user, deserialized);
   }


### PR DESCRIPTION
Add a config to allow properties to be omitted during serialization.  Fixes #2732