### PR TITLE
Update service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -24,4 +24,3 @@ code_artifact:
     - maven-snapshots/maven/io.confluent/kafka-json-*
     - maven-snapshots/maven/io.confluent/kafka-schema-*
     - maven-snapshots/maven/io.confluent/kafka-avro-serializer
-    - pypi-internal/pypi//confluent-ci-tools


### PR DESCRIPTION
  * package path  `pypi-internal/pypi//confluent-ci-tools` is already claimed by other repo.
