### PR TITLE
DGS-9006: Load FIPS extension before KafkaSchemaRegistry is initialized

### DIFF
--- a/config/schema-registry.properties
+++ b/config/schema-registry.properties
@@ -34,4 +34,6 @@ debug=false
 
 metadata.encoder.secret=REPLACE_ME_WITH_HIGH_ENTROPY_STRING
 
-resource.extension.class=io.confluent.dekregistry.DekRegistryResourceExtension
+enable.fips=true
+pre.init.resource.extension.class=io.confluent.kafka.schemaregistry.security.SchemaRegistryFipsResourceExtension
+security.providers=io.confluent.kafka.security.fips.provider.BcFipsProviderCreator,io.confluent.kafka.security.fips.provider.BcFipsJsseProviderCreator

--- a/config/schema-registry.properties
+++ b/config/schema-registry.properties
@@ -33,7 +33,3 @@ kafkastore.topic=_schemas
 debug=false
 
 metadata.encoder.secret=REPLACE_ME_WITH_HIGH_ENTROPY_STRING
-
-enable.fips=true
-pre.init.resource.extension.class=io.confluent.kafka.schemaregistry.security.SchemaRegistryFipsResourceExtension
-security.providers=io.confluent.kafka.security.fips.provider.BcFipsProviderCreator,io.confluent.kafka.security.fips.provider.BcFipsJsseProviderCreator

--- a/config/schema-registry.properties
+++ b/config/schema-registry.properties
@@ -33,3 +33,5 @@ kafkastore.topic=_schemas
 debug=false
 
 metadata.encoder.secret=REPLACE_ME_WITH_HIGH_ENTROPY_STRING
+
+resource.extension.class=io.confluent.dekregistry.DekRegistryResourceExtension

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -253,6 +253,8 @@ public class SchemaRegistryConfig extends RestConfig {
   @Deprecated
   public static final String SCHEMAREGISTRY_RESOURCE_EXTENSION_CONFIG =
       "schema.registry.resource.extension.class";
+  public static final String PRE_INIT_RESOURCE_EXTENSION_CONFIG =
+      "pre.init.resource.extension.class";
   public static final String RESOURCE_EXTENSION_CONFIG =
       "resource.extension.class";
   public static final String RESOURCE_STATIC_LOCATIONS_CONFIG =
@@ -427,6 +429,11 @@ public class SchemaRegistryConfig extends RestConfig {
       + " like filters to Schema Registry. Typically used to add custom capability like logging, "
       + " security, etc. The schema.registry.resource.extension.class name is deprecated; "
       + "prefer using resource.extension.class instead.";
+  protected static final String PRE_INIT_RESOURCE_EXTENSION_DOC =
+      "  A list of classes to use as SchemaRegistryResourceExtension. Implementing the interface "
+      + " <code>SchemaRegistryResourceExtension</code> allows you to inject user defined resources "
+      + " to Schema Registry. These resources will be injected before Schema Registry is "
+      + "initialized.";
   protected static final String RESOURCE_STATIC_LOCATIONS_DOC =
       "  A list of classpath resources containing static resources to serve using the default "
           + "servlet.";
@@ -674,6 +681,9 @@ public class SchemaRegistryConfig extends RestConfig {
     )
     .define(RESOURCE_EXTENSION_CONFIG, ConfigDef.Type.LIST, "",
             ConfigDef.Importance.LOW, SCHEMAREGISTRY_RESOURCE_EXTENSION_DOC
+    )
+    .define(PRE_INIT_RESOURCE_EXTENSION_CONFIG, ConfigDef.Type.LIST, "",
+            ConfigDef.Importance.LOW, PRE_INIT_RESOURCE_EXTENSION_DOC
     )
     .define(RESOURCE_STATIC_LOCATIONS_CONFIG, ConfigDef.Type.LIST, "",
         ConfigDef.Importance.LOW, RESOURCE_STATIC_LOCATIONS_DOC

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryExtensionTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryExtensionTest.java
@@ -48,7 +48,8 @@ public class SchemaRegistryExtensionTest extends ClusterTestHarness {
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][] {
         { SchemaRegistryConfig.RESOURCE_EXTENSION_CONFIG },
-        { SchemaRegistryConfig.SCHEMAREGISTRY_RESOURCE_EXTENSION_CONFIG }
+        { SchemaRegistryConfig.SCHEMAREGISTRY_RESOURCE_EXTENSION_CONFIG },
+        { SchemaRegistryConfig.PRE_INIT_RESOURCE_EXTENSION_CONFIG }
     });
   }
 


### PR DESCRIPTION
Added a new config `pre.init.resource.extension.class` to ensure that the FIPS resource extension can be injected before Kafka Schema Registry is initialized.

[DGS-9006](https://confluentinc.atlassian.net/browse/DGS-9006)



[DGS-9006]: https://confluentinc.atlassian.net/browse/DGS-9006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ