### PR TITLE
Improve the performance of invalid name scrubbing

### DIFF
--- a/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.confluent.kafka.schemaregistry.utils.BoundedConcurrentHashMap;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.util.regex.Pattern;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.generic.GenericData;
@@ -113,9 +112,6 @@ public class AvroData {
   public static final String AVRO_TYPE_ANYTHING = NAMESPACE + ".Anything";
 
   private static final Map<String, Schema.Type> NON_AVRO_TYPES_BY_TYPE_CODE = new HashMap<>();
-
-  private static Pattern NAME_START_CHAR = Pattern.compile("^[A-Za-z_]");
-  private static Pattern NAME_INVALID_CHARS = Pattern.compile("[^A-Za-z0-9_]");
 
   static {
     NON_AVRO_TYPES_BY_TYPE_CODE.put(CONNECT_TYPE_INT8, Schema.Type.INT8);
@@ -1136,15 +1132,45 @@ public class AvroData {
   // Visible for testing
   protected static String doScrubName(String name) {
     try {
-      if (name == null) {
+      if (name == null || name.isEmpty()) {
         return name;
       }
+
+      // This function was originally written more simply using regular expressions, but this was
+      // observed to significantly cut performance by half when locally sourcing data:
+      // https://github.com/confluentinc/schema-registry/issues/2929
+
+      // Fast code path for returning: avoids making a single memory allocation if the name does
+      // not need to be modified.
+      boolean nameOK = true;
+      for (int i = 0, n = name.length(); i < n; i++) {
+        char ch = name.charAt(i);
+        if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
+                || (ch >= '0' && ch <= '9') || ch == '_') {
+          continue;
+        }
+        nameOK = false;
+      }
+      nameOK = nameOK && (name.charAt(0) < '0' || name.charAt(0) > '9');
+      if (nameOK) {
+        return name;
+      }
+
+      // String needs to be scrubbed
       String encoded = URLEncoder.encode(name, "UTF-8");
-      if (!NAME_START_CHAR.matcher(encoded).lookingAt()) {
+      if (encoded.charAt(0) >= '0' && encoded.charAt(0) <= '9') {
         encoded = "x" + encoded;  // use an arbitrary valid prefix
       }
-      encoded = NAME_INVALID_CHARS.matcher(encoded).replaceAll("_");
-      return encoded;
+      StringBuilder sb = new StringBuilder(encoded);
+      for (int i = 0, n = sb.length(); i < n; i++) {
+        char ch = sb.charAt(i);
+        if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
+                || (ch >= '0' && ch <= '9') || ch == '_') {
+          continue;
+        }
+        sb.setCharAt(i, '_');
+      }
+      return sb.toString();
     } catch (UnsupportedEncodingException e) {
       return name;
     }

--- a/avro-data/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-data/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -419,12 +419,17 @@ public class AvroDataTest {
 
   @Test
   public void testNameScrubbing() {
+    assertEquals(null, AvroData.doScrubName(null));
+    assertEquals("", AvroData.doScrubName(""));
+    assertEquals("abc_DEF_123", AvroData.doScrubName("abc_DEF_123")); // nothing to scrub
+
     assertEquals("abc_2B____", AvroData.doScrubName("abc+-.*_"));
     assertEquals("abc_def", AvroData.doScrubName("abc-def"));
     assertEquals("abc_2Bdef", AvroData.doScrubName("abc+def"));
     assertEquals("abc__def", AvroData.doScrubName("abc  def"));
     assertEquals("abc_def", AvroData.doScrubName("abc.def"));
-    assertEquals("x0abc_def", AvroData.doScrubName("0abc.def"));
+    assertEquals("x0abc_def", AvroData.doScrubName("0abc.def")); // invalid start char
+    assertEquals("x0abc", AvroData.doScrubName("0abc")); // (only) invalid start char
   }
 
   @Test

--- a/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufData.java
+++ b/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufData.java
@@ -47,7 +47,6 @@ import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.Set;
 import java.util.TimeZone;
-import java.util.regex.Pattern;
 import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Field;
@@ -284,9 +283,6 @@ public class ProtobufData {
       return Timestamps.fromMillis(Timestamp.fromLogical(schema, date));
     });
   }
-
-  private static Pattern NAME_START_CHAR = Pattern.compile("^[A-Za-z]");  // underscore not allowed
-  private static Pattern NAME_INVALID_CHARS = Pattern.compile("[^A-Za-z0-9_]");
 
   private final Map<Schema, ProtobufSchema> fromConnectSchemaCache;
   private final Map<Pair<String, ProtobufSchema>, Schema> toConnectSchemaCache;
@@ -1665,15 +1661,45 @@ public class ProtobufData {
   // Visible for testing
   protected static String doScrubName(String name) {
     try {
-      if (name == null) {
+      if (name == null || name.isEmpty()) {
         return name;
       }
+
+      // This function was originally written more simply using regular expressions, but this was
+      // observed to significantly cut performance by half when locally sourcing data:
+      // https://github.com/confluentinc/schema-registry/issues/2929
+
+      // Fast code path for returning: avoids making a single memory allocation if the name does
+      // not need to be modified.
+      boolean nameOK = true;
+      for (int i = 0, n = name.length(); i < n; i++) {
+        char ch = name.charAt(i);
+        if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
+                || (ch >= '0' && ch <= '9') || ch == '_') {
+          continue;
+        }
+        nameOK = false;
+      }
+      nameOK = nameOK && (name.charAt(0) < '0' || name.charAt(0) > '9') && name.charAt(0) != '_';
+      if (nameOK) {
+        return name;
+      }
+
+      // String needs to be scrubbed
       String encoded = URLEncoder.encode(name, "UTF-8");
-      if (!NAME_START_CHAR.matcher(encoded).lookingAt()) {
+      if ((encoded.charAt(0) >= '0' && encoded.charAt(0) <= '9') || encoded.charAt(0) == '_') {
         encoded = "x" + encoded;  // use an arbitrary valid prefix
       }
-      encoded = NAME_INVALID_CHARS.matcher(encoded).replaceAll("_");
-      return encoded;
+      StringBuilder sb = new StringBuilder(encoded);
+      for (int i = 0, n = sb.length(); i < n; i++) {
+        char ch = sb.charAt(i);
+        if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
+                || (ch >= '0' && ch <= '9') || ch == '_') {
+          continue;
+        }
+        sb.setCharAt(i, '_');
+      }
+      return sb.toString();
     } catch (UnsupportedEncodingException e) {
       return name;
     }

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
@@ -1723,13 +1723,19 @@ public class ProtobufDataTest {
 
   @Test
   public void testNameScrubbing() {
+    assertEquals(null, ProtobufData.doScrubName(null));
+    assertEquals("", ProtobufData.doScrubName(""));
+    assertEquals("abc_DEF_123", ProtobufData.doScrubName("abc_DEF_123")); // nothing to scrub
+
     assertEquals("abc_2B____", ProtobufData.doScrubName("abc+-.*_"));
     assertEquals("abc_def", ProtobufData.doScrubName("abc-def"));
     assertEquals("abc_2Bdef", ProtobufData.doScrubName("abc+def"));
     assertEquals("abc__def", ProtobufData.doScrubName("abc  def"));
     assertEquals("abc_def", ProtobufData.doScrubName("abc.def"));
-    assertEquals("x0abc_def", ProtobufData.doScrubName("0abc.def"));
-    assertEquals("x_abc_def", ProtobufData.doScrubName("_abc.def"));
+    assertEquals("x0abc_def", ProtobufData.doScrubName("0abc.def")); // invalid start char
+    assertEquals("x_abc_def", ProtobufData.doScrubName("_abc.def")); // invalid start char
+    assertEquals("x0abc", ProtobufData.doScrubName("0abc")); // (only) invalid start char
+    assertEquals("x_abc", ProtobufData.doScrubName("_abc")); // (only) invalid start char
   }
 
   @Test


### PR DESCRIPTION
Cherry pick [c53b8f0](https://github.com/confluentinc/schema-registry/pull/2932/commits/c53b8f006316e28667fbaa46cac02e0ca6dd92ec) to 7.0.x

When scrubbing names, avoid regular expressions at all cost.  Also avoid URL encoding (or really, any memory allocation) when it is not necessary.  This makes a huge difference processing large numbers of records.  Fixes #2929.