### PR TITLE
Revert jackson to 2.14.2

### DIFF
--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/Jackson.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/Jackson.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.cfg.CacheProvider;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -103,11 +102,6 @@ public class Jackson {
       _unknownTypeSerializer = DEFAULT_UNKNOWN_SERIALIZER;
     }
 
-    public DefaultSerializerProviderImpl(DefaultSerializerProviderImpl src, CacheProvider cp) {
-      super(src, cp);
-      _unknownTypeSerializer = DEFAULT_UNKNOWN_SERIALIZER;
-    }
-
     protected DefaultSerializerProviderImpl(
         SerializerProvider src, SerializationConfig config, SerializerFactory f) {
       super(src, config, f);
@@ -124,11 +118,6 @@ public class Jackson {
         SerializationConfig config, SerializerFactory jsf) {
       return new DefaultSerializerProviderImpl(this, config, jsf);
     }
-
-    public DefaultSerializerProviderImpl withCaches(CacheProvider cp) {
-      return new DefaultSerializerProviderImpl(this, cp);
-    }
-  }
 
   static class UnknownSerializerImpl extends UnknownSerializer {
     public UnknownSerializerImpl() {

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/Jackson.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/jackson/Jackson.java
@@ -118,6 +118,7 @@ public class Jackson {
         SerializationConfig config, SerializerFactory jsf) {
       return new DefaultSerializerProviderImpl(this, config, jsf);
     }
+  }
 
   static class UnknownSerializerImpl extends UnknownSerializer {
     public UnknownSerializerImpl() {

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,6 @@
         <commons.compress.version>1.26.1</commons.compress.version>
         <dropwizard.version>4.1.12.1</dropwizard.version>
         <bouncycastle.jdk18.version>1.77</bouncycastle.jdk18.version>
-        <jackson.version>2.16.2</jackson.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Reverting Jackson to 2.14.2 (reverting this PR to 6.2.x: https://github.com/confluentinc/schema-registry/pull/3105) and removing the associated changes made to support Jackson 2.16.2(https://github.com/confluentinc/schema-registry/pull/3099/files).

Build is passing on 6.0.x and 6.1.x without this revert (both of those branches are already on Jackson 2.14.2).
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for kafka-schema-registry-parent 6.0.16-SNAPSHOT:
[INFO]
[INFO] kafka-schema-registry-parent ....................... SUCCESS [  1.808 s]
[INFO] kafka-schema-registry-client ....................... SUCCESS [  7.389 s]
[INFO] kafka-json-schema-provider ......................... SUCCESS [  5.032 s]
[INFO] kafka-protobuf-provider ............................ SUCCESS [  6.060 s]
[INFO] kafka-schema-serializer ............................ SUCCESS [  2.372 s]
[INFO] kafka-avro-serializer .............................. SUCCESS [  3.645 s]
[INFO] kafka-schema-registry .............................. SUCCESS [ 10.720 s]
[INFO] kafka-json-serializer .............................. SUCCESS [  2.964 s]
[INFO] kafka-connect-avro-data ............................ SUCCESS [  5.682 s]
[INFO] kafka-connect-avro-converter ....................... SUCCESS [  2.522 s]
[INFO] kafka-schema-registry-package ...................... SUCCESS [  0.104 s]
[INFO] kafka-streams-avro-serde ........................... SUCCESS [  2.707 s]
[INFO] kafka-json-schema-serializer ....................... SUCCESS [  3.294 s]
[INFO] kafka-connect-json-schema-converter ................ SUCCESS [  3.799 s]
[INFO] kafka-streams-json-schema-serde .................... SUCCESS [  2.421 s]
[INFO] kafka-protobuf-serializer .......................... SUCCESS [  6.660 s]
[INFO] kafka-connect-protobuf-converter ................... SUCCESS [  5.013 s]
[INFO] kafka-streams-protobuf-serde ....................... SUCCESS [  2.168 s]
[INFO] kafka-serde-tools-package .......................... SUCCESS [  0.109 s]
[INFO] maven-plugin ....................................... SUCCESS [  4.941 s]
[INFO] client-console-scripts ............................. SUCCESS [  0.088 s]
[INFO] schema-registry-console-scripts .................... SUCCESS [  0.056 s]
[INFO] kafka-schema-registry-benchmark .................... SUCCESS [  3.530 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:23 min
[INFO] Finished at: 2024-05-02T14:44:25-05:00
[INFO] ------------------------------------------------------------------------
```

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for kafka-schema-registry-parent 6.1.16-0:
[INFO]
[INFO] kafka-schema-registry-parent ....................... SUCCESS [  9.033 s]
[INFO] kafka-schema-registry-client ....................... SUCCESS [ 11.388 s]
[INFO] kafka-json-schema-provider ......................... SUCCESS [  5.326 s]
[INFO] kafka-protobuf-provider ............................ SUCCESS [  6.095 s]
[INFO] kafka-schema-serializer ............................ SUCCESS [  8.856 s]
[INFO] kafka-avro-serializer .............................. SUCCESS [  3.960 s]
[INFO] kafka-schema-registry .............................. SUCCESS [ 19.753 s]
[INFO] kafka-json-serializer .............................. SUCCESS [  5.512 s]
[INFO] kafka-connect-avro-data ............................ SUCCESS [  8.578 s]
[INFO] kafka-connect-avro-converter ....................... SUCCESS [  2.808 s]
[INFO] kafka-schema-registry-package ...................... SUCCESS [  0.118 s]
[INFO] kafka-streams-avro-serde ........................... SUCCESS [  8.637 s]
[INFO] kafka-json-schema-serializer ....................... SUCCESS [  3.401 s]
[INFO] kafka-connect-json-schema-converter ................ SUCCESS [  4.116 s]
[INFO] kafka-streams-json-schema-serde .................... SUCCESS [  2.473 s]
[INFO] kafka-protobuf-serializer .......................... SUCCESS [  7.802 s]
[INFO] kafka-connect-protobuf-converter ................... SUCCESS [  4.854 s]
[INFO] kafka-streams-protobuf-serde ....................... SUCCESS [  2.257 s]
[INFO] kafka-serde-tools-package .......................... SUCCESS [ 11.694 s]
[INFO] maven-plugin ....................................... SUCCESS [  5.066 s]
[INFO] client-console-scripts ............................. SUCCESS [  0.087 s]
[INFO] schema-registry-console-scripts .................... SUCCESS [  0.061 s]
[INFO] kafka-schema-registry-benchmark .................... SUCCESS [  3.536 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:22 min
[INFO] Finished at: 2024-05-02T14:47:02-05:00
[INFO] ------------------------------------------------------------------------
```