### PR TITLE
Clean up LocalKmsClient/TestKmsClient

### DIFF
--- a/client-encryption/src/main/java/io/confluent/kafka/schemaregistry/encryption/local/LocalKmsDriver.java
+++ b/client-encryption/src/main/java/io/confluent/kafka/schemaregistry/encryption/local/LocalKmsDriver.java
@@ -19,19 +19,14 @@ package io.confluent.kafka.schemaregistry.encryption.local;
 import com.google.crypto.tink.KmsClient;
 import io.confluent.kafka.schemaregistry.encryption.tink.KmsDriver;
 import java.security.GeneralSecurityException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 public class LocalKmsDriver implements KmsDriver {
 
   public static final String SECRET = "secret";
-  public static final String OLD_SECRETS = "old.secrets";
 
   public static final String LOCAL_SECRET = "LOCAL_SECRET";
-  public static final String LOCAL_OLD_SECRETS = "LOCAL_OLD_SECRETS";
 
   public LocalKmsDriver() {
   }
@@ -52,23 +47,10 @@ public class LocalKmsDriver implements KmsDriver {
     return secret;
   }
 
-  private List<String> getOldSecrets(Map<String, ?> configs) {
-    String oldSecretsStr = (String) configs.get(OLD_SECRETS);
-    if (oldSecretsStr == null) {
-      oldSecretsStr = System.getenv(LOCAL_OLD_SECRETS);
-    }
-    if (oldSecretsStr != null) {
-      return Arrays.asList(oldSecretsStr.split(","));
-    } else {
-      return Collections.emptyList();
-    }
-  }
-
   @Override
   public KmsClient newKmsClient(Map<String, ?> configs, Optional<String> kekUrl)
       throws GeneralSecurityException {
-    return new LocalKmsClient(
-        kekUrl.orElse(LocalKmsClient.PREFIX), getSecret(configs), getOldSecrets(configs));
+    return new LocalKmsClient(kekUrl.orElse(LocalKmsClient.PREFIX), getSecret(configs));
   }
 }
 

--- a/client-encryption/src/test/java/io/confluent/kafka/schemaregistry/encryption/local/LocalFieldEncryptionProperties.java
+++ b/client-encryption/src/test/java/io/confluent/kafka/schemaregistry/encryption/local/LocalFieldEncryptionProperties.java
@@ -14,7 +14,6 @@
  */
 package io.confluent.kafka.schemaregistry.encryption.local;
 
-import static io.confluent.kafka.schemaregistry.encryption.local.LocalKmsDriver.OLD_SECRETS;
 import static io.confluent.kafka.schemaregistry.encryption.local.LocalKmsDriver.SECRET;
 
 import io.confluent.kafka.schemaregistry.encryption.FieldEncryptionProperties;
@@ -63,8 +62,6 @@ public class LocalFieldEncryptionProperties extends FieldEncryptionProperties {
           getRuleExecutor().getName());
       props.put(AbstractKafkaSchemaSerDeConfig.RULE_EXECUTORS + "." + ruleName
           + ".param." + SECRET, "mysecret");
-      props.put(AbstractKafkaSchemaSerDeConfig.RULE_EXECUTORS + "." + ruleName
-          + ".param." + OLD_SECRETS, "old1, old2");
     }
     return props;
   }


### PR DESCRIPTION
Remove use of PrimitiveSet as it is removed from Tink 1.13.0.  The OLD_SECRETS property was not documented and should not be used.