### PR TITLE
DGS-16209 Fix error using synthetic anyOf (#25)

### DIFF
--- a/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
+++ b/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
@@ -2198,6 +2198,52 @@ public class JsonSchemaDataTest {
   }
 
   @Test
+  public void testAnyOfWithArray() {
+    String schema = "{\n"
+        + "  \"$defs\": {\n"
+        + "    \"review\": {\n"
+        + "      \"properties\": {\n"
+        + "        \"created_on\": {\n"
+        + "          \"type\": [\n"
+        + "            \"string\",\n"
+        + "            \"null\"\n"
+        + "          ]\n"
+        + "        },\n"
+        + "        \"reason_code\": {\n"
+        + "          \"type\": [\n"
+        + "            \"string\",\n"
+        + "            \"null\"\n"
+        + "          ]\n"
+        + "        }\n"
+        + "      },\n"
+        + "      \"required\": [],\n"
+        + "      \"type\": \"object\"\n"
+        + "    }\n"
+        + "  },\n"
+        + "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n"
+        + "  \"properties\": {\n"
+        + "    \"change_operation\": {\n"
+        + "      \"type\": \"string\"\n"
+        + "    },\n"
+        + "    \"reviews\": {\n"
+        + "      \"items\": {\n"
+        + "        \"$ref\": \"#/$defs/review\"\n"
+        + "      },\n"
+        + "      \"required\": [],\n"
+        + "      \"type\": [\n"
+        + "        \"array\",\n"
+        + "        \"null\"\n"
+        + "      ]\n"
+        + "    }\n"
+        + "  }\n"
+        + "}\n";
+    JsonSchema jsonSchema = new JsonSchema(schema);
+    JsonSchemaData jsonSchemaData = new JsonSchemaData();
+    Schema connectSchema = jsonSchemaData.toConnectSchema(jsonSchema);
+    assertTrue(connectSchema.field("reviews").schema().type() == Schema.Type.ARRAY);
+  }
+
+  @Test
   public void testToConnectRecursiveSchema() {
     JsonSchema jsonSchema = getRecursiveJsonSchema();
     JsonSchemaData jsonSchemaData = new JsonSchemaData();

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiff.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiff.java
@@ -173,7 +173,7 @@ public class SchemaDiff {
       }
     }
 
-    if (!original.getClass().equals(update.getClass())) {
+    if (!schemaTypesEqual(original, update)) {
       // TrueSchema extends EmptySchema
       if (!(original instanceof FalseSchema) && !(update instanceof EmptySchema)) {
         ctx.addDifference(Type.TYPE_CHANGED);
@@ -223,5 +223,11 @@ public class SchemaDiff {
     } else {
       return schema;
     }
+  }
+
+  public static boolean schemaTypesEqual(final Schema schema1, final Schema schema2) {
+    return (schema1.getClass().equals(schema2.getClass()))
+        // to handle CombinedSchema and CombinedSchemaExt comparisons
+        || (schema1 instanceof CombinedSchema && schema2 instanceof CombinedSchema);
   }
 }

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/schema/CombinedSchemaExt.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/schema/CombinedSchemaExt.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2024 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json.schema;
+
+import java.util.Collection;
+import java.util.Objects;
+import org.everit.json.schema.CombinedSchema;
+import org.everit.json.schema.Schema;
+
+/**
+ * Validator for {@code allOf}, {@code oneOf}, {@code anyOf} schemas.
+ */
+public class CombinedSchemaExt extends CombinedSchema {
+
+  /**
+   * Builder class for {@link CombinedSchemaExt}.
+   */
+  public static class Builder extends CombinedSchema.Builder {
+
+    private boolean generated;
+
+    @Override
+    public CombinedSchemaExt build() {
+      return new CombinedSchemaExt(this);
+    }
+
+    public Builder criterion(ValidationCriterion criterion) {
+      return (Builder) super.criterion(criterion);
+    }
+
+    public Builder subschema(Schema subschema) {
+      return (Builder) super.subschema(subschema);
+    }
+
+    public Builder subschemas(Collection<Schema> subschemas) {
+      return (Builder) super.subschemas(subschemas);
+    }
+
+    public Builder isSynthetic(boolean synthetic) {
+      return (Builder) super.isSynthetic(synthetic);
+    }
+
+    public Builder isGenerated(boolean generated) {
+      this.generated = generated;
+      return this;
+    }
+  }
+
+  public static Builder allOf(Collection<Schema> schemas) {
+    return builder(schemas).criterion(ALL_CRITERION);
+  }
+
+  public static Builder anyOf(Collection<Schema> schemas) {
+    return builder(schemas).criterion(ANY_CRITERION);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static Builder builder(Collection<Schema> subschemas) {
+    return new Builder().subschemas(subschemas);
+  }
+
+  public static Builder oneOf(Collection<Schema> schemas) {
+    return builder(schemas).criterion(ONE_CRITERION);
+  }
+
+  private final boolean generated;
+
+  /**
+   * Constructor.
+   *
+   * @param builder the builder containing the validation criterion and the subschemas to be
+   *                checked
+   */
+  public CombinedSchemaExt(Builder builder) {
+    super(builder);
+    this.generated = builder.generated;
+  }
+
+  boolean isGenerated() {
+    return generated;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    CombinedSchemaExt that = (CombinedSchemaExt) o;
+    return generated == that.generated;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), generated);
+  }
+}


### PR DESCRIPTION
Synthetic anyOf's can generate an exception when calling toString(). Instead of using the built-in synthetic flag, use an explicit generated flag.
