### PR TITLE
Fix SystemTime that change visibility and compilation issue of KafkaGroupLeaderElector

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/KafkaGroupLeaderElector.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/KafkaGroupLeaderElector.java
@@ -153,8 +153,7 @@ public class KafkaGroupLeaderElector implements LeaderElector, SchemaRegistryReb
           true,
           new ApiVersions(),
           logContext,
-          MetadataRecoveryStrategy.forName(
-              clientConfig.getString(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG)));
+          MetadataRecoveryStrategy.NONE);
 
       this.client = new ConsumerNetworkClient(
           logContext,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/KafkaGroupLeaderElector.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/KafkaGroupLeaderElector.java
@@ -153,7 +153,8 @@ public class KafkaGroupLeaderElector implements LeaderElector, SchemaRegistryReb
           true,
           new ApiVersions(),
           logContext,
-          MetadataRecoveryStrategy.forName(clientConfig.getString(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG)));
+          MetadataRecoveryStrategy.forName(
+              clientConfig.getString(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG)));
 
       this.client = new ConsumerNetworkClient(
           logContext,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/KafkaGroupLeaderElector.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/KafkaGroupLeaderElector.java
@@ -27,6 +27,7 @@ import org.apache.kafka.clients.ApiVersions;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.Metadata;
+import org.apache.kafka.clients.MetadataRecoveryStrategy;
 import org.apache.kafka.clients.NetworkClient;
 import org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient;
 import org.apache.kafka.common.KafkaException;
@@ -151,7 +152,8 @@ public class KafkaGroupLeaderElector implements LeaderElector, SchemaRegistryReb
           time,
           true,
           new ApiVersions(),
-          logContext);
+          logContext,
+          MetadataRecoveryStrategy.forName(clientConfig.getString(CommonClientConfigs.METADATA_RECOVERY_STRATEGY_CONFIG)));
 
       this.client = new ConsumerNetworkClient(
           logContext,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/metrics/MetricsContainer.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/metrics/MetricsContainer.java
@@ -34,7 +34,7 @@ import org.apache.kafka.common.metrics.MetricsContext;
 import org.apache.kafka.common.metrics.MetricsReporter;
 import org.apache.kafka.common.metrics.stats.CumulativeCount;
 import org.apache.kafka.common.metrics.stats.Value;
-import org.apache.kafka.common.utils.SystemTime;
+import org.apache.kafka.common.utils.Time;
 
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -115,7 +115,7 @@ public class MetricsContainer {
             new MetricConfig().samples(config.getInt(ProducerConfig.METRICS_NUM_SAMPLES_CONFIG))
                     .timeWindow(config.getLong(ProducerConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG),
                             TimeUnit.MILLISECONDS);
-    this.metrics = new Metrics(metricConfig, reporters, new SystemTime(), metricsContext);
+    this.metrics = new Metrics(metricConfig, reporters, Time.SYSTEM, metricsContext);
 
     this.isLeaderNode = createMetric(METRIC_NAME_MASTER_SLAVE_ROLE,
             "1.0 indicates the node is the active leader in the cluster and is the"


### PR DESCRIPTION
- [SystemTime is changed visibility](https://github.com/apache/kafka/commit/133f2b0f311ba1fd5a999f477bad38370c1772ca), we should use public interface Time instead
- [NetworkClient public constructor also changed](https://github.com/confluentinc/kafka/commit/dd755b7ea95b3f9c277d9778d6624ab05407cac6), so make change accordingly