### PR TITLE
Fix classname for ConsoleConsumer 

### DIFF
--- a/bin/kafka-avro-console-consumer
+++ b/bin/kafka-avro-console-consumer
@@ -47,4 +47,4 @@ do
       ;;
     esac
 done
-exec $(dirname $0)/schema-registry-run-class kafka.tools.ConsoleConsumer $DEFAULT_AVRO_FORMATTER $DEFAULT_SCHEMA_REGISTRY_URL "$@"
+exec $(dirname $0)/schema-registry-run-class org.apache.kafka.tools.consumer.ConsoleConsumer $DEFAULT_AVRO_FORMATTER $DEFAULT_SCHEMA_REGISTRY_URL "$@"

--- a/bin/kafka-json-schema-console-consumer
+++ b/bin/kafka-json-schema-console-consumer
@@ -47,4 +47,4 @@ do
       ;;
     esac
 done
-exec $(dirname $0)/schema-registry-run-class kafka.tools.ConsoleConsumer $DEFAULT_PROTOBUF_FORMATTER $DEFAULT_SCHEMA_REGISTRY_URL "$@"
+exec $(dirname $0)/schema-registry-run-class org.apache.kafka.tools.consumer.ConsoleConsumer $DEFAULT_PROTOBUF_FORMATTER $DEFAULT_SCHEMA_REGISTRY_URL "$@"

--- a/bin/kafka-protobuf-console-consumer
+++ b/bin/kafka-protobuf-console-consumer
@@ -47,4 +47,4 @@ do
       ;;
     esac
 done
-exec $(dirname $0)/schema-registry-run-class kafka.tools.ConsoleConsumer $DEFAULT_PROTOBUF_FORMATTER $DEFAULT_SCHEMA_REGISTRY_URL "$@"
+exec $(dirname $0)/schema-registry-run-class org.apache.kafka.tools.consumer.ConsoleConsumer $DEFAULT_PROTOBUF_FORMATTER $DEFAULT_SCHEMA_REGISTRY_URL "$@"


### PR DESCRIPTION
`ce-kafka` has updated class name https://github.com/confluentinc/ce-kafka/commit/3e055624105874782de99b5c19e10089f9581ec1, need to update it here 
(commit in kafka 7.8.x I assume only needed in master)

causing test failure https://confluent.slack.com/archives/CM6PEBEGM/p1715573662303919