### PR TITLE
fix: invalid behaviour for stringSchema in allOfToConnectSchema

### DIFF
--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
@@ -1216,6 +1216,7 @@ public class JsonSchemaData {
         // This is a number or integer with a format
         return toConnectSchema(ctx, numberSchema, version, forceOptional);
       }
+      return toConnectSchema(ctx, stringSchema, version, forceOptional);
     }
     throw new IllegalArgumentException("Unsupported criterion "
         + combinedSchema.getCriterion() + " for " + combinedSchema);


### PR DESCRIPTION
allOfToConnectSchema doesn't have a case for when the combinedSchema is just a plain stringSchema and causes an error to be thrown