### PR TITLE
Handle bug where `enable.fips` config is true but FIPS resource extension class is not configured

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -269,7 +269,7 @@ public class SchemaRegistryConfig extends RestConfig {
       "init.resource.extension.class";
   public static final String RESOURCE_EXTENSION_CONFIG =
       "resource.extension.class";
-  protected static final String ENABLE_FIPS_CONFIG =
+  public static final String ENABLE_FIPS_CONFIG =
       "enable.fips";
   public static final String RESOURCE_STATIC_LOCATIONS_CONFIG =
       "resource.static.locations";

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -269,6 +269,8 @@ public class SchemaRegistryConfig extends RestConfig {
       "init.resource.extension.class";
   public static final String RESOURCE_EXTENSION_CONFIG =
       "resource.extension.class";
+  protected static final String ENABLE_FIPS_CONFIG =
+      "enable.fips";
   public static final String RESOURCE_STATIC_LOCATIONS_CONFIG =
       "resource.static.locations";
   @Deprecated
@@ -697,6 +699,9 @@ public class SchemaRegistryConfig extends RestConfig {
     )
     .define(SCHEMAREGISTRY_RESOURCE_EXTENSION_CONFIG, ConfigDef.Type.LIST, "",
             ConfigDef.Importance.LOW, SCHEMAREGISTRY_RESOURCE_EXTENSION_DOC
+    )
+    .define(ENABLE_FIPS_CONFIG, ConfigDef.Type.BOOLEAN, "false",
+        ConfigDef.Importance.LOW, ""
     )
     .define(RESOURCE_EXTENSION_CONFIG, ConfigDef.Type.LIST, "",
             ConfigDef.Importance.LOW, SCHEMAREGISTRY_RESOURCE_EXTENSION_DOC

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -441,6 +441,9 @@ public class SchemaRegistryConfig extends RestConfig {
       "Login thread will sleep until the specified window factor of time from last refresh to "
       + "ticket's expiry has "
       + "been reached, at which time it will try to renew the ticket.";
+  protected static final String ENABLE_FIPS_DOC =
+      "Enable FIPS mode on the server. If FIPS mode is enabled, broker listener security protocols,"
+      + " TLS versions and cipher suites will be validated based on FIPS compliance requirement.";
   protected static final String SCHEMAREGISTRY_RESOURCE_EXTENSION_DOC =
       "  A list of classes to use as SchemaRegistryResourceExtension. Implementing the interface "
       + " <code>SchemaRegistryResourceExtension</code> allows you to inject user defined resources "
@@ -700,8 +703,8 @@ public class SchemaRegistryConfig extends RestConfig {
     .define(SCHEMAREGISTRY_RESOURCE_EXTENSION_CONFIG, ConfigDef.Type.LIST, "",
             ConfigDef.Importance.LOW, SCHEMAREGISTRY_RESOURCE_EXTENSION_DOC
     )
-    .define(ENABLE_FIPS_CONFIG, ConfigDef.Type.BOOLEAN, "false",
-        ConfigDef.Importance.LOW, ""
+    .define(ENABLE_FIPS_CONFIG, ConfigDef.Type.BOOLEAN, false,
+        ConfigDef.Importance.LOW, ENABLE_FIPS_DOC
     )
     .define(RESOURCE_EXTENSION_CONFIG, ConfigDef.Type.LIST, "",
             ConfigDef.Importance.LOW, SCHEMAREGISTRY_RESOURCE_EXTENSION_DOC

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
@@ -163,7 +163,7 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
     if (schemaRegistryConfig.getBoolean(SchemaRegistryConfig.ENABLE_FIPS_CONFIG)
         && !fipsExtensionProvided) {
       log.error("Error enabling the FIPS resource extension: `enable.fips` is set to true but the "
-          + "`init.resource.extension.class` config does not contain \""
+          + "`init.resource.extension.class` config is either not configured or does not contain \""
           + fipsResourceExtensionClassName + "\"");
       System.exit(1);
     }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
@@ -142,16 +142,29 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
         schemaRegistryConfig.getConfiguredInstances(
           SchemaRegistryConfig.INIT_RESOURCE_EXTENSION_CONFIG,
           SchemaRegistryResourceExtension.class);
+    boolean fipsExtensionProvided = false;
+    String fipsResourceExtensionClassName =
+        "io.confluent.kafka.schemaregistry.security.SchemaRegistryFipsResourceExtension";
     if (preInitResourceExtensions != null) {
       try {
         for (SchemaRegistryResourceExtension
             schemaRegistryResourceExtension : preInitResourceExtensions) {
           schemaRegistryResourceExtension.register(config, schemaRegistryConfig, schemaRegistry);
+          if (schemaRegistryResourceExtension.toString().equals(fipsResourceExtensionClassName)) {
+            fipsExtensionProvided = true;
+          }
         }
       } catch (SchemaRegistryException e) {
         log.error("Error starting the schema registry resource extension", e);
         System.exit(1);
       }
+    }
+    if (schemaRegistryConfig.getBoolean(SchemaRegistryConfig.ENABLE_FIPS_CONFIG)
+        && !fipsExtensionProvided) {
+      log.error("Error enabling the FIPS resource extension: `enable.fips` is set to true but the "
+          + "`init.resource.extension.class` config does not contain \""
+          + fipsResourceExtensionClassName + "\"");
+      System.exit(1);
     }
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryRestApplication.java
@@ -143,14 +143,15 @@ public class SchemaRegistryRestApplication extends Application<SchemaRegistryCon
           SchemaRegistryConfig.INIT_RESOURCE_EXTENSION_CONFIG,
           SchemaRegistryResourceExtension.class);
     boolean fipsExtensionProvided = false;
-    String fipsResourceExtensionClassName =
+    final String fipsResourceExtensionClassName =
         "io.confluent.kafka.schemaregistry.security.SchemaRegistryFipsResourceExtension";
     if (preInitResourceExtensions != null) {
       try {
         for (SchemaRegistryResourceExtension
             schemaRegistryResourceExtension : preInitResourceExtensions) {
           schemaRegistryResourceExtension.register(config, schemaRegistryConfig, schemaRegistry);
-          if (schemaRegistryResourceExtension.toString().equals(fipsResourceExtensionClassName)) {
+          if (fipsResourceExtensionClassName.equals(
+              schemaRegistryResourceExtension.getClass().getCanonicalName())) {
             fipsExtensionProvided = true;
           }
         }


### PR DESCRIPTION
In order to enable FIPS in SR, the `enable.fips` config must be set to `true` AND the `init.resource.extension.class` config must contain `io.confluent.kafka.schemaregistry.security.SchemaRegistryFipsResourceExtension`.

If `enable.fips=true` but the FIPS resource extension class is not provided, throw an error.

[Doc comment](https://confluentinc.atlassian.net/wiki/spaces/DG/pages/3167981097/Implementing+FIPS+Compliance+in+Self-Managed+SR?focusedCommentId=3277922874)