### PR TITLE
Update commons-compress to 1.25.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <wire.version>4.9.0</wire.version>
         <swagger.version>2.1.10</swagger.version>
         <io.confluent.schema-registry.version>7.7.0-0</io.confluent.schema-registry.version>
-        <commons.compress.version>1.21</commons.compress.version>
+        <commons.compress.version>1.25.0</commons.compress.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
         <commons.validator.version>1.7</commons.validator.version>
     </properties>


### PR DESCRIPTION
org.apache.commons:commons-compress:1.22.0, which is brought in by Avro, has known vulnerabilities: https://security.snyk.io/package/maven/org.apache.commons:commons-compress/1.22