### PR TITLE
DGS-15318 Convert 429 to a retriable exception (#8)

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -392,7 +392,10 @@ public class RestService implements Closeable, Configurable {
                                requestBodyData,
                                requestProperties,
                                responseFormat);
-      } catch (IOException e) {
+      } catch (IOException | RestClientException e) {
+        if (e instanceof RestClientException && !isRetriable((RestClientException) e)) {
+          throw e;
+        }
         baseUrls.fail(baseUrl);
         if (i == n - 1) {
           throw e; // Raise the exception since we have no more urls to try
@@ -400,6 +403,13 @@ public class RestService implements Closeable, Configurable {
       }
     }
     throw new IOException("Internal HTTP retry error"); // Can't get here
+  }
+
+  private boolean isRetriable(RestClientException e) {
+    int status = e.getStatus();
+    boolean isClientErrorToIgnore = status == 408 || status == 429;
+    boolean isServerErrorToIgnore = status == 502 || status == 503 || status == 504;
+    return isClientErrorToIgnore || isServerErrorToIgnore;
   }
 
   // Visible for testing

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -29,7 +29,7 @@ import io.confluent.kafka.serializers.context.strategy.ContextNameStrategy;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
 import org.apache.kafka.common.KafkaException;
-import org.apache.kafka.common.errors.InvalidConfigurationException;
+import org.apache.kafka.common.errors.DisconnectException;
 import org.apache.kafka.common.errors.SerializationException;
 
 import java.io.IOException;
@@ -46,6 +46,8 @@ import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientExcept
 import io.confluent.kafka.schemaregistry.testutil.MockSchemaRegistry;
 import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
 import io.confluent.kafka.serializers.subject.TopicNameStrategy;
+import org.apache.kafka.common.errors.ThrottlingQuotaExceededException;
+import org.apache.kafka.common.errors.TimeoutException;
 
 /**
  * Common fields and helper methods for both the serializer and the deserializer.
@@ -257,8 +259,15 @@ public abstract class AbstractKafkaSchemaSerDe implements Closeable {
   }
 
   protected static KafkaException toKafkaException(RestClientException e, String errorMessage) {
-    if (e.getErrorCode() / 100 == 4 /* Client Error */) {
-      return new InvalidConfigurationException(e.getMessage());
+    int status = e.getStatus();
+    if (status == 429) {        // Too Many Requests
+      return new ThrottlingQuotaExceededException(e.getMessage());
+    } else if (status == 408    // Request Timeout
+        || status == 503        // Service Unavailable
+        || status == 504) {     // Gateway Timeout
+      return new TimeoutException(errorMessage, e);
+    } else if (status == 502) { // Bad Gateway
+      return new DisconnectException(errorMessage, e);
     } else {
       return new SerializationException(errorMessage, e);
     }


### PR DESCRIPTION
Convert 429 to a retriable exception. Also convert some other status codes to retriable exceptions

Fixes https://github.com/confluentinc/schema-registry/issues/902 and https://github.com/confluentinc/schema-registry/issues/1635

Also, this PR removes some dead code which was never getting called, as the error code is of the form 40400

```
if (e.getErrorCode() / 100 == 4 /* Client Error */) {
      return new InvalidConfigurationException(e.getMessage());
}
```