### PR TITLE
Minor change to pass array as type to rule

### DIFF
--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -2409,6 +2409,9 @@ public class ProtobufSchema implements ParsedSchema {
     if (field.isMapField()) {
       return RuleContext.Type.MAP;
     }
+    if (field.isRepeated()) {
+      return RuleContext.Type.ARRAY;
+    }
     switch (field.getType()) {
       case MESSAGE:
         return RuleContext.Type.RECORD;


### PR DESCRIPTION
Minor change to pass array as type to rule.  This allows a rule to see that the type of the field is "ARRAY"