### PR TITLE
remove pin of bouncycastle to favor version defined in common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,6 @@
         <swagger.version>2.1.10</swagger.version>
         <io.confluent.schema-registry.version>7.1.15-0</io.confluent.schema-registry.version>
         <commons.compress.version>1.26.1</commons.compress.version>
-        <bouncycastle.jdk18.version>1.77</bouncycastle.jdk18.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Bouncycastle version is defined here:
https://github.com/confluentinc/common/blob/d3201e65b8d83a6ae6eeb6280fe2724c8518cf8c/pom.xml#L108
we should remove this to avoid duplicating the dependency updates. 