### PR TITLE
fix: nested schemas were not considered in matching the correct Json Union schema

### DIFF
--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
@@ -194,7 +194,7 @@ public class JsonSchemaData {
         String fieldNamePrefix = generalizedSumTypeSupport
             ? GENERALIZED_TYPE_UNION_FIELD_PREFIX
             : JSON_TYPE_ONE_OF + ".field.";
-        int numMatchingProperties = -1;
+        int numMatchingProperties = 0;
         Field matchingField = null;
         for (Field field : schema.fields()) {
           Schema fieldSchema = field.schema();
@@ -266,7 +266,7 @@ public class JsonSchemaData {
 
   private static int matchStructSchema(Schema fieldSchema, JsonNode value) {
     if (fieldSchema.type() != Schema.Type.STRUCT || !value.isObject()) {
-      return -1;
+      return 0;
     }
     Set<String> schemaFields = fieldSchema.fields()
         .stream()
@@ -278,7 +278,15 @@ public class JsonSchemaData {
     }
     Set<String> intersectSet = new HashSet<>(schemaFields);
     intersectSet.retainAll(objectFields);
-    return intersectSet.size();
+
+    int childrenMatchFactor = 0;
+    for (String intersectedElement: intersectSet){
+      Schema childSchema = fieldSchema.field(intersectedElement).schema();
+      JsonNode childValue = value.get(intersectedElement);
+      childrenMatchFactor += matchStructSchema(childSchema, childValue);
+    }
+
+    return intersectSet.size() + childrenMatchFactor;
   }
 
   // Convert values in Kafka Connect form into their logical types. These logical converters are

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
@@ -280,7 +280,7 @@ public class JsonSchemaData {
     intersectSet.retainAll(objectFields);
 
     int childrenMatchFactor = 0;
-    for (String intersectedElement: intersectSet){
+    for (String intersectedElement: intersectSet) {
       Schema childSchema = fieldSchema.field(intersectedElement).schema();
       JsonNode childValue = value.get(intersectedElement);
       childrenMatchFactor += matchStructSchema(childSchema, childValue);

--- a/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
+++ b/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
@@ -1533,6 +1533,63 @@ public class JsonSchemaDataTest {
   }
 
   @Test
+  public void testToConnectUnionSecondNestedSchemas() {
+    StringSchema stringSchema = StringSchema.builder()
+            .unprocessedProperties(ImmutableMap.of("connect.index", 0))
+            .build();
+    ObjectSchema firstSchemaNested = ObjectSchema.builder()
+            .addPropertySchema("differentFieldNameA", stringSchema)
+            .build();
+    ObjectSchema firstSchema = ObjectSchema.builder()
+            .addPropertySchema("commonFieldName", firstSchemaNested)
+            .unprocessedProperties(ImmutableMap.of("connect.index", 0))
+            .build();
+    ObjectSchema secondSchemaNested = ObjectSchema.builder()
+            .addPropertySchema("differentFieldNameB", stringSchema)
+            .build();
+    ObjectSchema secondSchema = ObjectSchema.builder()
+            .addPropertySchema("commonFieldName", secondSchemaNested)
+            .unprocessedProperties(ImmutableMap.of("connect.index", 1))
+            .build();
+    CombinedSchema schema = CombinedSchema.oneOf(ImmutableList.of(firstSchema, secondSchema))
+            .build();
+
+    Schema field0Nested = SchemaBuilder.struct().field("differentFieldNameA", Schema.STRING_SCHEMA).build();
+    Schema field0 = SchemaBuilder.struct()
+            .field("commonFieldName", field0Nested)
+            .optional()
+            .build();
+    Schema field1Nested = SchemaBuilder.struct().field("differentFieldNameB", Schema.STRING_SCHEMA).build();
+    Schema field1 = SchemaBuilder.struct()
+            .field("commonFieldName", field1Nested)
+            .optional()
+            .build();
+    Schema connectSchema = SchemaBuilder.struct().name(JSON_TYPE_ONE_OF)
+            .field(JSON_TYPE_ONE_OF + ".field.0", field0)
+            .field(JSON_TYPE_ONE_OF + ".field.1", field1)
+            .build();
+
+    ObjectNode firstObj = JsonNodeFactory.instance.objectNode()
+            .set("differentFieldNameA", TextNode.valueOf("sample string A"));
+    ObjectNode secondObj = JsonNodeFactory.instance.objectNode()
+            .set("differentFieldNameB", TextNode.valueOf("sample string B"));
+    Struct firstStruct = new Struct(field0Nested).put("differentFieldNameA", "sample string A");
+    Struct secondStruct = new Struct(field1Nested).put("differentFieldNameB", "sample string B");
+
+    ObjectNode obj = JsonNodeFactory.instance.objectNode().
+            set("commonFieldName", firstObj);
+    Struct struct = new Struct(field0).put("commonFieldName", firstStruct);
+    Struct expected = new Struct(connectSchema).put(JSON_TYPE_ONE_OF + ".field.0", struct);
+    checkNonObjectConversion(connectSchema, expected, schema, obj);
+
+    obj = JsonNodeFactory.instance.objectNode().
+            set("commonFieldName", secondObj);
+    struct = new Struct(field1).put("commonFieldName", secondStruct);
+    expected = new Struct(connectSchema).put(JSON_TYPE_ONE_OF + ".field.1", struct);
+    checkNonObjectConversion(connectSchema, expected, schema, obj);
+  }
+  
+  @Test
   public void testToConnectMapOptionalValue() {
     testToConnectMapOptional("some value");
   }


### PR DESCRIPTION
Currently when presented with a schema like this:
```json
{
  "oneOf": [
    { 
      "type": "object", 
      "properties": {
        "message": {
          "type": "object",
          "properties": {
            "A": {"type": "string"}
          }
        }
      }
    },
    { 
      "type": "object", 
      "properties": {
        "message": {
          "type": "object",
          "properties": {
            "B": {"type": "integer"}
          }
        }
      }
    }
  ]
}
```
JsonSchemaConverter will always assume that the first schema is the correct one. Regardless if the message received is:
```json
{
  "message": {
    "A": "sample string"
  }
}
```
or
```json
{
  "message": {
    "B": 27
  }
}
```
And in the second case this will cause an error as field "A" will be in the chosen schema but not present inside the record.