### PR TITLE
Reduce downstream builds in confluent-cloud-plugins and confluent-security-plugins

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -85,9 +85,7 @@ after_pipeline:
             if [[ -z "$SEMAPHORE_GIT_PR_BRANCH" ]] && [[ "$SEMAPHORE_PIPELINE_RESULT" == "passed" ]]; then
               sem-trigger -p kafka-rest -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p ksql -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
-              sem-trigger -p confluent-security-plugins -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p kafka-connect-replicator -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p ce-kafka-rest -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
-              sem-trigger -p confluent-cloud-plugins -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p schema-registry-plugins -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
             fi

--- a/service.yml
+++ b/service.yml
@@ -8,8 +8,7 @@ semaphore:
   pipeline_type: cp
   nano_version: true
   execution_time_limit: {"hours": 2}
-  downstream_projects: ["kafka-rest", "ksql",
-    "confluent-security-plugins", "kafka-connect-replicator",
-    "ce-kafka-rest", "confluent-cloud-plugins", "schema-registry-plugins"]
+  downstream_projects: ["kafka-rest", "ksql", "kafka-connect-replicator",
+    "ce-kafka-rest", "schema-registry-plugins"]
 git:
   enable: true


### PR DESCRIPTION
`confluent-cloud-plugins` and `confluent-security-plugins` are facing excessive builds being triggered by upstream repos. The root cause is duplicate mentions of these repos in `downStreamRepos`. This repo directly lists `confluent-cloud-plugins` and `confluent-security-plugins` as downstream repos. This a duplicate as this repo has `kafka-rest` and `ksql` as downstream repos which both independently also have `confluent-cloud-plugins` and `confluent-security-plugins` as downstream repos.

This means that for every build in this repo `confluent-security-plugins`is built three times, and `confluent-cloud-plugins` is built six times (`confluent-cloud-plugins` is listed as downstream repo in `confluent-security-plugins`).

Removing `confluent-cloud-plugins` and `confluent-security-plugins` as downstream repos in this repo will still trigger the downstream builds in those repos from the `kafka-rest` and `ksql` downstream builds but this change will reduce duplicate builds from this repo directly building `confluent-cloud-plugins` and `confluent-security-plugins`.

This commit will be pint merged all the way to master.

Slack: https://confluent.slack.com/archives/C09EP1SS3/p1702678296430679 and
https://confluent.slack.com/archives/C09EP1SS3/p1701141343781609?thread_ts=1701138034.078119&cid=C09EP1SS3