### PR TITLE
upgrade wire-schema to 4.9.7 from 6.2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <kotlin.version>1.9.10</kotlin.version>
         <json-schema.version>1.14.3</json-schema.version>
         <protoc.jar.maven.plugin.version>3.11.4</protoc.jar.maven.plugin.version>
-        <wire.version>4.9.0</wire.version>
+        <wire.version>4.9.7</wire.version>
         <swagger.version>1.6.12</swagger.version>
         <io.confluent.schema-registry.version>6.2.15-0</io.confluent.schema-registry.version>
         <commons.compress.version>1.21</commons.compress.version>

--- a/pom.xml
+++ b/pom.xml
@@ -77,10 +77,10 @@
         <podam.version>6.0.2.RELEASE</podam.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
-        <kotlin.version>1.6.0</kotlin.version>
+        <kotlin.version>1.9.10</kotlin.version>
         <json-schema.version>1.14.3</json-schema.version>
         <protoc.jar.maven.plugin.version>3.11.4</protoc.jar.maven.plugin.version>
-        <wire.version>4.8.1</wire.version>
+        <wire.version>4.9.0</wire.version>
         <swagger.version>1.6.12</swagger.version>
         <io.confluent.schema-registry.version>6.2.15-0</io.confluent.schema-registry.version>
         <commons.compress.version>1.21</commons.compress.version>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <kotlin.version>1.6.0</kotlin.version>
         <json-schema.version>1.14.3</json-schema.version>
         <protoc.jar.maven.plugin.version>3.11.4</protoc.jar.maven.plugin.version>
-        <wire.version>4.8.0</wire.version>
+        <wire.version>4.8.1</wire.version>
         <swagger.version>1.6.12</swagger.version>
         <io.confluent.schema-registry.version>6.2.15-0</io.confluent.schema-registry.version>
         <commons.compress.version>1.21</commons.compress.version>

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,10 @@
                         <groupId>org.jetbrains.kotlin</groupId>
                         <artifactId>kotlin-stdlib</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>com.squareup.okio</groupId>
+                        <artifactId>okio</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <kotlin.version>1.6.0</kotlin.version>
         <json-schema.version>1.14.3</json-schema.version>
         <protoc.jar.maven.plugin.version>3.11.4</protoc.jar.maven.plugin.version>
-        <wire.version>3.6.0</wire.version>
+        <wire.version>4.8.0</wire.version>
         <swagger.version>1.6.12</swagger.version>
         <io.confluent.schema-registry.version>6.2.15-0</io.confluent.schema-registry.version>
         <commons.compress.version>1.21</commons.compress.version>
@@ -134,16 +134,27 @@
             </dependency>
             <dependency>
                 <groupId>com.squareup.wire</groupId>
-                <artifactId>wire-schema</artifactId>
+                <artifactId>wire-schema-jvm</artifactId>
                 <version>${wire.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jetbrains.kotlin</groupId>
                         <artifactId>kotlin-stdlib</artifactId>
                     </exclusion>
+<!--                    <exclusion>-->
+<!--                        <groupId>com.squareup.okio</groupId>-->
+<!--                        <artifactId>okio</artifactId>-->
+<!--                    </exclusion>-->
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.wire</groupId>
+                <artifactId>wire-runtime-jvm</artifactId>
+                <version>${wire.version}</version>
+                <exclusions>
                     <exclusion>
-                        <groupId>com.squareup.okio</groupId>
-                        <artifactId>okio</artifactId>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-stdlib</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -141,10 +141,6 @@
                         <groupId>org.jetbrains.kotlin</groupId>
                         <artifactId>kotlin-stdlib</artifactId>
                     </exclusion>
-<!--                    <exclusion>-->
-<!--                        <groupId>com.squareup.okio</groupId>-->
-<!--                        <artifactId>okio</artifactId>-->
-<!--                    </exclusion>-->
                 </exclusions>
             </dependency>
             <dependency>

--- a/protobuf-converter/pom.xml
+++ b/protobuf-converter/pom.xml
@@ -50,17 +50,7 @@
         </dependency>
         <dependency>
             <groupId>com.squareup.wire</groupId>
-            <artifactId>wire-schema</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jetbrains.kotlin</groupId>
-                    <artifactId>kotlin-stdlib-jdk8</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jetbrains.kotlin</groupId>
-                    <artifactId>kotlin-stdlib-common</artifactId>
-                </exclusion>
-            </exclusions>
+            <artifactId>wire-schema-jvm</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/protobuf-provider/pom.xml
+++ b/protobuf-provider/pom.xml
@@ -34,7 +34,11 @@
         </dependency>
         <dependency>
             <groupId>com.squareup.wire</groupId>
-            <artifactId>wire-schema</artifactId>
+            <artifactId>wire-schema-jvm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.wire</groupId>
+            <artifactId>wire-runtime-jvm</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -457,6 +457,7 @@ public class ProtobufSchema implements ParsedSchema {
             .map(e -> toOneof(e.getKey(), e.getValue()))
             .collect(Collectors.toList()),
         Collections.emptyList(),
+        Collections.emptyList(),
         Collections.emptyList()
     );
   }
@@ -494,7 +495,7 @@ public class ProtobufSchema implements ParsedSchema {
     log.trace("*** oneof name: {}", name);
     // NOTE: skip groups
     return new OneOfElement(name, "", fields.build(),
-        Collections.emptyList(), Collections.emptyList());
+        Collections.emptyList(), Collections.emptyList(), DEFAULT_LOCATION);
   }
 
   private static EnumElement toEnum(EnumDescriptorProto ed) {
@@ -538,7 +539,8 @@ public class ProtobufSchema implements ParsedSchema {
       }
     }
     // NOTE: skip some options
-    return new EnumElement(DEFAULT_LOCATION, name, "", options.build(), constants.build());
+    return new EnumElement(DEFAULT_LOCATION, name, "", options.build(), constants.build(),
+            Collections.emptyList());
   }
 
   private static FieldElement toField(


### PR DESCRIPTION
wire version 3.6.0 using the older okio version which has CVE.
JIRA: https://confluentinc.atlassian.net/browse/DGS-8893 
Upgrade the wire schema version to 4.9.7 and kotlin to 1.19 because the wire schema >=4.9.0 is not compatible with kotlin 1.16.