### PR TITLE
DGS-12288: Call kafkaStore on healthy checks

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -445,6 +445,13 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   }
 
   public boolean healthy() {
+    // Get dummy context key
+    try {
+      // Should return null if key does not exist
+      kafkaStore.get(new ContextKey(tenant(), "dummy"));
+    } catch (Throwable t) {
+      return false;
+    }
     return initialized()
         && getResourceExtensions().stream().allMatch(SchemaRegistryResourceExtension::healthy);
   }


### PR DESCRIPTION
Call the `kafkaStore` on healthy checks so we can detect any issues with the storage. 

Testing:
- There are integration tests in our Confluent Cloud repos that depend on the `healthy()` method
- We will monitor for performance concerns when deploying to pre-prod environments