### PR TITLE
fixed self closing paragraph tags causing javadoc errors

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
@@ -203,9 +203,9 @@ public interface ParsedSchema {
 
   /**
    * Checks the backward compatibility between this schema and the specified schema.
-   * <p/>
-   * Custom providers may choose to modify this schema during this check,
-   * to ensure that it is compatible with the specified schema.
+   *
+   * <p>Custom providers may choose to modify this schema during this check,
+   * to ensure that it is compatible with the specified schema.</p>
    *
    * @param previousSchema previous schema
    * @return an empty list if this schema is backward compatible with the previous schema,
@@ -215,9 +215,9 @@ public interface ParsedSchema {
 
   /**
    * Checks the compatibility between this schema and the specified schemas.
-   * <p/>
-   * Custom providers may choose to modify this schema during this check,
-   * to ensure that it is compatible with the specified schemas.
+   *
+   * <p>Custom providers may choose to modify this schema during this check,
+   * to ensure that it is compatible with the specified schemas.</p>
    *
    * @param level the compatibility level
    * @param previousSchemas full schema history in chronological order


### PR DESCRIPTION
javadoc maven generation command fails with error: self-closing element not allowed due to two occurrences of self closing paragraph elements in ParsedSchema.java. These are now removed and properly wrapped around the text