### PR TITLE
DGS-10135 Allow rule onFailure/onSuccess to be overridden via props

### DIFF
--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelExecutorTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelExecutorTest.java
@@ -95,6 +95,7 @@ import org.mockito.ArgumentCaptor;
 
 public class CelExecutorTest {
 
+  private final Map<String, Object> defaultConfig;
   private final SchemaRegistryClient schemaRegistry;
   private final KafkaAvroSerializer avroSerializer;
   private final KafkaAvroDeserializer avroDeserializer;
@@ -127,7 +128,7 @@ public class CelExecutorTest {
     when(producer2.send(any(ProducerRecord.class), any(Callback.class))).thenReturn(
         CompletableFuture.completedFuture(null));
 
-    Map<String, Object> defaultConfig = new HashMap<>();
+    defaultConfig = new HashMap<>();
     defaultConfig.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "bogus");
     defaultConfig.put(AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, "false");
     defaultConfig.put(AbstractKafkaSchemaSerDeConfig.USE_LATEST_VERSION, "true");
@@ -607,6 +608,56 @@ public class CelExecutorTest {
     // Verify producer record has both key and value
     assertNotNull(argument.getValue().key());
     assertNotNull(argument.getValue().value());
+    verifyNoInteractions(producer2);
+  }
+
+  @Test
+  public void testKafkaAvroSerializerConstraintDlqFromRuleConfig() throws Exception {
+    IndexedRecord avroRecord = createUserRecord();
+    AvroSchema avroSchema = new AvroSchema(avroRecord.getSchema());
+    Rule rule = new Rule("myRule", null, RuleKind.CONDITION, RuleMode.WRITE,
+        CelExecutor.TYPE, null, null, "message.name != \"testUser\" || message.kind != \"ONE\"",
+        null, null, false);
+    RuleSet ruleSet = new RuleSet(Collections.emptyList(), Collections.singletonList(rule));
+    avroSchema = avroSchema.copy(null, ruleSet);
+    schemaRegistry.register(topic + "-value", avroSchema);
+
+    Map<String, Object> config = new HashMap<>(defaultConfig);
+    config.put("rule.executors.myRule.onFailure", "DLQ");
+    KafkaAvroSerializer customSerializer = new KafkaAvroSerializer(schemaRegistry, config);
+    try {
+      byte[] bytes = customSerializer.serialize(topic, avroRecord);
+      fail("Should send to DLQ and throw exception");
+    } catch (SerializationException e) {
+      // expected
+    }
+
+    verify(producer).send(any(ProducerRecord.class), any(Callback.class));
+    verifyNoInteractions(producer2);
+  }
+
+  @Test
+  public void testKafkaAvroSerializerConstraintDlqFromDefaultConfig() throws Exception {
+    IndexedRecord avroRecord = createUserRecord();
+    AvroSchema avroSchema = new AvroSchema(avroRecord.getSchema());
+    Rule rule = new Rule("myRule", null, RuleKind.CONDITION, RuleMode.WRITE,
+        CelExecutor.TYPE, null, null, "message.name != \"testUser\" || message.kind != \"ONE\"",
+        null, null, false);
+    RuleSet ruleSet = new RuleSet(Collections.emptyList(), Collections.singletonList(rule));
+    avroSchema = avroSchema.copy(null, ruleSet);
+    schemaRegistry.register(topic + "-value", avroSchema);
+
+    Map<String, Object> config = new HashMap<>(defaultConfig);
+    config.put("rule.executors._default_.onFailure", "DLQ");
+    KafkaAvroSerializer customSerializer = new KafkaAvroSerializer(schemaRegistry, config);
+    try {
+      byte[] bytes = customSerializer.serialize(topic, avroRecord);
+      fail("Should send to DLQ and throw exception");
+    } catch (SerializationException e) {
+      // expected
+    }
+
+    verify(producer).send(any(ProducerRecord.class), any(Callback.class));
     verifyNoInteractions(producer2);
   }
 

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -122,6 +122,9 @@ public abstract class AbstractKafkaSchemaSerDe implements Closeable {
   private static final ErrorAction ERROR_ACTION = new ErrorAction();
   private static final NoneAction NONE_ACTION = new NoneAction();
 
+  private static final String ON_SUCCESS = "onSuccess";
+  private static final String ON_FAILURE = "onFailure";
+
   // Track the key for use when deserializing/serializing the value, such as for a DLQ.
   // We take advantage of the fact the value serde is called after the key serde.
   private static final ThreadLocal<Object> key = new ThreadLocal<>();
@@ -691,19 +694,48 @@ public abstract class AbstractKafkaSchemaSerDe implements Closeable {
               throw new IllegalStateException("Unsupported rule kind " + rule.getKind());
           }
           runAction(ctx, ruleMode, rule,
-              message != null ? rule.getOnSuccess() : rule.getOnFailure(),
+              message != null ? getOnSuccess(rule) : getOnFailure(rule),
               message, null, message != null ? null : ErrorAction.TYPE
           );
         } catch (RuleException e) {
-          runAction(ctx, ruleMode, rule, rule.getOnFailure(), message, e, ErrorAction.TYPE);
+          runAction(ctx, ruleMode, rule, getOnFailure(rule), message, e, ErrorAction.TYPE);
         }
       } else {
-        runAction(ctx, ruleMode, rule, rule.getOnFailure(), message,
+        runAction(ctx, ruleMode, rule, getOnFailure(rule), message,
             new RuleException("Could not find rule executor of type " + rule.getType()),
             ErrorAction.TYPE);
       }
     }
     return message;
+  }
+
+  private String getOnSuccess(Rule rule) {
+    Object propertyValue = getRuleConfig(rule.getName(), ON_SUCCESS);
+    if (propertyValue != null) {
+      return propertyValue.toString();
+    }
+    propertyValue = getRuleConfig(RuleBase.DEFAULT_NAME, ON_SUCCESS);
+    if (propertyValue != null) {
+      return propertyValue.toString();
+    }
+    return rule.getOnSuccess();
+  }
+
+  private String getOnFailure(Rule rule) {
+    Object propertyValue = getRuleConfig(rule.getName(), ON_FAILURE);
+    if (propertyValue != null) {
+      return propertyValue.toString();
+    }
+    propertyValue = getRuleConfig(RuleBase.DEFAULT_NAME, ON_FAILURE);
+    if (propertyValue != null) {
+      return propertyValue.toString();
+    }
+    return rule.getOnFailure();
+  }
+
+  private Object getRuleConfig(String name, String suffix) {
+    String propertyName = RULE_EXECUTORS + "." + name + "." + suffix;
+    return configOriginals.get(propertyName);
   }
 
   private boolean skipRule(Rule rule, Headers headers) {


### PR DESCRIPTION
The config `rule.executors._default_.onFailure` and `rule.executors._default_.onSuccess` can be set via props