### PR TITLE
Revert "do not reinstantiate objectmapper as it's expensive (#2686)

### DIFF
--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
@@ -42,7 +42,7 @@ import io.confluent.kafka.schemaregistry.json.jackson.Jackson;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDe;
 
 public abstract class AbstractKafkaJsonSchemaDeserializer<T> extends AbstractKafkaSchemaSerDe {
-  protected static final ObjectMapper objectMapper = Jackson.newObjectMapper();
+  protected ObjectMapper objectMapper = Jackson.newObjectMapper();
   protected Class<T> type;
   protected String typeProperty;
   protected boolean validate;

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaSerializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaSerializer.java
@@ -41,7 +41,7 @@ public abstract class AbstractKafkaJsonSchemaSerializer<T> extends AbstractKafka
   protected boolean autoRegisterSchema;
   protected boolean useLatestVersion;
   protected boolean latestCompatStrict;
-  protected static final ObjectMapper objectMapper = Jackson.newObjectMapper();
+  protected ObjectMapper objectMapper = Jackson.newObjectMapper();
   protected SpecificationVersion specVersion;
   protected boolean oneofForNullables;
   protected boolean failUnknownProperties;


### PR DESCRIPTION
Reverting this change to fix https://github.com/confluentinc/schema-registry/issues/3145

We will possibly need a different change to optimize ObjectMapper creation performance.