### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,7 @@
         <commons.lang3.version>3.12.0</commons.lang3.version>
         <bouncycastle.jdk18.version>1.77</bouncycastle.jdk18.version>
         <commons.validator.version>1.7</commons.validator.version>
+        <protobuf.version>3.21.12</protobuf.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Upgrade protobuf to `3.21.12`

Before this change -> 
```
[INFO] |  +- com.google.protobuf:protobuf-java:jar:3.19.6:compile
[INFO] |  +- com.google.protobuf:protobuf-java-util:jar:3.19.6:compile
```

```
[INFO] --- dependency:3.3.0:tree (default-cli) @ kafka-schema-rules ---
[INFO] io.confluent:kafka-schema-rules:jar:7.6.3-0
[INFO] +- io.confluent:kafka-schema-registry-client:jar:7.6.3-0:compile
[INFO] +- io.confluent:kafka-schema-serializer:jar:7.6.3-0:compile
[INFO] +- org.antlr:antlr4-runtime:jar:4.13.1:compile
[INFO] +- org.projectnessie.cel:cel-jackson:jar:0.3.12:compile
[INFO] |  +- org.projectnessie.cel:cel-core:jar:0.3.12:compile
[INFO] |  |  +- org.projectnessie.cel:cel-generated-pb:jar:0.3.12:compile
[INFO] |  |  +- org.projectnessie.cel:cel-generated-antlr:jar:0.3.12:runtime
[INFO] |  |  \- org.agrona:agrona:jar:1.17.1:runtime
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.14.2:compile
[INFO] |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-protobuf:jar:2.14.2:runtime
[INFO] |  |  \- com.squareup:protoparser:jar:4.0.3:runtime
[INFO] |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.14.2:runtime
[INFO] |     \- org.yaml:snakeyaml:jar:2.0:runtime
[INFO] +- org.projectnessie.cel:cel-tools:jar:0.3.12:compile
[INFO] +- commons-validator:commons-validator:jar:1.7:compile
[INFO] |  +- commons-beanutils:commons-beanutils:jar:1.9.4:compile
[INFO] |  +- commons-digester:commons-digester:jar:2.1:compile
[INFO] |  +- commons-logging:commons-logging:jar:1.2:compile
[INFO] |  \- commons-collections:commons-collections:jar:3.2.2:compile
[INFO] +- com.ibm.jsonata4java:JSONata4Java:jar:2.4.5:compile
[INFO] |  +- com.fasterxml.woodstox:woodstox-core:jar:6.5.1:compile
[INFO] |  |  \- org.codehaus.woodstox:stax2-api:jar:4.2.1:compile
[INFO] |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-xml:jar:2.14.2:compile
[INFO] |  +- org.apache.commons:commons-text:jar:1.10.0:compile
[INFO] |  |  \- org.apache.commons:commons-lang3:jar:3.12.0:compile
[INFO] |  \- com.google.code.gson:gson:jar:2.9.0:compile
[INFO] +- com.hubspot.jackson:jackson-datatype-protobuf:jar:0.9.13:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.14.2:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.14.2:compile
[INFO] |  +- com.google.guava:guava:jar:32.0.1-jre:compile
[INFO] |  |  +- com.google.guava:failureaccess:jar:1.0.1:compile
[INFO] |  |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
[INFO] |  |  +- org.checkerframework:checker-qual:jar:3.33.0:compile
[INFO] |  |  +- com.google.errorprone:error_prone_annotations:jar:2.18.0:compile
[INFO] |  |  \- com.google.j2objc:j2objc-annotations:jar:2.8:compile
[INFO] |  +- com.google.protobuf:protobuf-java:jar:3.19.6:compile
[INFO] |  +- com.google.protobuf:protobuf-java-util:jar:3.19.6:compile
[INFO] |  |  \- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO] |  \- com.google.code.findbugs:annotations:jar:3.0.1:compile
```

After this change -> 

```
[INFO] |  +- com.google.protobuf:protobuf-java:jar:3.21.12:compile
[INFO] |  +- com.google.protobuf:protobuf-java-util:jar:3.21.12:compile
```

```
[INFO]
[INFO] --- dependency:3.3.0:tree (default-cli) @ kafka-schema-rules ---
[INFO] io.confluent:kafka-schema-rules:jar:7.6.3-0
[INFO] +- io.confluent:kafka-schema-registry-client:jar:7.6.3-0:compile
[INFO] +- io.confluent:kafka-schema-serializer:jar:7.6.3-0:compile
[INFO] +- org.antlr:antlr4-runtime:jar:4.13.1:compile
[INFO] +- org.projectnessie.cel:cel-jackson:jar:0.3.12:compile
[INFO] |  +- org.projectnessie.cel:cel-core:jar:0.3.12:compile
[INFO] |  |  +- org.projectnessie.cel:cel-generated-pb:jar:0.3.12:compile
[INFO] |  |  +- org.projectnessie.cel:cel-generated-antlr:jar:0.3.12:runtime
[INFO] |  |  \- org.agrona:agrona:jar:1.17.1:runtime
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.14.2:compile
[INFO] |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-protobuf:jar:2.14.2:runtime
[INFO] |  |  \- com.squareup:protoparser:jar:4.0.3:runtime
[INFO] |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.14.2:runtime
[INFO] |     \- org.yaml:snakeyaml:jar:2.0:runtime
[INFO] +- org.projectnessie.cel:cel-tools:jar:0.3.12:compile
[INFO] +- commons-validator:commons-validator:jar:1.7:compile
[INFO] |  +- commons-beanutils:commons-beanutils:jar:1.9.4:compile
[INFO] |  +- commons-digester:commons-digester:jar:2.1:compile
[INFO] |  +- commons-logging:commons-logging:jar:1.2:compile
[INFO] |  \- commons-collections:commons-collections:jar:3.2.2:compile
[INFO] +- com.ibm.jsonata4java:JSONata4Java:jar:2.4.5:compile
[INFO] |  +- com.fasterxml.woodstox:woodstox-core:jar:6.5.1:compile
[INFO] |  |  \- org.codehaus.woodstox:stax2-api:jar:4.2.1:compile
[INFO] |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-xml:jar:2.14.2:compile
[INFO] |  +- org.apache.commons:commons-text:jar:1.10.0:compile
[INFO] |  |  \- org.apache.commons:commons-lang3:jar:3.12.0:compile
[INFO] |  \- com.google.code.gson:gson:jar:2.9.0:compile
[INFO] +- com.hubspot.jackson:jackson-datatype-protobuf:jar:0.9.13:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.14.2:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-core:jar:2.14.2:compile
[INFO] |  +- com.google.guava:guava:jar:32.0.1-jre:compile
[INFO] |  |  +- com.google.guava:failureaccess:jar:1.0.1:compile
[INFO] |  |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
[INFO] |  |  +- org.checkerframework:checker-qual:jar:3.33.0:compile
[INFO] |  |  +- com.google.errorprone:error_prone_annotations:jar:2.18.0:compile
[INFO] |  |  \- com.google.j2objc:j2objc-annotations:jar:2.8:compile
[INFO] |  +- com.google.protobuf:protobuf-java:jar:3.21.12:compile
[INFO] |  +- com.google.protobuf:protobuf-java-util:jar:3.21.12:compile
[INFO] |  |  \- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO] |  \- com.google.code.findbugs:annotations:jar:3.0.1:compile
[INFO] +- io.confluent:kafka-schema-registry:jar:7.6.3-0:test
```