### PR TITLE
Fix issues relating deprecated interfaces in upstream kafka

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDecoder.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDecoder.java
@@ -17,10 +17,10 @@
 package io.confluent.kafka.serializers;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import kafka.serializer.Decoder;
 import kafka.utils.VerifiableProperties;
 
 import org.apache.avro.Schema;
+import org.apache.kafka.tools.api.Decoder;
 
 public class KafkaAvroDecoder extends AbstractKafkaAvroDeserializer implements Decoder<Object> {
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThread.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThread.java
@@ -20,6 +20,7 @@ import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.storage.StoreUpdateHandler.ValidationStatus;
 import io.confluent.kafka.schemaregistry.utils.ShutdownableThread;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -194,7 +195,7 @@ public class KafkaStoreReaderThread<K, V> extends ShutdownableThread {
   @Override
   public void doWork() {
     try {
-      ConsumerRecords<byte[], byte[]> records = consumer.poll(Long.MAX_VALUE);
+      ConsumerRecords<byte[], byte[]> records = consumer.poll(Duration.ofMillis(Long.MAX_VALUE));
       storeUpdateHandler.startBatch(records.count());
       for (ConsumerRecord<byte[], byte[]> record : records) {
         K messageKey = null;

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/SASLClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/SASLClusterTestHarness.java
@@ -96,10 +96,7 @@ public class SASLClusterTestHarness extends ClusterTestHarness {
   }
 
   private void createPrincipal(File keytab, String principalNoRealm) throws Exception {
-    Seq<String> principals = JavaConverters.asScalaBuffer(
-            Arrays.asList(principalNoRealm)
-    ).toList();
-    kdc.createPrincipal(keytab, principals);
+    kdc.createPrincipal(keytab, Arrays.asList(principalNoRealm));
   }
 
   @Override

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/SASLClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/SASLClusterTestHarness.java
@@ -27,8 +27,6 @@ import org.junit.Before;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;
-import scala.collection.JavaConverters;
-import scala.collection.immutable.Seq;
 
 import javax.security.auth.login.Configuration;
 import java.io.File;

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
@@ -15,6 +15,7 @@
 package io.confluent.kafka.schemaregistry.client;
 
 import io.confluent.kafka.serializers.context.strategy.ContextNameStrategy;
+import java.time.Duration;
 import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -84,7 +85,7 @@ public class CachedSchemaRegistryClientTest extends ClusterTestHarness {
 
     int i = 0;
     while (i < numMessages) {
-      ConsumerRecords<String, Object> records = consumer.poll(1000);
+      ConsumerRecords<String, Object> records = consumer.poll(Duration.ofMillis(1000));
       for (ConsumerRecord<String, Object> record : records) {
         recordList.add(record.value());
         i++;

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClientTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClientTest.java
@@ -19,6 +19,7 @@ import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -81,7 +82,7 @@ public class MockSchemaRegistryClientTest extends ClusterTestHarness {
 
     int i = 0;
     while (i < numMessages) {
-      ConsumerRecords<String, Object> records = consumer.poll(1000);
+      ConsumerRecords<String, Object> records = consumer.poll(Duration.ofMillis(1000));
       for (ConsumerRecord<String, Object> record : records) {
         recordList.add(record.value());
         i++;

--- a/json-serializer/src/main/java/io/confluent/kafka/serializers/KafkaJsonDecoder.java
+++ b/json-serializer/src/main/java/io/confluent/kafka/serializers/KafkaJsonDecoder.java
@@ -16,8 +16,9 @@
 
 package io.confluent.kafka.serializers;
 
-import kafka.serializer.Decoder;
 import kafka.utils.VerifiableProperties;
+
+import org.apache.kafka.tools.api.Decoder;
 
 /**
  * Decode JSON data to an Object.

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelExecutorIntegrationTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelExecutorIntegrationTest.java
@@ -42,6 +42,7 @@ import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import io.confluent.kafka.serializers.WrapperKeyDeserializer;
 import io.confluent.kafka.serializers.WrapperKeySerializer;
+import java.time.Duration;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -166,7 +167,7 @@ public class CelExecutorIntegrationTest extends ClusterTestHarness {
 
     int i = 0;
     do {
-      ConsumerRecords<String, Object> records = consumer.poll(1000);
+      ConsumerRecords<String, Object> records = consumer.poll(Duration.ofMillis(1000));
       for (ConsumerRecord<String, Object> record : records) {
         recordList.add(new SimpleEntry<>(record.key(), record.value()));
         i++;

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/jsonata/JsonataExecutorIntegrationTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/jsonata/JsonataExecutorIntegrationTest.java
@@ -66,6 +66,7 @@ import io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializerConfig;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
+import java.time.Duration;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -159,7 +160,7 @@ public class JsonataExecutorIntegrationTest extends ClusterTestHarness {
 
     int i = 0;
     do {
-      ConsumerRecords<String, Object> records = consumer.poll(1000);
+      ConsumerRecords<String, Object> records = consumer.poll(Duration.ofMillis(1000));
       for (ConsumerRecord<String, Object> record : records) {
         recordList.add(new SimpleEntry<>(record.key(), record.value()));
         i++;


### PR DESCRIPTION
Decoder class is moved to new package in
https://github.com/confluentinc/kafka/commit/4d04eb83ea2cf67484d81e30603e976f63616428

`Consumer.poll(long timeoutMs)` is also deprecated in https://github.com/apache/kafka/commit/284a3db28aa5f76844f1b1e696d36d88b161c090

This fixes the issues accordingly.