### PR TITLE
DGS-8088 Get the mode in scope rather that just for the subject

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -1734,7 +1734,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     ModeKey modeKey = new ModeKey(subject);
     try {
       kafkaStore.waitUntilKafkaReaderReachesLastOffset(subject, kafkaStoreTimeoutMs);
-      if (mode == Mode.IMPORT && getMode(subject) != Mode.IMPORT && !force) {
+      if (mode == Mode.IMPORT && getModeInScope(subject) != Mode.IMPORT && !force) {
         // Changing to import mode requires that no schemas exist with matching subjects.
         if (hasSubjects(subject, false)) {
           throw new OperationNotPermittedException("Cannot import since found existing subjects");


### PR DESCRIPTION
The previous code was just calling `getMode()` rather than `getModeInScope()`.  This led to erroneous messages that the mode was not currently in IMPORT mode.