### PR TITLE
DGS-10520: Update Netty Dependency to 4.1.108-Final

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
-            <version>${netty.version}</version>
+            <version>4.1.108.Final</version>
         </dependency>
         <dependency>
             <groupId>com.101tec</groupId>

--- a/licenses-and-notices.html
+++ b/licenses-and-notices.html
@@ -109,7 +109,7 @@ th {
 <TR>
 <TD>metrics-core-2.2.0</TD><TD>jar</TD><TD>2.2.0</TD><TD></TD></TR>
 <TR>
-<TD><A HREF="http://netty.io/">netty-3.7.0.Final</A></TD><TD>jar</TD><TD>3.7.0.Final</TD><TD><A HREF="http://www.apache.org/licenses/LICENSE-2.0">Apache 2.0</A><br></TD></TR>
+<TD><A HREF="http://netty.io/">netty-4.1.68.Final</A></TD><TD>jar</TD><TD>4.1.68.Final</TD><TD><A HREF="http://www.apache.org/licenses/LICENSE-2.0">Apache 2.0</A><br></TD></TR>
 <TR>
 <TD><A HREF="dav:http://glassfish-maven-repository.us.oracle.com/maven/repositories/glassfish/">osgi-resource-locator-1.0.1</A></TD><TD>jar</TD><TD>1.0.1</TD><TD><A HREF="https://glassfish.dev.java.net/nonav/public/CDDL+GPL.html">link from artifact (META-INF/MANIFEST.MF)</A><br></TD></TR>
 <TR>


### PR DESCRIPTION
This PR updates the Netty Dependency to 4.1.108-Final

Build passes locally. Will merge this PR after Jenkins build passes (Jenkins builds on 6.0.x look stable).

