### PR TITLE
DP-13727 Add CodeArtifact package paths to service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -19,9 +19,9 @@ code_artifact:
     - maven-snapshots/maven/io.confluent/kafka-serde-tools-package
     - maven-snapshots/maven/io.confluent/kafka-streams-*
     - maven-snapshots/maven/io.confluent/kafka-connect-*
-    - maven-snapshots/maven/io.confluent/dek-registry
-    - maven-snapshots/maven/io.confluent/dek-registry-client
+    - maven-snapshots/maven/io.confluent/dek-registry*
     - maven-snapshots/maven/io.confluent/kafka-protobuf-*
     - maven-snapshots/maven/io.confluent/kafka-json-*
     - maven-snapshots/maven/io.confluent/kafka-schema-*
     - maven-snapshots/maven/io.confluent/kafka-avro-serializer
+    - pypi-internal/pypi//confluent-ci-tools


### PR DESCRIPTION
One of the Capsaicin requirements requires that all artifacts uploaded to CodeArtifacts come from specific Semaphore jobs.
This PR adds package_paths to service.yml so that each GitHub repo can declare the path of the CodeArtifact packages that it writes to.
For newer GitHub repos, the package_paths needs to be added to the service.yml file manually before it can write to CodeArtifact in the Semaphore pipeline.
For more information about this, see https://confluent.slack.com/archives/C038ZJ00P/p1708464192287999