### PR TITLE
Cache missing subjects (and not just missing schemas)

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -82,6 +82,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   private static final int HTTP_NOT_FOUND = 404;
   private static final int VERSION_NOT_FOUND_ERROR_CODE = 40402;
   private static final int SCHEMA_NOT_FOUND_ERROR_CODE = 40403;
+  private static final int SUBJECT_NOT_FOUND_ERROR_CODE = 40401;
 
   public static final Map<String, String> DEFAULT_REQUEST_PROPERTIES;
 
@@ -331,7 +332,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
     try {
       restSchema = restService.getId(id, subject);
     } catch (RestClientException rce) {
-      if (isSchemaNotFoundException(rce)) {
+      if (isSchemaOrSubjectNotFoundException(rce)) {
         missingIdCache.put(new SubjectAndInt(subject, id), System.currentTimeMillis());
       }
       throw rce;
@@ -351,7 +352,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
       RegisterSchemaRequest request = new RegisterSchemaRequest(schema);
       response = restService.lookUpSubjectVersion(request, subject, normalize, true);
     } catch (RestClientException rce) {
-      if (isSchemaNotFoundException(rce)) {
+      if (isSchemaOrSubjectNotFoundException(rce)) {
         missingSchemaCache.put(
             new SubjectAndSchema(subject, schema, normalize), System.currentTimeMillis());
       }
@@ -370,7 +371,7 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
       RegisterSchemaRequest request = new RegisterSchemaRequest(schema);
       response = restService.lookUpSubjectVersion(request, subject, normalize, false);
     } catch (RestClientException rce) {
-      if (isSchemaNotFoundException(rce)) {
+      if (isSchemaOrSubjectNotFoundException(rce)) {
         missingSchemaCache.put(
             new SubjectAndSchema(subject, schema, normalize), System.currentTimeMillis());
       }
@@ -830,8 +831,9 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
     return rce.getStatus() == HTTP_NOT_FOUND && rce.getErrorCode() == VERSION_NOT_FOUND_ERROR_CODE;
   }
 
-  private boolean isSchemaNotFoundException(RestClientException rce) {
-    return rce.getStatus() == HTTP_NOT_FOUND && rce.getErrorCode() == SCHEMA_NOT_FOUND_ERROR_CODE;
+  private boolean isSchemaOrSubjectNotFoundException(RestClientException rce) {
+    return rce.getStatus() == HTTP_NOT_FOUND &&
+            (rce.getErrorCode() == SCHEMA_NOT_FOUND_ERROR_CODE || rce.getErrorCode() == SUBJECT_NOT_FOUND_ERROR_CODE);
   }
 
   private static String toQualifiedContext(String subject) {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -832,8 +832,9 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   private boolean isSchemaOrSubjectNotFoundException(RestClientException rce) {
-    return rce.getStatus() == HTTP_NOT_FOUND &&
-            (rce.getErrorCode() == SCHEMA_NOT_FOUND_ERROR_CODE || rce.getErrorCode() == SUBJECT_NOT_FOUND_ERROR_CODE);
+    return rce.getStatus() == HTTP_NOT_FOUND
+        && (rce.getErrorCode() == SCHEMA_NOT_FOUND_ERROR_CODE
+        || rce.getErrorCode() == SUBJECT_NOT_FOUND_ERROR_CODE);
   }
 
   private static String toQualifiedContext(String subject) {

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
@@ -634,7 +634,7 @@ public class CachedSchemaRegistryClientTest {
       client.getId(SUBJECT_0, AVRO_SCHEMA_0);
       fail();
     } catch (RestClientException rce) {
-      assertEquals("Subject not found; error code: 40401", rce.getMessage());
+      assertEquals("Schema not found; error code: 40403", rce.getMessage());
     }
 
     fakeTicker.advance(2, TimeUnit.SECONDS);

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
@@ -594,6 +594,55 @@ public class CachedSchemaRegistryClientTest {
   }
 
   @Test
+  public void testMissingSubjectCache() throws Exception {
+    Map<String, Object> configs = new HashMap<>();
+    configs.put(SchemaRegistryClientConfig.MISSING_ID_CACHE_TTL_CONFIG, 60L);
+    configs.put(SchemaRegistryClientConfig.MISSING_SCHEMA_CACHE_TTL_CONFIG, 60L);
+
+    FakeTicker fakeTicker = new FakeTicker();
+    client = new CachedSchemaRegistryClient(
+            restService,
+            CACHE_CAPACITY,
+            null,
+            configs,
+            null,
+            fakeTicker
+    );
+
+    int version = 7;
+    expect(restService.lookUpSubjectVersion(anyObject(RegisterSchemaRequest.class),
+            eq(SUBJECT_0), anyBoolean(),
+            eq(false)))
+            .andThrow(new RestClientException("Subject not found",
+                    404, 40401))
+            .andReturn(
+                    new io.confluent.kafka.schemaregistry.client.rest.entities.Schema(SUBJECT_0, version,
+                            ID_25, AvroSchema.TYPE, Collections.emptyList(), SCHEMA_STR_0));
+
+    replay(restService);
+
+    try {
+      client.getId(SUBJECT_0, AVRO_SCHEMA_0);
+      fail();
+    } catch (RestClientException rce) {
+      assertEquals("Subject not found; error code: 40401", rce.getMessage());
+    }
+
+    fakeTicker.advance(59, TimeUnit.SECONDS);
+
+    try {
+      client.getId(SUBJECT_0, AVRO_SCHEMA_0);
+      fail();
+    } catch (RestClientException rce) {
+      assertEquals("Subject not found; error code: 40401", rce.getMessage());
+    }
+
+    fakeTicker.advance(2, TimeUnit.SECONDS);
+    Thread.sleep(100);
+    client.getId(SUBJECT_0, AVRO_SCHEMA_0);
+  }
+
+  @Test
   public void testMissingSchemaCache() throws Exception {
     Map<String, Object> configs = new HashMap<>();
     configs.put(SchemaRegistryClientConfig.MISSING_ID_CACHE_TTL_CONFIG, 60L);


### PR DESCRIPTION
When using the KafkaAvroSerializer to publish a new message, if a subject has not been registered yet, the `getIdFromRegistry` call fails with a `404` and a error code `40401` for unknown subject.

The expected behaviour is (I believe) that this failure would be added in the missingSchemaCache.
However, since the error code returned is a `40403`, for unknown schema and not a `40401`, this is not added to the cache and subsequent attempts result in repeated calls to the schema registry.