### PR TITLE
DGS-16412: Handle 401/403 errors appropriately

### DIFF
--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -29,6 +29,8 @@ import io.confluent.kafka.serializers.context.strategy.ContextNameStrategy;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
 import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.errors.AuthorizationException;
 import org.apache.kafka.common.errors.DisconnectException;
 import org.apache.kafka.common.errors.SerializationException;
 
@@ -260,7 +262,11 @@ public abstract class AbstractKafkaSchemaSerDe implements Closeable {
 
   protected static KafkaException toKafkaException(RestClientException e, String errorMessage) {
     int status = e.getStatus();
-    if (status == 429) {        // Too Many Requests
+    if (status == 401) {
+      return new AuthenticationException(errorMessage, e);
+    } else if (status == 403) {
+      return new AuthorizationException(errorMessage, e);
+    } else if (status == 429) {        // Too Many Requests
       return new ThrottlingQuotaExceededException(e.getMessage());
     } else if (status == 408    // Request Timeout
         || status == 503        // Service Unavailable


### PR DESCRIPTION
Handle 401 and 403 errors appropriately. Customer had a hard time triaging the error due to this. The following was the update from the customer:
```
Root cause:

Existing Schema Registry Key was deleted on our side (likely when converting from local user accounts to SSO, still TBD). 

This caused our applications to start failing with an inscrutable exception. 
 

org.apache.kafka.common.errors.InvalidConfigurationException: Unauthorized; error code: 401


This would have bene much quicker to diagnose except the real exception which points directly at a Schema Registry issue was obfuscated by confluent's code.

[This code](https://github.com/confluentinc/schema-registry/blob/master/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java#L574) throws an exception:

io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException: Unauthorized; error code: 401

Which quite clearly indicates that there is a problem authenticating to the Schema Registry. Unfortunately though, that exception is handled by [this code](https://github.com/confluentinc/schema-registry/blob/master/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaSerializer.java#L175) - which uses [this](https://github.com/confluentinc/schema-registry/blob/v7.7.0-1/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java#L806) method:
to convert from the Schema Registry-specific exception type into the completely generic org.apache.kafka.common.errors.InvalidConfigurationException: Unauthorized; error code: 401 instance. This is very information-lossy, and destroys any indication that the problem originated from the schema registry.
```