### PR TITLE
DGS-9520 Better handling of JSON Schema singleton combined types

### DIFF
--- a/json-schema-provider/src/test/resources/diff-combined-schema-examples.json
+++ b/json-schema-provider/src/test/resources/diff-combined-schema-examples.json
@@ -522,6 +522,240 @@
     "compatible": true
   },
   {
+    "description": "Detect compatible change from anyOf to oneOf schema with more properties",
+    "original_schema": {
+      "type": "object",
+      "properties": {
+        "prop1": {
+          "anyOf": [
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "update_schema": {
+      "type": "object",
+      "properties": {
+        "prop1": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "changes": [
+      "COMBINED_TYPE_EXTENDED #/properties/prop1",
+      "SUM_TYPE_EXTENDED #/properties/prop1"
+    ],
+    "compatible": true
+  },
+  {
+    "description": "Detect incompatible change from anyOf with more properties to oneOf schema",
+    "original_schema": {
+      "type": "object",
+      "properties": {
+        "prop1": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "update_schema": {
+      "type": "object",
+      "properties": {
+        "prop1": {
+          "oneOf": [
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "changes": [
+      "COMBINED_TYPE_CHANGED #/properties/prop1"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect compatible change from allOf to oneOf schema with more properties",
+    "original_schema": {
+      "type": "object",
+      "properties": {
+        "prop1": {
+          "allOf": [
+            {
+              "type": "number"
+            }
+          ]
+        }
+      }
+    },
+    "update_schema": {
+      "type": "object",
+      "properties": {
+        "prop1": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "changes": [
+      "COMBINED_TYPE_EXTENDED #/properties/prop1",
+      "SUM_TYPE_EXTENDED #/properties/prop1"
+    ],
+    "compatible": true
+  },
+  {
+    "description": "Detect compatible change from anyOf to allOf schema",
+    "original_schema": {
+      "type": "object",
+      "properties": {
+        "prop1": {
+          "anyOf": [
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "update_schema": {
+      "type": "object",
+      "properties": {
+        "prop1": {
+          "allOf": [
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "changes": [
+      "COMBINED_TYPE_EXTENDED #/properties/prop1"
+    ],
+    "compatible": true
+  },
+  {
+    "description": "Detect compatible change from oneOf to allOf schema",
+    "original_schema": {
+      "type": "object",
+      "properties": {
+        "prop1": {
+          "oneOf": [
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "update_schema": {
+      "type": "object",
+      "properties": {
+        "prop1": {
+          "allOf": [
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "changes": [
+      "COMBINED_TYPE_EXTENDED #/properties/prop1"
+    ],
+    "compatible": true
+  },
+  {
+    "description": "Detect incompatible change from anyOf to allOf schema",
+    "original_schema": {
+      "type": "object",
+      "properties": {
+        "prop1": {
+          "anyOf": [
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "update_schema": {
+      "type": "object",
+      "properties": {
+        "prop1": {
+          "allOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "changes": [
+      "COMBINED_TYPE_CHANGED #/properties/prop1"
+    ],
+    "compatible": false
+  },
+  {
+    "description": "Detect incompatible change from oneOf to allOf schema",
+    "original_schema": {
+      "type": "object",
+      "properties": {
+        "prop1": {
+          "oneOf": [
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "update_schema": {
+      "type": "object",
+      "properties": {
+        "prop1": {
+          "allOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "changes": [
+      "COMBINED_TYPE_CHANGED #/properties/prop1"
+    ],
+    "compatible": false
+  },
+  {
     "description": "Detect compatible change from non-combined to anyOf schema",
     "original_schema": {
       "type": "object",

--- a/json-schema-provider/src/test/resources/diff-schema-examples.json
+++ b/json-schema-provider/src/test/resources/diff-schema-examples.json
@@ -888,11 +888,35 @@
     "compatible": false
   },
   {
+    "description": "Detect changes to validation criteria in composed schema type for singleton",
+    "original_schema": {
+      "oneOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "update_schema": {
+      "allOf": [
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "changes": [
+      "COMBINED_TYPE_EXTENDED #/"
+    ],
+    "compatible": true
+  },
+  {
     "description": "Detect changes to validation criteria in composed schema type",
     "original_schema": {
       "oneOf": [
         {
           "type": "string"
+        },
+        {
+          "type": "integer"
         }
       ]
     },


### PR DESCRIPTION
More lenient handling of JSON Schema singleton combined types.  Allows the following schema evolutions to be backward compatible:
- Changing a singleton allOf/anyOf to a oneOf (with possibly more subschemas in the oneOf)
- Changing a singleton anyOf/oneOf to a singleton allOf