### PR TITLE
Upgrade jackson package to fix build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <commons.compress.version>1.26.1</commons.compress.version>
         <dropwizard.version>4.1.12.1</dropwizard.version>
         <bouncycastle.jdk18.version>1.77</bouncycastle.jdk18.version>
+        <jackson.version>2.16.2</jackson.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
The jackson version was recently reverted from `2.16.2` to `2.14.2` to fix kafka build issues by this PR in common repo: https://github.com/confluentinc/common/pull/598. This broke the build in schema-registry in all branches starting at 6.2.x. 
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project kafka-json-schema-provider: Compilation failure: Compilation failure:
[ERROR] /Users/srimangaddam/schema-registry/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/Jackson.java:[27,42] cannot find symbol
[ERROR]   symbol:   class CacheProvider
[ERROR]   location: package com.fasterxml.jackson.databind.cfg
[ERROR] /Users/srimangaddam/schema-registry/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/Jackson.java:[106,77] cannot find symbol
[ERROR]   symbol:   class CacheProvider
[ERROR]   location: class io.confluent.kafka.schemaregistry.json.jackson.Jackson.DefaultSerializerProviderImpl
[ERROR] /Users/srimangaddam/schema-registry/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/Jackson.java:[128,53] cannot find symbol
[ERROR]   symbol:   class CacheProvider
[ERROR]   location: class io.confluent.kafka.schemaregistry.json.jackson.Jackson.DefaultSerializerProviderImpl
[ERROR] -> [Help 1]
```
Setting the schema-registry jackson version to `2.16.2` instead of using the `2.14.2` version from common repo fixes the build errors.