### PR TITLE
Add tombstoned metric to JMX

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/metrics/MetricsContainer.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/metrics/MetricsContainer.java
@@ -57,6 +57,7 @@ public class MetricsContainer {
   public static final String METRIC_NAME_API_FAILURE_COUNT = "api-failure-count";
   public static final String METRIC_NAME_REGISTERED_COUNT = "registered-count";
   public static final String METRIC_NAME_DELETED_COUNT = "deleted-count";
+  public static final String METRIC_NAME_TOMBSTONED_COUNT = "tombstoned-count";
   public static final String METRIC_NAME_AVRO_SCHEMAS_CREATED = "avro-schemas-created";
   public static final String METRIC_NAME_AVRO_SCHEMAS_DELETED = "avro-schemas-deleted";
   public static final String METRIC_NAME_JSON_SCHEMAS_CREATED = "json-schemas-created";
@@ -73,6 +74,7 @@ public class MetricsContainer {
 
   private final SchemaRegistryMetric schemasCreated;
   private final SchemaRegistryMetric schemasDeleted;
+  private final SchemaRegistryMetric schemasTombstoned;
   private final SchemaRegistryMetric customSchemaProviders;
   private final SchemaRegistryMetric apiCallsSuccess;
   private final SchemaRegistryMetric apiCallsFailure;
@@ -126,6 +128,9 @@ public class MetricsContainer {
     this.schemasCreated = createMetric(METRIC_NAME_REGISTERED_COUNT, "Number of registered schemas",
             new CumulativeCount());
     this.schemasDeleted = createMetric(METRIC_NAME_DELETED_COUNT, "Number of deleted schemas",
+            new CumulativeCount());
+    this.schemasTombstoned = createMetric(METRIC_NAME_TOMBSTONED_COUNT,
+            "Number of tombstoned schemas",
             new CumulativeCount());
 
     this.avroSchemasCreated = createMetric(METRIC_NAME_AVRO_SCHEMAS_CREATED,
@@ -214,6 +219,10 @@ public class MetricsContainer {
 
   public SchemaRegistryMetric getSchemasDeleted(String type) {
     return getSchemaTypeMetric(type, false);
+  }
+
+  public SchemaRegistryMetric getSchemasTombstoned() {
+    return schemasTombstoned;
   }
 
   private SchemaRegistryMetric getSchemaTypeMetric(String type, boolean isRegister) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -191,6 +191,7 @@ public class KafkaStoreMessageHandler implements SchemaUpdateHandler {
       }
     } else {
       lookupCache.schemaTombstoned(schemaKey, oldSchemaValue);
+      updateMetrics(metricsContainer.getSchemasTombstoned(), null);
     }
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/metrics/MetricsTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/metrics/MetricsTest.java
@@ -33,6 +33,7 @@ import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_
 import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_NAME_DELETED_COUNT;
 import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_NAME_MASTER_SLAVE_ROLE;
 import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_NAME_REGISTERED_COUNT;
+import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_NAME_TOMBSTONED_COUNT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -63,6 +64,8 @@ public class MetricsTest extends ClusterTestHarness {
             new ObjectName("kafka.schema.registry:type=" + METRIC_NAME_AVRO_SCHEMAS_CREATED);
     ObjectName schemasDeleted =
             new ObjectName("kafka.schema.registry:type=" + METRIC_NAME_DELETED_COUNT);
+    ObjectName schemasTombstoned =
+            new ObjectName("kafka.schema.registry:type=" + METRIC_NAME_TOMBSTONED_COUNT);
     ObjectName avroDeleted =
             new ObjectName("kafka.schema.registry:type=" + METRIC_NAME_AVRO_SCHEMAS_DELETED);
 
@@ -93,6 +96,7 @@ public class MetricsTest extends ClusterTestHarness {
     assertEquals((double) schemaCount, mBeanServer.getAttribute(schemasCreated, METRIC_NAME_REGISTERED_COUNT));
     assertEquals((double) schemaCount, mBeanServer.getAttribute(avroCreated, METRIC_NAME_AVRO_SCHEMAS_CREATED));
     assertEquals((double) schemaCount, mBeanServer.getAttribute(schemasDeleted, METRIC_NAME_DELETED_COUNT));
+    assertEquals((double) schemaCount, mBeanServer.getAttribute(schemasTombstoned, METRIC_NAME_TOMBSTONED_COUNT));
     assertEquals((double) schemaCount, mBeanServer.getAttribute(avroDeleted, METRIC_NAME_AVRO_SCHEMAS_DELETED));
   }
 


### PR DESCRIPTION
Adding metric for when schemas are hard deleted. These metrics do not overlap with soft-deleted metrics. 

**Testing**
Added test cases, as well as manually running requests. 

**FAQ:**

**What happens when a soft deleted schema gets restored then deleted again?**

Soft deleted schemas pertaining to a subject can be retrieved with the ```deleted=true``` flag, which allows you to find the deleted schema and recreate it using the same definition. However, this creates a new version for the subject, and does not map to the old version.

**What about the workaround to restore hard-deleted schemas?**

It is difficult to tell when a hard-deleted schema is restored, since it is recreated using the same definition then manually mapped to a schema id. These are separate operations that cannot definitively be mapped to restoring a hard-deleted schema.