### PR TITLE
DGS-18992 Handle refs with version of -1 when looking up schemas

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/AbstractSchemaProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/AbstractSchemaProvider.java
@@ -91,7 +91,7 @@ public abstract class AbstractSchemaProvider implements SchemaProvider {
 
   // Parking this method and the following ones here instead of in ParsedSchema as interfaces can't
   // have private methods in Java 8.  Move these to ParsedSchema in 8.0.x
-  protected static boolean areDeepEqualExcludingConfluentVersion(
+  protected static boolean canLookupIgnoringVersion(
       ParsedSchema current, ParsedSchema prev) {
     String schemaVer = getConfluentVersion(current.metadata());
     String prevVer = getConfluentVersion(prev.metadata());

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -175,7 +175,7 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
 
   private boolean schemasEqual(ParsedSchema schema1, ParsedSchema schema2) {
     return schema1.canonicalString().equals(schema2.canonicalString())
-        || schema1.deepEquals(schema2);
+        || schema1.canLookup(schema2, this);
   }
 
   private void generateVersion(String subject, ParsedSchema schema) {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Metadata.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Metadata.java
@@ -17,6 +17,7 @@
 package io.confluent.kafka.schemaregistry.client.rest.entities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -24,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -42,6 +44,8 @@ import java.util.stream.Collectors;
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Metadata {
+
+  public static final String CONFLUENT_VERSION = "confluent:version";
 
   @JsonPropertyOrder(alphabetic = true)
   private final SortedMap<String, SortedSet<String>> tags;
@@ -132,6 +136,34 @@ public class Metadata {
     if (sensitive != null) {
       sensitive.forEach(s -> md.update(s.getBytes(StandardCharsets.UTF_8)));
     }
+  }
+
+  @JsonIgnore
+  public String getConfluentVersion() {
+    return getProperties() != null ? getProperties().get(CONFLUENT_VERSION) : null;
+  }
+
+  public static Metadata setConfluentVersion(Metadata metadata, int version) {
+    Map<String, String> newProps = metadata != null && metadata.getProperties() != null
+        ? new HashMap<>(metadata.getProperties())
+        : new HashMap<>();
+    newProps.put(CONFLUENT_VERSION, String.valueOf(version));
+    return new Metadata(
+        metadata != null ? metadata.getTags() : null,
+        newProps,
+        metadata != null ? metadata.getSensitive() : null);
+  }
+
+  public static Metadata removeConfluentVersion(Metadata metadata) {
+    if (metadata == null || metadata.getProperties() == null) {
+      return metadata;
+    }
+    Map<String, String> newProps = new HashMap<>(metadata.getProperties());
+    newProps.remove(CONFLUENT_VERSION);
+    return new Metadata(
+        metadata.getTags(),
+        newProps,
+        metadata.getSensitive());
   }
 
   public static Metadata mergeMetadata(Metadata oldMetadata, Metadata newMetadata) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -127,7 +127,6 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
    */
   public static final int MIN_VERSION = 1;
   public static final int MAX_VERSION = Integer.MAX_VALUE;
-  public static final String CONFLUENT_VERSION = "confluent:version";
   private static final Logger log = LoggerFactory.getLogger(KafkaSchemaRegistry.class);
   private static final String RESERVED_FIELD_REMOVED = "The new schema has reserved field %s "
       + "removed from its metadata which is present in the old schema's metadata.";
@@ -711,7 +710,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
           ParsedSchema undeletedSchema = schemaHolder.schema();
           if (parsedSchema != null
               && (schemaId < 0 || schemaId == schemaValue.getId())
-              && areSchemasEquivalent(parsedSchema, undeletedSchema)) {
+              && parsedSchema.canLookup(undeletedSchema, this)) {
             // This handles the case where a schema is sent with all references resolved
             // or without confluent:version
             return modifiedSchema
@@ -828,33 +827,6 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     }
   }
 
-  private boolean areSchemasEquivalent(ParsedSchema schema, Schema prev)
-      throws SchemaRegistryException {
-    return areSchemasEquivalent(schema, parseSchema(prev));
-  }
-
-  private boolean areSchemasEquivalent(ParsedSchema schema, ParsedSchema prev) {
-    if (schema.references().isEmpty() && !prev.references().isEmpty()) {
-      if (schema.deepEquals(prev)) {
-        // This handles the case where a schema is sent with all references resolved
-        return true;
-      }
-    }
-    String schemaVer = getConfluentVersion(schema.metadata());
-    String prevVer = getConfluentVersion(prev.metadata());
-    if (schemaVer == null && prevVer != null) {
-      ParsedSchema newSchema = schema.metadata() != null
-          ? schema
-          : schema.copy(new Metadata(null, null, null), schema.ruleSet());
-      ParsedSchema newPrev = prev.copy(removeConfluentVersion(prev.metadata()), prev.ruleSet());
-      if (newSchema.deepEquals(newPrev)) {
-        // This handles the case where a schema is sent without confluent:version
-        return true;
-      }
-    }
-    return false;
-  }
-
   private boolean isReadOnlyMode(String subject) throws SchemaRegistryStoreException {
     Mode subjectMode = getModeInScope(subject);
     return subjectMode == Mode.READONLY || subjectMode == Mode.READONLY_OVERRIDE;
@@ -937,7 +909,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     // Set confluent:version if passed in version is not 0,
     // or update confluent:version if it already exists in the metadata
     if (schema.getVersion() != 0 || getConfluentVersion(mergedMetadata) != null) {
-      mergedMetadata = setConfluentVersion(mergedMetadata, newVersion);
+      mergedMetadata = Metadata.setConfluentVersion(mergedMetadata, newVersion);
     }
 
     if (mergedMetadata != null || mergedRuleSet != null) {
@@ -949,32 +921,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   }
 
   private String getConfluentVersion(Metadata metadata) {
-    return metadata != null && metadata.getProperties() != null
-        ? metadata.getProperties().get(CONFLUENT_VERSION)
-        : null;
-  }
-
-  private Metadata setConfluentVersion(Metadata metadata, int version) {
-    Map<String, String> newProps = metadata != null && metadata.getProperties() != null
-        ? new HashMap<>(metadata.getProperties())
-        : new HashMap<>();
-    newProps.put(CONFLUENT_VERSION, String.valueOf(version));
-    return new Metadata(
-        metadata != null ? metadata.getTags() : null,
-        newProps,
-        metadata != null ? metadata.getSensitive() : null);
-  }
-
-  private Metadata removeConfluentVersion(Metadata metadata) {
-    if (metadata == null || metadata.getProperties() == null) {
-      return metadata;
-    }
-    Map<String, String> newProps = new HashMap<>(metadata.getProperties());
-    newProps.remove(CONFLUENT_VERSION);
-    return new Metadata(
-        metadata.getTags(),
-        newProps,
-        metadata.getSensitive());
+    return metadata != null ? metadata.getConfluentVersion() : null;
   }
 
   public Schema registerOrForward(String subject,
@@ -1052,7 +999,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     Metadata mergedMetadata = request.getMetadata() != null
         ? request.getMetadata()
         : parsedSchema.metadata();
-    mergedMetadata = setConfluentVersion(mergedMetadata, newVersion);
+    mergedMetadata = Metadata.setConfluentVersion(mergedMetadata, newVersion);
 
     RuleSet ruleSet = maybeModifyPreviousRuleSet(subject, request);
 
@@ -1335,7 +1282,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
         Schema prev = getLatestVersion(subject);
         if (prev != null
             && parsedSchema != null
-            && areSchemasEquivalent(parsedSchema, prev)) {
+            && parsedSchema.canLookup(parseSchema(prev), this)) {
           // This handles the case where a schema is sent with all references resolved
           // or without confluent:version
           return prev;
@@ -1347,7 +1294,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
           Schema prev = get(schemaKey.getSubject(), schemaKey.getVersion(), lookupDeletedSchema);
           if (prev != null
               && parsedSchema != null
-              && areSchemasEquivalent(parsedSchema, prev)) {
+              && parsedSchema.canLookup(parseSchema(prev), this)) {
             // This handles the case where a schema is sent with all references resolved
             // or without confluent:version
             return prev;

--- a/protobuf-serializer/src/test/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufSerializerTest.java
+++ b/protobuf-serializer/src/test/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufSerializerTest.java
@@ -22,6 +22,7 @@ import com.google.protobuf.Descriptors.EnumValueDescriptor;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.Timestamp;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema.Format;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
@@ -815,4 +816,41 @@ public class KafkaProtobufSerializerTest {
     protobufSerializer.configure(new HashMap(serializerConfig), false);
     testMessageDeserializer.configure(new HashMap(deserializerConfig), false);
   }
+
+  @Test
+  public void testDependencyPreregisterRefWithNegativeOne() throws Exception {
+    String refSubject = "TestProto.proto";
+    String refSchemaString = "syntax = \"proto3\";\n"
+        + "package io.confluent.kafka.serializers.protobuf.test;\n"
+        + "\n"
+        + "option java_package = \"io.confluent.kafka.serializers.protobuf.test\";\n"
+        + "\n"
+        + "message TestMessage {\n"
+        + "  string test_string = 1;\n"
+        + "}\n";
+    schemaRegistry.register(refSubject, new ProtobufSchema(refSchemaString));
+    String subject = topic + "-value";
+    String schemaString = "syntax = \"proto3\";\n"
+        + "package io.confluent.kafka.serializers.protobuf.test;\n"
+        + "\n"
+        + "import \"TestProto.proto\";\n"
+        + "\n"
+        + "option java_package = \"io.confluent.kafka.serializers.protobuf.test\";\n"
+        + "\n"
+        + "message DependencyMessage {\n"
+        + "  TestMessage test_message = 1;\n"
+        + "  bool is_active = 2;\n"
+        + "}";
+    SchemaReference ref = new SchemaReference("TestProto.proto", "TestProto.proto", -1);
+    ParsedSchema parsedSchema = new ProtobufSchema(
+        schemaString, ImmutableList.of(ref), ImmutableMap.of(ref.getName(), refSchemaString), null, null);
+    schemaRegistry.register(subject, parsedSchema);
+
+    ParsedSchema schema = schemaRegistry.getSchemaBySubjectAndId("test-value", 2);
+    SchemaReference refCopy = new SchemaReference("TestProto.proto", "TestProto.proto", -1);
+    schema = schemaRegistry.parseSchema(ProtobufSchema.TYPE, schema.canonicalString(), ImmutableList.of(refCopy)).get();
+    int id = schemaRegistry.getId(subject, schema);
+    assertEquals(2, id);
+  }
+
 }


### PR DESCRIPTION
Handle refs with version of -1 when looking up schemas.  A ref with version of -1 will be replaced by the latest version during lookup.

Also refactored some code by adding it to ParsedSchema and Metadata