### PR TITLE
fix packaging of kafka-connect-avro-converter

### DIFF
--- a/avro-converter/pom.xml
+++ b/avro-converter/pom.xml
@@ -60,7 +60,6 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
The avro-converter project depends on avro-serializer which depends on guava. For some reason, marking it as a test dependency omits it as a transitive compile dependency.

This fixes issue #2804