### PR TITLE
DGS-7866: Disallow properties starting with $ by default in JsonSchema

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
@@ -180,7 +180,7 @@ public interface ParsedSchema {
    * Validates the schema and ensures all references are resolved properly.
    * Throws an exception if the schema is not valid.
    */
-  default void validate() {
+  default void validate(boolean strict) {
   }
 
   /**

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Config.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Config.java
@@ -32,6 +32,8 @@ public class Config {
 
   private String alias;
   private Boolean normalize;
+
+  private Boolean validateFields;
   private String compatibilityLevel;
   private String compatibilityGroup;
   private Metadata defaultMetadata;
@@ -42,6 +44,7 @@ public class Config {
   @JsonCreator
   public Config(@JsonProperty("alias") String alias,
                 @JsonProperty("normalize") Boolean normalize,
+                @JsonProperty("validateFields") Boolean validateFields,
                 @JsonProperty("compatibilityLevel") String compatibilityLevel,
                 @JsonProperty("compatibilityGroup") String compatibilityGroup,
                 @JsonProperty("defaultMetadata") Metadata defaultMetadata,
@@ -50,6 +53,7 @@ public class Config {
                 @JsonProperty("overrideRuleSet") RuleSet overrideRuleSet) {
     this.alias = alias;
     this.normalize = normalize;
+    this.validateFields = validateFields;
     this.compatibilityLevel = compatibilityLevel;
     this.compatibilityGroup = compatibilityGroup;
     this.defaultMetadata = defaultMetadata;
@@ -68,6 +72,7 @@ public class Config {
   public Config(ConfigUpdateRequest request) {
     this.alias = request.getAlias();
     this.normalize = request.isNormalize();
+    this.validateFields = request.isValidateFields();
     this.compatibilityLevel = request.getCompatibilityLevel();
     this.compatibilityGroup = request.getCompatibilityGroup();
     this.defaultMetadata = request.getDefaultMetadata();
@@ -94,6 +99,16 @@ public class Config {
   @JsonProperty("normalize")
   public void setNormalize(Boolean normalize) {
     this.normalize = normalize;
+  }
+
+  @JsonProperty("validateFields")
+  public Boolean isValidateFields() {
+    return validateFields;
+  }
+
+  @JsonProperty("validateFields")
+  public void setValidateFields(Boolean validateFieldNames) {
+    this.validateFields = validateFieldNames;
   }
 
   @Schema(description = "Compatibility Level",
@@ -179,6 +194,7 @@ public class Config {
     Config config = (Config) o;
     return Objects.equals(alias, config.alias)
         && Objects.equals(normalize, config.normalize)
+        && Objects.equals(validateFields, config.validateFields)
         && Objects.equals(compatibilityLevel, config.compatibilityLevel)
         && Objects.equals(compatibilityGroup, config.compatibilityGroup)
         && Objects.equals(defaultMetadata, config.defaultMetadata)
@@ -189,7 +205,7 @@ public class Config {
 
   @Override
   public int hashCode() {
-    return Objects.hash(alias, normalize, compatibilityLevel, compatibilityGroup,
+    return Objects.hash(alias, normalize, validateFields, compatibilityLevel, compatibilityGroup,
         defaultMetadata, overrideMetadata, defaultRuleSet, overrideRuleSet);
   }
 
@@ -198,6 +214,7 @@ public class Config {
     return "Config{"
         + "alias='" + alias + '\''
         + ", normalize=" + normalize
+        + ", validateFields=" + validateFields
         + ", compatibilityLevel='" + compatibilityLevel + '\''
         + ", compatibilityGroup='" + compatibilityGroup + '\''
         + ", defaultMetadata=" + defaultMetadata

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/ConfigUpdateRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/ConfigUpdateRequest.java
@@ -35,6 +35,7 @@ public class ConfigUpdateRequest {
 
   private String alias;
   private Boolean normalize;
+  private Boolean validateFields;
   private String compatibilityLevel;
   private String compatibilityGroup;
   private Metadata defaultMetadata;
@@ -48,6 +49,7 @@ public class ConfigUpdateRequest {
   public ConfigUpdateRequest(Config config) {
     this.alias = config.getAlias();
     this.normalize = config.isNormalize();
+    this.validateFields = config.isValidateFields();
     this.compatibilityLevel = config.getCompatibilityLevel();
     this.compatibilityGroup = config.getCompatibilityGroup();
     this.defaultMetadata = config.getDefaultMetadata();
@@ -78,6 +80,16 @@ public class ConfigUpdateRequest {
   @JsonProperty("normalize")
   public void setNormalize(Boolean normalize) {
     this.normalize = normalize;
+  }
+
+  @JsonProperty("validateFields")
+  public Boolean isValidateFields() {
+    return validateFields;
+  }
+
+  @JsonProperty("validateFields")
+  public void setValidateFields(Boolean validateFields) {
+    this.validateFields = validateFields;
   }
 
   @Schema(description = "Compatibility Level",
@@ -159,6 +171,7 @@ public class ConfigUpdateRequest {
     ConfigUpdateRequest that = (ConfigUpdateRequest) o;
     return Objects.equals(alias, that.alias)
         && Objects.equals(normalize, that.normalize)
+        && Objects.equals(validateFields, that.validateFields)
         && Objects.equals(compatibilityLevel, that.compatibilityLevel)
         && Objects.equals(compatibilityGroup, that.compatibilityGroup)
         && Objects.equals(defaultMetadata, that.defaultMetadata)
@@ -169,7 +182,7 @@ public class ConfigUpdateRequest {
 
   @Override
   public int hashCode() {
-    return Objects.hash(alias, normalize, compatibilityLevel, compatibilityGroup,
+    return Objects.hash(alias, normalize, validateFields, compatibilityLevel, compatibilityGroup,
         defaultMetadata, overrideMetadata, defaultRuleSet, overrideRuleSet);
   }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/ConfigValue.java
@@ -30,6 +30,7 @@ public class ConfigValue extends SubjectValue {
 
   private String alias;
   private Boolean normalize;
+  private Boolean validateFields;
   private CompatibilityLevel compatibilityLevel;
   private String compatibilityGroup;
   private Metadata defaultMetadata;
@@ -40,6 +41,7 @@ public class ConfigValue extends SubjectValue {
   public ConfigValue(@JsonProperty("subject") String subject,
                      @JsonProperty("alias") String alias,
                      @JsonProperty("normalize") Boolean normalize,
+                     @JsonProperty("validateFields") Boolean validateFields,
                      @JsonProperty("compatibilityLevel") CompatibilityLevel compatibilityLevel,
                      @JsonProperty("compatibilityGroup") String compatibilityGroup,
                      @JsonProperty("defaultMetadata") Metadata defaultMetadata,
@@ -49,6 +51,7 @@ public class ConfigValue extends SubjectValue {
     super(subject);
     this.alias = alias;
     this.normalize = normalize;
+    this.validateFields = validateFields;
     this.compatibilityLevel = compatibilityLevel;
     this.compatibilityGroup = compatibilityGroup;
     this.defaultMetadata = defaultMetadata;
@@ -61,6 +64,7 @@ public class ConfigValue extends SubjectValue {
     super(subject);
     this.alias = configEntity.getAlias();
     this.normalize = configEntity.isNormalize();
+    this.validateFields = configEntity.isValidateFields();
     this.compatibilityLevel = CompatibilityLevel.forName(configEntity.getCompatibilityLevel());
     this.compatibilityGroup = configEntity.getCompatibilityGroup();
     io.confluent.kafka.schemaregistry.client.rest.entities.Metadata defaultMetadata =
@@ -81,6 +85,7 @@ public class ConfigValue extends SubjectValue {
     super(subject);
     this.alias = configEntity.getAlias();
     this.normalize = configEntity.isNormalize();
+    this.validateFields = configEntity.isValidateFields();
     this.compatibilityLevel = CompatibilityLevel.forName(configEntity.getCompatibilityLevel());
     this.compatibilityGroup = configEntity.getCompatibilityGroup();
     io.confluent.kafka.schemaregistry.client.rest.entities.Metadata defaultMetadata =
@@ -116,6 +121,16 @@ public class ConfigValue extends SubjectValue {
   @JsonProperty("normalize")
   public void setNormalize(Boolean normalize) {
     this.normalize = normalize;
+  }
+
+  @JsonProperty("validateFields")
+  public Boolean isValidateFields() {
+    return validateFields;
+  }
+
+  @JsonProperty("validateFields")
+  public void setValidateFields(Boolean validateFields) {
+    this.validateFields = validateFields;
   }
 
   @JsonProperty("compatibilityLevel")
@@ -192,6 +207,7 @@ public class ConfigValue extends SubjectValue {
     ConfigValue that = (ConfigValue) o;
     return Objects.equals(alias, that.alias)
         && Objects.equals(normalize, that.normalize)
+        && Objects.equals(validateFields, that.validateFields)
         && compatibilityLevel == that.compatibilityLevel
         && Objects.equals(compatibilityGroup, that.compatibilityGroup)
         && Objects.equals(defaultMetadata, that.defaultMetadata)
@@ -202,8 +218,9 @@ public class ConfigValue extends SubjectValue {
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), alias, normalize, compatibilityLevel, compatibilityGroup,
-        defaultMetadata, overrideMetadata, defaultRuleSet, overrideRuleSet);
+    return Objects.hash(super.hashCode(), alias, normalize, validateFields, compatibilityLevel,
+            compatibilityGroup, defaultMetadata, overrideMetadata, defaultRuleSet,
+            overrideRuleSet);
   }
 
   @Override
@@ -211,6 +228,7 @@ public class ConfigValue extends SubjectValue {
     return "ConfigValue{"
         + "alias='" + alias + '\''
         + ", normalize=" + normalize
+        + ", validateFields=" + validateFields
         + ", compatibilityLevel=" + compatibilityLevel
         + ", compatibilityGroup='" + compatibilityGroup + '\''
         + ", defaultMetadata=" + defaultMetadata
@@ -229,6 +247,7 @@ public class ConfigValue extends SubjectValue {
     return new Config(
         alias,
         normalize,
+        validateFields,
         compatibilityLevel != null ? compatibilityLevel.name : null,
         compatibilityGroup,
         defaultMetadata != null ? defaultMetadata.toMetadataEntity() : null,
@@ -251,6 +270,8 @@ public class ConfigValue extends SubjectValue {
               ? newConfig.getAlias() : oldConfig.getAlias(),
           newConfig.isNormalize() != null
               ? newConfig.isNormalize() : oldConfig.isNormalize(),
+          newConfig.isValidateFields() != null
+              ? newConfig.isValidateFields() : oldConfig.isValidateFields(),
           newConfig.getCompatibilityLevel() != null
               ? newConfig.getCompatibilityLevel() : oldConfig.getCompatibilityLevel(),
           newConfig.getCompatibilityGroup() != null

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -51,6 +51,7 @@ import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.Optional;
 import java.util.Set;
 import org.everit.json.schema.ArraySchema;
 import org.everit.json.schema.BooleanSchema;
@@ -399,9 +400,25 @@ public class JsonSchema implements ParsedSchema {
   }
 
   @Override
-  public void validate() {
+  public void validate(boolean strict) {
     // Access the raw schema since it is computed lazily
-    rawSchema();
+    Schema rawSchema = rawSchema();
+    if (strict) {
+      if (rawSchema instanceof ObjectSchema) {
+        ObjectSchema schema = (ObjectSchema) rawSchema;
+        Optional<String> restrictedField = schema.getPropertySchemas()
+                .keySet()
+                .stream()
+                .filter(field -> field.startsWith("$"))
+                .findAny();
+        if (restrictedField.isPresent()) {
+          throw new ValidationException(schema,
+                  "Field names cannot start with $ symbol",
+                  "properties",
+                  String.format("#/properties/%s", restrictedField.get()));
+        }
+      }
+    }
   }
 
   public void validate(Object value) throws JsonProcessingException, ValidationException {

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
@@ -961,6 +961,27 @@ public class JsonSchemaTest {
     JsonSchema jsonSchema = new JsonSchema(schema);
     jsonSchema.validate(false);
     assertThrows(ValidationException.class, () -> jsonSchema.validate(true));
+    String stringSchema = "{\n"
+            + "  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n"
+            + "  \"$id\": \"task.schema.json\",\n"
+            + "  \"title\": \"Task\",\n"
+            + "  \"description\": \"A task\",\n"
+            + "  \"type\": \"object\",\n"
+            + "  \"properties\": {\n"
+            + "    \"id\": {\n"
+            + "        \"type\": \"string\"\n"
+            + "    },    \n"
+            + "    \"title\": {\n"
+            + "        \"description\": \"Task title\",\n"
+            + "        \"type\": \"string\"\n"
+            + "    },    \n"
+            + "    \"status\": {\n"
+            + "        \"type\": \"string\"\n"
+            + "    }\n"
+            + "  }\n"
+            + "}";
+    JsonSchema validSchema = new JsonSchema(stringSchema);
+    validSchema.validate(true);
   }
 
   private static Map<String, String> getJsonSchemaWithReferences() {

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
@@ -49,6 +49,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -934,6 +935,32 @@ public class JsonSchemaTest {
                     " property at path '#/properties/status' that conflicts with the reserved properties which is " +
                     "missing in the %s schema.'}",
             errorMessages.get(1));
+  }
+
+  @Test
+  public void testRestrictedFields() {
+    String schema = "{\n"
+            + "  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n"
+            + "  \"$id\": \"task.schema.json\",\n"
+            + "  \"title\": \"Task\",\n"
+            + "  \"description\": \"A task\",\n"
+            + "  \"type\": \"object\",\n"
+            + "  \"properties\": {\n"
+            + "    \"$id\": {\n"
+            + "        \"type\": \"string\"\n"
+            + "    },    \n"
+            + "    \"$title\": {\n"
+            + "        \"description\": \"Task title\",\n"
+            + "        \"type\": \"string\"\n"
+            + "    },    \n"
+            + "    \"status\": {\n"
+            + "        \"type\": \"string\"\n"
+            + "    }\n"
+            + "  }\n"
+            + "}";
+    JsonSchema jsonSchema = new JsonSchema(schema);
+    jsonSchema.validate(false);
+    assertThrows(ValidationException.class, () -> jsonSchema.validate(true));
   }
 
   private static Map<String, String> getJsonSchemaWithReferences() {

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/ValidateSchemaRegistryMojo.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/ValidateSchemaRegistryMojo.java
@@ -38,8 +38,7 @@ public class ValidateSchemaRegistryMojo extends UploadSchemaRegistryMojo {
           String.format("Calling validate('%s', '%s')", subject, schema)
       );
     }
-
-    schema.validate();
+    schema.validate(false);
     return true;
   }
 }

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/derive/schema/DeriveAvroSchema.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/derive/schema/DeriveAvroSchema.java
@@ -114,7 +114,7 @@ public class DeriveAvroSchema extends DeriveSchema {
   protected JsonNode convertToFormat(JsonNode schema, String name) {
     ObjectNode schemaForRecord = convertToFormatForRecord(schema, name);
     AvroSchema avroSchema = new AvroSchema(schemaForRecord.toString());
-    avroSchema.validate();
+    avroSchema.validate(false);
     try {
       return mapper.readTree(avroSchema.toString());
     } catch (JsonProcessingException e) {

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/derive/schema/DeriveJsonSchema.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/derive/schema/DeriveJsonSchema.java
@@ -105,7 +105,7 @@ public class DeriveJsonSchema extends DeriveSchema {
    */
   protected JsonNode convertToFormat(JsonNode schema, String name) {
     JsonSchema jsonSchema = new JsonSchema(schema);
-    jsonSchema.validate();
+    jsonSchema.validate(false);
     // Input schema is in json format, hence no conversion is needed. Returning schema as is
     return schema;
   }

--- a/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/derive/schema/DeriveProtobufSchema.java
+++ b/maven-plugin/src/main/java/io/confluent/kafka/schemaregistry/maven/derive/schema/DeriveProtobufSchema.java
@@ -144,7 +144,7 @@ public class DeriveProtobufSchema extends DeriveSchema {
     }
     schemaBuilder.append(schemaForRecord);
     ProtobufSchema protobufSchema = new ProtobufSchema(schemaBuilder.toString());
-    protobufSchema.validate();
+    protobufSchema.validate(false);
     return mapper.convertValue(protobufSchema.toString(), TextNode.class);
   }
 

--- a/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/derive/schema/DeriveAvroSchemaTest.java
+++ b/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/derive/schema/DeriveAvroSchemaTest.java
@@ -60,7 +60,7 @@ public class DeriveAvroSchemaTest extends DeriveSchemaTest {
   protected void matchAndValidate(String message, JsonNode schemaString, String expectedSchema)
       throws IOException {
     AvroSchema schema = new AvroSchema(schemaString.toString());
-    schema.validate();
+    schema.validate(false);
     assertEquals(schema.toString(), expectedSchema);
     Object test = AvroSchemaUtils.toObject(message, schema);
     byte[] bytes = this.avroSerializer.serialize("test", test);

--- a/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/derive/schema/DeriveJsonSchemaTest.java
+++ b/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/derive/schema/DeriveJsonSchemaTest.java
@@ -43,14 +43,14 @@ public class DeriveJsonSchemaTest extends DeriveSchemaTest {
     }
     JsonNode schemaString = derive.getSchemaForArray(messagesJson, "ArrayObject");
     JsonSchema schema = new JsonSchema(schemaString.toString());
-    schema.validate();
+    schema.validate(false);
     assertEquals(schema.toString(), expectedSchema);
   }
 
   public void matchAndValidate(String message, JsonNode schemaString, String expectedSchema)
       throws IOException {
     JsonSchema schema = new JsonSchema(schemaString.toString());
-    schema.validate();
+    schema.validate(false);
     schema.validate(mapper.readValue(message, ObjectNode.class));
     assertEquals(schema.toString(), expectedSchema);
   }

--- a/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/derive/schema/DeriveProtoBufSchemaTest.java
+++ b/maven-plugin/src/test/java/io/confluent/kafka/schemaregistry/maven/derive/schema/DeriveProtoBufSchemaTest.java
@@ -53,7 +53,7 @@ public class DeriveProtoBufSchemaTest extends DeriveSchemaTest {
   protected void matchAndValidate(String message, JsonNode schemaString, String expectedSchema)
       throws IOException {
     ProtobufSchema schema = new ProtobufSchema(schemaString.asText());
-    schema.validate();
+    schema.validate(false);
     assertEquals(schema.toString(), expectedSchema);
     String formattedString = mapper.readTree(message).toString();
     Object protobufObject = ProtobufSchemaUtils.toObject(formattedString, schema);

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -1992,7 +1992,7 @@ public class ProtobufSchema implements ParsedSchema {
   }
 
   @Override
-  public void validate() {
+  public void validate(boolean strict) {
     // Normalization will try to resolve types
     normalize();
   }


### PR DESCRIPTION
https://confluentinc.atlassian.net/browse/DGS-7866

Added a new config property to validate fields in Json schema. If `validateFields` is `true` or `null`, we will disallow property names starting with `$`. To allow properties beginning with `$`, users can explicitly set `validateFields` to `false`