### PR TITLE
DGS-18989 Allow empty fragment (#) in $schema prop for JSON Schema

### DIFF
--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/SpecificationVersion.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/SpecificationVersion.java
@@ -73,6 +73,9 @@ public enum SpecificationVersion {
   }
 
   public static SpecificationVersion getFromUrl(String url) {
+    if (url != null && url.endsWith("#")) {
+      url = url.substring(0, url.length() - 1);
+    }
     return urlLookup.get(url);
   }
 

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
@@ -481,7 +481,23 @@ public class JsonSchemaTest {
     Optional<ParsedSchema> parsedSchemaOptional = jsonSchemaProvider.parseSchema(recordSchemaString,
             new ArrayList<>(), false, false);
 
-    assertNotNull(parsedSchema);
+    assertNotNull(parsedSchema.rawSchema());
+    assertTrue(parsedSchemaOptional.isPresent());
+  }
+
+  @Test
+  public void testParseSchemaDraft4() {
+    String schemaString = "{\"$schema\":\"http://json-schema.org/draft-04/schema#\","
+        + "\"title\":\"Test Obj\",\"type\":\"object\",\"additionalProperties\":false,"
+        + "\"properties\":{\"prop\":{\"oneOf\":[{\"type\":\"null\",\"title\":\"Not included\"},"
+        + "{\"type\":\"string\"}]}}}";
+    SchemaProvider jsonSchemaProvider = new JsonSchemaProvider();
+    ParsedSchema parsedSchema = jsonSchemaProvider.parseSchemaOrElseThrow(
+        new Schema(null, null, null, JsonSchema.TYPE, new ArrayList<>(), schemaString), false, false);
+    Optional<ParsedSchema> parsedSchemaOptional = jsonSchemaProvider.parseSchema(schemaString,
+            new ArrayList<>(), false, false);
+
+    assertNotNull(parsedSchema.rawSchema());
     assertTrue(parsedSchemaOptional.isPresent());
   }
 


### PR DESCRIPTION
Allow empty fragment (#) in $schema prop for JSON Schema, e.g.

http://json-schema.org/draft-07/schema# 

vs

http://json-schema.org/draft-07/schema