### PR TITLE
DGS-18928 Don't create a new version if latest is equivalent

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -650,9 +650,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       kafkaStore.waitUntilKafkaReaderReachesLastOffset(subject, kafkaStoreTimeoutMs);
 
       // determine the latest version of the schema in the subject
-      List<SchemaKey> allVersions = getAllSchemaKeys(subject);
-      // sort versions in descending
-      Collections.reverse(allVersions);
+      List<SchemaKey> allVersions = getAllSchemaKeysDescending(subject);
 
       List<Schema> deletedVersions = new ArrayList<>();
       List<ParsedSchemaHolder> undeletedVersions = new ArrayList<>();
@@ -1343,8 +1341,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
           return prev;
         }
       } else {
-        List<SchemaKey> allVersions = getAllSchemaKeys(subject);
-        Collections.reverse(allVersions);
+        List<SchemaKey> allVersions = getAllSchemaKeysDescending(subject);
 
         for (SchemaKey schemaKey : allVersions) {
           Schema prev = get(schemaKey.getSubject(), schemaKey.getVersion(), lookupDeletedSchema);
@@ -1368,8 +1365,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   public Schema getLatestWithMetadata(
       String subject, Map<String, String> metadata, boolean lookupDeletedSchema)
       throws SchemaRegistryException {
-    List<SchemaKey> allVersions = getAllSchemaKeys(subject);
-    Collections.reverse(allVersions);
+    List<SchemaKey> allVersions = getAllSchemaKeysDescending(subject);
 
     for (SchemaKey schemaKey : allVersions) {
       Schema schema = get(schemaKey.getSubject(), schemaKey.getVersion(), lookupDeletedSchema);
@@ -2038,11 +2034,11 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     }
   }
 
-  private List<SchemaKey> getAllSchemaKeys(String subject)
+  private List<SchemaKey> getAllSchemaKeysDescending(String subject)
       throws SchemaRegistryException {
     try (CloseableIterator<SchemaRegistryValue> allVersions = allVersions(subject, false)) {
       List<SchemaKey> schemaKeys = schemaKeysByVersion(allVersions, LookupFilter.INCLUDE_DELETED);
-      Collections.sort(schemaKeys);
+      Collections.sort(schemaKeys, Collections.reverseOrder());
       return schemaKeys;
     }
   }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/protobuf/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/protobuf/RestApiTest.java
@@ -633,6 +633,11 @@ public class RestApiTest extends ClusterTestHarness {
     request.setMetadata(null);
     registerAndVerifySchema(restApp.restClient, request, 2, subject);
 
+    // Register schema with version -1
+    request.setVersion(-1);
+    request.setMetadata(null);
+    registerAndVerifySchema(restApp.restClient, request, 2, subject);
+
     result = restApp.restClient.getLatestVersion(subject);
     assertEquals(schemaString, result.getSchema());
     assertEquals((Integer) 2, result.getVersion());
@@ -672,6 +677,16 @@ public class RestApiTest extends ClusterTestHarness {
     assertEquals(schemaString, result.getSchema());
     assertEquals((Integer) 2, result.getVersion());
     assertEquals("2", result.getMetadata().getProperties().get("confluent:version"));
+
+    // Register schema with version 3
+    request.setVersion(3);
+    request.setMetadata(null);
+    registerAndVerifySchema(restApp.restClient, request, 3, subject);
+
+    // Register schema with version -1
+    request.setVersion(-1);
+    request.setMetadata(null);
+    registerAndVerifySchema(restApp.restClient, request, 3, subject);
 
     // Register schema with version -1
     request.setVersion(-1);


### PR DESCRIPTION
When registering a schema, -1 can be passed for the version to ensure it is the latest.  However, if the latest schema is equivalent to the schema being registered, a new version should not be created.