### PR TITLE
Fix build breakage caused by dependency change

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -109,6 +109,11 @@
             <artifactId>netty-codec</artifactId>
             <version>${netty.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-java-server</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.confluent</groupId>


### PR DESCRIPTION
Build is failing because of the change in https://github.com/confluentinc/rest-utils/pull/472.