### PR TITLE
Add performance metric to all SR APIs

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -51,6 +51,7 @@ import io.confluent.kafka.schemaregistry.exceptions.UnknownLeaderException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidCompatibilityException;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
+import io.confluent.rest.annotations.PerformanceMetric;
 
 @Path("/config")
 @Produces({Versions.SCHEMA_REGISTRY_V1_JSON_WEIGHTED,
@@ -79,6 +80,7 @@ public class ConfigResource {
       @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store\n"
           + "Error code 50003 -- Error while forwarding the request to the primary")
   })
+  @PerformanceMetric("config.update-subject")
   public ConfigUpdateRequest updateSubjectLevelConfig(
       @ApiParam(value = "Name of the Subject", required = true)@PathParam("subject") String subject,
       @Context HttpHeaders headers,
@@ -119,6 +121,7 @@ public class ConfigResource {
   @ApiResponses(value = {
       @ApiResponse(code = 404, message = "Subject not found"),
       @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store")})
+  @PerformanceMetric("config.get-subject")
   public Config getSubjectLevelConfig(
       @PathParam("subject") String subject,
       @QueryParam("defaultToGlobal") boolean defaultToGlobal) {
@@ -150,6 +153,7 @@ public class ConfigResource {
       @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store\n"
           + "Error code 50003 -- Error while forwarding the request to the primary\n")
   })
+  @PerformanceMetric("config.update-global")
   public ConfigUpdateRequest updateTopLevelConfig(
       @Context HttpHeaders headers,
       @ApiParam(value = "Config Update Request", required = true)
@@ -182,6 +186,7 @@ public class ConfigResource {
   @ApiResponses(value = {@ApiResponse(code = 500,
       message = "Error code 50001 -- Error in the backend data store")}
   )
+  @PerformanceMetric("config.get-global")
   public Config getTopLevelConfig() {
     Config config = null;
     try {
@@ -201,6 +206,7 @@ public class ConfigResource {
       @ApiResponse(code = 404, message = "Error code 40401 -- Subject not found"),
       @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend datastore")
   })
+  @PerformanceMetric("config.delete-subject")
   public void deleteSubjectConfig(
       final @Suspended AsyncResponse asyncResponse,
       @Context HttpHeaders headers,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
@@ -51,6 +51,7 @@ import io.confluent.kafka.schemaregistry.exceptions.UnknownLeaderException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidModeException;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
+import io.confluent.rest.annotations.PerformanceMetric;
 
 @Path("/mode")
 @Produces({Versions.SCHEMA_REGISTRY_V1_JSON_WEIGHTED,
@@ -80,6 +81,7 @@ public class ModeResource {
           + "Error code 50003 -- Error while forwarding the request to the primary\n"
           + "Error code 50004 -- Unknown leader")
   })
+  @PerformanceMetric("mode.update-subject")
   public ModeUpdateRequest updateMode(
       @ApiParam(value = "Name of the Subject", required = true)
       @PathParam("subject") String subject,
@@ -124,6 +126,7 @@ public class ModeResource {
   @ApiResponses(value = {
       @ApiResponse(code = 404, message = "Subject not found"),
       @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store")})
+  @PerformanceMetric("mode.get-subject")
   public Mode getMode(
       @ApiParam(value = "Name of the Subject", required = true)
       @PathParam("subject") String subject,
@@ -153,6 +156,7 @@ public class ModeResource {
           + "Error code 50003 -- Error while forwarding the request to the primary\n"
           + "Error code 50004 -- Unknown leader")
   })
+  @PerformanceMetric("mode.update-global")
   public ModeUpdateRequest updateTopLevelMode(
       @Context HttpHeaders headers,
       @ApiParam(value = "Update Request", required = true) @NotNull ModeUpdateRequest request,
@@ -164,6 +168,7 @@ public class ModeResource {
   @ApiOperation(value = "Get global mode.")
   @ApiResponses(value = {
       @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store")})
+  @PerformanceMetric("mode.get-global")
   public Mode getTopLevelMode() {
     return getMode(null, false);
   }
@@ -176,6 +181,7 @@ public class ModeResource {
       @ApiResponse(code = 404, message = "Error code 40401 -- Subject not found"),
       @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend datastore")
   })
+  @PerformanceMetric("mode.delete-subject")
   public void deleteSubjectMode(
       final @Suspended AsyncResponse asyncResponse,
       @Context HttpHeaders headers,

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
@@ -132,6 +132,7 @@ public class SchemasResource {
   @ApiResponses(value = {
       @ApiResponse(code = 404, message = "Error code 40403 -- Schema not found\n"),
       @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store\n")})
+  @PerformanceMetric("schemas.get-subjects")
   public Set<String> getSubjects(
       @ApiParam(value = "Globally unique identifier of the schema", required = true)
       @PathParam("id") Integer id,
@@ -163,6 +164,7 @@ public class SchemasResource {
   @ApiResponses(value = {
       @ApiResponse(code = 404, message = "Error code 40403 -- Schema not found\n"),
       @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store\n")})
+  @PerformanceMetric("schemas.get-versions")
   public List<SubjectVersion> getVersions(
       @ApiParam(value = "Globally unique identifier of the schema", required = true)
       @PathParam("id") Integer id,
@@ -193,6 +195,7 @@ public class SchemasResource {
   @ApiOperation("Get the schema types supported by this registry.")
   @ApiResponses(value = {
       @ApiResponse(code = 500, message = "Error code 50001 -- Error in the backend data store\n")})
+  @PerformanceMetric("schemas.get-types")
   public Set<String> getSchemaTypes() {
     return schemaRegistry.schemaTypes();
   }


### PR DESCRIPTION
We want to track latency for all SR APIs, this PR adds performance metrics annotation for APIs that don't have them right now. Recreated the approved PR from here: https://github.com/confluentinc/schema-registry/pull/3223 but added the missing imports