### PR TITLE
DGS-8901 Ensure logical type config is applied to Reflect/Specific Avro data types

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -493,7 +493,7 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
         DatumReader<?> reader;
         if (!migrations.isEmpty()) {
           // if migration is required, then initially use GenericDatumReader
-          reader =new GenericDatumReader<>(writerSchema, writerSchema,
+          reader = new GenericDatumReader<>(writerSchema, writerSchema,
               avroUseLogicalTypeConverters
                   ? AvroSchemaUtils.getGenericData()
                   : GenericData.get());

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -493,10 +493,8 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
         DatumReader<?> reader;
         if (!migrations.isEmpty()) {
           // if migration is required, then initially use GenericDatumReader
-          reader = new GenericDatumReader<>(writerSchema, writerSchema,
-              avroUseLogicalTypeConverters
-                  ? AvroSchemaUtils.getGenericData()
-                  : GenericData.get());
+          reader = new GenericDatumReader<>(
+              writerSchema, writerSchema, AvroSchemaUtils.getGenericData());
         } else {
           reader = getDatumReader(writerSchema, readerSchema);
         }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -490,7 +490,10 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
         DatumReader<?> reader;
         if (!migrations.isEmpty()) {
           // if migration is required, then initially use GenericDatumReader
-          reader = new GenericDatumReader<>(writerSchema);
+          reader = avroUseLogicalTypeConverters
+              ? new GenericDatumReader<>(
+                  writerSchema, writerSchema, AvroSchemaUtils.getGenericData())
+              : new GenericDatumReader<>(writerSchema);
         } else {
           reader = getDatumReader(writerSchema, readerSchema);
         }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutionException;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
 import org.apache.avro.generic.GenericContainer;
+import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DecoderFactory;
@@ -74,23 +75,25 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
             boolean writerSchemaIsPrimitive =
                 AvroSchemaUtils.getPrimitiveSchemas().containsValue(writerSchema);
             if (writerSchemaIsPrimitive) {
-              if (avroUseLogicalTypeConverters) {
-                return new GenericDatumReader<>(writerSchema, finalReaderSchema,
-                    AvroSchemaUtils.getGenericData());
-              } else {
-                return new GenericDatumReader<>(writerSchema, finalReaderSchema);
-              }
+              return new GenericDatumReader<>(writerSchema, finalReaderSchema,
+                  avroUseLogicalTypeConverters
+                      ? AvroSchemaUtils.getGenericData()
+                      : GenericData.get());
             } else if (useSchemaReflection) {
-              return new ReflectDatumReader<>(writerSchema, finalReaderSchema);
+              return new ReflectDatumReader<>(writerSchema, finalReaderSchema,
+                  avroUseLogicalTypeConverters
+                      ? AvroSchemaUtils.getReflectData()
+                      : ReflectData.get());
             } else if (useSpecificAvroReader) {
-              return new SpecificDatumReader<>(writerSchema, finalReaderSchema);
+              return new SpecificDatumReader<>(writerSchema, finalReaderSchema,
+                  avroUseLogicalTypeConverters
+                      ? AvroSchemaUtils.getSpecificData()
+                      : SpecificData.get());
             } else {
-              if (avroUseLogicalTypeConverters) {
-                return new GenericDatumReader<>(writerSchema, finalReaderSchema,
-                    AvroSchemaUtils.getGenericData());
-              } else {
-                return new GenericDatumReader<>(writerSchema, finalReaderSchema);
-              }
+              return new GenericDatumReader<>(writerSchema, finalReaderSchema,
+                  avroUseLogicalTypeConverters
+                      ? AvroSchemaUtils.getGenericData()
+                      : GenericData.get());
             }
           }
         };
@@ -490,10 +493,10 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
         DatumReader<?> reader;
         if (!migrations.isEmpty()) {
           // if migration is required, then initially use GenericDatumReader
-          reader = avroUseLogicalTypeConverters
-              ? new GenericDatumReader<>(
-                  writerSchema, writerSchema, AvroSchemaUtils.getGenericData())
-              : new GenericDatumReader<>(writerSchema);
+          reader =new GenericDatumReader<>(writerSchema, writerSchema,
+              avroUseLogicalTypeConverters
+                  ? AvroSchemaUtils.getGenericData()
+                  : GenericData.get());
         } else {
           reader = getDatumReader(writerSchema, readerSchema);
         }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaUtils.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaUtils.java
@@ -330,7 +330,7 @@ public class AvroSchemaUtils {
       return new GenericDatumWriter<>(schema,
           avroUseLogicalTypeConverters ? getGenericData() : GenericData.get());
     } else {
-      return new GenericDatumWriter<>(schema,
+      return new ReflectDatumWriter<>(schema,
           avroUseLogicalTypeConverters ? getReflectData() : ReflectData.get());
     }
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaUtils.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaUtils.java
@@ -255,7 +255,8 @@ public class AvroSchemaUtils {
   }
 
   public static Object toObject(JsonNode value, AvroSchema schema) throws IOException {
-    return toObject(value, schema, new GenericDatumReader<>(schema.rawSchema()));
+    return toObject(value, schema, new GenericDatumReader<>(
+        schema.rawSchema(), schema.rawSchema(), getGenericData()));
   }
 
   public static Object toObject(
@@ -271,7 +272,8 @@ public class AvroSchemaUtils {
   }
 
   public static Object toObject(String value, AvroSchema schema) throws IOException {
-    return toObject(value, schema, new GenericDatumReader<>(schema.rawSchema()));
+    return toObject(value, schema, new GenericDatumReader<>(
+        schema.rawSchema(), schema.rawSchema(), getGenericData()));
   }
 
   public static Object toObject(

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/jsonata/JsonataExecutorIntegrationTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/jsonata/JsonataExecutorIntegrationTest.java
@@ -79,7 +79,6 @@ import java.util.UUID;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.reflect.ReflectData;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/jsonata/JsonataExecutorIntegrationTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/jsonata/JsonataExecutorIntegrationTest.java
@@ -28,6 +28,7 @@ import com.google.protobuf.DynamicMessage;
 import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
@@ -74,6 +75,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.SortedMap;
+import java.util.UUID;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -103,6 +105,8 @@ public class JsonataExecutorIntegrationTest extends ClusterTestHarness {
   private static final String SCHEMA_REGISTRY_URL = "schema.registry.url";
 
   private static final String TOPIC = "widget";
+
+  private static final UUID ID = UUID.fromString("2182b6f9-6422-43d8-819e-822b2b678eec");
 
   public JsonataExecutorIntegrationTest() {
     super(1, true);
@@ -139,6 +143,7 @@ public class JsonataExecutorIntegrationTest extends ClusterTestHarness {
     props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
     props.put(SCHEMA_REGISTRY_URL, schemaRegistryUrl);
     props.put("use.latest.with.metadata", "application.version=" + applicationVersion);
+    props.put("avro.use.logical.type.converters", "true");
     props.putAll(additionalProps);
     return props;
   }
@@ -174,6 +179,7 @@ public class JsonataExecutorIntegrationTest extends ClusterTestHarness {
     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
     props.put("auto.register.schemas", "false");
     props.put("use.latest.with.metadata", "application.version=" + applicationVersion);
+    props.put("avro.use.logical.type.converters", "true");
     props.put("latest.compatibility.strict", "false");
     props.putAll(additionalProps);
     return props;
@@ -196,13 +202,13 @@ public class JsonataExecutorIntegrationTest extends ClusterTestHarness {
     additionalProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class);
     additionalProps.put(KafkaAvroSerializerConfig.SCHEMA_REFLECTION_CONFIG, "true");
     List<Object> payloads = new ArrayList<>();
-    OldWidget widget = new OldWidget("alice");
+    OldWidget widget = new OldWidget(ID, "alice");
     widget.setSize(123);
     payloads.add(widget);
-    NewWidget newWidget = new NewWidget("alice");
+    NewWidget newWidget = new NewWidget(ID, "alice");
     newWidget.setHeight(123);
     payloads.add(newWidget);
-    NewerWidget newerWidget = new NewerWidget("alice");
+    NewerWidget newerWidget = new NewerWidget(ID, "alice");
     newerWidget.setLength(123);
     payloads.add(newerWidget);
     produceAndConsume(additionalProps, payloads);
@@ -231,14 +237,14 @@ public class JsonataExecutorIntegrationTest extends ClusterTestHarness {
     config.setCompatibilityLevel("NONE");
     schemaRegistry.updateConfig(TOPIC + "-value", config);
 
-    Schema schema = ReflectData.get().getSchema(OldWidget.class);
+    Schema schema = AvroSchemaUtils.getReflectData().getSchema(OldWidget.class);
     AvroSchema avroSchema = new AvroSchema(schema);
     SortedMap<String, String> props = ImmutableSortedMap.of("application.version", "v1");
     Metadata metadata = new Metadata(Collections.emptySortedMap(), props, Collections.emptySortedSet());
     avroSchema = avroSchema.copy(metadata, null);
     schemaRegistry.register(TOPIC + "-value", avroSchema);
 
-    schema = ReflectData.get().getSchema(NewWidget.class);
+    schema = AvroSchemaUtils.getReflectData().getSchema(NewWidget.class);
     avroSchema = new AvroSchema(schema);
     Rule rule = new Rule("myRule1", null, RuleKind.TRANSFORM, RuleMode.UPGRADE,
         JsonataExecutor.TYPE, null, null, rule1To2, null, null, false);
@@ -250,7 +256,7 @@ public class JsonataExecutorIntegrationTest extends ClusterTestHarness {
     avroSchema = avroSchema.copy(metadata, ruleSet);
     schemaRegistry.register(TOPIC + "-value", avroSchema);
 
-    schema = ReflectData.get().getSchema(NewerWidget.class);
+    schema = AvroSchemaUtils.getReflectData().getSchema(NewerWidget.class);
     avroSchema = new AvroSchema(schema);
     rule = new Rule("myRule1", null, RuleKind.TRANSFORM, RuleMode.UPGRADE,
         JsonataExecutor.TYPE, null, null, rule2To3, null, null, false);
@@ -474,13 +480,13 @@ public class JsonataExecutorIntegrationTest extends ClusterTestHarness {
     additionalProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaJsonSchemaSerializer.class);
     additionalProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaJsonSchemaDeserializer.class);
     List<Object> payloads = new ArrayList<>();
-    OldWidget widget = new OldWidget("alice");
+    OldWidget widget = new OldWidget(ID, "alice");
     widget.setSize(123);
     payloads.add(widget);
-    NewWidget newWidget = new NewWidget("alice");
+    NewWidget newWidget = new NewWidget(ID, "alice");
     newWidget.setHeight(123);
     payloads.add(newWidget);
-    NewerWidget newerWidget = new NewerWidget("alice");
+    NewerWidget newerWidget = new NewerWidget(ID, "alice");
     newerWidget.setLength(123);
     payloads.add(newerWidget);
     produceAndConsume(additionalProps, payloads);
@@ -494,13 +500,13 @@ public class JsonataExecutorIntegrationTest extends ClusterTestHarness {
     additionalProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaJsonSchemaDeserializer.class);
     additionalProps.put(KafkaJsonSchemaDeserializerConfig.JSON_VALUE_TYPE, JsonNode.class);
     List<Object> payloads = new ArrayList<>();
-    OldWidget widget = new OldWidget("alice");
+    OldWidget widget = new OldWidget(ID, "alice");
     widget.setSize(123);
     payloads.add(mapper.valueToTree(widget));
-    NewWidget newWidget = new NewWidget("alice");
+    NewWidget newWidget = new NewWidget(ID, "alice");
     newWidget.setHeight(123);
     payloads.add(mapper.valueToTree(newWidget));
-    NewerWidget newerWidget = new NewerWidget("alice");
+    NewerWidget newerWidget = new NewerWidget(ID, "alice");
     newerWidget.setLength(123);
     payloads.add(mapper.valueToTree(newerWidget));
     produceAndConsume(additionalProps, payloads);

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/jsonata/JsonataExecutorTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/jsonata/JsonataExecutorTest.java
@@ -29,6 +29,7 @@ import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaString;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
@@ -54,11 +55,13 @@ import io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializerConfig;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
+import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.SortedMap;
+import java.util.UUID;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.reflect.ReflectData;
@@ -83,6 +86,7 @@ public class JsonataExecutorTest {
   private final KafkaJsonSchemaDeserializer<JsonNode> jsonSchemaDeserializer;
   private final KafkaJsonSchemaDeserializer<NewWidget> specificJsonSchemaDeserializer;
   private final String topic;
+  private final UUID id = UUID.fromString("2182b6f9-6422-43d8-819e-822b2b678eec");
 
   public JsonataExecutorTest() {
     topic = "test";
@@ -95,6 +99,7 @@ public class JsonataExecutorTest {
     defaultConfig.put(KafkaAvroSerializerConfig.USE_LATEST_VERSION, "false");
     defaultConfig.put(KafkaAvroSerializerConfig.USE_LATEST_WITH_METADATA,
         "application.version=v1");
+    defaultConfig.put(KafkaAvroSerializerConfig.AVRO_USE_LOGICAL_TYPE_CONVERTERS_CONFIG, "true");
     defaultConfig.put(KafkaAvroSerializerConfig.LATEST_COMPATIBILITY_STRICT, "false");
     defaultConfig.put(KafkaAvroSerializerConfig.RULE_EXECUTORS, "jsonata");
     defaultConfig.put(KafkaAvroSerializerConfig.RULE_EXECUTORS + ".jsonata.class",
@@ -143,7 +148,10 @@ public class JsonataExecutorTest {
         "\"name\": \"NewGenericWidget\"," +
         "\"fields\": [{\"name\": \"name\", \"type\": \"string\"},"
         + "{\"name\": \"height\", \"type\": \"int\"},"
-        + "{\"name\": \"version\", \"type\": \"int\"}]}";
+        + "{\"name\": \"version\", \"type\": \"int\"},"
+        + "{\"name\": \"id\", \"type\":"
+        + "{\"type\": \"string\", \"logicalType\": \"uuid\"}}]}";
+
     Schema.Parser parser = new Schema.Parser();
     Schema schema = parser.parse(userSchema);
     return schema;
@@ -157,9 +165,9 @@ public class JsonataExecutorTest {
     String ruleString =
         "$merge([$sift($, function($v, $k) {$k != 'size'}), {'height': $.'size'}])";
 
-    OldWidget widget = new OldWidget("alice");
+    OldWidget widget = new OldWidget(id, "alice");
     widget.setSize(123);
-    Schema schema = ReflectData.get().getSchema(OldWidget.class);
+    Schema schema = AvroSchemaUtils.getReflectData().getSchema(OldWidget.class);
     AvroSchema avroSchema = new AvroSchema(schema);
     SortedMap<String, String> props = ImmutableSortedMap.of("application.version", "v1");
     Metadata metadata = new Metadata(Collections.emptySortedMap(), props, Collections.emptySortedSet());
@@ -188,6 +196,10 @@ public class JsonataExecutorTest {
         123,
         ((GenericRecord)obj).get("height")
     );
+    assertEquals(
+        id,
+        ((GenericRecord)obj).get("id")
+    );
   }
 
   @Test
@@ -198,16 +210,16 @@ public class JsonataExecutorTest {
     String ruleString =
         "$merge([$sift($, function($v, $k) {$k != 'size'}), {'height': $.'size'}])";
 
-    OldWidget widget = new OldWidget("alice");
+    OldWidget widget = new OldWidget(id, "alice");
     widget.setSize(123);
-    Schema schema = ReflectData.get().getSchema(OldWidget.class);
+    Schema schema = AvroSchemaUtils.getReflectData().getSchema(OldWidget.class);
     AvroSchema avroSchema = new AvroSchema(schema);
     SortedMap<String, String> props = ImmutableSortedMap.of("application.version", "v1");
     Metadata metadata = new Metadata(Collections.emptySortedMap(), props, Collections.emptySortedSet());
     avroSchema = avroSchema.copy(metadata, null);
     schemaRegistry.register(topic + "-value", avroSchema);
 
-    schema = ReflectData.get().getSchema(NewWidget.class);
+    schema = AvroSchemaUtils.getReflectData().getSchema(NewWidget.class);
     avroSchema = new AvroSchema(schema);
     Rule rule = new Rule("myRule", null, RuleKind.TRANSFORM, RuleMode.UPGRADE,
         JsonataExecutor.TYPE, null, null, ruleString, null, null, false);
@@ -239,9 +251,9 @@ public class JsonataExecutorTest {
     String ruleString =
         "$merge([$sift($, function($v, $k) {$k != 'size'}), {'height': $.'size'}])";
 
-    OldWidget widget = new OldWidget("alice");
+    OldWidget widget = new OldWidget(id, "alice");
     widget.setSize(123);
-    Schema schema = ReflectData.get().getSchema(OldWidget.class);
+    Schema schema = AvroSchemaUtils.getReflectData().getSchema(OldWidget.class);
     AvroSchema avroSchema = new AvroSchema(schema);
     SortedMap<String, String> props = ImmutableSortedMap.of("application.version", "v1");
     Metadata metadata = new Metadata(Collections.emptySortedMap(), props, Collections.emptySortedSet());
@@ -285,16 +297,16 @@ public class JsonataExecutorTest {
     String rule3To2 =
         "$merge([$sift($, function($v, $k) {$k != 'length'}), {'height': $.'length'}])";
 
-    OldWidget widget = new OldWidget("alice");
+    OldWidget widget = new OldWidget(id, "alice");
     widget.setSize(123);
-    Schema schema = ReflectData.get().getSchema(OldWidget.class);
+    Schema schema = AvroSchemaUtils.getReflectData().getSchema(OldWidget.class);
     AvroSchema avroSchema = new AvroSchema(schema);
     SortedMap<String, String> props = ImmutableSortedMap.of("application.version", "v1");
     Metadata metadata = new Metadata(Collections.emptySortedMap(), props, Collections.emptySortedSet());
     avroSchema = avroSchema.copy(metadata, null);
     schemaRegistry.register(topic + "-value", avroSchema);
 
-    schema = ReflectData.get().getSchema(NewWidget.class);
+    schema = AvroSchemaUtils.getReflectData().getSchema(NewWidget.class);
     avroSchema = new AvroSchema(schema);
     Rule rule = new Rule("myRule1", null, RuleKind.TRANSFORM, RuleMode.UPGRADE,
         JsonataExecutor.TYPE, null, null, rule1To2, null, null, false);
@@ -306,7 +318,7 @@ public class JsonataExecutorTest {
     avroSchema = avroSchema.copy(metadata, ruleSet);
     schemaRegistry.register(topic + "-value", avroSchema);
 
-    schema = ReflectData.get().getSchema(NewerWidget.class);
+    schema = AvroSchemaUtils.getReflectData().getSchema(NewerWidget.class);
     avroSchema = new AvroSchema(schema);
     rule = new Rule("myRule1", null, RuleKind.TRANSFORM, RuleMode.UPGRADE,
         JsonataExecutor.TYPE, null, null, rule2To3, null, null, false);
@@ -322,13 +334,13 @@ public class JsonataExecutorTest {
 
     deserializeWithAllVersions(bytes);
 
-    NewWidget newWidget = new NewWidget("alice");
+    NewWidget newWidget = new NewWidget(id, "alice");
     newWidget.setHeight(123);
     bytes = reflectionAvroSerializer2.serialize(topic, newWidget);
 
     deserializeWithAllVersions(bytes);
 
-    NewerWidget newerWidget = new NewerWidget("alice");
+    NewerWidget newerWidget = new NewerWidget(id, "alice");
     newerWidget.setLength(123);
     bytes = reflectionAvroSerializer3.serialize(topic, newerWidget);
 
@@ -464,7 +476,7 @@ public class JsonataExecutorTest {
     String ruleString =
         "$merge([$sift($, function($v, $k) {$k != 'size'}), {'height': $.'size'}])";
 
-    OldWidget widget = new OldWidget("alice");
+    OldWidget widget = new OldWidget(id, "alice");
     widget.setSize(123);
     JsonSchema jsonSchema = JsonSchemaUtils.getSchema(widget);
     SortedMap<String, String> props = ImmutableSortedMap.of("application.version", "v1");
@@ -472,7 +484,7 @@ public class JsonataExecutorTest {
     jsonSchema = jsonSchema.copy(metadata, null);
     schemaRegistry.register(topic + "-value", jsonSchema);
 
-    NewWidget newWidget = new NewWidget("alice");
+    NewWidget newWidget = new NewWidget(id, "alice");
     jsonSchema = JsonSchemaUtils.getSchema(newWidget);
     Rule rule = new Rule("myRule", null, RuleKind.TRANSFORM, RuleMode.UPGRADE,
         JsonataExecutor.TYPE, null, null, ruleString, null, null, false);
@@ -504,7 +516,7 @@ public class JsonataExecutorTest {
     String ruleString =
         "$merge([$sift($, function($v, $k) {$k != 'size'}), {'height': $.'size'}])";
 
-    OldWidget widget = new OldWidget("alice");
+    OldWidget widget = new OldWidget(id, "alice");
     widget.setSize(123);
     JsonSchema jsonSchema = JsonSchemaUtils.getSchema(widget);
     SortedMap<String, String> props = ImmutableSortedMap.of("application.version", "v1");
@@ -512,7 +524,7 @@ public class JsonataExecutorTest {
     jsonSchema = jsonSchema.copy(metadata, null);
     schemaRegistry.register(topic + "-value", jsonSchema);
 
-    NewWidget newWidget = new NewWidget("alice");
+    NewWidget newWidget = new NewWidget(id, "alice");
     jsonSchema = JsonSchemaUtils.getSchema(newWidget);
     Rule rule = new Rule("myRule", null, RuleKind.TRANSFORM, RuleMode.UPGRADE,
         JsonataExecutor.TYPE, null, null, ruleString, null, null, false);
@@ -539,12 +551,14 @@ public class JsonataExecutorTest {
   @JsonSchemaInject(strings = {@JsonSchemaString(path="javaType",
       value= "io.confluent.kafka.schemaregistry.rules.jsonata.JsonataExecutorTest$OldWidget")})
   public static class OldWidget {
+    private UUID id;
     private String name;
     private int size;
     private int version;
 
     public OldWidget() {}
-    public OldWidget(String name) {
+    public OldWidget(UUID id, String name) {
+      this.id = id;
       this.name = name;
     }
 
@@ -572,6 +586,14 @@ public class JsonataExecutorTest {
       this.version = version;
     }
 
+    public UUID getId() {
+      return id;
+    }
+
+    public void setId(UUID id) {
+      this.id = id;
+    }
+
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
@@ -579,25 +601,36 @@ public class JsonataExecutorTest {
       OldWidget widget = (OldWidget) o;
       return name.equals(widget.name)
           && size == widget.size
-          && version == widget.version;
+          && version == widget.version
+          && Objects.equals(id, widget.id);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(name, size, version);
+      return Objects.hash(id, name, size, version);
     }
   }
 
   @JsonSchemaInject(strings = {@JsonSchemaString(path="javaType",
       value= "io.confluent.kafka.schemaregistry.rules.jsonata.JsonataExecutorTest$NewWidget")})
   public static class NewWidget {
+    private UUID id;
     private String name;
     private int height;
     private int version;
 
     public NewWidget() {}
-    public NewWidget(String name) {
+    public NewWidget(UUID id, String name) {
+      this.id = id;
       this.name = name;
+    }
+
+    public UUID getId() {
+      return id;
+    }
+
+    public void setId(UUID id) {
+      this.id = id;
     }
 
     public String getName() {
@@ -631,25 +664,36 @@ public class JsonataExecutorTest {
       NewWidget widget = (NewWidget) o;
       return name.equals(widget.name)
           && height == widget.height
-          && version == widget.version;
+          && version == widget.version
+          && Objects.equals(id, widget.id);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(name, height, version);
+      return Objects.hash(id, name, height, version);
     }
   }
 
   @JsonSchemaInject(strings = {@JsonSchemaString(path="javaType",
       value= "io.confluent.kafka.schemaregistry.rules.jsonata.JsonataExecutorTest$NewerWidget")})
   public static class NewerWidget {
+    private UUID id;
     private String name;
     private int length;
     private int version;
 
     public NewerWidget() {}
-    public NewerWidget(String name) {
+    public NewerWidget(UUID id, String name) {
+      this.id = id;
       this.name = name;
+    }
+
+    public UUID getId() {
+      return id;
+    }
+
+    public void setId(UUID id) {
+      this.id = id;
     }
 
     public String getName() {
@@ -683,12 +727,13 @@ public class JsonataExecutorTest {
       NewerWidget widget = (NewerWidget) o;
       return name.equals(widget.name)
           && length == widget.length
-          && version == widget.version;
+          && version == widget.version
+          && Objects.equals(id, widget.id);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(name, length, version);
+      return Objects.hash(id, name, length, version);
     }
   }
 }

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/jsonata/JsonataExecutorTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/jsonata/JsonataExecutorTest.java
@@ -55,7 +55,6 @@ import io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializerConfig;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
-import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -64,7 +63,6 @@ import java.util.SortedMap;
 import java.util.UUID;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.reflect.ReflectData;
 import org.junit.Test;
 
 public class JsonataExecutorTest {


### PR DESCRIPTION
If the user specified `avro.use.logical.type.converters=true`, it was only being used by Generic Avro types, and not by Reflect/Specific Avro types.

Fixes https://github.com/confluentinc/schema-registry/issues/2803