### PR TITLE
Ensure kek name is prefixed with context

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/filters/ContextFilter.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/filters/ContextFilter.java
@@ -107,7 +107,10 @@ public class ContextFilter implements ContainerRequestFilter {
       }
 
       boolean isRootConfigOrMode = isRootConfigOrMode(isFirst, uriPathStr);
-      if (uriPathStr.equals("subjects") || uriPathStr.equals("deks") || isRootConfigOrMode) {
+      if (uriPathStr.equals("subjects")
+          || uriPathStr.equals("keks")
+          || uriPathStr.equals("deks")
+          || isRootConfigOrMode) {
         subjectPathFound = true;
         if (isRootConfigOrMode) {
           configOrModeFound = true;

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/filters/ContextFilterTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/filters/ContextFilterTest.java
@@ -183,11 +183,21 @@ public class ContextFilterTest {
   }
 
   @Test
+  public void testKekPartOfUri() {
+    String path = "/contexts/.test-ctx/dek-registry/v1/keks/test-kek";
+    Assert.assertEquals(
+        "Dek must be prefixed",
+        "/dek-registry/v1/keks/:.test-ctx:test-kek/",
+        contextFilter.modifyUri(UriBuilder.fromPath(path), path, new MultivaluedHashMap<>()).getPath()
+    );
+  }
+
+  @Test
   public void testDekPartOfUri() {
     String path = "/contexts/.test-ctx/dek-registry/v1/keks/test-kek/deks/test-subject";
     Assert.assertEquals(
         "Dek must be prefixed",
-        "/dek-registry/v1/keks/test-kek/deks/:.test-ctx:test-subject/",
+        "/dek-registry/v1/keks/:.test-ctx:test-kek/deks/:.test-ctx:test-subject/",
         contextFilter.modifyUri(UriBuilder.fromPath(path), path, new MultivaluedHashMap<>()).getPath()
     );
   }


### PR DESCRIPTION
Simliar to deks, ensure that kek names are prefixed by context by the ContextFilter