### PR TITLE
Fix CP Build on 7.8.0 by switching effectiveAdvertisedListeners to effectiveAdvertisedBrokerListeners

### DIFF
--- a/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
@@ -140,7 +140,7 @@ public abstract class ClusterTestHarness {
     for(int i = 0; i < servers.size(); i++) {
       serverUrls[i] = getSecurityProtocol() + "://" +
                       Utils.formatAddress(
-                          servers.get(i).config().effectiveAdvertisedListeners().head().host(),
+                          servers.get(i).config().effectiveAdvertisedBrokerListeners().head().host(),
                           servers.get(i).boundPort(listenerType)
                       );
     }


### PR DESCRIPTION
This recent PR seems to have broke schema-registry CP build for 7.8.x: https://github.com/confluentinc/kafka/commit/9be27e715a209a892941bf35e66859d9c39c28c4#diff-cbe6a8b71b05ed22cf09d97591225b588e9fca6caaf95d3b34a43262cfd23aa6L796 by renaming effectiveAdvertisedListeners to effectiveAdvertisedBrokerListeners.

This PR uses the renamed version of the method to fix CP build 7.8.x as per this Slack: https://confluent.slack.com/archives/C07AUS8GRFS/p1719572874287549?thread_ts=1719568628.758559&cid=C07AUS8GRFS 