### PR TITLE
DGS-10707 Fix handleDeleteSubject to pass right oldSchemaValue

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -149,8 +149,8 @@ public class KafkaStoreMessageHandler implements SchemaUpdateHandler {
         SchemaValue schemaValue = (SchemaValue) this.lookupCache.get(schemaKey);
         if (schemaValue != null) {
           schemaValue.setDeleted(true);
-          lookupCache.put(schemaKey, schemaValue);
-          lookupCache.schemaDeleted(schemaKey, schemaValue, schemaValue);
+          SchemaValue oldSchemaValue = (SchemaValue) lookupCache.put(schemaKey, schemaValue);
+          lookupCache.schemaDeleted(schemaKey, schemaValue, oldSchemaValue);
         }
       } catch (StoreException e) {
         log.error("Failed to delete subject {} in the local cache", subject, e);


### PR DESCRIPTION
What
----
Fix handleDeleteSubject to pass right oldSchemaValue. If right oldValue is not passed it would affect how schema soft delete updates the schema count

References
----------
https://confluentinc.atlassian.net/browse/DGS-10707