### PR TITLE
fix: update commons-compress to 1.26.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <wire.version>4.9.7</wire.version>
         <swagger.version>2.1.10</swagger.version>
         <io.confluent.schema-registry.version>7.8.0-0</io.confluent.schema-registry.version>
-        <commons.compress.version>1.26.0</commons.compress.version>
+        <commons.compress.version>1.26.1</commons.compress.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
         <bouncycastle.jdk18.version>1.77</bouncycastle.jdk18.version>
         <commons.validator.version>1.7</commons.validator.version>


### PR DESCRIPTION
fixes java.lang.ClassNotFoundException: org.apache.commons.io.Charsets
https://github.com/confluentinc/schema-registry/issues/3073