### PR TITLE
DGS-18880 Minor optimization to reduce schema ID lookups

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -465,10 +465,10 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
         List<Migration> migrations = Collections.emptyList();
         if (readerAvroSchema == null) {
           if (metadata != null) {
-            readerAvroSchema = (AvroSchema) getLatestWithMetadata(getSubject());
+            readerAvroSchema = (AvroSchema) getLatestWithMetadata(getSubject()).getSchema();
           } else if (useLatestVersion) {
             readerAvroSchema =
-                (AvroSchema) lookupLatestVersion(getSubject(), writerAvroSchema, false);
+                (AvroSchema) lookupLatestVersion(getSubject(), writerAvroSchema, false).getSchema();
           }
           if (readerAvroSchema != null) {
             // set version on the writer schema

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -128,15 +128,17 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
         restClientErrorMsg = "Error retrieving schema ID";
         schema = (AvroSchema)
             lookupSchemaBySubjectAndId(subject, useSchemaId, schema, idCompatStrict);
-        id = schemaRegistry.getId(subject, schema);
+        id = useSchemaId;
       } else if (metadata != null) {
         restClientErrorMsg = "Error retrieving latest with metadata '" + metadata + "'";
-        schema = (AvroSchema) getLatestWithMetadata(subject);
-        id = schemaRegistry.getId(subject, schema);
+        ExtendedSchema extendedSchema = getLatestWithMetadata(subject);
+        schema = (AvroSchema) extendedSchema.getSchema();
+        id = extendedSchema.getId();
       } else if (useLatestVersion) {
         restClientErrorMsg = "Error retrieving latest version of Avro schema";
-        schema = (AvroSchema) lookupLatestVersion(subject, schema, latestCompatStrict);
-        id = schemaRegistry.getId(subject, schema);
+        ExtendedSchema extendedSchema = lookupLatestVersion(subject, schema, latestCompatStrict);
+        schema = (AvroSchema) extendedSchema.getSchema();
+        id = extendedSchema.getId();
       } else {
         restClientErrorMsg = "Error retrieving Avro schema";
         id = schemaRegistry.getId(subject, schema, normalizeSchema);

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
@@ -138,9 +138,9 @@ public abstract class AbstractKafkaJsonSchemaDeserializer<T> extends AbstractKaf
 
       ParsedSchema readerSchema = null;
       if (metadata != null) {
-        readerSchema = getLatestWithMetadata(subject);
+        readerSchema = getLatestWithMetadata(subject).getSchema();
       } else if (useLatestVersion) {
-        readerSchema = lookupLatestVersion(subject, schema, false);
+        readerSchema = lookupLatestVersion(subject, schema, false).getSchema();
       }
       if (includeSchemaAndVersion || readerSchema != null) {
         Integer version = schemaVersion(topic, isKey, id, subject, schema, null);

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaSerializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaSerializer.java
@@ -141,15 +141,17 @@ public abstract class AbstractKafkaJsonSchemaSerializer<T> extends AbstractKafka
         restClientErrorMsg = "Error retrieving schema ID";
         schema = (JsonSchema)
             lookupSchemaBySubjectAndId(subject, useSchemaId, schema, idCompatStrict);
-        id = schemaRegistry.getId(subject, schema);
+        id = useSchemaId;
       } else if (metadata != null) {
         restClientErrorMsg = "Error retrieving latest with metadata '" + metadata + "'";
-        schema = (JsonSchema) getLatestWithMetadata(subject);
-        id = schemaRegistry.getId(subject, schema);
+        ExtendedSchema extendedSchema = getLatestWithMetadata(subject);
+        schema = (JsonSchema) extendedSchema.getSchema();
+        id = extendedSchema.getId();
       } else if (useLatestVersion) {
         restClientErrorMsg = "Error retrieving latest version: ";
-        schema = (JsonSchema) lookupLatestVersion(subject, schema, latestCompatStrict);
-        id = schemaRegistry.getId(subject, schema);
+        ExtendedSchema extendedSchema = lookupLatestVersion(subject, schema, latestCompatStrict);
+        schema = (JsonSchema) extendedSchema.getSchema();
+        id = extendedSchema.getId();
       } else {
         restClientErrorMsg = "Error retrieving JSON schema: ";
         id = schemaRegistry.getId(subject, schema, normalizeSchema);

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufDeserializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufDeserializer.java
@@ -148,9 +148,9 @@ public abstract class AbstractKafkaProtobufDeserializer<T extends Message>
 
       ParsedSchema readerSchema = null;
       if (metadata != null) {
-        readerSchema = getLatestWithMetadata(subject);
+        readerSchema = getLatestWithMetadata(subject).getSchema();
       } else if (useLatestVersion) {
-        readerSchema = lookupLatestVersion(subject, schema, false);
+        readerSchema = lookupLatestVersion(subject, schema, false).getSchema();
       }
       if (includeSchemaAndVersion || readerSchema != null) {
         Integer version = schemaVersion(topic, isKey, id, subject, schema, null);

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufSerializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufSerializer.java
@@ -136,15 +136,17 @@ public abstract class AbstractKafkaProtobufSerializer<T extends Message>
         }
         schema = (ProtobufSchema)
             lookupSchemaBySubjectAndId(subject, useSchemaId, schema, idCompatStrict);
-        id = schemaRegistry.getId(subject, schema);
+        id = useSchemaId;
       } else if (metadata != null) {
         restClientErrorMsg = "Error retrieving latest with metadata '" + metadata + "'";
-        schema = (ProtobufSchema) getLatestWithMetadata(subject);
-        id = schemaRegistry.getId(subject, schema);
+        ExtendedSchema extendedSchema = getLatestWithMetadata(subject);
+        schema = (ProtobufSchema) extendedSchema.getSchema();
+        id = extendedSchema.getId();
       } else if (useLatestVersion) {
         restClientErrorMsg = "Error retrieving latest version: ";
-        schema = (ProtobufSchema) lookupLatestVersion(subject, schema, latestCompatStrict);
-        id = schemaRegistry.getId(subject, schema);
+        ExtendedSchema extendedSchema = lookupLatestVersion(subject, schema, latestCompatStrict);
+        schema = (ProtobufSchema) extendedSchema.getSchema();
+        id = extendedSchema.getId();
       } else {
         restClientErrorMsg = "Error retrieving Protobuf schema: ";
         id = schemaRegistry.getId(subject, schema, normalizeSchema);
@@ -192,7 +194,7 @@ public abstract class AbstractKafkaProtobufSerializer<T extends Message>
       boolean autoRegisterSchema,
       boolean useLatestVersion,
       boolean latestCompatStrict,
-      Map<SubjectSchema, ParsedSchema> latestVersions,
+      Map<SubjectSchema, ExtendedSchema> latestVersions,
       ReferenceSubjectNameStrategy strategy,
       String topic,
       boolean isKey,
@@ -232,7 +234,7 @@ public abstract class AbstractKafkaProtobufSerializer<T extends Message>
       boolean autoRegisterSchema,
       boolean useLatestVersion,
       boolean latestCompatStrict,
-      Map<SubjectSchema, ParsedSchema> latestVersions,
+      Map<SubjectSchema, ExtendedSchema> latestVersions,
       boolean skipKnownTypes,
       ReferenceSubjectNameStrategy strategy,
       String topic,
@@ -277,7 +279,7 @@ public abstract class AbstractKafkaProtobufSerializer<T extends Message>
       boolean autoRegisterSchema,
       boolean useLatestVersion,
       boolean latestCompatStrict,
-      Map<SubjectSchema, ParsedSchema> latestVersions,
+      Map<SubjectSchema, ExtendedSchema> latestVersions,
       boolean skipKnownTypes,
       ReferenceSubjectNameStrategy strategy,
       String topic,
@@ -312,7 +314,7 @@ public abstract class AbstractKafkaProtobufSerializer<T extends Message>
       boolean autoRegisterSchema,
       boolean useLatestVersion,
       boolean latestCompatStrict,
-      Map<SubjectSchema, ParsedSchema> latestVersions,
+      Map<SubjectSchema, ExtendedSchema> latestVersions,
       boolean skipKnownTypes,
       ReferenceSubjectNameStrategy strategy,
       String topic,
@@ -383,10 +385,11 @@ public abstract class AbstractKafkaProtobufSerializer<T extends Message>
         id = response.getId();
         version = schemaRegistry.getVersion(subject, schema, normalizeSchema);
       } else if (useLatestVersion) {
-        schema = (ProtobufSchema) lookupLatestVersion(
+        ExtendedSchema extendedSchema = lookupLatestVersion(
             schemaRegistry, subject, schema, latestVersions, latestCompatStrict);
-        id = schemaRegistry.getId(subject, schema);
-        version = schemaRegistry.getVersion(subject, schema);
+        schema = (ProtobufSchema) extendedSchema.getSchema();
+        id = extendedSchema.getId();
+        version = extendedSchema.getVersion();
       } else {
         id = schemaRegistry.getId(subject, schema, normalizeSchema);
         version = schemaRegistry.getVersion(subject, schema, normalizeSchema);

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -115,8 +115,8 @@ public abstract class AbstractKafkaSchemaSerDe implements Closeable {
   protected ContextNameStrategy contextNameStrategy = new NullContextNameStrategy();
   protected Object keySubjectNameStrategy = new TopicNameStrategy();
   protected Object valueSubjectNameStrategy = new TopicNameStrategy();
-  protected Cache<SubjectSchema, ParsedSchema> latestVersions;
-  protected Cache<String, ParsedSchema> latestWithMetadata;
+  protected Cache<SubjectSchema, ExtendedSchema> latestVersions;
+  protected Cache<String, ExtendedSchema> latestWithMetadata;
   protected boolean useSchemaReflection;
   protected boolean useLatestVersion;
   protected Map<String, String> metadata;
@@ -358,34 +358,36 @@ public abstract class AbstractKafkaSchemaSerDe implements Closeable {
     return isKey;
   }
 
-  protected Map<SubjectSchema, ParsedSchema> latestVersionsCache() {
+  protected Map<SubjectSchema, ExtendedSchema> latestVersionsCache() {
     return latestVersions != null ? latestVersions.asMap() : new HashMap<>();
   }
 
-  protected Map<String, ParsedSchema> latestWithMetadataCache() {
+  protected Map<String, ExtendedSchema> latestWithMetadataCache() {
     return latestWithMetadata != null ? latestWithMetadata.asMap() : new HashMap<>();
   }
 
-  protected ParsedSchema getLatestWithMetadata(String subject)
+  protected ExtendedSchema getLatestWithMetadata(String subject)
       throws IOException, RestClientException {
     if (metadata == null || metadata.isEmpty()) {
       return null;
     }
-    ParsedSchema schema = latestWithMetadata.getIfPresent(subject);
-    if (schema == null) {
+    ExtendedSchema extendedSchema = latestWithMetadata.getIfPresent(subject);
+    if (extendedSchema == null) {
       SchemaMetadata schemaMetadata = schemaRegistry.getLatestWithMetadata(subject, metadata, true);
       Optional<ParsedSchema> optSchema =
           schemaRegistry.parseSchema(
               new io.confluent.kafka.schemaregistry.client.rest.entities.Schema(
                   null, schemaMetadata));
-      schema = optSchema.orElseThrow(
+      ParsedSchema schema = optSchema.orElseThrow(
           () -> new IOException("Invalid schema " + schemaMetadata.getSchema()
               + " with refs " + schemaMetadata.getReferences()
               + " of type " + schemaMetadata.getSchemaType()));
       schema = schema.copy(schemaMetadata.getVersion());
-      latestWithMetadata.put(subject, schema);
+      extendedSchema = new ExtendedSchema(
+          schemaMetadata.getId(), schemaMetadata.getVersion(), schema);
+      latestWithMetadata.put(subject, extendedSchema);
     }
-    return schema;
+    return extendedSchema;
   }
 
   private ParsedSchema getSchemaMetadata(String subject, int version)
@@ -582,32 +584,32 @@ public abstract class AbstractKafkaSchemaSerDe implements Closeable {
     return lookupSchema;
   }
 
-  protected ParsedSchema lookupLatestVersion(
+  protected ExtendedSchema lookupLatestVersion(
       String subject, ParsedSchema schema, boolean latestCompatStrict)
       throws IOException, RestClientException {
     return lookupLatestVersion(
         schemaRegistry, subject, schema, latestVersionsCache(), latestCompatStrict);
   }
 
-  protected static ParsedSchema lookupLatestVersion(
+  protected static ExtendedSchema lookupLatestVersion(
       SchemaRegistryClient schemaRegistry,
       String subject,
       ParsedSchema schema,
-      Map<SubjectSchema, ParsedSchema> cache,
+      Map<SubjectSchema, ExtendedSchema> cache,
       boolean latestCompatStrict)
       throws IOException, RestClientException {
     SubjectSchema ss = new SubjectSchema(subject, schema);
-    ParsedSchema latestVersion = null;
+    ExtendedSchema extendedSchema = null;
     if (cache != null) {
-      latestVersion = cache.get(ss);
+      extendedSchema = cache.get(ss);
     }
-    if (latestVersion == null) {
+    if (extendedSchema == null) {
       SchemaMetadata schemaMetadata = schemaRegistry.getLatestSchemaMetadata(subject);
       Optional<ParsedSchema> optSchema =
           schemaRegistry.parseSchema(
               new io.confluent.kafka.schemaregistry.client.rest.entities.Schema(
                   null, schemaMetadata));
-      latestVersion = optSchema.orElseThrow(
+      ParsedSchema latestVersion = optSchema.orElseThrow(
           () -> new IOException("Invalid schema " + schemaMetadata.getSchema()
               + " with refs " + schemaMetadata.getReferences()
               + " of type " + schemaMetadata.getSchemaType()));
@@ -621,11 +623,13 @@ public abstract class AbstractKafkaSchemaSerDe implements Closeable {
             + "' for schema '" + schema.canonicalString()
             + "'. Set latest.compatibility.strict=false to disable this check");
       }
+      extendedSchema = new ExtendedSchema(
+          schemaMetadata.getId(), schemaMetadata.getVersion(), latestVersion);
       if (cache != null) {
-        cache.put(ss, latestVersion);
+        cache.put(ss, extendedSchema);
       }
     }
-    return latestVersion;
+    return extendedSchema;
   }
 
   protected ByteBuffer getByteBuffer(byte[] payload) {
@@ -940,6 +944,49 @@ public abstract class AbstractKafkaSchemaSerDe implements Closeable {
     @Override
     public int hashCode() {
       return Objects.hash(subject, schema);
+    }
+  }
+
+  protected static class ExtendedSchema {
+    private final Integer id;
+    private final Integer version;
+    private final ParsedSchema schema;
+
+    public ExtendedSchema(Integer id, Integer version, ParsedSchema schema) {
+      this.id = id;
+      this.version = version;
+      this.schema = schema;
+    }
+
+    public Integer getId() {
+      return id;
+    }
+
+    public Integer getVersion() {
+      return version;
+    }
+
+    public ParsedSchema getSchema() {
+      return schema;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ExtendedSchema that = (ExtendedSchema) o;
+      return id.equals(that.id)
+          && version.equals(that.version)
+          && schema.equals(that.schema);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(id, version, schema);
     }
   }
 


### PR DESCRIPTION
Minor optimization to reduce schema ID lookups.  The ID is now cached from the first request to avoid having to do a second request.