### PR TITLE
Less ambiguous error message when unable to parse body from schema registry

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -77,6 +77,8 @@ import io.confluent.kafka.schemaregistry.client.security.basicauth.BasicAuthCred
 import io.confluent.kafka.schemaregistry.client.security.bearerauth.BearerAuthCredentialProviderFactory;
 import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 
+import static java.lang.String.format;
+
 /**
  * Rest access layer for sending requests to the schema registry.
  */
@@ -219,7 +221,7 @@ public class RestService implements Closeable, Configurable {
         (String) configs.get(SchemaRegistryClientConfig.BEARER_AUTH_CREDENTIALS_SOURCE);
 
     if (isNonEmpty(basicCredentialsSource) && isNonEmpty(bearerCredentialsSource)) {
-      throw new ConfigException(String.format(
+      throw new ConfigException(format(
           "Only one of '%s' and '%s' may be specified",
           SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE,
           SchemaRegistryClientConfig.BEARER_AUTH_CREDENTIALS_SOURCE
@@ -293,7 +295,7 @@ public class RestService implements Closeable, Configurable {
     String requestData = requestBodyData == null
                          ? "null"
                          : new String(requestBodyData, StandardCharsets.UTF_8);
-    log.debug(String.format("Sending %s with input %s to %s",
+    log.debug(format("Sending %s with input %s to %s",
                             method, requestData,
                             requestUrl));
 
@@ -330,7 +332,7 @@ public class RestService implements Closeable, Configurable {
             try {
               errorMessage = jsonDeserializer.readValue(errorString, ErrorMessage.class);
             } catch (JsonProcessingException e) {
-              errorMessage = new ErrorMessage(JSON_PARSE_ERROR_CODE, errorString);
+              errorMessage = new ErrorMessage(JSON_PARSE_ERROR_CODE, format("Unable to parse error message from schema registry: '(%s)'", errorString));
             }
           } else {
             errorMessage = new ErrorMessage(JSON_PARSE_ERROR_CODE, "Error");


### PR DESCRIPTION
Our schema registry is behind a load balancer that, occasionally returns a "504 Gateway timeout".

The schema registry client does handle this error correctly, however the error message is misleading.

```
Unrecognized token 'Gateway': was expecting (JSON String, Number (or 'NaN'/'+INF'/'-INF'), Array, Object or token 'null', 'true' or 'false')
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 9]; error code: 50005
	at io.confluent.kafka.schemaregistry.client.rest.RestService.sendHttpRequest(RestService.java:314)
	at io.confluent.kafka.schemaregistry.client.rest.RestService.httpRequest(RestService.java:384)
	at io.confluent.kafka.schemaregistry.client.rest.RestService.getVersion(RestService.java:911)
	at io.confluent.kafka.schemaregistry.client.rest.RestService.getVersion(RestService.java:895)
	at 
```

This happens because it expects the error message to have the following structure:
```
{
  "error_code": "foo",
  "message": "bar"
}
```

Which obviously it doesn't.

If the person troubleshooting this has never came across this error before, usually what happens is that they assume that the problem is not on actually pulling the schema from schema registry, but on parsing the encoded message.

This usually leads to time being wasted on rabbit holes like trying to confirm why there is a field called "gateway" in the schema or message 😅

I suggest using a less ambiguous error message, like the one proposed here.