### PR TITLE
Refactor storage value to entity conversions

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -783,7 +783,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
         ? ((LazyParsedSchemaHolder) undeletedVersions.get(0)).schemaValue()
         : null;
     Schema previousSchema = previousSchemaValue != null
-        ? previousSchemaValue.toSchemaEntity()
+        ? toSchemaEntity(previousSchemaValue)
         : null;
     if (schema == null
         || schema.getSchema() == null
@@ -1220,7 +1220,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       SchemaRegistryValue existingValue = this.lookupCache.get(existingKey);
       if (existingValue instanceof SchemaValue) {
         SchemaValue existingSchemaValue = (SchemaValue) existingValue;
-        Schema existingSchema = existingSchemaValue.toSchemaEntity();
+        Schema existingSchema = toSchemaEntity(existingSchemaValue);
         Schema schemaCopy = schema.copy();
         schemaCopy.setId(existingSchema.getId());
         schemaCopy.setSubject(existingSchema.getSubject());
@@ -1528,7 +1528,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       SchemaValue schemaValue = getSchemaValue(new SchemaKey(subject, version));
       Schema schema = null;
       if (schemaValue != null && (!schemaValue.isDeleted() || returnDeletedSchema)) {
-        schema = schemaValue.toSchemaEntity();
+        schema = toSchemaEntity(schemaValue);
       }
       return schema;
     }
@@ -1551,7 +1551,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       if (subjectVersionKey == null) {
         return null;
       }
-      schema = getSchemaValue(subjectVersionKey);
+      schema = (SchemaValue) kafkaStore.get(subjectVersionKey);
     } catch (StoreException e) {
       throw new SchemaRegistryStoreException(
           "Error while retrieving schema with id "
@@ -1559,7 +1559,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
           + " from the backend Kafka"
           + " store", e);
     }
-    Schema schemaEntity = schema.toSchemaEntity();
+    Schema schemaEntity = toSchemaEntity(schema);
     SchemaString schemaString = new SchemaString(schemaEntity);
     if (format != null && !format.trim().isEmpty()) {
       ParsedSchema parsedSchema = parseSchema(schemaEntity, false, false);
@@ -1573,12 +1573,15 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     return schemaString;
   }
 
+  public Schema toSchemaEntity(SchemaValue schemaValue) {
+    metadataEncoder.decodeMetadata(schemaValue);
+    return schemaValue.toSchemaEntity();
+  }
+
   protected SchemaValue getSchemaValue(SchemaKey key)
       throws SchemaRegistryException {
     try {
-      SchemaValue schemaValue = (SchemaValue) kafkaStore.get(key);
-      metadataEncoder.decodeMetadata(schemaValue);
-      return schemaValue;
+      return (SchemaValue) kafkaStore.get(key);
     } catch (StoreException e) {
       throw new SchemaRegistryStoreException(
           "Error while retrieving schema from the backend Kafka"
@@ -1695,12 +1698,12 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       if (subjectVersionKey == null) {
         return null;
       }
-      schema = getSchemaValue(subjectVersionKey);
+      schema = (SchemaValue) kafkaStore.get(subjectVersionKey);
       if (schema == null) {
         return null;
       }
 
-      return lookupCache.schemaIdAndSubjects(schema.toSchemaEntity())
+      return lookupCache.schemaIdAndSubjects(toSchemaEntity(schema))
           .allSubjectVersions()
           .entrySet()
           .stream()
@@ -1810,7 +1813,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       }
     }
 
-    return latestSchemaValue != null ? latestSchemaValue.toSchemaEntity() : null;
+    return latestSchemaValue != null ? toSchemaEntity(latestSchemaValue) : null;
   }
 
   private CloseableIterator<SchemaRegistryValue> allVersions(
@@ -2206,7 +2209,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       if (!shouldInclude) {
         continue;
       }
-      Schema schema = schemaValue.toSchemaEntity();
+      Schema schema = toSchemaEntity(schemaValue);
       if (returnLatestOnly) {
         if (previousSchema != null && !schema.getSubject().equals(previousSchema.getSubject())) {
           schemaList.add(previousSchema);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LazyParsedSchemaHolder.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LazyParsedSchemaHolder.java
@@ -45,7 +45,7 @@ public class LazyParsedSchemaHolder implements ParsedSchemaHolder {
   @Override
   public ParsedSchema schema() {
     try {
-      return schemaRegistry.parseSchema(schemaValue().toSchemaEntity());
+      return schemaRegistry.parseSchema(schemaRegistry.toSchemaEntity(schemaValue()));
     } catch (SchemaRegistryException e) {
       throw new IllegalStateException(e);
     }

--- a/dek-registry/src/main/java/io/confluent/dekregistry/web/rest/resources/DekRegistryResource.java
+++ b/dek-registry/src/main/java/io/confluent/dekregistry/web/rest/resources/DekRegistryResource.java
@@ -132,7 +132,7 @@ public class DekRegistryResource extends SchemaRegistryResource {
     if (key == null) {
       throw DekRegistryErrors.keyNotFoundException(name);
     }
-    return key.toKekEntity();
+    return dekRegistry.toKekEntity(key);
   }
 
   @GET


### PR DESCRIPTION
Ensure same logic is applied when converting from storage values to entities.  This also fixes some issues where metadata wasn't always being decoded correctly.