### PR TITLE
[DGS-8554] Fix javadoc annotations to have no errors

### DIFF
--- a/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/GenericAvroSerde.java
+++ b/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/GenericAvroSerde.java
@@ -43,7 +43,6 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
  * <p>Example for configuring this serde as a Kafka Streams application's default serde for both
  * record keys and record values:</p>
  *
- * <p>
  * <pre>{@code
  * Properties streamsConfiguration = new Properties();
  * streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, GenericAvroSerde.class);
@@ -52,12 +51,10 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
  *     AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
  *     "http://confluent-schema-registry-server:8081/");
  * }</pre>
- * </p>
  *
  * <p>Example for explicitly overriding the application's default serdes (whatever they were
  * configured to) so that only specific operations such as {@code KStream#to()} use this serde:</p>
  *
- * <p>
  * <pre>{@code
  * Serde<GenericRecord> genericAvroSerde = new GenericAvroSerde();
  * boolean isKeySerde = false;
@@ -69,7 +66,6 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
  * KStream<String, GenericRecord> stream = ...;
  * stream.to(Serdes.String(), genericAvroSerde, "my-output-topic");
  * }</pre>
- * </p>
  */
 @InterfaceStability.Unstable
 public class GenericAvroSerde implements Serde<GenericRecord> {

--- a/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/PrimitiveAvroSerde.java
+++ b/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/PrimitiveAvroSerde.java
@@ -51,7 +51,6 @@ import java.util.Map;
  * <p>Example for configuring this serde as a Kafka Streams application's default serde for both
  * record keys and record values:</p>
  *
- * <p>
  * <pre>{@code
  * Properties streamsConfiguration = new Properties();
  * streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, PrimitiveAvroSerde.class);
@@ -60,7 +59,6 @@ import java.util.Map;
  *     AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
  *     "http://confluent-schema-registry-server:8081/");
  * }</pre>
- * </p>
  *
  * <p>
  * In practice, it's expected that the {@link PrimitiveAvroSerde} primary use case will be keys.
@@ -69,7 +67,6 @@ import java.util.Map;
  * <p>Example for explicitly overriding the application's default serdes (whatever they were
  * configured to) so that only specific operations such as {@code KStream#to()} use this serde:</p>
  *
- * <p>
  * <pre>{@code
  * Serde<Long> longAvroSerde = new PrimitiveAvroSerde<Long>();
  * boolean isKeySerde = true;
@@ -91,7 +88,6 @@ import java.util.Map;
  * Consumed.with(longAvroSerde, genericAvroSerde));
  *
  * }</pre>
- * </p>
  */
 
 // need to have this as KafkaAvro(De)Serializer uses type Object

--- a/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/ReflectionAvroSerde.java
+++ b/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/ReflectionAvroSerde.java
@@ -39,7 +39,6 @@ import org.apache.kafka.common.serialization.Serializer;
  * <p>Example for configuring this serde as a Kafka Streams application's default serde for both
  * record keys and record values:</p>
  *
- * <p>
  * <pre>{@code
  * Properties streamsConfiguration = new Properties();
  * streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, ReflectionAvroSerde.class);
@@ -48,12 +47,10 @@ import org.apache.kafka.common.serialization.Serializer;
  *     AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
  *     "http://confluent-schema-registry-server:8081/");
  * }</pre>
- * </p>
  *
  * <p>Example for explicitly overriding the application's default serdes (whatever they were
  * configured to) so that only specific operations such as {@code KStream#to()} use this serde:</p>
  *
- * <p>
  * <pre>{@code
  * Serde<MyJavaClassGeneratedFromAvroSchema> reflectionAvroSerde = new ReflectionAvroSerde<>();
  * boolean isKeySerde = false;
@@ -65,7 +62,6 @@ import org.apache.kafka.common.serialization.Serializer;
  * KStream<String, MyJavaClassGeneratedFromAvroSchema> stream = ...;
  * stream.to(Serdes.String(), reflectionAvroSerde, "my-output-topic");
  * }</pre>
- * </p>
  */
 @InterfaceStability.Unstable
 public class ReflectionAvroSerde<T> implements Serde<T> {

--- a/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/SpecificAvroSerde.java
+++ b/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/SpecificAvroSerde.java
@@ -42,7 +42,6 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
  * <p>Example for configuring this serde as a Kafka Streams application's default serde for both
  * record keys and record values:</p>
  *
- * <p>
  * <pre>{@code
  * Properties streamsConfiguration = new Properties();
  * streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, SpecificAvroSerde.class);
@@ -51,12 +50,10 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
  *     AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
  *     "http://confluent-schema-registry-server:8081/");
  * }</pre>
- * </p>
  *
  * <p>Example for explicitly overriding the application's default serdes (whatever they were
  * configured to) so that only specific operations such as {@code KStream#to()} use this serde:</p>
  *
- * <p>
  * <pre>{@code
  * Serde<MyJavaClassGeneratedFromAvroSchema> specificAvroSerde = new SpecificAvroSerde<>();
  * boolean isKeySerde = false;
@@ -68,7 +65,6 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
  * KStream<String, MyJavaClassGeneratedFromAvroSchema> stream = ...;
  * stream.to(Serdes.String(), specificAvroSerde, "my-output-topic");
  * }</pre>
- * </p>
  */
 @InterfaceStability.Unstable
 public class SpecificAvroSerde<T extends org.apache.avro.specific.SpecificRecord>

--- a/client-encryption-hcvault/src/main/java/io/confluent/kafka/schemaregistry/encryption/hcvault/HcVaultKmsClient.java
+++ b/client-encryption-hcvault/src/main/java/io/confluent/kafka/schemaregistry/encryption/hcvault/HcVaultKmsClient.java
@@ -129,14 +129,13 @@ public class HcVaultKmsClient implements KmsClient {
   /**
    * Loads default Vault config.
    *
-   * <p>Token and timeouts can be loaded from environment variables.
+   * <p>Token and timeouts can be loaded from environment variables.</p>
    *
    * <ul>
    *     <li>Vault Token read from "VAULT_TOKEN" environment variable</li>
    *     <li>Open Timeout read from "VAULT_OPEN_TIMEOUT" environment variable</li>
    *     <li>Read Timeout read from "VAULT_READ_TIMEOUT" environment variable</li>
    * </ul>
-   * </p>
    */
   @Override
   public KmsClient withDefaultCredentials() throws GeneralSecurityException {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/utils/BoundedConcurrentHashMap.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/utils/BoundedConcurrentHashMap.java
@@ -47,28 +47,27 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * A hash table supporting full concurrency of retrievals and adjustable expected concurrency for
+ * <p> A hash table supporting full concurrency of retrievals and adjustable expected concurrency for
  * updates. This class obeys the same functional specification as {@link java.util.Hashtable}, and
  * includes versions of methods corresponding to each method of
- * <tt>Hashtable</tt>. However, even though all operations are
+ * <code>Hashtable</code>. However, even though all operations are
  * thread-safe, retrieval operations do <em>not</em> entail locking, and there is <em>not</em> any
  * support for locking the entire table in a way that prevents all access.  This class is fully
- * interoperable with <tt>Hashtable</tt> in programs that rely on its thread safety but not on its
- * synchronization details.
- * <p/>
- * <p> Retrieval operations (including <tt>get</tt>) generally do not
+ * interoperable with <code>Hashtable</code> in programs that rely on its thread safety but not on its
+ * synchronization details. </p>
+ * <p> Retrieval operations (including <code>get</code>) generally do not
  * block, so may overlap with update operations (including
- * <tt>put</tt> and <tt>remove</tt>). Retrievals reflect the results
+ * <code>put</code> and <code>remove</code>). Retrievals reflect the results
  * of the most recently <em>completed</em> update operations holding upon their onset.  For
- * aggregate operations such as <tt>putAll</tt> and <tt>clear</tt>, concurrent retrievals may
+ * aggregate operations such as <code>putAll</code> and <code>clear</code>, concurrent retrievals may
  * reflect insertion or removal of only some entries.  Similarly, Iterators and Enumerations return
  * elements reflecting the state of the hash table at some point at or since the creation of the
  * iterator/enumeration. They do <em>not</em> throw
  * {@link java.util.ConcurrentModificationException}.
  * However, iterators are designed to be used by only one thread at a time.
- * <p/>
+ * </p>
  * <p> The allowed concurrency among update operations is guided by
- * the optional <tt>concurrencyLevel</tt> constructor argument (default <tt>16</tt>), which is used
+ * the optional <code>concurrencyLevel</code> constructor argument (default <code>16</code>), which is used
  * as a hint for internal sizing.  The table is internally partitioned to try to permit the
  * indicated number of concurrent updates without contention. Because placement in hash tables is
  * essentially random, the actual concurrency will vary.  Ideally, you should choose a value to
@@ -78,20 +77,17 @@ import java.util.concurrent.locks.ReentrantLock;
  * usually have much noticeable impact. A value of one is appropriate when it is known that only one
  * thread will modify and all others will only read. Also, resizing this or any other kind of hash
  * table is a relatively slow operation, so, when possible, it is a good idea to provide estimates
- * of expected table sizes in constructors.
- * <p/>
+ * of expected table sizes in constructors. </p>
  * <p>This class and its views and iterators implement all of the
  * <em>optional</em> methods of the {@link Map} and {@link Iterator}
  * interfaces.
- * <p/>
+ * </p>
  * <p>This class is copied from Debezium, (which took it from Hibernate,
  * which took it from Infinispan) and was originally written by Doug Lea with assistance from
  * members of JCP JSR-166 Expert Group and released to the public domain, as explained at
  * http://creativecommons.org/licenses/publicdomain</p>
- * <p/>
- * <p/>
  * <p> Like {@link java.util.Hashtable} but unlike {@link HashMap}, this class
- * does <em>not</em> allow <tt>null</tt> to be used as a key or value.
+ * does <em>not</em> allow <code>null</code> to be used as a key or value.
  *
  * @param <K> the type of keys maintained by this map
  * @param <V> the type of mapped values
@@ -306,8 +302,6 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
 
     /**
      * Invokes eviction policy algorithm and returns set of evicted entries.
-     * <p/>
-     * <p/>
      * Set cannot be null but could possibly be an empty set.
      *
      * @return set of evicted entries.
@@ -324,9 +318,8 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
     Set<HashEntry<K, V>> onEntryMiss(HashEntry<K, V> e);
 
     /**
-     * Invoked to notify EvictionPolicy implementation that an entry in Segment has been accessed.
-     * Returns true if batching threshold has been reached, false otherwise.
-     * <p/>
+     * <p> Invoked to notify EvictionPolicy implementation that an entry in Segment has been accessed.
+     * Returns true if batching threshold has been reached, false otherwise. </p>
      * Note that this method is potentially invoked without holding a lock on Segment.
      *
      * @param e accessed entry in Segment
@@ -355,8 +348,7 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
     Eviction strategy();
 
     /**
-     * Returns true if batching threshold has expired, false otherwise.
-     * <p/>
+     * <p> Returns true if batching threshold has expired, false otherwise. </p>
      * Note that this method is potentially invoked without holding a lock on Segment.
      *
      * @return true if batching threshold has expired, false otherwise.
@@ -1170,7 +1162,7 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
 
     /**
      * The table is rehashed when its size exceeds this threshold. (The value of this field is
-     * always <tt>(int)(capacity * loadFactor)</tt>.)
+     * always <code>(int)(capacity * loadFactor)</code>.)
      */
     transient int threshold;
 
@@ -1692,9 +1684,9 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
   }
 
   /**
-   * Returns <tt>true</tt> if this map contains no key-value mappings.
+   * Returns <code>true</code> if this map contains no key-value mappings.
    *
-   * @return <tt>true</tt> if this map contains no key-value mappings
+   * @return <code>true</code> if this map contains no key-value mappings
    */
   @Override
   public boolean isEmpty() {
@@ -1732,8 +1724,8 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
 
   /**
    * Returns the number of key-value mappings in this map.  If the map contains more than
-   * <tt>Integer.MAX_VALUE</tt> elements, returns
-   * <tt>Integer.MAX_VALUE</tt>.
+   * <code>Integer.MAX_VALUE</code> elements, returns
+   * <code>Integer.MAX_VALUE</code>.
    *
    * @return the number of key-value mappings in this map
    */
@@ -1789,9 +1781,8 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
   }
 
   /**
-   * Returns the value to which the specified key is mapped, or {@code null} if this map contains no
-   * mapping for the key.
-   * <p/>
+   * <p> Returns the value to which the specified key is mapped, or {@code null} if this map contains no
+   * mapping for the key. </p>
    * <p>More formally, if this map contains a mapping from a key
    * {@code k} to a value {@code v} such that {@code key.equals(k)}, then this method returns {@code
    * v}; otherwise it returns {@code null}.  (There can be at most one such mapping.)
@@ -1808,9 +1799,9 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
    * Tests if the specified object is a key in this table.
    *
    * @param key possible key
-   * @return <tt>true</tt> if and only if the specified object
+   * @return <code>true</code> if and only if the specified object
    * is a key in this table, as determined by the
-   * <tt>equals</tt> method; <tt>false</tt> otherwise.
+   * <code>equals</code> method; <code>false</code> otherwise.
    * @throws NullPointerException if the specified key is null
    */
   @Override
@@ -1820,12 +1811,12 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
   }
 
   /**
-   * Returns <tt>true</tt> if this map maps one or more keys to the specified value. Note: This
+   * Returns <code>true</code> if this map maps one or more keys to the specified value. Note: This
    * method requires a full internal traversal of the hash table, and so is much slower than method
-   * <tt>containsKey</tt>.
+   * <code>containsKey</code>.
    *
    * @param value value whose presence in this map is to be tested
-   * @return <tt>true</tt> if this map maps one or more keys to the
+   * @return <code>true</code> if this map maps one or more keys to the
    * specified value
    * @throws NullPointerException if the specified value is null
    */
@@ -1893,10 +1884,10 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
    * introduction of the Java Collections framework.
    *
    * @param value a value to search for
-   * @return <tt>true</tt> if and only if some key maps to the
-   * <tt>value</tt> argument in this table as
-   * determined by the <tt>equals</tt> method;
-   * <tt>false</tt> otherwise
+   * @return <code>true</code> if and only if some key maps to the
+   * <code>value</code> argument in this table as
+   * determined by the <code>equals</code> method;
+   * <code>false</code> otherwise
    * @throws NullPointerException if the specified value is null
    */
   public boolean contains(Object value) {
@@ -1904,16 +1895,15 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
   }
 
   /**
-   * Maps the specified key to the specified value in this table. Neither the key nor the value can
-   * be null.
-   * <p/>
-   * <p> The value can be retrieved by calling the <tt>get</tt> method
+   * <p> Maps the specified key to the specified value in this table. Neither the key nor the value can
+   * be null. </p>
+   * <p> The value can be retrieved by calling the <code>get</code> method
    * with a key that is equal to the original key.
    *
    * @param key   key with which the specified value is to be associated
    * @param value value to be associated with the specified key
-   * @return the previous value associated with <tt>key</tt>, or
-   * <tt>null</tt> if there was no mapping for <tt>key</tt>
+   * @return the previous value associated with <code>key</code>, or
+   * <code>null</code> if there was no mapping for <code>key</code>
    * @throws NullPointerException if the specified key or value is null
    */
   @Override
@@ -1928,7 +1918,7 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
   /**
    * {@inheritDoc}
    *
-   * @return the previous value associated with the specified key, or <tt>null</tt> if there was no
+   * @return the previous value associated with the specified key, or <code>null</code> if there was no
    * mapping for the key
    * @throws NullPointerException if the specified key or value is null
    */
@@ -1959,8 +1949,8 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
    * key is not in the map.
    *
    * @param key the key that needs to be removed
-   * @return the previous value associated with <tt>key</tt>, or
-   * <tt>null</tt> if there was no mapping for <tt>key</tt>
+   * @return the previous value associated with <code>key</code>, or
+   * <code>null</code> if there was no mapping for <code>key</code>
    * @throws NullPointerException if the specified key is null
    */
   @Override
@@ -2000,7 +1990,7 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
   /**
    * {@inheritDoc}
    *
-   * @return the previous value associated with the specified key, or <tt>null</tt> if there was no
+   * @return the previous value associated with the specified key, or <code>null</code> if there was no
    * mapping for the key
    * @throws NullPointerException if the specified key or value is null
    */
@@ -2024,15 +2014,14 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
   }
 
   /**
-   * Returns a {@link Set} view of the keys contained in this map. The set is backed by the map, so
+   * <p>Returns a {@link Set} view of the keys contained in this map. The set is backed by the map, so
    * changes to the map are reflected in the set, and vice-versa.  The set supports element removal,
-   * which removes the corresponding mapping from this map, via the <tt>Iterator.remove</tt>,
-   * <tt>Set.remove</tt>,
-   * <tt>removeAll</tt>, <tt>retainAll</tt>, and <tt>clear</tt>
-   * operations.  It does not support the <tt>add</tt> or
-   * <tt>addAll</tt> operations.
-   * <p/>
-   * <p>The view's <tt>iterator</tt> is a "weakly consistent" iterator
+   * which removes the corresponding mapping from this map, via the <code>Iterator.remove</code>,
+   * <code>Set.remove</code>,
+   * <code>removeAll</code>, <code>retainAll</code>, and <code>clear</code>
+   * operations.  It does not support the <code>add</code> or
+   * <code>addAll</code> operations. </p>
+   * <p>The view's <code>iterator</code> is a "weakly consistent" iterator
    * that will never throw {@link java.util.ConcurrentModificationException}, and guarantees to
    * traverse elements as they existed upon construction of the iterator, and may (but is not
    * guaranteed to) reflect any modifications subsequent to construction.
@@ -2044,15 +2033,14 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
   }
 
   /**
-   * Returns a {@link Collection} view of the values contained in this map. The collection is backed
+   * <p> Returns a {@link Collection} view of the values contained in this map. The collection is backed
    * by the map, so changes to the map are reflected in the collection, and vice-versa.  The
    * collection supports element removal, which removes the corresponding mapping from this map, via
-   * the <tt>Iterator.remove</tt>,
-   * <tt>Collection.remove</tt>, <tt>removeAll</tt>,
-   * <tt>retainAll</tt>, and <tt>clear</tt> operations.  It does not
-   * support the <tt>add</tt> or <tt>addAll</tt> operations.
-   * <p/>
-   * <p>The view's <tt>iterator</tt> is a "weakly consistent" iterator
+   * the <code>Iterator.remove</code>,
+   * <code>Collection.remove</code>, <code>removeAll</code>,
+   * <code>retainAll</code>, and <code>clear</code> operations.  It does not
+   * support the <code>add</code> or <code>addAll</code> operations. </p>
+   * <p>The view's <code>iterator</code> is a "weakly consistent" iterator
    * that will never throw {@link java.util.ConcurrentModificationException}, and guarantees to
    * traverse elements as they existed upon construction of the iterator, and may (but is not
    * guaranteed to) reflect any modifications subsequent to construction.
@@ -2064,15 +2052,14 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
   }
 
   /**
-   * Returns a {@link Set} view of the mappings contained in this map. The set is backed by the map,
+   * <p> Returns a {@link Set} view of the mappings contained in this map. The set is backed by the map,
    * so changes to the map are reflected in the set, and vice-versa.  The set supports element
    * removal, which removes the corresponding mapping from the map, via the
-   * <tt>Iterator.remove</tt>, <tt>Set.remove</tt>,
-   * <tt>removeAll</tt>, <tt>retainAll</tt>, and <tt>clear</tt>
-   * operations.  It does not support the <tt>add</tt> or
-   * <tt>addAll</tt> operations.
-   * <p/>
-   * <p>The view's <tt>iterator</tt> is a "weakly consistent" iterator
+   * <code>Iterator.remove</code>, <code>Set.remove</code>,
+   * <code>removeAll</code>, <code>retainAll</code>, and <code>clear</code>
+   * operations.  It does not support the <code>add</code> or
+   * <code>addAll</code> operations. </p>
+   * <p>The view's <code>iterator</code> is a "weakly consistent" iterator
    * that will never throw {@link java.util.ConcurrentModificationException}, and guarantees to
    * traverse elements as they existed upon construction of the iterator, and may (but is not
    * guaranteed to) reflect any modifications subsequent to construction.
@@ -2344,7 +2331,7 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
   /* ---------------- Serialization Support -------------- */
 
   /**
-   * Save the state of the <tt>ConcurrentHashMap</tt> instance to a stream (i.e., serialize it).
+   * Save the state of the <code>ConcurrentHashMap</code> instance to a stream (i.e., serialize it).
    *
    * @param s the stream
    * @serialData the key (Object) and value (Object) for each key-value mapping, followed by a null
@@ -2373,7 +2360,7 @@ public class BoundedConcurrentHashMap<K, V> extends AbstractMap<K, V>
   }
 
   /**
-   * Reconstitute the <tt>ConcurrentHashMap</tt> instance from a stream (i.e., deserialize it).
+   * Reconstitute the <code>ConcurrentHashMap</code> instance from a stream (i.e., deserialize it).
    *
    * @param s the stream
    */

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaIdAndSubjects.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaIdAndSubjects.java
@@ -22,7 +22,8 @@ import java.util.function.Predicate;
 
 /**
  * Kafka schema registry maintains a few in memory indices to facilitate schema lookups. One such
- * index is the md5 index that maps MD5 -> SchemaIdAndSubjects. This index is used to do 2 things.
+ * index is the md5 index that maps MD5 -&gt; SchemaIdAndSubjects.
+ * This index is used to do 2 things.
  * Firstly, to prevent the same schema string from being registered multiple times. So, if the MD5
  * of the canonicalized schema is present in the registry, we simply return the id. However, the
  * same schema string can be registered under multiple subjects. And if so, it may be assigned

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/serialization/Serializer.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/serialization/Serializer.java
@@ -22,8 +22,9 @@ import org.apache.kafka.common.Configurable;
 import io.confluent.kafka.schemaregistry.storage.exceptions.SerializationException;
 
 /**
- * @param <K> Key type to be serialized from. <p/> A class that implements this interface is
- *            expected to have a constructor with no parameter.
+ * @param <K> Key type to be serialized from.
+ *            <p>A class that implements this interface is
+ *            expected to have a constructor with no parameter.</p>
  */
 public interface Serializer<K, V> extends Configurable, Serializable, Closeable {
 

--- a/dek-registry-client/src/main/java/io/confluent/dekregistry/client/MockDekRegistryClientFactory.java
+++ b/dek-registry-client/src/main/java/io/confluent/dekregistry/client/MockDekRegistryClientFactory.java
@@ -26,7 +26,7 @@ import org.apache.kafka.common.config.ConfigException;
  * A repository for mocked DEK Registry clients, to aid in testing.
  *
  * <p>Logically independent "instances" of mocked DEK Registry are created or retrieved
- * via named scopes {@link MockDekRegistryClientFactory#getClientForScope(String)}.
+ * via named scopes {@link MockDekRegistryClientFactory#getClientForScope(String, Map)}.
  * Each named scope is an independent registry.
  * Each named-scope registry is statically defined and visible to the entire JVM.
  * Scopes can be cleaned up when no longer needed via
@@ -38,7 +38,7 @@ import org.apache.kafka.common.config.ConfigException;
  * in serde configurations, so that testing code doesn't have to run an actual instance of
  * Schema Registry listening on a local port. For example,
  * {@code schema.registry.url: 'mock://my-scope-name'} corresponds to
- * {@code MockDekRegistryClientFactory.getClientForScope("my-scope-name")}.
+ * {@code MockDekRegistryClientFactory.getClientForScope("my-scope-name", configs)}.
  */
 public final class MockDekRegistryClientFactory {
   private static final String MOCK_URL_PREFIX = "mock://";


### PR DESCRIPTION
**What**
Annotations are changed to prevent errors. Examples include using the \<code\> tag, removing self-closing tags like \<p/\>, not using \<p\>\</p\> to contain block-level elements.

**Links**
[Ticket](https://confluentinc.atlassian.net/browse/DGS-8554)

**Testing:**

Ran ```mvn javadoc:javadoc```, manually inspected pages to check formatting.

