### PR TITLE
Handle schema migrations for Proto message types after first

### DIFF
--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufDeserializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufDeserializer.java
@@ -146,11 +146,16 @@ public abstract class AbstractKafkaProtobufDeserializer<T extends Message>
         schema = schemaForDeserialize(id, schema, subject, isKey);
       }
 
-      ParsedSchema readerSchema = null;
+      ProtobufSchema readerSchema = null;
       if (metadata != null) {
-        readerSchema = getLatestWithMetadata(subject).getSchema();
+        readerSchema = (ProtobufSchema) getLatestWithMetadata(subject).getSchema();
       } else if (useLatestVersion) {
-        readerSchema = lookupLatestVersion(subject, schema, false).getSchema();
+        readerSchema = (ProtobufSchema) lookupLatestVersion(subject, schema, false).getSchema();
+      }
+      if (readerSchema != null) {
+        if (readerSchema.toDescriptor(name) != null) {
+          readerSchema = schemaWithName(readerSchema, name);
+        }
       }
       if (includeSchemaAndVersion || readerSchema != null) {
         Integer version = schemaVersion(topic, isKey, id, subject, schema, null);
@@ -175,7 +180,7 @@ public abstract class AbstractKafkaProtobufDeserializer<T extends Message>
       }
 
       if (readerSchema != null) {
-        schema = (ProtobufSchema) readerSchema;
+        schema = readerSchema;
       }
       if (schema.ruleSet() != null && schema.ruleSet().hasRules(RuleMode.READ)) {
         if (message == null) {


### PR DESCRIPTION
Handle schema migrations for Protobuf messages after the first message type. Previously the code only handled the first message type in a Protobuf schema.