### PR TITLE
DGS-10608: Don't allow subjects named __EMPTY

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
@@ -40,6 +40,9 @@ public class QualifiedSubject implements Comparable<QualifiedSubject> {
   // Subject name under which global permissions are stored.
   public static final String GLOBAL_SUBJECT_NAME = "__GLOBAL";
 
+  // Subject name that represents empty string
+  public static final String EMPTY_SUBJECT_NAME = "__EMPTY";
+
   private final String tenant;
   private final String context;  // assumed to start with CONTEXT_SEPARATOR
   private final String subject;
@@ -218,7 +221,8 @@ public class QualifiedSubject implements Comparable<QualifiedSubject> {
     }
     QualifiedSubject qs = QualifiedSubject.create(tenant, qualifiedSubject);
     // For backward compatibility, we allow an empty subject
-    if (qs == null || qs.getSubject().equals(GLOBAL_SUBJECT_NAME)) {
+    if (qs == null || qs.getSubject().equals(GLOBAL_SUBJECT_NAME)
+        || qs.getSubject().equals(EMPTY_SUBJECT_NAME)) {
       return false;
     }
     return true;

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubjectTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubjectTest.java
@@ -197,5 +197,6 @@ public class QualifiedSubjectTest {
     assertFalse(QualifiedSubject.isValidSubject("default", String.valueOf((char) 31)));
     assertTrue(QualifiedSubject.isValidSubject("default", "  "));
     assertFalse(QualifiedSubject.isValidSubject("default", "__GLOBAL"));
+    assertFalse(QualifiedSubject.isValidSubject("default", "__EMPTY"));
   }
 }


### PR DESCRIPTION
`__EMPTY` subject name should be reserved for subjects with empty name. This is for resource-level RBAC