### PR TITLE
DGS-10203 Add JSON Schema converter config to ignore modern dialects

### DIFF
--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
@@ -925,6 +925,9 @@ public class JsonSchemaData {
     if (schema == null) {
       return null;
     }
+    if (config.ignoreModernDialects()) {
+      schema = schema.copyIgnoringModernDialects();
+    }
     Schema cachedSchema = toConnectSchemaCache.get(schema);
     if (cachedSchema != null) {
       return cachedSchema;

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaDataConfig.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaDataConfig.java
@@ -42,6 +42,11 @@ public class JsonSchemaDataConfig extends AbstractDataConfig {
   public static final String USE_OPTIONAL_FOR_NON_REQUIRED_DOC =
       "Whether to set non-required properties to be optional.";
 
+  public static final String IGNORE_MODERN_DIALECTS_CONFIG = "ignore.modern.dialects";
+  public static final boolean IGNORE_MODERN_DIALECTS_DEFAULT = false;
+  public static final String IGNORE_MODERN_DIALECTS_DOC = "Whether to ignore modern dialects "
+      + "of JSON Schema after draft 7, in which case draft 7 will be used.";
+
   public static final String DECIMAL_FORMAT_CONFIG = "decimal.format";
   public static final String DECIMAL_FORMAT_DEFAULT = DecimalFormat.BASE64.name();
   private static final String DECIMAL_FORMAT_DOC =
@@ -61,6 +66,12 @@ public class JsonSchemaDataConfig extends AbstractDataConfig {
         USE_OPTIONAL_FOR_NON_REQUIRED_DEFAULT,
         ConfigDef.Importance.MEDIUM,
         USE_OPTIONAL_FOR_NON_REQUIRED_DOC
+    ).define(
+        IGNORE_MODERN_DIALECTS_CONFIG,
+        ConfigDef.Type.BOOLEAN,
+        IGNORE_MODERN_DIALECTS_DEFAULT,
+        ConfigDef.Importance.LOW,
+        IGNORE_MODERN_DIALECTS_DOC
     ).define(
         DECIMAL_FORMAT_CONFIG,
         ConfigDef.Type.STRING,
@@ -91,6 +102,10 @@ public class JsonSchemaDataConfig extends AbstractDataConfig {
    */
   public DecimalFormat decimalFormat() {
     return DecimalFormat.valueOf(getString(DECIMAL_FORMAT_CONFIG).toUpperCase(Locale.ROOT));
+  }
+
+  public boolean ignoreModernDialects() {
+    return getBoolean(IGNORE_MODERN_DIALECTS_CONFIG);
   }
 
   public static class Builder {

--- a/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
+++ b/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
@@ -1917,6 +1917,53 @@ public class JsonSchemaDataTest {
     Schema connectSchema = jsonSchemaData.toConnectSchema(jsonSchema);
     assertTrue(connectSchema.field("assetMetadata").schema().isOptional());
   }
+
+  @Test
+  public void testIgnoreModernDialects() {
+    String schema = "{ \n"
+        + "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n"
+        + "  \"type\": \"object\",\n"
+        + "  \"properties\": {\n"
+        + "   \"object_details\": {\n"
+        + "      \"additionalProperties\": true,\n"
+        + "      \"properties\": {\n"
+        + "        \"object_parents\": {\n"
+        + "          \"items\": {\n"
+        + "            \"properties\": {\n"
+        + "              \"object_parents_file_location\": {\n"
+        + "                \"type\": [\n"
+        + "                  \"string\",\n"
+        + "                  \"null\"\n"
+        + "                ]\n"
+        + "              },\n"
+        + "              \"object_parents_id\": {\n"
+        + "                \"type\": [\n"
+        + "                  \"string\",\n"
+        + "                  \"null\"\n"
+        + "                ]\n"
+        + "              }\n"
+        + "            },\n"
+        + "            \"type\": [\n"
+        + "              \"object\",\n"
+        + "              \"null\"\n"
+        + "            ]\n"
+        + "          },\n"
+        + "          \"type\": [\n"
+        + "            \"array\",\n"
+        + "            \"null\"\n"
+        + "          ]\n"
+        + "        }\n"
+        + "      }\n"
+        + "    }\n"
+        + "  }\n"
+        + "}";
+    JsonSchema jsonSchema = new JsonSchema(schema);
+    JsonSchemaData jsonSchemaData =
+        new JsonSchemaData(new JsonSchemaDataConfig(
+            Collections.singletonMap(JsonSchemaDataConfig.IGNORE_MODERN_DIALECTS_CONFIG, "true")));
+    Schema connectSchema = jsonSchemaData.toConnectSchema(jsonSchema);
+    System.out.println(connectSchema);
+  }
   
   @Test
   public void testToConnectRecursiveSchema() {


### PR DESCRIPTION
Add a JSON Schema converter config "ignore.modern.dialects" to retain the previous behavior, before support for Draft 2020-12 was added. 