### PR TITLE
Add jacoco-report-aggregate module to fix sonarqube 0 covergae

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -393,6 +393,20 @@
                     <doUpdate>false</doUpdate>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-code-coverage-report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
 
         <resources>

--- a/jacoco-aggregate-schema-registry/pom.xml
+++ b/jacoco-aggregate-schema-registry/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>io.confluent</groupId>
+        <artifactId>kafka-schema-registry-parent</artifactId>
+        <version>7.7.2-0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jacoco-aggregate-schema-registry</artifactId>
+    <packaging>pom</packaging>
+
+    <description>Aggregate Coverage Report for Multi-Module Project</description>
+
+    <dependencies>
+        <!-- Add dependencies for each module that you want to aggregate -->
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-registry</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!-- Add more modules as needed -->
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <!-- we do not want to create any jars for this module -->
+                <configuration>
+                    <skipIfEmpty>true</skipIfEmpty>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>report-aggregate</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                        <!-- putting the aggregate report in parent target -->
+                        <configuration>
+                            <outputDirectory>${project.parent.build.directory}/site/jacoco/</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <module>client-encryption-hcvault</module>
         <module>client-encryption</module>
         <module>benchmark</module>
+        <module>jacoco-aggregate-schema-registry</module>
     </modules>
 
     <properties>
@@ -564,6 +565,19 @@
                         <phase>compile</phase>
                         <goals>
                             <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.8</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/service.yml
+++ b/service.yml
@@ -11,6 +11,13 @@ semaphore:
   downstream_projects: ["kafka-rest", "ksql", "confluent-security-plugins", "kafka-connect-replicator", "ce-kafka-rest", "confluent-cloud-plugins", "schema-registry-plugins"]
 git:
   enable: true
+sonarqube:
+  enable: true
+  languages:
+    - go
+    - java
+    - python
+    - javascript
 code_artifact:
   enable: true
   package_paths:
@@ -24,4 +31,5 @@ code_artifact:
     - maven-snapshots/maven/io.confluent/kafka-json-*
     - maven-snapshots/maven/io.confluent/kafka-schema-*
     - maven-snapshots/maven/io.confluent/kafka-avro-serializer
+    - maven-snapshots/maven/io.confluent/jacoco-aggregate-schema-registry
     - pypi-internal/pypi//confluent-ci-tools


### PR DESCRIPTION
Adding a new module jacoco-report-agreggate, which will be responsible for aggregating jacoco reports from all modules and combine it into a single report which sonarqube can consume.
This is the way which is recommended by the jacoco plugin to support multi-module projects.
https://github.com/jacoco/jacoco/wiki/MavenMultiModule