### PR TITLE
DGS-10206 Fix handling of multitype JSON schemas for 2020-12

### DIFF
--- a/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
+++ b/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
@@ -1964,7 +1964,54 @@ public class JsonSchemaDataTest {
     Schema connectSchema = jsonSchemaData.toConnectSchema(jsonSchema);
     assertNotNull(connectSchema.field("object_details").schema());
   }
-  
+
+  @Test
+  public void testUseModernDialects() {
+    String schema = "{ \n"
+        + "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n"
+        + "  \"type\": \"object\",\n"
+        + "  \"properties\": {\n"
+        + "   \"object_details\": {\n"
+        + "      \"additionalProperties\": true,\n"
+        + "      \"properties\": {\n"
+        + "        \"object_parents\": {\n"
+        + "          \"items\": {\n"
+        + "            \"properties\": {\n"
+        + "              \"object_parents_file_location\": {\n"
+        + "                \"type\": [\n"
+        + "                  \"string\",\n"
+        + "                  \"null\"\n"
+        + "                ]\n"
+        + "              },\n"
+        + "              \"object_parents_id\": {\n"
+        + "                \"type\": [\n"
+        + "                  \"string\",\n"
+        + "                  \"null\"\n"
+        + "                ]\n"
+        + "              }\n"
+        + "            },\n"
+        + "            \"type\": [\n"
+        + "              \"object\",\n"
+        + "              \"null\"\n"
+        + "            ]\n"
+        + "          },\n"
+        + "          \"type\": [\n"
+        + "            \"array\",\n"
+        + "            \"null\"\n"
+        + "          ]\n"
+        + "        }\n"
+        + "      }\n"
+        + "    }\n"
+        + "  }\n"
+        + "}";
+    JsonSchema jsonSchema = new JsonSchema(schema);
+    JsonSchemaData jsonSchemaData =
+        new JsonSchemaData(new JsonSchemaDataConfig(
+            Collections.singletonMap(JsonSchemaDataConfig.IGNORE_MODERN_DIALECTS_CONFIG, "false")));
+    Schema connectSchema = jsonSchemaData.toConnectSchema(jsonSchema);
+    assertNotNull(connectSchema.field("object_details").schema());
+  }
+
   @Test
   public void testToConnectRecursiveSchema() {
     JsonSchema jsonSchema = getRecursiveJsonSchema();

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/schema/SchemaUtils.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/schema/SchemaUtils.java
@@ -23,6 +23,7 @@ import java.util.regex.Pattern;
 import org.everit.json.schema.ArraySchema;
 import org.everit.json.schema.BooleanSchema;
 import org.everit.json.schema.CombinedSchema;
+import org.everit.json.schema.CombinedSchema.ValidationCriterion;
 import org.everit.json.schema.ConditionalSchema;
 import org.everit.json.schema.ConstSchema;
 import org.everit.json.schema.ConstSchema.ConstSchemaBuilder;
@@ -387,6 +388,30 @@ public class SchemaUtils {
     if (s.getUnprocessedProperties() != null) {
       builder.unprocessedProperties(s.getUnprocessedProperties());
     }
+  }
+
+  protected static boolean containsType(CombinedSchema combinedSchema, Schema schema) {
+    for (Schema subschema : combinedSchema.getSubschemas()) {
+      if (subschema.getClass().equals(schema.getClass())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  protected static boolean isSyntheticAll(Schema schema) {
+    return schema instanceof CombinedSchema
+        && isSyntheticCombined((CombinedSchema) schema, CombinedSchema.ALL_CRITERION);
+  }
+
+  protected static boolean isSyntheticAny(Schema schema) {
+    return schema instanceof CombinedSchema
+        && isSyntheticCombined((CombinedSchema) schema, CombinedSchema.ANY_CRITERION);
+  }
+
+  protected static boolean isSyntheticCombined(
+      CombinedSchema schema, ValidationCriterion criterion) {
+    return schema.getCriterion() == criterion && isSynthetic(schema);
   }
 
   protected static boolean isSynthetic(CombinedSchema schema) {

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
@@ -981,6 +981,51 @@ public class JsonSchemaTest {
   }
 
   @Test
+  public void testMultiTypeSchemaDraft_2020_12() {
+    String schema = "{ \n"
+        + "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n"
+        + "  \"type\": \"object\",\n"
+        + "  \"properties\": {\n"
+        + "   \"object_details\": {\n"
+        + "      \"additionalProperties\": true,\n"
+        + "      \"properties\": {\n"
+        + "        \"object_parents\": {\n"
+        + "          \"items\": {\n"
+        + "            \"properties\": {\n"
+        + "              \"object_parents_file_location\": {\n"
+        + "                \"type\": [\n"
+        + "                  \"string\",\n"
+        + "                  \"null\"\n"
+        + "                ]\n"
+        + "              },\n"
+        + "              \"object_parents_id\": {\n"
+        + "                \"type\": [\n"
+        + "                  \"string\",\n"
+        + "                  \"null\"\n"
+        + "                ]\n"
+        + "              }\n"
+        + "            },\n"
+        + "            \"type\": [\n"
+        + "              \"object\",\n"
+        + "              \"null\"\n"
+        + "            ]\n"
+        + "          },\n"
+        + "          \"type\": [\n"
+        + "            \"array\",\n"
+        + "            \"null\"\n"
+        + "          ]\n"
+        + "        }\n"
+        + "      }\n"
+        + "    }\n"
+        + "  }\n"
+        + "}";
+    JsonSchema jsonSchema = new JsonSchema(schema);
+    JsonSchema jsonSchema2 = jsonSchema.copyIgnoringModernDialects();
+    assertTrue(jsonSchema2.isBackwardCompatible(jsonSchema).isEmpty());
+    assertTrue(jsonSchema.isBackwardCompatible(jsonSchema2).isEmpty());
+  }
+
+  @Test
   public void testLocalReferenceDraft_2020_12() {
     String parent = "{\n"
         + "    \"$id\": \"acme.webhooks.checkout-application_updated.jsonschema.json\",\n"


### PR DESCRIPTION
Better handling of multitype JSON schemas (where a type is specified as an array of subtypes) in the context of compatibility checks and Connect converters.