### PR TITLE
KSECURITY-2211: update azure-identity to match the version used in ce-kafka

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-identity</artifactId>
-                <version>1.9.2</version>
+                <version>1.11.2</version>
             </dependency>
             <dependency>
                 <groupId>com.azure</groupId>


### PR DESCRIPTION
Please update azure-identity to match the version used in ce-kafka  to fix CVE-2023-34062