### PR TITLE
DGS-16357 Include default ctx in mock getContexts() (#33)

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -16,7 +16,6 @@
 
 package io.confluent.kafka.schemaregistry.client;
 
-import static io.confluent.kafka.schemaregistry.utils.QualifiedSubject.DEFAULT_CONTEXT;
 import static io.confluent.kafka.schemaregistry.utils.QualifiedSubject.DEFAULT_TENANT;
 
 import com.google.common.collect.Lists;
@@ -716,8 +715,8 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
   public Collection<String> getAllContexts() throws IOException, RestClientException {
     List<String> results = new ArrayList<>(schemaToIdCache.keySet()).stream()
         .map(s -> QualifiedSubject.create(DEFAULT_TENANT, s).getContext())
-        .filter(s -> !s.isEmpty() && !s.equals(DEFAULT_CONTEXT))
         .sorted()
+        .distinct()
         .collect(Collectors.toList());
     return results;
   }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClientTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClientTest.java
@@ -227,11 +227,16 @@ public class MockSchemaRegistryClientTest extends ClusterTestHarness {
     id = client.register(":.context1:test-value", avroSchema);
     assertEquals(1, id);
 
+    id = client.register(":.context1:test-value2", avroSchema);
+    assertEquals(1, id);
+
+    id = client.register("test-value", avroSchema);
     id = client.register("test-value", avroSchema);
     assertEquals(1, id);
 
     Collection<String> contexts = client.getAllContexts();
     Iterator<String> iter = contexts.iterator();
+    assertEquals(".", iter.next());
     assertEquals(".context1", iter.next());
     assertEquals(".context2", iter.next());
   }


### PR DESCRIPTION
* DGS-16357 Include default ctx in mock getContexts()

* Use distinct

* Fix checkstyle