### PR TITLE
limit log message on rest client exception

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -173,7 +173,7 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
       // ClassCastException, etc
       throw new SerializationException("Error serializing Avro message", e);
     } catch (RestClientException e) {
-      throw toKafkaException(e, restClientErrorMsg + schema);
+      throw toKafkaException(e, restClientErrorMsg);
     } finally {
       postOp(object);
     }


### PR DESCRIPTION
Logging the whole avro-schema could lead to very large log messages. In our case we generated many 16 KB logs.

I would propose to not log the whole schema to avoid that risk.