### PR TITLE
Add missing parameter to HttpAccessTokenRetriever

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/OauthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/OauthCredentialProvider.java
@@ -108,7 +108,7 @@ public class OauthCredentialProvider implements BearerAuthCredentialProvider {
     }
 
     return new HttpAccessTokenRetriever(clientId, clientSecret, scope, sslSocketFactory,
-        url.toString(), retryBackoffMs, retryBackoffMaxMs, loginConnectTimeoutMs, loginReadTimeoutMs
+        url.toString(), retryBackoffMs, retryBackoffMaxMs, loginConnectTimeoutMs, loginReadTimeoutMs, false
     );
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/OauthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/OauthCredentialProvider.java
@@ -108,7 +108,8 @@ public class OauthCredentialProvider implements BearerAuthCredentialProvider {
     }
 
     return new HttpAccessTokenRetriever(clientId, clientSecret, scope, sslSocketFactory,
-        url.toString(), retryBackoffMs, retryBackoffMaxMs, loginConnectTimeoutMs, loginReadTimeoutMs, false
+        url.toString(), retryBackoffMs, retryBackoffMaxMs, loginConnectTimeoutMs,
+            loginReadTimeoutMs, false
     );
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/SaslOauthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/SaslOauthCredentialProvider.java
@@ -136,7 +136,8 @@ public class SaslOauthCredentialProvider implements BearerAuthCredentialProvider
     }
 
     return new HttpAccessTokenRetriever(clientId, clientSecret, scope, sslSocketFactory,
-        url.toString(), retryBackoffMs, retryBackoffMaxMs, loginConnectTimeoutMs, loginReadTimeoutMs, false
+        url.toString(), retryBackoffMs, retryBackoffMaxMs, loginConnectTimeoutMs,
+            loginReadTimeoutMs, false
     );
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/SaslOauthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/SaslOauthCredentialProvider.java
@@ -136,7 +136,7 @@ public class SaslOauthCredentialProvider implements BearerAuthCredentialProvider
     }
 
     return new HttpAccessTokenRetriever(clientId, clientSecret, scope, sslSocketFactory,
-        url.toString(), retryBackoffMs, retryBackoffMaxMs, loginConnectTimeoutMs, loginReadTimeoutMs
+        url.toString(), retryBackoffMs, retryBackoffMaxMs, loginConnectTimeoutMs, loginReadTimeoutMs, false
     );
   }
 


### PR DESCRIPTION
Fix compile err https://semaphore.ci.confluent.io/jobs/344348e5-e616-44b0-9be6-30dc40e503a4

New parameter was added to this func in kafka-client 7.8.0, setting to false to maintain behavior (see code)
https://github.com/confluentinc/kafka/commit/cfc7bb90ae40669d6eb284ae1987ce93b14990f4
```
public static final String SASL_OAUTHBEARER_HEADER_URLENCODE_DOC = "The (optional) setting to enable the OAuth client to URL-encode the client_id and client_secret in the authorization header"
            + " in accordance with RFC6749, see <a href=\"https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1\">here</a> for more details. The default value is set to 'false' for backward compatibility";
```