### PR TITLE
DGS-11418 Fix alias search when using context wildcard

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/ExtendedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/ExtendedSchema.java
@@ -86,4 +86,22 @@ public class ExtendedSchema extends Schema {
   public int hashCode() {
     return Objects.hash(super.hashCode(), aliases);
   }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{subject=" + getSubject() + ",");
+    sb.append("version=" + getVersion() + ",");
+    sb.append("id=" + getId() + ",");
+    sb.append("schemaType=" + getSchemaType() + ",");
+    sb.append("references=" + getReferences() + ",");
+    sb.append("metadata=" + getMetadata() + ",");
+    sb.append("ruleSet=" + getRuleSet() + ",");
+    sb.append("schema=" + getSchema() + ",");
+    sb.append("schemaTags=" + getSchemaTags() + ",");
+    sb.append("aliases=" + getAliases() + "}");
+    return sb.toString();
+  }
+
+
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -1925,8 +1925,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
         if (alias == null) {
           continue;
         }
-        QualifiedSubject qualAlias =
-            QualifiedSubject.qualifySubjectWithParent(tenant(), subjectPrefix, alias, true);
+        // Use the subject of the configValue as the qualifying parent (not the subjectPrefix)
+        QualifiedSubject qualAlias = QualifiedSubject.qualifySubjectWithParent(
+            tenant(), configValue.getSubject(), alias, true);
         List<String> aliases = subjectToAliases.computeIfAbsent(
             qualAlias.toQualifiedSubject(), k -> new ArrayList<>());
         aliases.add(configValue.getSubject());


### PR DESCRIPTION
When qualifying an alias with the parent context, don't use the subjectPrefix because it may be the context wildcard (:*:).  Instead use the subject obtained from the config as the parent context.