### PR TITLE
Add SSL configurations to OAuth client

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClientConfig.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClientConfig.java
@@ -16,9 +16,11 @@
 
 package io.confluent.kafka.schemaregistry.client;
 
-import java.util.Map;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.SaslConfigs;
+
+import java.util.Map;
+import java.util.stream.Collectors;
 
 
 public class SchemaRegistryClientConfig {
@@ -75,6 +77,7 @@ public class SchemaRegistryClientConfig {
   public static final String BEARER_AUTH_CUSTOM_PROVIDER_CLASS =
       "bearer.auth.custom.provider.class";
 
+  public static final String SSL_PREFIX = "ssl.";
 
   public static void withClientSslSupport(ConfigDef configDef, String namespace) {
     org.apache.kafka.common.config.ConfigDef sslConfigDef = new org.apache.kafka.common.config
@@ -166,4 +169,9 @@ public class SchemaRegistryClientConfig {
         : BEARER_AUTH_SUB_CLAIM_NAME_DEFAULT;
   }
 
+  public static Map<String, Object> getClientSslConfig(Map<String, ?> configs) {
+    return configs.entrySet().stream()
+        .filter(e -> e.getKey().startsWith(SSL_PREFIX))
+        .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
+  }
 }

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/OauthCredentialProviderTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/OauthCredentialProviderTest.java
@@ -25,6 +25,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.ConfigException;
 import org.junit.Assert;
 import org.junit.Before;
@@ -86,6 +88,21 @@ public class OauthCredentialProviderTest {
           });
 
     }
+  }
+
+  @Test
+  public void testClientSslConfigurations() throws MalformedURLException {
+
+    Map<String, Object> CONFIG_WITH_SSL = new HashMap<>(CONFIG_MAP);
+    CONFIG_WITH_SSL.put("ssl.truststore.location", "truststore.jks");
+    CONFIG_WITH_SSL.put("ssl.truststore.password", "password");
+
+    // SSL configurations should get loaded if present in configuration
+    Assert.assertThrows("Message", KafkaException.class,
+        () -> {
+          oAuthCredentialProvider.configure(CONFIG_WITH_SSL);
+        });
+
   }
 
   private Map<String, Object> getInsufficentConfigs(String missingConfig) {


### PR DESCRIPTION
Adding client ssl configurations if they are available. 
We need this support the CP use case where we may have IDP with self signed certificates. 

JIRA - https://confluentinc.atlassian.net/browse/CPSEC-75