### PR TITLE
Upgrade tink to 1.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,9 +100,9 @@
         <proto-google-common-protos.version>2.22.1</proto-google-common-protos.version>
         <protoc.jar.maven.plugin.version>3.11.4</protoc.jar.maven.plugin.version>
         <okio.version>3.4.0</okio.version>
-        <tink.version>1.12.0</tink.version>
+        <tink.version>1.13.0</tink.version>
         <tink.aws.kms.version>1.9.1</tink.aws.kms.version>
-        <tink.gcp.kms.version>1.9.0</tink.gcp.kms.version>
+        <tink.gcp.kms.version>1.10.0</tink.gcp.kms.version>
         <wire.version>4.9.7</wire.version>
         <swagger.version>2.1.10</swagger.version>
         <io.confluent.schema-registry.version>7.8.0-0</io.confluent.schema-registry.version>


### PR DESCRIPTION
We can't upgrade to tink 1.14.0 yet as it requires protobuf-java 3.27 and common is on 3.25.1