### PR TITLE
remove hibernate-validator exclusion and pin as the updated dependency uses new version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,17 +41,6 @@
         <dependency>
             <groupId>org.glassfish.jersey.ext</groupId>
             <artifactId>jersey-bean-validation</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.hibernate.validator</groupId>
-                    <artifactId>hibernate-validator</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <version>6.1.7.Final</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>


### PR DESCRIPTION
The update of jersey-bean should have removed the exlclusion of hibernate validator. 
This is a cleanup for the previous fix and CVE remediation