### PR TITLE
update swagger core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <json-schema.version>1.14.3</json-schema.version>
         <protoc.jar.maven.plugin.version>3.11.4</protoc.jar.maven.plugin.version>
         <wire.version>3.6.0</wire.version>
-        <swagger.version>1.6.2</swagger.version>
+        <swagger.version>1.6.12</swagger.version>
         <spotbugs.plugin.version>4.0.0</spotbugs.plugin.version>
         <io.confluent.schema-registry.version>6.1.15-0</io.confluent.schema-registry.version>
         <commons.compress.version>1.21</commons.compress.version>


### PR DESCRIPTION
The outdated swagger brings several outdated dependencies. Updating swagger core helps clean up public component
(io.confluent:kafka-schema-registry-client)