### PR TITLE
DGS-19038 More robust retries in RetryExecutor

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/client/RetryExecutor.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/client/RetryExecutor.java
@@ -15,12 +15,12 @@
 
 package io.confluent.kafka.schemaregistry.rest.client;
 
+import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import java.io.IOException;
 import java.util.concurrent.Callable;
 
 public class RetryExecutor {
-  private static final int HTTP_TOO_MANY_REQUESTS = 429;
   private final int maxRetries;
   private final int retriesWaitMs;
 
@@ -35,7 +35,7 @@ public class RetryExecutor {
       try {
         result = callable.call();
       } catch (RestClientException e) {
-        if (i >= maxRetries || e.getStatus() != HTTP_TOO_MANY_REQUESTS) {
+        if (i >= maxRetries || !RestService.isRetriable(e)) {
           throw e;
         }
       } catch (IOException e) {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/client/RetryExecutorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/client/RetryExecutorTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rest.client;
+
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RetryExecutorTest {
+
+  @Test
+  public void testRetryExecutor() throws IOException, RestClientException {
+    RetryExecutor retryExecutor = new RetryExecutor(3, 0);
+    TestCallable testCallable = new TestCallable();
+    int result = retryExecutor.retry(testCallable);
+    Assert.assertEquals(3, result);
+  }
+
+  class TestCallable implements Callable<Integer> {
+    private int count = 0;
+    @Override
+    public Integer call() throws RestClientException {
+      if (count < 3) {
+        count++;
+        throw new RestClientException("test", 500, 50001);
+      }
+      return count;
+    }
+  }
+}


### PR DESCRIPTION
More robust retries in RetryExecutor, which is used by the schema exporters.  This will allow for retries when a 500 is returned due to failing to forward to the leader