### PR TITLE
Allow create kek/dek to act like undelete

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -40,7 +40,7 @@
               files="(KafkaSchemaRegistry|SchemaRegistryConfig|ProtobufData|JsonSchemaData).java"/>
 
     <suppress checks="BooleanExpressionComplexity"
-              files="(AvroData|JsonSchema|KafkaSchemaRegistry|ProtobufData|ProtobufSchema|CelExecutor|FieldRuleExecutor|MetadataEncoderService|MockDekRegistryClient).java"/>
+              files="(AvroData|JsonSchema|KafkaSchemaRegistry|ProtobufData|ProtobufSchema|CelExecutor|FieldRuleExecutor|MetadataEncoderService|MockDekRegistryClient|DataEncryptionKey|KeyEncryptionKey).java"/>
 
     <suppress checks="MemberName"
               files="(DynamicSchema|EnumDefinition|MessageDefinition|ServiceDefinition).java"/>

--- a/dek-registry/src/main/java/io/confluent/dekregistry/storage/DataEncryptionKey.java
+++ b/dek-registry/src/main/java/io/confluent/dekregistry/storage/DataEncryptionKey.java
@@ -89,6 +89,15 @@ public class DataEncryptionKey extends EncryptionKey {
     this.keyMaterial = keyMaterial;
   }
 
+  @JsonIgnore
+  public boolean isEquivalent(DataEncryptionKey that) {
+    return Objects.equals(kekName, that.kekName)
+        && Objects.equals(subject, that.subject)
+        && algorithm == that.algorithm
+        && version == that.version
+        && Objects.equals(encryptedKeyMaterial, that.encryptedKeyMaterial);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/dek-registry/src/main/java/io/confluent/dekregistry/storage/KeyEncryptionKey.java
+++ b/dek-registry/src/main/java/io/confluent/dekregistry/storage/KeyEncryptionKey.java
@@ -16,6 +16,7 @@
 package io.confluent.dekregistry.storage;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -88,6 +89,16 @@ public class KeyEncryptionKey extends EncryptionKey {
   @JsonProperty("shared")
   public boolean isShared() {
     return this.shared;
+  }
+
+  @JsonIgnore
+  public boolean isEquivalent(KeyEncryptionKey that) {
+    return shared == that.shared
+        && Objects.equals(name, that.name)
+        && Objects.equals(kmsType, that.kmsType)
+        && Objects.equals(kmsKeyId, that.kmsKeyId)
+        && Objects.equals(kmsProps, that.kmsProps)
+        && Objects.equals(doc, that.doc);
   }
 
   @Override

--- a/dek-registry/src/test/java/io/confluent/dekregistry/web/rest/RestApiTest.java
+++ b/dek-registry/src/test/java/io/confluent/dekregistry/web/rest/RestApiTest.java
@@ -134,6 +134,13 @@ public class RestApiTest extends ClusterTestHarness {
     Kek newKek = client.createKek(headers, kekName, kmsType, kmsKeyId, null, null, false);
     assertEquals(kek, newKek);
 
+    // Delete kek
+    client.deleteKek(headers, kekName, false);
+
+    // Allow create to act like undelete
+    newKek = client.createKek(headers, kekName, kmsType, kmsKeyId, null, null, false);
+    assertEquals(kek, newKek);
+
     newKek = client.getKek(kekName, false);
     assertEquals(kek, newKek);
 
@@ -215,6 +222,12 @@ public class RestApiTest extends ClusterTestHarness {
 
     // Create dek
     Dek newDek = client.createDek(headers, kekName, subject, null, algorithm, encryptedDekStr);
+    assertEquals(dek, newDek);
+
+    client.deleteDek(headers, kekName, subject, algorithm, false);
+
+    // Allow create to act like undelete
+    newDek = client.createDek(headers, kekName, subject, null, algorithm, encryptedDekStr);
     assertEquals(dek, newDek);
 
     newDek = client.getDek(kekName, subject, algorithm, false);


### PR DESCRIPTION
If a kek/dek is created with the exact same args as the original that was deleted, allow it to be undeleted.  This will be used when copying kek/deks during schema linking.