### PR TITLE
DGS-11418 Ensure aliases are properly qualified

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/ExtendedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/ExtendedSchema.java
@@ -52,6 +52,10 @@ public class ExtendedSchema extends Schema {
     this.aliases = aliases;
   }
 
+  public ExtendedSchema copy() {
+    return new ExtendedSchema(this, aliases);
+  }
+
   @io.swagger.v3.oas.annotations.media.Schema(description = ALIASES_DESC)
   @JsonProperty("aliases")
   public List<String> getAliases() {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
@@ -164,6 +164,11 @@ public class QualifiedSubject implements Comparable<QualifiedSubject> {
 
   public static QualifiedSubject qualifySubjectWithParent(
       String tenant, String parent, String subjectWithoutTenant) {
+    return qualifySubjectWithParent(tenant, parent, subjectWithoutTenant, false);
+  }
+
+  public static QualifiedSubject qualifySubjectWithParent(
+      String tenant, String parent, String subjectWithoutTenant, boolean prefixTenant) {
     // Since the subject has no tenant, pass the default tenant
     QualifiedSubject qualifiedSubject =
         QualifiedSubject.create(DEFAULT_TENANT, subjectWithoutTenant);
@@ -180,6 +185,13 @@ public class QualifiedSubject implements Comparable<QualifiedSubject> {
         qualifiedSubject = new QualifiedSubject(
             DEFAULT_TENANT, qualifiedParent.getContext(), subjectWithoutTenant);
       }
+    }
+    if (prefixTenant) {
+      // Prefix the tenant if prefixTenant is true.
+      // For example, references are stored without tenant prefixes,
+      // while alias replacements need the tenant.
+      qualifiedSubject = new QualifiedSubject(
+          tenant, qualifiedSubject.getContext(), qualifiedSubject.getSubject());
     }
     return qualifiedSubject;
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/filters/AliasFilter.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/filters/AliasFilter.java
@@ -15,12 +15,10 @@
 
 package io.confluent.kafka.schemaregistry.rest.filters;
 
-import static io.confluent.kafka.schemaregistry.utils.QualifiedSubject.DEFAULT_TENANT;
-import static io.confluent.kafka.schemaregistry.utils.QualifiedSubject.TENANT_DELIMITER;
-
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Config;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
+import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLDecoder;
@@ -131,10 +129,9 @@ public class AliasFilter implements ContainerRequestFilter {
     }
     String alias = config.getAlias();
     if (alias != null && !alias.isEmpty()) {
-      if (!DEFAULT_TENANT.equals(schemaRegistry.tenant())) {
-        alias = schemaRegistry.tenant() + TENANT_DELIMITER + alias;
-      }
-      return alias;
+      QualifiedSubject qualAlias =
+          QualifiedSubject.qualifySubjectWithParent(schemaRegistry.tenant(), subject, alias, true);
+      return qualAlias.toQualifiedSubject();
     } else {
       return subject;
     }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/InMemoryCache.java
@@ -174,7 +174,7 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
     addToSchemaHashToGuid(schemaKey, schemaValue);
     for (SchemaReference ref : schemaValue.getReferences()) {
       QualifiedSubject refSubject = QualifiedSubject.qualifySubjectWithParent(
-          tenant(), schemaKey.getSubject(), ref.getSubject());
+          tenant(), schemaKey.getSubject(), ref.getSubject(), true);
       SchemaKey refKey = new SchemaKey(refSubject.toQualifiedSubject(), ref.getVersion());
       Map<String, Map<SchemaKey, Set<Integer>>> ctxRefBy =
           referencedBy.getOrDefault(tenant(), Collections.emptyMap());
@@ -226,7 +226,7 @@ public class InMemoryCache<K, V> implements LookupCache<K, V> {
     addToSchemaHashToGuid(schemaKey, schemaValue);
     for (SchemaReference ref : schemaValue.getReferences()) {
       QualifiedSubject refSubject = QualifiedSubject.qualifySubjectWithParent(
-          tenant(), schemaKey.getSubject(), ref.getSubject());
+          tenant(), schemaKey.getSubject(), ref.getSubject(), true);
       SchemaKey refKey = new SchemaKey(refSubject.toQualifiedSubject(), ref.getVersion());
       Map<String, Map<SchemaKey, Set<Integer>>> ctxRefBy =
           referencedBy.computeIfAbsent(tenant(), k -> new ConcurrentHashMap<>());

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -1925,7 +1925,10 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
         if (alias == null) {
           continue;
         }
-        List<String> aliases = subjectToAliases.computeIfAbsent(alias, k -> new ArrayList<>());
+        QualifiedSubject qualAlias =
+            QualifiedSubject.qualifySubjectWithParent(tenant(), subjectPrefix, alias, true);
+        List<String> aliases = subjectToAliases.computeIfAbsent(
+            qualAlias.toQualifiedSubject(), k -> new ArrayList<>());
         aliases.add(configValue.getSubject());
       }
       return subjectToAliases;


### PR DESCRIPTION
Ensure aliases are properly qualified.  If an alias does not specify a context, it should use the context of the corresponding subject.  This is similar to how references behave.