### PR TITLE
DGS-4287 Flatten singleton unions in Avro/JSON converters

### DIFF
--- a/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -335,7 +335,7 @@ public class AvroData {
   private boolean scrubInvalidNames;
   private boolean discardTypeDocDefault;
   private boolean allowOptionalMapKey;
-  private boolean flattenSingletonUnion;
+  private boolean flattenSingletonUnions;
 
   public AvroData(int cacheSize) {
     this(new AvroDataConfig.Builder()
@@ -353,7 +353,7 @@ public class AvroData {
     this.scrubInvalidNames = avroDataConfig.isScrubInvalidNames();
     this.discardTypeDocDefault = avroDataConfig.isDiscardTypeDocDefault();
     this.allowOptionalMapKey = avroDataConfig.isAllowOptionalMapKeys();
-    this.flattenSingletonUnion = avroDataConfig.isFlattenSingletonUnion();
+    this.flattenSingletonUnions = avroDataConfig.isFlattenSingletonUnions();
   }
 
   /**
@@ -1922,7 +1922,7 @@ public class AvroData {
         break;
 
       case UNION: {
-        if (schema.getTypes().size() == 1 && flattenSingletonUnion) {
+        if (schema.getTypes().size() == 1 && flattenSingletonUnions) {
           return toConnectSchemaWithCycles(schema.getTypes().get(0), getForceOptionalDefault(),
               null, docDefaultVal, toConnectContext);
         } else if (schema.getTypes().size() == 2) {

--- a/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -335,6 +335,7 @@ public class AvroData {
   private boolean scrubInvalidNames;
   private boolean discardTypeDocDefault;
   private boolean allowOptionalMapKey;
+  private boolean flattenSingletonUnion;
 
   public AvroData(int cacheSize) {
     this(new AvroDataConfig.Builder()
@@ -352,6 +353,7 @@ public class AvroData {
     this.scrubInvalidNames = avroDataConfig.isScrubInvalidNames();
     this.discardTypeDocDefault = avroDataConfig.isDiscardTypeDocDefault();
     this.allowOptionalMapKey = avroDataConfig.isAllowOptionalMapKeys();
+    this.flattenSingletonUnion = avroDataConfig.isFlattenSingletonUnion();
   }
 
   /**
@@ -1920,7 +1922,10 @@ public class AvroData {
         break;
 
       case UNION: {
-        if (schema.getTypes().size() == 2) {
+        if (schema.getTypes().size() == 1 && flattenSingletonUnion) {
+          return toConnectSchemaWithCycles(schema.getTypes().get(0), getForceOptionalDefault(),
+              null, docDefaultVal, toConnectContext);
+        } else if (schema.getTypes().size() == 2) {
           if (schema.getTypes().contains(NULL_AVRO_SCHEMA)) {
             for (org.apache.avro.Schema memberSchema : schema.getTypes()) {
               if (!memberSchema.equals(NULL_AVRO_SCHEMA)) {

--- a/avro-data/src/main/java/io/confluent/connect/avro/AvroDataConfig.java
+++ b/avro-data/src/main/java/io/confluent/connect/avro/AvroDataConfig.java
@@ -47,6 +47,10 @@ public class AvroDataConfig extends AbstractDataConfig {
   public static final String ALLOW_OPTIONAL_MAP_KEYS_DOC =
       "Allow optional string map key when converting from Connect Schema to Avro Schema.";
 
+  public static final String FLATTEN_SINGLETON_UNION_CONFIG = "flatten.singleton.union";
+  public static final boolean FLATTEN_SINGLETON_UNION_DEFAULT = true;
+  public static final String FLATTEN_SINGLETON_UNION_DOC = "Whether to flatten singleton unions";
+
   @Deprecated
   public static final String DISCARD_TYPE_DOC_DEFAULT_CONFIG = "discard.type.doc.default";
   public static final boolean DISCARD_TYPE_DOC_DEFAULT_DEFAULT = false;
@@ -74,7 +78,12 @@ public class AvroDataConfig extends AbstractDataConfig {
                 ConfigDef.Type.BOOLEAN,
                 ALLOW_OPTIONAL_MAP_KEYS_DEFAULT,
                 ConfigDef.Importance.LOW,
-                ALLOW_OPTIONAL_MAP_KEYS_DOC);
+                ALLOW_OPTIONAL_MAP_KEYS_DOC)
+        .define(FLATTEN_SINGLETON_UNION_CONFIG,
+                ConfigDef.Type.BOOLEAN,
+                FLATTEN_SINGLETON_UNION_DEFAULT,
+                ConfigDef.Importance.LOW,
+                FLATTEN_SINGLETON_UNION_DOC);
   }
 
   public AvroDataConfig(Map<?, ?> props) {
@@ -99,6 +108,10 @@ public class AvroDataConfig extends AbstractDataConfig {
 
   public boolean isAllowOptionalMapKeys() {
     return this.getBoolean(ALLOW_OPTIONAL_MAP_KEYS_CONFIG);
+  }
+
+  public boolean isFlattenSingletonUnion() {
+    return this.getBoolean(FLATTEN_SINGLETON_UNION_CONFIG);
   }
 
   public static class Builder {

--- a/avro-data/src/main/java/io/confluent/connect/avro/AvroDataConfig.java
+++ b/avro-data/src/main/java/io/confluent/connect/avro/AvroDataConfig.java
@@ -47,9 +47,9 @@ public class AvroDataConfig extends AbstractDataConfig {
   public static final String ALLOW_OPTIONAL_MAP_KEYS_DOC =
       "Allow optional string map key when converting from Connect Schema to Avro Schema.";
 
-  public static final String FLATTEN_SINGLETON_UNION_CONFIG = "flatten.singleton.union";
-  public static final boolean FLATTEN_SINGLETON_UNION_DEFAULT = true;
-  public static final String FLATTEN_SINGLETON_UNION_DOC = "Whether to flatten singleton unions";
+  public static final String FLATTEN_SINGLETON_UNIONS_CONFIG = "flatten.singleton.unions";
+  public static final boolean FLATTEN_SINGLETON_UNIONS_DEFAULT = true;
+  public static final String FLATTEN_SINGLETON_UNIONS_DOC = "Whether to flatten singleton unions";
 
   @Deprecated
   public static final String DISCARD_TYPE_DOC_DEFAULT_CONFIG = "discard.type.doc.default";
@@ -79,11 +79,11 @@ public class AvroDataConfig extends AbstractDataConfig {
                 ALLOW_OPTIONAL_MAP_KEYS_DEFAULT,
                 ConfigDef.Importance.LOW,
                 ALLOW_OPTIONAL_MAP_KEYS_DOC)
-        .define(FLATTEN_SINGLETON_UNION_CONFIG,
+        .define(FLATTEN_SINGLETON_UNIONS_CONFIG,
                 ConfigDef.Type.BOOLEAN,
-                FLATTEN_SINGLETON_UNION_DEFAULT,
+            FLATTEN_SINGLETON_UNIONS_DEFAULT,
                 ConfigDef.Importance.LOW,
-                FLATTEN_SINGLETON_UNION_DOC);
+            FLATTEN_SINGLETON_UNIONS_DOC);
   }
 
   public AvroDataConfig(Map<?, ?> props) {
@@ -110,8 +110,8 @@ public class AvroDataConfig extends AbstractDataConfig {
     return this.getBoolean(ALLOW_OPTIONAL_MAP_KEYS_CONFIG);
   }
 
-  public boolean isFlattenSingletonUnion() {
-    return this.getBoolean(FLATTEN_SINGLETON_UNION_CONFIG);
+  public boolean isFlattenSingletonUnions() {
+    return this.getBoolean(FLATTEN_SINGLETON_UNIONS_CONFIG);
   }
 
   public static class Builder {

--- a/avro-data/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-data/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -2333,6 +2333,16 @@ public class AvroDataTest {
   }
 
   @Test
+  public void testToConnectSingletonUnion() {
+    org.apache.avro.Schema avroStringSchema = org.apache.avro.SchemaBuilder.builder().stringType();
+    org.apache.avro.Schema unionAvroSchema = org.apache.avro.SchemaBuilder.builder()
+        .unionOf().type(avroStringSchema).endUnion();
+    SchemaBuilder builder = SchemaBuilder.string();
+    assertEquals(new SchemaAndValue(builder.build(), "bar"),
+        avroData.toConnectData(unionAvroSchema, "bar"));
+  }
+
+  @Test
   public void testToConnectEnum() {
     // Enums are just converted to strings, original enum is preserved in parameters
     org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.builder()
@@ -3225,6 +3235,7 @@ public class AvroDataTest {
 
     AvroDataConfig avroDataConfig = new AvroDataConfig.Builder()
         .with(AvroDataConfig.CONNECT_META_DATA_CONFIG, false)
+        .with(AvroDataConfig.FLATTEN_SINGLETON_UNION_CONFIG, false)
         .build();
     AvroData testAvroData = new AvroData(avroDataConfig);
 

--- a/avro-data/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-data/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -3235,7 +3235,7 @@ public class AvroDataTest {
 
     AvroDataConfig avroDataConfig = new AvroDataConfig.Builder()
         .with(AvroDataConfig.CONNECT_META_DATA_CONFIG, false)
-        .with(AvroDataConfig.FLATTEN_SINGLETON_UNION_CONFIG, false)
+        .with(AvroDataConfig.FLATTEN_SINGLETON_UNIONS_CONFIG, false)
         .build();
     AvroData testAvroData = new AvroData(avroDataConfig);
 

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
@@ -393,6 +393,7 @@ public class JsonSchemaData {
   private final Map<Schema, JsonSchema> fromConnectSchemaCache;
   private final Map<JsonSchema, Schema> toConnectSchemaCache;
   private final boolean generalizedSumTypeSupport;
+  private final boolean flattenSingletonUnions;
 
   public JsonSchemaData() {
     this(new JsonSchemaDataConfig.Builder().with(
@@ -406,6 +407,7 @@ public class JsonSchemaData {
     fromConnectSchemaCache = new BoundedConcurrentHashMap<>(jsonSchemaDataConfig.schemaCacheSize());
     toConnectSchemaCache = new BoundedConcurrentHashMap<>(jsonSchemaDataConfig.schemaCacheSize());
     generalizedSumTypeSupport = jsonSchemaDataConfig.isGeneralizedSumTypeSupport();
+    flattenSingletonUnions = jsonSchemaDataConfig.isFlattenSingletonUnions();
   }
 
   /**
@@ -1023,6 +1025,9 @@ public class JsonSchemaData {
       builder = toConnectEnums(possibleValues);
     } else if (jsonSchema instanceof CombinedSchema) {
       CombinedSchema combinedSchema = (CombinedSchema) jsonSchema;
+      if (combinedSchema.getSubschemas().size() == 1 && flattenSingletonUnions) {
+        return toConnectSchema(ctx, combinedSchema.getSubschemas().iterator().next());
+      }
       CombinedSchema.ValidationCriterion criterion = combinedSchema.getCriterion();
       String name;
       if (criterion == CombinedSchema.ONE_CRITERION || criterion == CombinedSchema.ANY_CRITERION) {

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaDataConfig.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaDataConfig.java
@@ -49,9 +49,13 @@ public class JsonSchemaDataConfig extends AbstractDataConfig {
 
   public static final String DECIMAL_FORMAT_CONFIG = "decimal.format";
   public static final String DECIMAL_FORMAT_DEFAULT = DecimalFormat.BASE64.name();
-  private static final String DECIMAL_FORMAT_DOC =
+  public static final String DECIMAL_FORMAT_DOC =
       "Controls which format this converter will serialize decimals in."
       + " This value is case insensitive and can be either 'BASE64' (default) or 'NUMERIC'";
+
+  public static final String FLATTEN_SINGLETON_UNIONS_CONFIG = "flatten.singleton.unions";
+  public static final boolean FLATTEN_SINGLETON_UNIONS_DEFAULT = true;
+  public static final String FLATTEN_SINGLETON_UNIONS_DOC = "Whether to flatten singleton unions";
 
   public static ConfigDef baseConfigDef() {
     return AbstractDataConfig.baseConfigDef().define(
@@ -80,7 +84,13 @@ public class JsonSchemaDataConfig extends AbstractDataConfig {
             DecimalFormat.BASE64.name(),
             DecimalFormat.NUMERIC.name()),
         ConfigDef.Importance.LOW,
-        DECIMAL_FORMAT_DOC);
+        DECIMAL_FORMAT_DOC
+    ).define(
+        FLATTEN_SINGLETON_UNIONS_CONFIG,
+        ConfigDef.Type.BOOLEAN,
+        FLATTEN_SINGLETON_UNIONS_DEFAULT,
+        ConfigDef.Importance.LOW,
+        FLATTEN_SINGLETON_UNIONS_DOC);
   }
 
   public JsonSchemaDataConfig(Map<?, ?> props) {
@@ -106,6 +116,10 @@ public class JsonSchemaDataConfig extends AbstractDataConfig {
 
   public boolean ignoreModernDialects() {
     return getBoolean(IGNORE_MODERN_DIALECTS_CONFIG);
+  }
+
+  public boolean isFlattenSingletonUnions() {
+    return this.getBoolean(FLATTEN_SINGLETON_UNIONS_CONFIG);
   }
 
   public static class Builder {

--- a/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
+++ b/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
@@ -1487,6 +1487,15 @@ public class JsonSchemaDataTest {
   }
 
   @Test
+  public void testToConnectSingletonUnion() {
+    StringSchema firstSchema = StringSchema.builder().build();
+    CombinedSchema schema = CombinedSchema.oneOf(ImmutableList.of(firstSchema)).build();
+    Schema expectedSchema = SchemaBuilder.string().build();
+
+    checkNonObjectConversion(expectedSchema, "bar", schema, TextNode.valueOf("bar"));
+  }
+
+  @Test
   public void testToConnectUnionWithGeneralizedSumTypeSupport() {
     jsonSchemaData =
         new JsonSchemaData(new JsonSchemaDataConfig(


### PR DESCRIPTION
Flatten singleton unions in the Avro and JSON converters.  This is consistent with how a union of a type and null is flattened to an optional type.

Set `flatten.singleton.unions=false` to keep the old behavior.