### PR TITLE
DGS-9457 Better exception handling in DlqAction

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/rules/DlqAction.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/rules/DlqAction.java
@@ -130,7 +130,7 @@ public class DlqAction implements RuleAction {
       if (autoFlush) {
         producer.flush();
       }
-    } catch (IOException e) {
+    } catch (Exception e) {
       log.error("Could not produce message to DLQ topic {}", dlqTopic, e);
     }
 

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -745,7 +745,7 @@ public abstract class AbstractKafkaSchemaSerDe implements Closeable {
       }
       try {
         ruleAction.run(ctx, message, ex);
-      } catch (RuleException e) {
+      } catch (Exception e) {
         log.error("Could not run post-rule action {}", action, e);
       }
     }

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -745,7 +745,7 @@ public abstract class AbstractKafkaSchemaSerDe implements Closeable {
       }
       try {
         ruleAction.run(ctx, message, ex);
-      } catch (Exception e) {
+      } catch (RuleException e) {
         log.error("Could not run post-rule action {}", action, e);
       }
     }


### PR DESCRIPTION
Better exception handling in DlqAction.  When DlqAction cannot create a producer, it throws a KafkaException 