### PR TITLE
update azure-identity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-identity</artifactId>
-                <version>1.11.2</version>
+                <version>1.12.1</version>
             </dependency>
             <dependency>
                 <groupId>com.azure</groupId>


### PR DESCRIPTION
Update azure-identity to match version in ce-kafka and update transitive dependency that brings CVE-2024-21634
This dependency definition should be removed after https://github.com/confluentinc/common/pull/616 is merged. 