### PR TITLE
DGS-18979 Handle doubly nested CombinedSchema when getting tags

### DIFF
--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaComparator.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaComparator.java
@@ -70,6 +70,12 @@ public class JsonSchemaComparator implements Comparator<Schema> {
           return value;
         }
       }
+      // Check whether subclass of the known types, such as CombinedSchemaExt
+      for (SchemaType value : values()) {
+        if (value.cls.isAssignableFrom(cls)) {
+          return value;
+        }
+      }
       throw new IllegalArgumentException("Unknown schema type : " + cls);
     }
   }

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
@@ -771,6 +771,67 @@ public class JsonSchemaTest {
   }
 
   @Test
+  public void testNestedCombinedSchemasDraft_2020_12() {
+    String schemaString = "{\n" +
+        "  \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n" +
+        "  \"$id\": \"http://example.com/myURI.schema.json\",\n" +
+        "  \"title\": \"SampleRecord\",\n" +
+        "  \"description\": \"Sample schema to help you get started.\",\n" +
+        "  \"type\": \"object\",\n" +
+        "  \"additionalProperties\": false,\n" +
+        "  \"properties\": {\n" +
+        "    \"myfield1\": {\n" +
+        "      \"type\": \"array\",\n" +
+        "      \"items\": {\n" +
+        "        \"type\": \"object\",\n" +
+        "        \"title\": \"arrayRecord\",\n" +
+        "        \"properties\": {\n" +
+        "          \"field1\" : {\n" +
+        "            \"type\": \"string\",\n" +
+        "            \"confluent:tags\": [ \"PII\" ]\n" +
+        "          },\n" +
+        "          \"field2\": {\n" +
+        "            \"type\": \"number\"\n" +
+        "          }\n" +
+        "        }\n" +
+        "      }\n" +
+        "    },\n" +
+        "    \"myfield2\": {\n" +
+        "      \"allOf\": [\n" +
+        "        { \"type\": \"string\" },\n" +
+        "        { \"type\": \"object\",\n" +
+        "          \"title\": \"nestedUnion\",\n" +
+        "          \"properties\": {\n" +
+        "            \"nestedUnionField1\": { \"type\": \"boolean\"},\n" +
+        "            \"nestedUnionField2\": { \"type\": \"number\"}\n" +
+        "          }\n" +
+        "        },\n" +
+        "        {\n" +
+        "          \"oneOf\": [\n" +
+        "            {\n" +
+        "              \"title\": \"Not included\",\n" +
+        "              \"type\": \"null\"\n" +
+        "            },\n" +
+        "            {\n" +
+        "              \"type\": \"string\"\n" +
+        "            }\n" +
+        "          ]\n" +
+        "        }\n" +
+        "      ]\n" +
+        "    }\n" +
+        "  }\n" +
+        "}";
+    JsonSchema schema = new JsonSchema(schemaString);
+
+    Map<SchemaEntity, Set<String>> tags = new HashMap<>();
+    tags.put(new SchemaEntity("object.myfield1.array.object.field1",
+            SchemaEntity.EntityType.SR_FIELD),
+        Collections.singleton("PII"));
+    Map<SchemaEntity, Set<String>> expectedTags = new HashMap<>(tags);
+    assertEquals(expectedTags, schema.inlineTaggedEntities());
+  }
+
+  @Test
   public void testAddTagsToConditional() {
     String schemaString = "{\n" +
       "  \"else\": {\n" +


### PR DESCRIPTION
Handle doubly nested CombinedSchema when getting tags.  A doubly nested CombinedSchema is a oneOf/allOf/anyOf directly nested under another oneOf/allOf/anyOf.   When comparing the elements of a CombinedSchema, derived classes were not being taken into account (such as CombinedSchemaExt, which extends CombinedSchema).