### PR TITLE
DGS-10892: Produce register schema message after tombstones

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -731,14 +731,13 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
           throw new InvalidSchemaException("Version is not one more than previous version");
         }
 
-        SchemaKey schemaKey = new SchemaKey(subject, schema.getVersion());
-        SchemaValue schemaValue = new SchemaValue(schema, ruleSetHandler);
+        final SchemaKey schemaKey = new SchemaKey(subject, schema.getVersion());
+        final SchemaValue schemaValue = new SchemaValue(schema, ruleSetHandler);
         metadataEncoder.encodeMetadata(schemaValue);
         if (schemaId >= 0) {
           checkIfSchemaWithIdExist(schemaId, schema);
           schema.setId(schemaId);
           schemaValue.setId(schemaId);
-          kafkaStore.put(schemaKey, schemaValue);
         } else {
           String qctx = QualifiedSubject.qualifiedContextFor(tenant(), subject);
           int retries = 0;
@@ -751,7 +750,6 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
               if (retries > 1) {
                 log.warn(String.format("Retrying to register the schema with ID %s", newId));
               }
-              kafkaStore.put(schemaKey, schemaValue);
               break;
             }
           }
@@ -768,6 +766,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
             kafkaStore.put(key, null);
           }
         }
+        kafkaStore.put(schemaKey, schemaValue);
 
         return modifiedSchema
             ? schema


### PR DESCRIPTION
This is a bugfix for Data Catalog.

The register schema message should go _after_ the tombstones so that Data Catalog can correctly delete the sr_* entities before creating new sr_* entities.

Background: In Atlas, for a unique `qualifiedName` there can be multiple entities in the DELETED state, and one entity in the ACTIVE state. Entities cannot be transitions from DELETED to ACTIVE. This change will make Data Catalog delete the entities before creating new ones. 