### PR TITLE
DGS-8323 Always populate version metadata prop for tags API

### DIFF
--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/protobuf/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/protobuf/RestApiTest.java
@@ -486,7 +486,7 @@ public class RestApiTest extends ClusterTestHarness {
     Schema result = restApp.restClient.getLatestVersion(subject);
     assertEquals(expectedSchema, result.getSchema());
     assertEquals((Integer) 2, result.getVersion());
-    assertNull(result.getMetadata());
+    assertEquals("2", result.getMetadata().getProperties().get("confluent:version"));
 
     tagSchemaRequest = new TagSchemaRequest();
     tagSchemaRequest.setNewVersion(3);


### PR DESCRIPTION
When using the new tags API, always set the `confluent:version` metadata property even if not passed