### PR TITLE
Fix breaking change to ParsedSchema.validate method

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
@@ -181,6 +181,14 @@ public interface ParsedSchema {
    * Validates the schema and ensures all references are resolved properly.
    * Throws an exception if the schema is not valid.
    */
+  default void validate() {
+    validate(false);
+  }
+
+  /**
+   * Validates the schema and ensures all references are resolved properly.
+   * Throws an exception if the schema is not valid.
+   */
   default void validate(boolean strict) {
   }
 


### PR DESCRIPTION
fixes: https://github.com/confluentinc/schema-registry/issues/2944

Obviously, there is nothing we can do to "fix" the 7.5.3 release. That's always going to have this breaking change. But it would be nice if this change could be merged and added to 7.5.4 and later minor versions in the pipeline.

Side note, it would probably be useful if the meaning of the new `strict` parameter was included in the javadocs of the `validate(boolean strict)` method.

