### PR TITLE
DGS-19081 Return 404 instead of 429 if schema lookup fails

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -1137,8 +1137,12 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
             new QualifiedSubject(v.getTenant(), v.getContext(), qs.getSubject());
         Schema qualSchema = schema.copy();
         qualSchema.setSubject(qualSub.toQualifiedSubject());
-        matchingSchema = lookUpSchemaUnderSubject(
-            qualSub.toQualifiedSubject(), qualSchema, normalize, lookupDeletedSchema);
+        try {
+          matchingSchema = lookUpSchemaUnderSubject(
+              qualSub.toQualifiedSubject(), qualSchema, normalize, lookupDeletedSchema);
+        } catch (InvalidSchemaException e) {
+          // ignore
+        }
         if (matchingSchema != null) {
           return matchingSchema;
         }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -249,6 +249,40 @@ public class RestApiTest extends ClusterTestHarness {
   }
 
   @Test
+  public void testRegisterBadReferenceInContext() throws Exception {
+    List<String> avroSchemas = TestUtils.getRandomCanonicalAvroString(2);
+
+    String subject = "testSubject";
+    String avroSchema = avroSchemas.get(0);
+
+    int id1 = restApp.restClient.registerSchema(avroSchema, subject);
+    assertEquals("1st schema registered in first context should have id 1", 1,
+        id1);
+
+    // Create another context so that lookup will search it
+    String subject2 = ":.ctx:testFoo";
+    String avroSchema2 = avroSchemas.get(1);
+
+    int id2 = restApp.restClient.registerSchema(avroSchema2, subject2);
+    assertEquals("2nd schema registered in second context should have id 1", 1,
+        id2);
+
+    SchemaReference reference = new SchemaReference("testSubject", "testSubject", 1);
+    String schemaString = "{\"type\":\"record\","
+        + "\"name\":\"somerecord\","
+        + "\"fields\":"
+        + "[{\"type\":\"string\",\"name\":\"field1\"}]}";
+
+    try {
+      restApp.restClient.lookUpSubjectVersion(schemaString, "AVRO",
+          Collections.singletonList(reference), subject, false);
+      fail(String.format("Subject %s should not be found", subject));
+    } catch (RestClientException rce) {
+      assertEquals("Subject Not Found", Errors.SCHEMA_NOT_FOUND_ERROR_CODE, rce.getErrorCode());
+    }
+  }
+
+  @Test
   public void testRegisterDiffSchemaType() throws Exception {
     String subject = "testSubject";
     String avroSchema = TestUtils.getRandomCanonicalAvroString(1).get(0);


### PR DESCRIPTION
Return 404 instead of 429 if schema lookup fails when searching through contexts