### PR TITLE
Fix jsonata4java to be compatible with java version

### DIFF
--- a/schema-rules/pom.xml
+++ b/schema-rules/pom.xml
@@ -52,6 +52,7 @@
         <dependency>
             <groupId>com.ibm.jsonata4java</groupId>
             <artifactId>JSONata4Java</artifactId>
+            <version>2.4.5</version>
         </dependency>
         <dependency>
             <groupId>com.hubspot.jackson</groupId>


### PR DESCRIPTION
https://confluentinc.atlassian.net/browse/DGS-14015

jsonata4java was bumped to 2.5.0 which is not compatible with java 8, expects java 11

Verified with `mvn clean pacakge` locally (is this how I verify the jar build works?)