### PR TITLE
DGS-10391 Add query param to extract schema entities with given tags

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
@@ -131,6 +131,15 @@ public interface ParsedSchema {
   }
 
   /**
+   * Returns the inline tagged entities of the schema.
+   *
+   * @return a map of entity name to tags
+   */
+  default Map<SchemaEntity, Set<String>> inlineTaggedEntities() {
+    return Collections.emptyMap();
+  }
+
+  /**
    * Returns a copy of this schema.
    *
    * @return a copy of this schema

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
@@ -31,7 +31,6 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleKind;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
-import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity.EntityType;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.rules.FieldTransform;
 import io.confluent.kafka.schemaregistry.rules.RuleConditionException;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
@@ -16,6 +16,9 @@
 
 package io.confluent.kafka.schemaregistry.avro;
 
+import static io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity.EntityType.SR_FIELD;
+import static io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity.EntityType.SR_RECORD;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,6 +31,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleKind;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity.EntityType;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.rules.FieldTransform;
 import io.confluent.kafka.schemaregistry.rules.RuleConditionException;
@@ -41,8 +45,8 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -684,11 +688,68 @@ public class AvroSchema implements ParsedSchema {
     node.forEach(n -> getInlineTagsRecursively(tags, n));
   }
 
+  @Override
+  public Map<SchemaEntity, Set<String>> inlineTaggedEntities() {
+    Map<SchemaEntity, Set<String>> tags = new LinkedHashMap<>();
+    Schema schema = rawSchema();
+    if (schema == null) {
+      return tags;
+    }
+    getInlineTaggedEntitiesRecursively(tags, schema);
+    return tags;
+  }
+
+  private void getInlineTaggedEntitiesRecursively(
+      Map<SchemaEntity, Set<String>> tags, Schema schema) {
+    switch (schema.getType()) {
+      case UNION:
+        for (Schema subtype : schema.getTypes()) {
+          getInlineTaggedEntitiesRecursively(tags, subtype);
+        }
+        break;
+      case ARRAY:
+        getInlineTaggedEntitiesRecursively(tags, schema.getElementType());
+        break;
+      case MAP:
+        getInlineTaggedEntitiesRecursively(tags, schema.getValueType());
+        break;
+      case RECORD:
+        Set<String> recordTags = getInlineTags(schema);
+        if (!recordTags.isEmpty()) {
+          tags.put(new SchemaEntity(schema.getFullName(), SR_RECORD), recordTags);
+        }
+        for (Schema.Field f : schema.getFields()) {
+          Set<String> fieldTags = getInlineTags(f);
+          if (!fieldTags.isEmpty()) {
+            String x = schema.getFullName() + "." + f.name();
+            tags.put(new SchemaEntity(schema.getFullName() + "." + f.name(), SR_FIELD), fieldTags);
+          }
+          getInlineTaggedEntitiesRecursively(tags, f.schema());
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  private Set<String> getInlineTags(Schema record) {
+    Object prop = record.getObjectProp(TAGS);
+    if (prop instanceof List) {
+      List<?> tags = (List<?>) prop;
+      Set<String> result = new LinkedHashSet<>(tags.size());
+      for (Object tag : tags) {
+        result.add(tag.toString());
+      }
+      return result;
+    }
+    return Collections.emptySet();
+  }
+
   private Set<String> getInlineTags(Schema.Field field) {
     Object prop = field.getObjectProp(TAGS);
     if (prop instanceof List) {
       List<?> tags = (List<?>) prop;
-      Set<String> result = new HashSet<>(tags.size());
+      Set<String> result = new LinkedHashSet<>(tags.size());
       for (Object tag : tags) {
         result.add(tag.toString());
       }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -897,7 +897,7 @@ public class RestService implements Closeable, Configurable {
 
   public SchemaString getId(Map<String, String> requestProperties,
       int id, String subject, boolean fetchMaxId) throws IOException, RestClientException {
-    return getId(requestProperties, id, subject, null, false);
+    return getId(requestProperties, id, subject, null, fetchMaxId);
   }
 
   public SchemaString getId(Map<String, String> requestProperties,
@@ -967,7 +967,7 @@ public class RestService implements Closeable, Configurable {
   public Schema getVersion(Map<String, String> requestProperties,
                            String subject, int version, boolean lookupDeletedSchema)
       throws IOException, RestClientException {
-    return getVersion(requestProperties, subject, version, false, null);
+    return getVersion(requestProperties, subject, version, lookupDeletedSchema, null);
   }
 
   public Schema getVersion(Map<String, String> requestProperties,

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -241,8 +241,8 @@ public class RestService implements Closeable, Configurable {
     String proxyHost = (String) configs.get(SchemaRegistryClientConfig.PROXY_HOST);
     Object proxyPortVal = configs.get(SchemaRegistryClientConfig.PROXY_PORT);
     Integer proxyPort = proxyPortVal instanceof String
-        ? Integer.valueOf((String) proxyPortVal)
-        : (Integer) proxyPortVal;
+                        ? Integer.valueOf((String) proxyPortVal)
+                        : (Integer) proxyPortVal;
 
     if (isValidProxyConfig(proxyHost, proxyPort)) {
       setProxy(proxyHost, proxyPort);
@@ -283,15 +283,15 @@ public class RestService implements Closeable, Configurable {
    * @return The deserialized response to the HTTP request, or null if no data is expected.
    */
   private <T> T sendHttpRequest(String requestUrl, String method, byte[] requestBodyData,
-      Map<String, String> requestProperties,
-      TypeReference<T> responseFormat)
+                                Map<String, String> requestProperties,
+                                TypeReference<T> responseFormat)
       throws IOException, RestClientException {
     String requestData = requestBodyData == null
-        ? "null"
-        : new String(requestBodyData, StandardCharsets.UTF_8);
+                         ? "null"
+                         : new String(requestBodyData, StandardCharsets.UTF_8);
     log.debug(String.format("Sending %s with input %s to %s",
-        method, requestData,
-        requestUrl));
+                            method, requestData,
+                            requestUrl));
 
     HttpURLConnection connection = null;
     try {
@@ -333,7 +333,7 @@ public class RestService implements Closeable, Configurable {
           }
         }
         throw new RestClientException(errorMessage.getMessage(), responseCode,
-            errorMessage.getErrorCode());
+                                      errorMessage.getErrorCode());
       }
 
     } finally {
@@ -344,7 +344,7 @@ public class RestService implements Closeable, Configurable {
   }
 
   private HttpURLConnection buildConnection(URL url, String method, Map<String,
-      String> requestProperties)
+                                            String> requestProperties)
       throws IOException {
     HttpURLConnection connection = null;
     if (proxy == null) {
@@ -394,10 +394,10 @@ public class RestService implements Closeable, Configurable {
    * @return The deserialized response to the HTTP request, or null if no data is expected.
    */
   public <T> T httpRequest(String path,
-      String method,
-      byte[] requestBodyData,
-      Map<String, String> requestProperties,
-      TypeReference<T> responseFormat)
+                           String method,
+                           byte[] requestBodyData,
+                           Map<String, String> requestProperties,
+                           TypeReference<T> responseFormat)
       throws IOException, RestClientException {
     if (isForward) {
       requestProperties.put(X_FORWARD_HEADER, "true");
@@ -407,10 +407,10 @@ public class RestService implements Closeable, Configurable {
       String requestUrl = buildRequestUrl(baseUrl, path);
       try {
         return sendHttpRequest(requestUrl,
-            method,
-            requestBodyData,
-            requestProperties,
-            responseFormat);
+                               method,
+                               requestBodyData,
+                               requestProperties,
+                               responseFormat);
       } catch (IOException e) {
         baseUrls.fail(baseUrl);
         if (i == n - 1) {
@@ -435,16 +435,16 @@ public class RestService implements Closeable, Configurable {
 
   // Visible for testing
   public Schema lookUpSubjectVersion(String schemaString,
-      String subject,
-      boolean lookupDeletedSchema)
+                                     String subject,
+                                     boolean lookupDeletedSchema)
       throws IOException, RestClientException {
     return lookUpSubjectVersion(schemaString, subject, false, lookupDeletedSchema);
   }
 
   public Schema lookUpSubjectVersion(String schemaString,
-      String subject,
-      boolean normalize,
-      boolean lookupDeletedSchema)
+                                     String subject,
+                                     boolean normalize,
+                                     boolean lookupDeletedSchema)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
@@ -453,21 +453,21 @@ public class RestService implements Closeable, Configurable {
   }
 
   public Schema lookUpSubjectVersion(String schemaString,
-      String schemaType,
-      List<SchemaReference> references,
-      String subject,
-      boolean lookupDeletedSchema)
+                                     String schemaType,
+                                     List<SchemaReference> references,
+                                     String subject,
+                                     boolean lookupDeletedSchema)
       throws IOException, RestClientException {
     return lookUpSubjectVersion(
         schemaString, schemaType, references, subject, false, lookupDeletedSchema);
   }
 
   public Schema lookUpSubjectVersion(String schemaString,
-      String schemaType,
-      List<SchemaReference> references,
-      String subject,
-      boolean normalize,
-      boolean lookupDeletedSchema)
+                                     String schemaType,
+                                     List<SchemaReference> references,
+                                     String subject,
+                                     boolean normalize,
+                                     boolean lookupDeletedSchema)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
@@ -478,19 +478,19 @@ public class RestService implements Closeable, Configurable {
   }
 
   public Schema lookUpSubjectVersion(RegisterSchemaRequest registerSchemaRequest,
-      String subject,
-      boolean normalize,
-      boolean lookupDeletedSchema)
+                                     String subject,
+                                     boolean normalize,
+                                     boolean lookupDeletedSchema)
       throws IOException, RestClientException {
     return lookUpSubjectVersion(
         DEFAULT_REQUEST_PROPERTIES, registerSchemaRequest, subject, normalize, lookupDeletedSchema);
   }
 
   public Schema lookUpSubjectVersion(Map<String, String> requestProperties,
-      RegisterSchemaRequest registerSchemaRequest,
-      String subject,
-      boolean normalize,
-      boolean lookupDeletedSchema)
+                                     RegisterSchemaRequest registerSchemaRequest,
+                                     String subject,
+                                     boolean normalize,
+                                     boolean lookupDeletedSchema)
       throws IOException, RestClientException {
     UriBuilder builder = UriBuilder.fromPath("/subjects/{subject}")
         .queryParam("normalize", normalize)
@@ -498,8 +498,8 @@ public class RestService implements Closeable, Configurable {
     String path = builder.build(subject).toString();
 
     Schema schema = httpRequest(path, "POST",
-        registerSchemaRequest.toJson().getBytes(StandardCharsets.UTF_8),
-        requestProperties, SUBJECT_SCHEMA_VERSION_RESPONSE_TYPE_REFERENCE);
+                                registerSchemaRequest.toJson().getBytes(StandardCharsets.UTF_8),
+                                requestProperties, SUBJECT_SCHEMA_VERSION_RESPONSE_TYPE_REFERENCE);
     return schema;
   }
 
@@ -510,7 +510,7 @@ public class RestService implements Closeable, Configurable {
   }
 
   public RegisterSchemaResponse registerSchema(String schemaString, String subject,
-      boolean normalize)
+                                               boolean normalize)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
@@ -518,14 +518,14 @@ public class RestService implements Closeable, Configurable {
   }
 
   public RegisterSchemaResponse registerSchema(String schemaString, String schemaType,
-      List<SchemaReference> references, String subject)
+                                               List<SchemaReference> references, String subject)
       throws IOException, RestClientException {
     return registerSchema(schemaString, schemaType, references, subject, false);
   }
 
   public RegisterSchemaResponse registerSchema(String schemaString, String schemaType,
-      List<SchemaReference> references,
-      String subject, boolean normalize)
+                                               List<SchemaReference> references,
+                                               String subject, boolean normalize)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
@@ -541,7 +541,7 @@ public class RestService implements Closeable, Configurable {
   }
 
   public RegisterSchemaResponse registerSchema(String schemaString, String subject,
-      int version, int id, boolean normalize)
+                                               int version, int id, boolean normalize)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
@@ -551,16 +551,16 @@ public class RestService implements Closeable, Configurable {
   }
 
   public RegisterSchemaResponse registerSchema(String schemaString, String schemaType,
-      List<SchemaReference> references, String subject,
-      int version, int id)
+                                               List<SchemaReference> references, String subject,
+                                               int version, int id)
       throws IOException, RestClientException {
     return registerSchema(schemaString, schemaType, references, subject, version, id, false);
   }
 
   public RegisterSchemaResponse registerSchema(String schemaString, String schemaType,
-      List<SchemaReference> references, String subject,
-      int version, int id, boolean normalize)
-      throws IOException, RestClientException {
+                                               List<SchemaReference> references, String subject,
+                                               int version, int id, boolean normalize)
+                            throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
     request.setSchemaType(schemaType);
@@ -571,16 +571,16 @@ public class RestService implements Closeable, Configurable {
   }
 
   public RegisterSchemaResponse registerSchema(RegisterSchemaRequest registerSchemaRequest,
-      String subject,
-      boolean normalize)
+                                               String subject,
+                                               boolean normalize)
       throws IOException, RestClientException {
     return registerSchema(DEFAULT_REQUEST_PROPERTIES, registerSchemaRequest, subject, normalize);
   }
 
   public RegisterSchemaResponse registerSchema(Map<String, String> requestProperties,
-      RegisterSchemaRequest registerSchemaRequest,
-      String subject,
-      boolean normalize)
+                                               RegisterSchemaRequest registerSchemaRequest,
+                                               String subject,
+                                               boolean normalize)
       throws IOException, RestClientException {
     UriBuilder builder = UriBuilder.fromPath("/subjects/{subject}/versions")
         .queryParam("normalize", normalize);
@@ -596,9 +596,9 @@ public class RestService implements Closeable, Configurable {
   }
 
   public RegisterSchemaResponse modifySchemaTags(Map<String, String> requestProperties,
-      TagSchemaRequest tagSchemaRequest,
-      String subject,
-      String version)
+                                                 TagSchemaRequest tagSchemaRequest,
+                                                 String subject,
+                                                 String version)
       throws IOException, RestClientException {
     UriBuilder builder = UriBuilder.fromPath("/subjects/{subject}/versions/{version}/tags");
     String path = builder.build(subject, version).toString();
@@ -628,11 +628,11 @@ public class RestService implements Closeable, Configurable {
   }
 
   public List<String> testCompatibility(String schemaString,
-      String schemaType,
-      List<SchemaReference> references,
-      String subject,
-      String version,
-      boolean verbose)
+                                        String schemaType,
+                                        List<SchemaReference> references,
+                                        String subject,
+                                        String version,
+                                        boolean verbose)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
@@ -642,21 +642,21 @@ public class RestService implements Closeable, Configurable {
   }
 
   public List<String> testCompatibility(RegisterSchemaRequest registerSchemaRequest,
-      String subject,
-      String version,
-      boolean normalize,
-      boolean verbose)
+                                        String subject,
+                                        String version,
+                                        boolean normalize,
+                                        boolean verbose)
       throws IOException, RestClientException {
     return testCompatibility(DEFAULT_REQUEST_PROPERTIES, registerSchemaRequest,
-        subject, version, normalize, verbose);
+                             subject, version, normalize, verbose);
   }
 
   public List<String> testCompatibility(Map<String, String> requestProperties,
-      RegisterSchemaRequest registerSchemaRequest,
-      String subject,
-      String version,
-      boolean normalize,
-      boolean verbose)
+                                        RegisterSchemaRequest registerSchemaRequest,
+                                        String subject,
+                                        String version,
+                                        boolean normalize,
+                                        boolean verbose)
       throws IOException, RestClientException {
     String path;
     if (version != null) {
@@ -673,14 +673,14 @@ public class RestService implements Closeable, Configurable {
 
     CompatibilityCheckResponse response =
         httpRequest(path, "POST",
-            registerSchemaRequest.toJson().getBytes(StandardCharsets.UTF_8),
-            requestProperties, COMPATIBILITY_CHECK_RESPONSE_TYPE_REFERENCE);
+                    registerSchemaRequest.toJson().getBytes(StandardCharsets.UTF_8),
+                    requestProperties, COMPATIBILITY_CHECK_RESPONSE_TYPE_REFERENCE);
     if (response.getIsCompatible()) {
       return Collections.emptyList();
     } else {
       return Optional.ofNullable(response.getMessages())
-          .filter(it -> !it.isEmpty())
-          .orElseGet(() -> Collections.singletonList("Schemas are incompatible"));
+              .filter(it -> !it.isEmpty())
+              .orElseGet(() -> Collections.singletonList("Schemas are incompatible"));
     }
   }
 
@@ -692,7 +692,7 @@ public class RestService implements Closeable, Configurable {
   }
 
   public ConfigUpdateRequest updateConfig(ConfigUpdateRequest configUpdateRequest,
-      String subject)
+                                          String subject)
       throws IOException, RestClientException {
     return updateConfig(DEFAULT_REQUEST_PROPERTIES, configUpdateRequest, subject);
   }
@@ -701,16 +701,16 @@ public class RestService implements Closeable, Configurable {
    * On success, this api simply echoes the request in the response.
    */
   public ConfigUpdateRequest updateConfig(Map<String, String> requestProperties,
-      ConfigUpdateRequest configUpdateRequest,
-      String subject)
+                                          ConfigUpdateRequest configUpdateRequest,
+                                          String subject)
       throws IOException, RestClientException {
     String path = subject != null
-        ? UriBuilder.fromPath("/config/{subject}").build(subject).toString()
-        : "/config";
+                  ? UriBuilder.fromPath("/config/{subject}").build(subject).toString()
+                  : "/config";
 
     ConfigUpdateRequest response =
         httpRequest(path, "PUT", configUpdateRequest.toJson().getBytes(StandardCharsets.UTF_8),
-            requestProperties, UPDATE_CONFIG_RESPONSE_TYPE_REFERENCE);
+                    requestProperties, UPDATE_CONFIG_RESPONSE_TYPE_REFERENCE);
     return response;
   }
 
@@ -720,14 +720,14 @@ public class RestService implements Closeable, Configurable {
   }
 
   public Config getConfig(Map<String, String> requestProperties,
-      String subject)
+                          String subject)
       throws IOException, RestClientException {
     return getConfig(requestProperties, subject, false);
   }
 
   public Config getConfig(Map<String, String> requestProperties,
-      String subject,
-      boolean defaultToGlobal)
+                          String subject,
+                          boolean defaultToGlobal)
       throws IOException, RestClientException {
     String path = subject != null
         ? UriBuilder.fromPath("/config/{subject}")
@@ -775,9 +775,9 @@ public class RestService implements Closeable, Configurable {
    * On success, this api simply echoes the request in the response.
    */
   public ModeUpdateRequest setMode(Map<String, String> requestProperties,
-      ModeUpdateRequest modeUpdateRequest,
-      String subject,
-      boolean force)
+                                   ModeUpdateRequest modeUpdateRequest,
+                                   String subject,
+                                   boolean force)
       throws IOException, RestClientException {
     String path = subject != null
         ? UriBuilder.fromPath("/mode/{subject}")
@@ -886,12 +886,12 @@ public class RestService implements Closeable, Configurable {
   }
 
   public SchemaString getId(Map<String, String> requestProperties,
-      int id) throws IOException, RestClientException {
+                            int id) throws IOException, RestClientException {
     return getId(requestProperties, id, null, false);
   }
 
   public SchemaString getId(Map<String, String> requestProperties,
-      int id, String subject) throws IOException, RestClientException {
+                            int id, String subject) throws IOException, RestClientException {
     return getId(requestProperties, id, subject, false);
   }
 
@@ -914,7 +914,7 @@ public class RestService implements Closeable, Configurable {
     String path = builder.build(id).toString();
 
     SchemaString response = httpRequest(path, "GET", null, requestProperties,
-        GET_SCHEMA_BY_ID_RESPONSE_TYPE);
+                                        GET_SCHEMA_BY_ID_RESPONSE_TYPE);
     return response;
   }
 
@@ -923,15 +923,15 @@ public class RestService implements Closeable, Configurable {
   }
 
   public String getOnlySchemaById(Map<String, String> requestProperties,
-      int id, String subject)
-      throws IOException, RestClientException {
+                                  int id, String subject)
+          throws IOException, RestClientException {
     UriBuilder builder = UriBuilder.fromPath("/schemas/ids/{id}/schema");
     if (subject != null) {
       builder.queryParam("subject", subject);
     }
     String path = builder.build(id).toString();
     JsonNode response = httpRequest(path, "GET", null,
-        requestProperties, GET_SCHEMA_ONLY_BY_VERSION_RESPONSE_TYPE);
+            requestProperties, GET_SCHEMA_ONLY_BY_VERSION_RESPONSE_TYPE);
     return response.toString();
   }
 
@@ -959,13 +959,13 @@ public class RestService implements Closeable, Configurable {
   }
 
   public Schema getVersion(Map<String, String> requestProperties,
-      String subject, int version)
+                           String subject, int version)
       throws IOException, RestClientException {
     return getVersion(requestProperties, subject, version, false);
   }
 
   public Schema getVersion(Map<String, String> requestProperties,
-      String subject, int version, boolean lookupDeletedSchema)
+                           String subject, int version, boolean lookupDeletedSchema)
       throws IOException, RestClientException {
     return getVersion(requestProperties, subject, version, false, null);
   }
@@ -991,7 +991,7 @@ public class RestService implements Closeable, Configurable {
   }
 
   public Schema getLatestVersion(Map<String, String> requestProperties,
-      String subject)
+                                 String subject)
       throws IOException, RestClientException {
     return getLatestVersion(requestProperties, subject, null);
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -36,6 +36,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.requests.TagSchema
 import io.confluent.kafka.schemaregistry.client.security.basicauth.BasicAuthCredentialProviderFactory;
 import io.confluent.kafka.schemaregistry.client.security.bearerauth.BearerAuthCredentialProvider;
 
+import java.util.Set;
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.config.ConfigException;
 import org.slf4j.Logger;
@@ -156,7 +157,6 @@ public class RestService implements Closeable, Configurable {
       };
 
 
-
   private static final int JSON_PARSE_ERROR_CODE = 50005;
   private static ObjectMapper jsonDeserializer = JacksonMapper.INSTANCE;
 
@@ -241,8 +241,8 @@ public class RestService implements Closeable, Configurable {
     String proxyHost = (String) configs.get(SchemaRegistryClientConfig.PROXY_HOST);
     Object proxyPortVal = configs.get(SchemaRegistryClientConfig.PROXY_PORT);
     Integer proxyPort = proxyPortVal instanceof String
-                        ? Integer.valueOf((String) proxyPortVal)
-                        : (Integer) proxyPortVal;
+        ? Integer.valueOf((String) proxyPortVal)
+        : (Integer) proxyPortVal;
 
     if (isValidProxyConfig(proxyHost, proxyPort)) {
       setProxy(proxyHost, proxyPort);
@@ -283,15 +283,15 @@ public class RestService implements Closeable, Configurable {
    * @return The deserialized response to the HTTP request, or null if no data is expected.
    */
   private <T> T sendHttpRequest(String requestUrl, String method, byte[] requestBodyData,
-                                Map<String, String> requestProperties,
-                                TypeReference<T> responseFormat)
+      Map<String, String> requestProperties,
+      TypeReference<T> responseFormat)
       throws IOException, RestClientException {
     String requestData = requestBodyData == null
-                         ? "null"
-                         : new String(requestBodyData, StandardCharsets.UTF_8);
+        ? "null"
+        : new String(requestBodyData, StandardCharsets.UTF_8);
     log.debug(String.format("Sending %s with input %s to %s",
-                            method, requestData,
-                            requestUrl));
+        method, requestData,
+        requestUrl));
 
     HttpURLConnection connection = null;
     try {
@@ -333,7 +333,7 @@ public class RestService implements Closeable, Configurable {
           }
         }
         throw new RestClientException(errorMessage.getMessage(), responseCode,
-                                      errorMessage.getErrorCode());
+            errorMessage.getErrorCode());
       }
 
     } finally {
@@ -344,7 +344,7 @@ public class RestService implements Closeable, Configurable {
   }
 
   private HttpURLConnection buildConnection(URL url, String method, Map<String,
-                                            String> requestProperties)
+      String> requestProperties)
       throws IOException {
     HttpURLConnection connection = null;
     if (proxy == null) {
@@ -394,10 +394,10 @@ public class RestService implements Closeable, Configurable {
    * @return The deserialized response to the HTTP request, or null if no data is expected.
    */
   public <T> T httpRequest(String path,
-                           String method,
-                           byte[] requestBodyData,
-                           Map<String, String> requestProperties,
-                           TypeReference<T> responseFormat)
+      String method,
+      byte[] requestBodyData,
+      Map<String, String> requestProperties,
+      TypeReference<T> responseFormat)
       throws IOException, RestClientException {
     if (isForward) {
       requestProperties.put(X_FORWARD_HEADER, "true");
@@ -407,10 +407,10 @@ public class RestService implements Closeable, Configurable {
       String requestUrl = buildRequestUrl(baseUrl, path);
       try {
         return sendHttpRequest(requestUrl,
-                               method,
-                               requestBodyData,
-                               requestProperties,
-                               responseFormat);
+            method,
+            requestBodyData,
+            requestProperties,
+            responseFormat);
       } catch (IOException e) {
         baseUrls.fail(baseUrl);
         if (i == n - 1) {
@@ -435,16 +435,16 @@ public class RestService implements Closeable, Configurable {
 
   // Visible for testing
   public Schema lookUpSubjectVersion(String schemaString,
-                                     String subject,
-                                     boolean lookupDeletedSchema)
+      String subject,
+      boolean lookupDeletedSchema)
       throws IOException, RestClientException {
     return lookUpSubjectVersion(schemaString, subject, false, lookupDeletedSchema);
   }
 
   public Schema lookUpSubjectVersion(String schemaString,
-                                     String subject,
-                                     boolean normalize,
-                                     boolean lookupDeletedSchema)
+      String subject,
+      boolean normalize,
+      boolean lookupDeletedSchema)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
@@ -453,21 +453,21 @@ public class RestService implements Closeable, Configurable {
   }
 
   public Schema lookUpSubjectVersion(String schemaString,
-                                     String schemaType,
-                                     List<SchemaReference> references,
-                                     String subject,
-                                     boolean lookupDeletedSchema)
+      String schemaType,
+      List<SchemaReference> references,
+      String subject,
+      boolean lookupDeletedSchema)
       throws IOException, RestClientException {
     return lookUpSubjectVersion(
         schemaString, schemaType, references, subject, false, lookupDeletedSchema);
   }
 
   public Schema lookUpSubjectVersion(String schemaString,
-                                     String schemaType,
-                                     List<SchemaReference> references,
-                                     String subject,
-                                     boolean normalize,
-                                     boolean lookupDeletedSchema)
+      String schemaType,
+      List<SchemaReference> references,
+      String subject,
+      boolean normalize,
+      boolean lookupDeletedSchema)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
@@ -478,19 +478,19 @@ public class RestService implements Closeable, Configurable {
   }
 
   public Schema lookUpSubjectVersion(RegisterSchemaRequest registerSchemaRequest,
-                                     String subject,
-                                     boolean normalize,
-                                     boolean lookupDeletedSchema)
+      String subject,
+      boolean normalize,
+      boolean lookupDeletedSchema)
       throws IOException, RestClientException {
     return lookUpSubjectVersion(
         DEFAULT_REQUEST_PROPERTIES, registerSchemaRequest, subject, normalize, lookupDeletedSchema);
   }
 
   public Schema lookUpSubjectVersion(Map<String, String> requestProperties,
-                                     RegisterSchemaRequest registerSchemaRequest,
-                                     String subject,
-                                     boolean normalize,
-                                     boolean lookupDeletedSchema)
+      RegisterSchemaRequest registerSchemaRequest,
+      String subject,
+      boolean normalize,
+      boolean lookupDeletedSchema)
       throws IOException, RestClientException {
     UriBuilder builder = UriBuilder.fromPath("/subjects/{subject}")
         .queryParam("normalize", normalize)
@@ -498,8 +498,8 @@ public class RestService implements Closeable, Configurable {
     String path = builder.build(subject).toString();
 
     Schema schema = httpRequest(path, "POST",
-                                registerSchemaRequest.toJson().getBytes(StandardCharsets.UTF_8),
-                                requestProperties, SUBJECT_SCHEMA_VERSION_RESPONSE_TYPE_REFERENCE);
+        registerSchemaRequest.toJson().getBytes(StandardCharsets.UTF_8),
+        requestProperties, SUBJECT_SCHEMA_VERSION_RESPONSE_TYPE_REFERENCE);
     return schema;
   }
 
@@ -510,7 +510,7 @@ public class RestService implements Closeable, Configurable {
   }
 
   public RegisterSchemaResponse registerSchema(String schemaString, String subject,
-                                               boolean normalize)
+      boolean normalize)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
@@ -518,14 +518,14 @@ public class RestService implements Closeable, Configurable {
   }
 
   public RegisterSchemaResponse registerSchema(String schemaString, String schemaType,
-                                               List<SchemaReference> references, String subject)
+      List<SchemaReference> references, String subject)
       throws IOException, RestClientException {
     return registerSchema(schemaString, schemaType, references, subject, false);
   }
 
   public RegisterSchemaResponse registerSchema(String schemaString, String schemaType,
-                                               List<SchemaReference> references,
-                                               String subject, boolean normalize)
+      List<SchemaReference> references,
+      String subject, boolean normalize)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
@@ -541,7 +541,7 @@ public class RestService implements Closeable, Configurable {
   }
 
   public RegisterSchemaResponse registerSchema(String schemaString, String subject,
-                                               int version, int id, boolean normalize)
+      int version, int id, boolean normalize)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
@@ -551,16 +551,16 @@ public class RestService implements Closeable, Configurable {
   }
 
   public RegisterSchemaResponse registerSchema(String schemaString, String schemaType,
-                                               List<SchemaReference> references, String subject,
-                                               int version, int id)
+      List<SchemaReference> references, String subject,
+      int version, int id)
       throws IOException, RestClientException {
     return registerSchema(schemaString, schemaType, references, subject, version, id, false);
   }
 
   public RegisterSchemaResponse registerSchema(String schemaString, String schemaType,
-                                               List<SchemaReference> references, String subject,
-                                               int version, int id, boolean normalize)
-                            throws IOException, RestClientException {
+      List<SchemaReference> references, String subject,
+      int version, int id, boolean normalize)
+      throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
     request.setSchemaType(schemaType);
@@ -571,16 +571,16 @@ public class RestService implements Closeable, Configurable {
   }
 
   public RegisterSchemaResponse registerSchema(RegisterSchemaRequest registerSchemaRequest,
-                                               String subject,
-                                               boolean normalize)
+      String subject,
+      boolean normalize)
       throws IOException, RestClientException {
     return registerSchema(DEFAULT_REQUEST_PROPERTIES, registerSchemaRequest, subject, normalize);
   }
 
   public RegisterSchemaResponse registerSchema(Map<String, String> requestProperties,
-                                               RegisterSchemaRequest registerSchemaRequest,
-                                               String subject,
-                                               boolean normalize)
+      RegisterSchemaRequest registerSchemaRequest,
+      String subject,
+      boolean normalize)
       throws IOException, RestClientException {
     UriBuilder builder = UriBuilder.fromPath("/subjects/{subject}/versions")
         .queryParam("normalize", normalize);
@@ -596,9 +596,9 @@ public class RestService implements Closeable, Configurable {
   }
 
   public RegisterSchemaResponse modifySchemaTags(Map<String, String> requestProperties,
-                                                 TagSchemaRequest tagSchemaRequest,
-                                                 String subject,
-                                                 String version)
+      TagSchemaRequest tagSchemaRequest,
+      String subject,
+      String version)
       throws IOException, RestClientException {
     UriBuilder builder = UriBuilder.fromPath("/subjects/{subject}/versions/{version}/tags");
     String path = builder.build(subject, version).toString();
@@ -628,11 +628,11 @@ public class RestService implements Closeable, Configurable {
   }
 
   public List<String> testCompatibility(String schemaString,
-                                        String schemaType,
-                                        List<SchemaReference> references,
-                                        String subject,
-                                        String version,
-                                        boolean verbose)
+      String schemaType,
+      List<SchemaReference> references,
+      String subject,
+      String version,
+      boolean verbose)
       throws IOException, RestClientException {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(schemaString);
@@ -642,21 +642,21 @@ public class RestService implements Closeable, Configurable {
   }
 
   public List<String> testCompatibility(RegisterSchemaRequest registerSchemaRequest,
-                                        String subject,
-                                        String version,
-                                        boolean normalize,
-                                        boolean verbose)
+      String subject,
+      String version,
+      boolean normalize,
+      boolean verbose)
       throws IOException, RestClientException {
     return testCompatibility(DEFAULT_REQUEST_PROPERTIES, registerSchemaRequest,
-                             subject, version, normalize, verbose);
+        subject, version, normalize, verbose);
   }
 
   public List<String> testCompatibility(Map<String, String> requestProperties,
-                                        RegisterSchemaRequest registerSchemaRequest,
-                                        String subject,
-                                        String version,
-                                        boolean normalize,
-                                        boolean verbose)
+      RegisterSchemaRequest registerSchemaRequest,
+      String subject,
+      String version,
+      boolean normalize,
+      boolean verbose)
       throws IOException, RestClientException {
     String path;
     if (version != null) {
@@ -673,14 +673,14 @@ public class RestService implements Closeable, Configurable {
 
     CompatibilityCheckResponse response =
         httpRequest(path, "POST",
-                    registerSchemaRequest.toJson().getBytes(StandardCharsets.UTF_8),
-                    requestProperties, COMPATIBILITY_CHECK_RESPONSE_TYPE_REFERENCE);
+            registerSchemaRequest.toJson().getBytes(StandardCharsets.UTF_8),
+            requestProperties, COMPATIBILITY_CHECK_RESPONSE_TYPE_REFERENCE);
     if (response.getIsCompatible()) {
       return Collections.emptyList();
     } else {
       return Optional.ofNullable(response.getMessages())
-              .filter(it -> !it.isEmpty())
-              .orElseGet(() -> Collections.singletonList("Schemas are incompatible"));
+          .filter(it -> !it.isEmpty())
+          .orElseGet(() -> Collections.singletonList("Schemas are incompatible"));
     }
   }
 
@@ -692,7 +692,7 @@ public class RestService implements Closeable, Configurable {
   }
 
   public ConfigUpdateRequest updateConfig(ConfigUpdateRequest configUpdateRequest,
-                                          String subject)
+      String subject)
       throws IOException, RestClientException {
     return updateConfig(DEFAULT_REQUEST_PROPERTIES, configUpdateRequest, subject);
   }
@@ -701,16 +701,16 @@ public class RestService implements Closeable, Configurable {
    * On success, this api simply echoes the request in the response.
    */
   public ConfigUpdateRequest updateConfig(Map<String, String> requestProperties,
-                                          ConfigUpdateRequest configUpdateRequest,
-                                          String subject)
+      ConfigUpdateRequest configUpdateRequest,
+      String subject)
       throws IOException, RestClientException {
     String path = subject != null
-                  ? UriBuilder.fromPath("/config/{subject}").build(subject).toString()
-                  : "/config";
+        ? UriBuilder.fromPath("/config/{subject}").build(subject).toString()
+        : "/config";
 
     ConfigUpdateRequest response =
         httpRequest(path, "PUT", configUpdateRequest.toJson().getBytes(StandardCharsets.UTF_8),
-                    requestProperties, UPDATE_CONFIG_RESPONSE_TYPE_REFERENCE);
+            requestProperties, UPDATE_CONFIG_RESPONSE_TYPE_REFERENCE);
     return response;
   }
 
@@ -720,14 +720,14 @@ public class RestService implements Closeable, Configurable {
   }
 
   public Config getConfig(Map<String, String> requestProperties,
-                          String subject)
+      String subject)
       throws IOException, RestClientException {
     return getConfig(requestProperties, subject, false);
   }
 
   public Config getConfig(Map<String, String> requestProperties,
-                          String subject,
-                          boolean defaultToGlobal)
+      String subject,
+      boolean defaultToGlobal)
       throws IOException, RestClientException {
     String path = subject != null
         ? UriBuilder.fromPath("/config/{subject}")
@@ -775,9 +775,9 @@ public class RestService implements Closeable, Configurable {
    * On success, this api simply echoes the request in the response.
    */
   public ModeUpdateRequest setMode(Map<String, String> requestProperties,
-                                   ModeUpdateRequest modeUpdateRequest,
-                                   String subject,
-                                   boolean force)
+      ModeUpdateRequest modeUpdateRequest,
+      String subject,
+      boolean force)
       throws IOException, RestClientException {
     String path = subject != null
         ? UriBuilder.fromPath("/mode/{subject}")
@@ -886,26 +886,35 @@ public class RestService implements Closeable, Configurable {
   }
 
   public SchemaString getId(Map<String, String> requestProperties,
-                            int id) throws IOException, RestClientException {
+      int id) throws IOException, RestClientException {
     return getId(requestProperties, id, null, false);
   }
 
   public SchemaString getId(Map<String, String> requestProperties,
-                            int id, String subject) throws IOException, RestClientException {
+      int id, String subject) throws IOException, RestClientException {
     return getId(requestProperties, id, subject, false);
   }
 
   public SchemaString getId(Map<String, String> requestProperties,
       int id, String subject, boolean fetchMaxId) throws IOException, RestClientException {
+    return getId(requestProperties, id, subject, null, false);
+  }
+
+  public SchemaString getId(Map<String, String> requestProperties,
+      int id, String subject, Set<String> findTags, boolean fetchMaxId)
+      throws IOException, RestClientException {
     UriBuilder builder = UriBuilder.fromPath("/schemas/ids/{id}")
         .queryParam("fetchMaxId", fetchMaxId);
     if (subject != null) {
       builder.queryParam("subject", subject);
     }
+    if (findTags != null && !findTags.isEmpty()) {
+      builder.queryParam("findTags", String.join(",", findTags));
+    }
     String path = builder.build(id).toString();
 
     SchemaString response = httpRequest(path, "GET", null, requestProperties,
-                                        GET_SCHEMA_BY_ID_RESPONSE_TYPE);
+        GET_SCHEMA_BY_ID_RESPONSE_TYPE);
     return response;
   }
 
@@ -914,15 +923,15 @@ public class RestService implements Closeable, Configurable {
   }
 
   public String getOnlySchemaById(Map<String, String> requestProperties,
-                                  int id, String subject)
-          throws IOException, RestClientException {
+      int id, String subject)
+      throws IOException, RestClientException {
     UriBuilder builder = UriBuilder.fromPath("/schemas/ids/{id}/schema");
     if (subject != null) {
       builder.queryParam("subject", subject);
     }
     String path = builder.build(id).toString();
     JsonNode response = httpRequest(path, "GET", null,
-            requestProperties, GET_SCHEMA_ONLY_BY_VERSION_RESPONSE_TYPE);
+        requestProperties, GET_SCHEMA_ONLY_BY_VERSION_RESPONSE_TYPE);
     return response.toString();
   }
 
@@ -950,16 +959,25 @@ public class RestService implements Closeable, Configurable {
   }
 
   public Schema getVersion(Map<String, String> requestProperties,
-                           String subject, int version)
+      String subject, int version)
       throws IOException, RestClientException {
     return getVersion(requestProperties, subject, version, false);
   }
 
   public Schema getVersion(Map<String, String> requestProperties,
-                           String subject, int version, boolean lookupDeletedSchema)
+      String subject, int version, boolean lookupDeletedSchema)
+      throws IOException, RestClientException {
+    return getVersion(requestProperties, subject, version, false, null);
+  }
+
+  public Schema getVersion(Map<String, String> requestProperties,
+      String subject, int version, boolean lookupDeletedSchema, Set<String> findTags)
       throws IOException, RestClientException {
     UriBuilder builder = UriBuilder.fromPath("/subjects/{subject}/versions/{version}")
         .queryParam("deleted", lookupDeletedSchema);
+    if (findTags != null && !findTags.isEmpty()) {
+      builder.queryParam("findTags", String.join(",", findTags));
+    }
     String path = builder.build(subject, version).toString();
 
     Schema response = httpRequest(path, "GET", null, requestProperties,
@@ -973,9 +991,18 @@ public class RestService implements Closeable, Configurable {
   }
 
   public Schema getLatestVersion(Map<String, String> requestProperties,
-                                 String subject)
+      String subject)
+      throws IOException, RestClientException {
+    return getLatestVersion(requestProperties, subject, null);
+  }
+
+  public Schema getLatestVersion(Map<String, String> requestProperties,
+                                 String subject, Set<String> findTags)
       throws IOException, RestClientException {
     UriBuilder builder = UriBuilder.fromPath("/subjects/{subject}/versions/latest");
+    if (findTags != null && !findTags.isEmpty()) {
+      builder.queryParam("findTags", String.join(",", findTags));
+    }
     String path = builder.build(subject).toString();
 
     Schema response = httpRequest(path, "GET", null, requestProperties,

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
@@ -57,6 +57,8 @@ public class Schema implements Comparable<Schema> {
   public static final String SCHEMA_DESC = "Schema definition string";
   public static final String SCHEMA_EXAMPLE = "{\"schema\": \"{\"type\": \"string\"}\"}";
 
+  public static final String SCHEMA_TAGS_DESC = "Schema tags";
+
   private String subject;
   private Integer version;
   private Integer id;
@@ -65,6 +67,7 @@ public class Schema implements Comparable<Schema> {
   private Metadata metadata;
   private RuleSet ruleSet;
   private String schema;
+  private List<SchemaTags> schemaTags;
 
   @JsonCreator
   public Schema(@JsonProperty("subject") String subject,
@@ -74,7 +77,27 @@ public class Schema implements Comparable<Schema> {
                 @JsonProperty("references") List<SchemaReference> references,
                 @JsonProperty("metadata") Metadata metadata,
                 @JsonProperty("ruleset") RuleSet ruleSet,
-                @JsonProperty("schema") String schema) {
+                @JsonProperty("schema") String schema,
+                @JsonProperty("schemaTags") List<SchemaTags> schemaTags) {
+    this.subject = subject;
+    this.version = version;
+    this.id = id;
+    this.schemaType = schemaType != null ? schemaType : AvroSchema.TYPE;
+    this.references = references != null ? references : Collections.emptyList();
+    this.metadata = metadata;
+    this.ruleSet = ruleSet;
+    this.schema = schema;
+    this.schemaTags = schemaTags;
+  }
+
+  public Schema(@JsonProperty("subject") String subject,
+      @JsonProperty("version") Integer version,
+      @JsonProperty("id") Integer id,
+      @JsonProperty("schemaType") String schemaType,
+      @JsonProperty("references") List<SchemaReference> references,
+      @JsonProperty("metadata") Metadata metadata,
+      @JsonProperty("ruleset") RuleSet ruleSet,
+      @JsonProperty("schema") String schema) {
     this.subject = subject;
     this.version = version;
     this.id = id;
@@ -178,11 +201,13 @@ public class Schema implements Comparable<Schema> {
   }
 
   public Schema copy() {
-    return new Schema(subject, version, id, schemaType, references, metadata, ruleSet, schema);
+    return new Schema(
+        subject, version, id, schemaType, references, metadata, ruleSet, schema, schemaTags);
   }
 
   public Schema copy(Integer version, Integer id) {
-    return new Schema(subject, version, id, schemaType, references, metadata, ruleSet, schema);
+    return new Schema(
+        subject, version, id, schemaType, references, metadata, ruleSet, schema, schemaTags);
   }
 
   @io.swagger.v3.oas.annotations.media.Schema(description = SUBJECT_DESC, example = SUBJECT_EXAMPLE)
@@ -274,6 +299,17 @@ public class Schema implements Comparable<Schema> {
     this.schema = schema;
   }
 
+  @io.swagger.v3.oas.annotations.media.Schema(description = SCHEMA_TAGS_DESC)
+  @JsonProperty("schemaTags")
+  public List<SchemaTags> getSchemaTags() {
+    return this.schemaTags;
+  }
+
+  @JsonProperty("schemaTags")
+  public void setSchemaTags(List<SchemaTags> schemaTags) {
+    this.schemaTags = schemaTags;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -309,7 +345,8 @@ public class Schema implements Comparable<Schema> {
     sb.append("references=" + this.references + ",");
     sb.append("metadata=" + this.metadata + ",");
     sb.append("ruleSet=" + this.ruleSet + ",");
-    sb.append("schema=" + this.schema + "}");
+    sb.append("schema=" + this.schema + ",");
+    sb.append("schemaTags=" + this.schemaTags + "}");
     return sb.toString();
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaEntity.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaEntity.java
@@ -85,6 +85,7 @@ public class SchemaEntity {
   public String toString() {
     return "SchemaEntity{"
         + "entityType=" + entityType
+        + ", entityPath='" + entityPath + '\''
         + ", normalizedPath='" + normalizedPath + '\''
         + '}';
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaEntity.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaEntity.java
@@ -83,10 +83,10 @@ public class SchemaEntity {
 
   @Override
   public String toString() {
-    return "SchemaEntity{" +
-        "entityType=" + entityType +
-        ", normalizedPath='" + normalizedPath + '\'' +
-        '}';
+    return "SchemaEntity{"
+        + "entityType=" + entityType
+        + ", normalizedPath='" + normalizedPath + '\''
+        + '}';
   }
 
   public enum EntityType {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaEntity.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaEntity.java
@@ -81,6 +81,14 @@ public class SchemaEntity {
     return result;
   }
 
+  @Override
+  public String toString() {
+    return "SchemaEntity{" +
+        "entityType=" + entityType +
+        ", normalizedPath='" + normalizedPath + '\'' +
+        '}';
+  }
+
   public enum EntityType {
     @JsonProperty("sr_record")
     SR_RECORD("sr_record"),

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaString.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaString.java
@@ -38,6 +38,7 @@ public class SchemaString {
   private List<SchemaReference> references = Collections.emptyList();
   private Metadata metadata = null;
   private RuleSet ruleSet = null;
+  private List<SchemaTags> schemaTags;
   private Integer maxId;
 
   public SchemaString() {
@@ -54,6 +55,7 @@ public class SchemaString {
     this.references = schema.getReferences();
     this.metadata = schema.getMetadata();
     this.ruleSet = schema.getRuleSet();
+    this.schemaTags = schema.getSchemaTags();
   }
 
   public static SchemaString fromJson(String json) throws IOException {
@@ -118,6 +120,16 @@ public class SchemaString {
     this.ruleSet = ruleSet;
   }
 
+  @io.swagger.v3.oas.annotations.media.Schema(description = Schema.SCHEMA_TAGS_DESC)
+  @JsonProperty("schemaTags")
+  public List<SchemaTags> getSchemaTags() {
+    return this.schemaTags;
+  }
+
+  @JsonProperty("schemaTags")
+  public void setSchemaTags(List<SchemaTags> schemaTags) {
+    this.schemaTags = schemaTags;
+  }
 
   @io.swagger.v3.oas.annotations.media.Schema(description = "Maximum ID", example = "1")
   @JsonProperty("maxId")

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaTags.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaTags.java
@@ -88,4 +88,12 @@ public class SchemaTags {
   public int hashCode() {
     return Objects.hash(schemaEntity, tags);
   }
+
+  @Override
+  public String toString() {
+    return "SchemaTags{" +
+        "schemaEntity=" + schemaEntity +
+        ", tags=" + tags +
+        '}';
+  }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaTags.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/SchemaTags.java
@@ -91,9 +91,9 @@ public class SchemaTags {
 
   @Override
   public String toString() {
-    return "SchemaTags{" +
-        "schemaEntity=" + schemaEntity +
-        ", tags=" + tags +
-        '}';
+    return "SchemaTags{"
+        + "schemaEntity=" + schemaEntity
+        + ", tags=" + tags
+        + '}';
   }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -128,7 +128,9 @@ public class SubjectVersionsResource {
       @Parameter(description = VERSION_PARAM_DESC, required = true)
       @PathParam("version") String version,
       @Parameter(description = "Whether to include deleted schema")
-      @QueryParam("deleted") boolean lookupDeletedSchema) {
+      @QueryParam("deleted") boolean lookupDeletedSchema,
+      @Parameter(description = "Find tagged entities for the given tags or * for all tags")
+      @QueryParam("findTags") List<String> tags) {
 
     subject = QualifiedSubject.normalize(schemaRegistry.tenant(), subject);
 
@@ -153,6 +155,9 @@ public class SubjectVersionsResource {
         } else {
           throw Errors.versionNotFoundException(versionId.getVersionId());
         }
+      }
+      if (tags != null && !tags.isEmpty()) {
+        schemaRegistry.extractSchemaTags(schema, tags);
       }
     } catch (SchemaRegistryStoreException e) {
       log.debug(errorMessage, e);
@@ -199,7 +204,7 @@ public class SubjectVersionsResource {
       @PathParam("version") String version,
       @Parameter(description = "Whether to include deleted schema")
       @QueryParam("deleted") boolean lookupDeletedSchema) {
-    return getSchemaByVersion(subject, version, lookupDeletedSchema).getSchema();
+    return getSchemaByVersion(subject, version, lookupDeletedSchema, null).getSchema();
   }
 
   @GET
@@ -235,7 +240,7 @@ public class SubjectVersionsResource {
       @Parameter(description = VERSION_PARAM_DESC, required = true)
       @PathParam("version") String version) {
 
-    Schema schema = getSchemaByVersion(subject, version, true);
+    Schema schema = getSchemaByVersion(subject, version, true, null);
     if (schema == null) {
       return new ArrayList<>();
     }

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -927,8 +927,8 @@ public class JsonSchema implements ParsedSchema {
     }
   }
 
-  private void getInlineTaggedEntitiesRecursively(
-      Map<SchemaEntity, Set<String>> tags, Map<String, Object> unprocessedProperties, String scope) {
+  private void getInlineTaggedEntitiesRecursively(Map<SchemaEntity, Set<String>> tags,
+      Map<String, Object> unprocessedProperties, String scope) {
     Map<String, Object> defns = (Map<String, Object>) unprocessedProperties.get("definitions");
     if (defns != null) {
       for (Map.Entry<String, Object> entry : defns.entrySet()) {
@@ -952,19 +952,6 @@ public class JsonSchema implements ParsedSchema {
     }
   }
 
-  private Set<String> getInlineTags(Schema schema) {
-    Object prop = schema.getUnprocessedProperties().get(TAGS);
-    if (prop instanceof List) {
-      List<?> tags = (List<?>) prop;
-      Set<String> result = new LinkedHashSet<>(tags.size());
-      for (Object tag : tags) {
-        result.add(tag.toString());
-      }
-      return result;
-    }
-    return Collections.emptySet();
-  }
-
   private Map<String, Object> replaceRefs(Map<String, Object> defs) {
     Map<String, Object> result = new HashMap<>(defs);
     if (result.containsKey("$ref")) {
@@ -977,6 +964,19 @@ public class JsonSchema implements ParsedSchema {
       }
     }
     return result;
+  }
+
+  private Set<String> getInlineTags(Schema schema) {
+    Object prop = schema.getUnprocessedProperties().get(TAGS);
+    if (prop instanceof List) {
+      List<?> tags = (List<?>) prop;
+      Set<String> result = new LinkedHashSet<>(tags.size());
+      for (Object tag : tags) {
+        result.add(tag.toString());
+      }
+      return result;
+    }
+    return Collections.emptySet();
   }
 
   private Set<String> getInlineTags(JsonNode tagNode) {

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -16,6 +16,8 @@
 
 package io.confluent.kafka.schemaregistry.json;
 
+import static io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity.EntityType.SR_FIELD;
+import static io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity.EntityType.SR_RECORD;
 import static io.confluent.kafka.schemaregistry.json.JsonSchemaUtils.findMatchingEntity;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -74,8 +76,8 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -864,17 +866,117 @@ public class JsonSchema implements ParsedSchema {
     node.forEach(n -> getInlineTagsRecursively(tags, n));
   }
 
-  private Set<String> getInlineTags(Schema propertySchema) {
-    Object prop = propertySchema.getUnprocessedProperties().get(TAGS);
+  @Override
+  public Map<SchemaEntity, Set<String>> inlineTaggedEntities() {
+    Map<SchemaEntity, Set<String>> tags = new LinkedHashMap<>();
+    Schema schema = rawSchema();
+    if (schema == null) {
+      return tags;
+    }
+    getInlineTaggedEntitiesRecursively(tags, schema, "", false);
+    return tags;
+  }
+
+  private void getInlineTaggedEntitiesRecursively(
+      Map<SchemaEntity, Set<String>> tags, Schema schema, String scope, boolean inField) {
+    if (schema instanceof CombinedSchema) {
+      CombinedSchema combinedSchema = (CombinedSchema) schema;
+      String scopedName = scope + JsonSchemaComparator.getCriterion(combinedSchema);
+      List<Schema> subschemas = new ArrayList<>(combinedSchema.getSubschemas());
+      subschemas.sort(new JsonSchemaComparator());
+      for (int i = 0; i < subschemas.size(); i++) {
+        Schema subschema = subschemas.get(i);
+        getInlineTaggedEntitiesRecursively(tags, subschema, scopedName + "." + i + ".", false);
+      }
+    } else if (schema instanceof ArraySchema) {
+      Schema subschema = ((ArraySchema) schema).getAllItemSchema();
+      getInlineTaggedEntitiesRecursively(tags, subschema, scope + "array.", false);
+    } else if (schema instanceof ObjectSchema) {
+      ObjectSchema objectSchema = (ObjectSchema) schema;
+      String scopedName = scope + "object";
+      if (!inField) {
+        Set<String> recordTags = getInlineTags(schema);
+        if (!recordTags.isEmpty()) {
+          tags.put(new SchemaEntity(scopedName, SR_RECORD), recordTags);
+        }
+      }
+      for (Map.Entry<String, Schema> entry : objectSchema.getPropertySchemas().entrySet()) {
+        String propertyName = entry.getKey();
+        Schema propertySchema = entry.getValue();
+        String scopedPropertyName = scopedName + "." + propertyName;
+        Set<String> fieldTags = getInlineTags(propertySchema);
+        if (!fieldTags.isEmpty()) {
+          tags.put(new SchemaEntity(scopedPropertyName, SR_FIELD), fieldTags);
+        }
+        getInlineTaggedEntitiesRecursively(
+            tags, propertySchema, scopedPropertyName + ".", true);
+      }
+      getInlineTaggedEntitiesRecursively(tags, schema.getUnprocessedProperties(), scopedName + ".");
+    } else if (schema instanceof ConditionalSchema) {
+      ConditionalSchema condSchema = (ConditionalSchema) schema;
+      String scopedName = scope + "conditional";
+      condSchema.getIfSchema().ifPresent(
+          value -> getInlineTaggedEntitiesRecursively(tags, value, scopedName + ".if.", false));
+      condSchema.getThenSchema().ifPresent(
+          value -> getInlineTaggedEntitiesRecursively(tags, value, scopedName + ".then.", false));
+      condSchema.getElseSchema().ifPresent(
+          value -> getInlineTaggedEntitiesRecursively(tags, value, scopedName + ".else", false));
+    } else if (schema instanceof NotSchema) {
+      Schema subschema = ((NotSchema) schema).getMustNotMatch();
+      getInlineTaggedEntitiesRecursively(tags, subschema, scope + "not.", false);
+    }
+  }
+
+  private void getInlineTaggedEntitiesRecursively(
+      Map<SchemaEntity, Set<String>> tags, Map<String, Object> unprocessedProperties, String scope) {
+    Map<String, Object> defns = (Map<String, Object>) unprocessedProperties.get("definitions");
+    if (defns != null) {
+      for (Map.Entry<String, Object> entry : defns.entrySet()) {
+        if (entry.getValue() instanceof Map) {
+          Map<String, Object> rawSchema = replaceRefs((Map<String, Object>) entry.getValue());
+          JsonNode jsonNode = objectMapper.valueToTree(rawSchema);
+          JsonSchema jsonSchema = new JsonSchema(jsonNode);
+          getInlineTaggedEntitiesRecursively(
+              tags, jsonSchema.rawSchema(), scope + "definitions.", false);
+        }
+      }
+    }
+    Map<String, Object> defs = (Map<String, Object>) unprocessedProperties.get("$defs");
+    if (defs != null) {
+      for (Map.Entry<String, Object> entry : defs.entrySet()) {
+        if (entry.getValue() instanceof Schema) {
+          getInlineTaggedEntitiesRecursively(
+              tags, (Schema) entry.getValue(), scope + "$defs.", false);
+        }
+      }
+    }
+  }
+
+  private Set<String> getInlineTags(Schema schema) {
+    Object prop = schema.getUnprocessedProperties().get(TAGS);
     if (prop instanceof List) {
       List<?> tags = (List<?>) prop;
-      Set<String> result = new HashSet<>(tags.size());
+      Set<String> result = new LinkedHashSet<>(tags.size());
       for (Object tag : tags) {
         result.add(tag.toString());
       }
       return result;
     }
     return Collections.emptySet();
+  }
+
+  private Map<String, Object> replaceRefs(Map<String, Object> defs) {
+    Map<String, Object> result = new HashMap<>(defs);
+    if (result.containsKey("$ref")) {
+      // Use bare fragment as we don't care about the ref value during indexing
+      result.put("$ref", "#");
+    }
+    for (Map.Entry<String, Object> entry : result.entrySet()) {
+      if (entry.getValue() instanceof Map) {
+        entry.setValue(replaceRefs((Map<String, Object>) entry.getValue()));
+      }
+    }
+    return result;
   }
 
   private Set<String> getInlineTags(JsonNode tagNode) {

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
@@ -639,6 +639,8 @@ public class JsonSchemaTest {
     ParsedSchema resultSchema = schema.copy(tags, Collections.emptyMap());
     assertEquals(expectSchema.canonicalString(), resultSchema.canonicalString());
     assertEquals(ImmutableSet.of("record", "PII"), resultSchema.inlineTags());
+    Map<SchemaEntity, Set<String>> expectedTags = new HashMap<>(tags);
+    assertEquals(expectedTags, resultSchema.inlineTaggedEntities());
 
     resultSchema = resultSchema.copy(Collections.emptyMap(), tags);
     assertEquals(schema.canonicalString(), resultSchema.canonicalString());

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -18,6 +18,8 @@ package io.confluent.kafka.schemaregistry.protobuf;
 
 import static com.google.common.base.CaseFormat.LOWER_UNDERSCORE;
 import static com.google.common.base.CaseFormat.UPPER_CAMEL;
+import static io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity.EntityType.SR_FIELD;
+import static io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity.EntityType.SR_RECORD;
 import static io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils.findMatchingElement;
 import static io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils.findMatchingNode;
 import static io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils.jsonToFile;
@@ -106,6 +108,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleKind;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity.EntityType;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils.FormatContext;
 import io.confluent.kafka.schemaregistry.protobuf.diff.Difference;
@@ -2476,10 +2479,66 @@ public class ProtobufSchema implements ParsedSchema {
     }
   }
 
+  @Override
+  public Map<SchemaEntity, Set<String>> inlineTaggedEntities() {
+    Map<SchemaEntity, Set<String>> tags = new LinkedHashMap<>();
+    ProtoFileElement schema = rawSchema();
+    if (schema == null) {
+      return tags;
+    }
+    getInlineTaggedEntitiesRecursively(tags, schema.getTypes(), "");
+    return tags;
+  }
+
+  private void getInlineTaggedEntitiesRecursively(
+      Map<SchemaEntity, Set<String>> tags, List<TypeElement> types, String scope) {
+    for (TypeElement type : types) {
+      if (type instanceof MessageElement) {
+        getInlineTaggedEntitiesRecursively(tags, (MessageElement) type, scope);
+      }
+    }
+  }
+
+  private void getInlineTaggedEntitiesRecursively(
+      Map<SchemaEntity, Set<String>> tags, MessageElement message, String scope) {
+    String scopedName = scope + message.getName();
+    Set<String> recordTags = getInlineTags(CONFLUENT_MESSAGE_META, message.getOptions());
+    if (!recordTags.isEmpty()) {
+      tags.put(new SchemaEntity(scopedName, SR_RECORD), recordTags);
+    }
+    for (OneOfElement oneOf : message.getOneOfs()) {
+      for (FieldElement field : oneOf.getFields()) {
+        Set<String> fieldTags = getInlineTags(CONFLUENT_FIELD_META, field.getOptions());
+        if (!fieldTags.isEmpty()) {
+          tags.put(new SchemaEntity(
+              scopedName + "." + field.getName(), SR_FIELD), fieldTags);
+        }
+      }
+    }
+    for (FieldElement field : message.getFields()) {
+      Set<String> fieldTags = getInlineTags(CONFLUENT_FIELD_META, field.getOptions());
+      if (!fieldTags.isEmpty()) {
+        tags.put(new SchemaEntity(scopedName + "." + field.getName(), SR_FIELD), fieldTags);
+      }
+    }
+    getInlineTaggedEntitiesRecursively(tags, message.getNestedTypes(), scopedName + ".");
+  }
+
+
   private Set<String> getInlineTags(FieldDescriptor fd) {
     if (fd.getOptions().hasExtension(MetaProto.fieldMeta)) {
       Meta meta = fd.getOptions().getExtension(MetaProto.fieldMeta);
       return new LinkedHashSet<>(meta.getTagsList());
+    }
+    return Collections.emptySet();
+  }
+
+  private Set<String> getInlineTags(String optionName, List<OptionElement> options) {
+    ProtobufMeta meta = ProtobufSchema.findMeta(optionName, options);
+    if (meta != null) {
+      if (meta.getTags() != null) {
+        return new LinkedHashSet<>(meta.getTags());
+      }
     }
     return Collections.emptySet();
   }
@@ -2499,7 +2558,7 @@ public class ProtobufSchema implements ParsedSchema {
       JsonNode entityNode;
       Object matchingElement;
 
-      if (SchemaEntity.EntityType.SR_RECORD == entity.getEntityType()) {
+      if (SR_RECORD == entity.getEntityType()) {
         metaName = CONFLUENT_MESSAGE_META;
         matchingElement = findMatchingElement(original, identifiers, false);
         MessageElement messageElement = (MessageElement) matchingElement;

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -108,7 +108,6 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleKind;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
-import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity.EntityType;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils.FormatContext;
 import io.confluent.kafka.schemaregistry.protobuf.diff.Difference;

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -2648,6 +2648,20 @@ public class ProtobufSchemaTest {
     ParsedSchema schema = new ProtobufSchema(schemaString).copy(tagsToAdd, Collections.emptyMap());
     assertEquals(expectedString, schema.canonicalString());
     assertEquals(ImmutableSet.of("FILE", "OTHER", "PII", "PRIVATE", "ENUM", "CONST"), schema.inlineTags());
+    Map<SchemaEntity, Set<String>> expectedTags = new HashMap<>(tagsToAdd);
+    expectedTags.put(new SchemaEntity(
+        "SampleRecord",
+        SchemaEntity.EntityType.SR_RECORD),
+        ImmutableSet.of("OTHER", "PII"));
+    expectedTags.put(new SchemaEntity(
+        "SampleRecord.my_field1",
+        SchemaEntity.EntityType.SR_FIELD),
+        ImmutableSet.of("OTHER", "PRIVATE", "PII"));
+    expectedTags.put(new SchemaEntity(
+        "SampleRecord.my_field2",
+        SchemaEntity.EntityType.SR_FIELD),
+        ImmutableSet.of("PRIVATE", "PII"));
+    assertEquals(expectedTags, schema.inlineTaggedEntities());
 
     Map<SchemaEntity, Set<String>> tagsToRemove = new HashMap<>();
     tagsToRemove.put(new SchemaEntity(".SampleRecord.my_field1",


### PR DESCRIPTION
Add a query param, findTags, when retrieving a schema, that will extract schema entities with the given set of tags.  This functionality will be used by the Cloud UI to display the tags in a tree view.