### PR TITLE
Fix failing spec validation

### DIFF
--- a/core/generated/swagger-ui/schema-registry-api-spec.yaml
+++ b/core/generated/swagger-ui/schema-registry-api-spec.yaml
@@ -115,7 +115,8 @@ paths:
       description: The Root resource is a no-op.
       operationId: get
       responses:
-        default:
+        'default':
+          description: default response
           content:
             application/vnd.schemaregistry.v1+json:
               schema:
@@ -151,7 +152,7 @@ paths:
               additionalProperties:
                 type: string
       responses:
-        default:
+        'default':
           description: default response
           content:
             application/vnd.schemaregistry.v1+json:


### PR DESCRIPTION
Declare default responses as a string literal.
Add mandatory description to the root resource get operationId