### PR TITLE
DGS-10369 Add support for $defs for JSON Schema 2020-12

### DIFF
--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaUtils.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaUtils.java
@@ -348,6 +348,9 @@ public class JsonSchemaUtils {
         if ("definitions".equals(word)) {
           identifiersList.poll();
           result = findNodeFromNameBuilder(node.get("definitions"), identifiersList);
+        } else if ("$defs".equals(word)) {
+          identifiersList.poll();
+          result = findNodeFromNameBuilder(node.get("$defs"), identifiersList);
         } else {
           result = findNodeFromNameBuilder(node.get("properties"), identifiersList);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <guice.version>5.1.0</guice.version>
         <jsonata-version>2.4.5</jsonata-version>
         <json-schema.version>1.14.3</json-schema.version>
-        <json-skema.version>0.13.0</json-skema.version>
+        <json-skema.version>0.14.0</json-skema.version>
         <kcache.version>4.0.11</kcache.version>
         <proto-google-common-protos.version>2.22.1</proto-google-common-protos.version>
         <protoc.jar.maven.plugin.version>3.11.4</protoc.jar.maven.plugin.version>


### PR DESCRIPTION
The JSON Schema 2020-12 library that we use, json-skema, recently added better support for $defs (see [json-sKema: //github taking subschemas defined under $defs into account while resolving dynamic references](https://github.com/erosb/json-sKema/commit/c8c1352e48a45f750e715b590a375a9ff22abe32) ).  