### PR TITLE
Add config to specify packages to scan when deriving JSON Schema

### DIFF
--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaUtils.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaUtils.java
@@ -25,6 +25,7 @@ import com.kjetland.jackson.jsonSchema.JsonSchemaConfig.JsonSchemaConfigBuilder;
 import com.kjetland.jackson.jsonSchema.JsonSchemaDraft;
 import com.kjetland.jackson.jsonSchema.JsonSchemaGenerator;
 
+import com.kjetland.jackson.jsonSchema.SubclassesResolver;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
@@ -158,6 +159,17 @@ public class JsonSchemaUtils {
       boolean failUnknownProperties,
       ObjectMapper objectMapper,
       SchemaRegistryClient client) throws IOException {
+    return getSchema(object, specVersion, null, useOneofForNullables, true, objectMapper, client);
+  }
+
+  public static JsonSchema getSchema(
+      Object object,
+      SpecificationVersion specVersion,
+      List<String> scanPackages,
+      boolean useOneofForNullables,
+      boolean failUnknownProperties,
+      ObjectMapper objectMapper,
+      SchemaRegistryClient client) throws IOException {
     if (object == null) {
       return null;
     }
@@ -205,6 +217,9 @@ public class JsonSchemaUtils {
         break;
     }
     config = config.jsonSchemaDraft(draft);
+    if (scanPackages != null && !scanPackages.isEmpty()) {
+      config = config.subclassesResolver(new SubclassesResolver(scanPackages, null));
+    }
     JsonSchemaGenerator jsonSchemaGenerator = new JsonSchemaGenerator(objectMapper, config.build());
     JsonNode jsonSchema = jsonSchemaGenerator.generateJsonSchema(cls);
     return new JsonSchema(jsonSchema);

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaUtils.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaUtils.java
@@ -159,7 +159,8 @@ public class JsonSchemaUtils {
       boolean failUnknownProperties,
       ObjectMapper objectMapper,
       SchemaRegistryClient client) throws IOException {
-    return getSchema(object, specVersion, null, useOneofForNullables, true, objectMapper, client);
+    return getSchema(object, specVersion, null, useOneofForNullables,
+        failUnknownProperties, objectMapper, client);
   }
 
   public static JsonSchema getSchema(

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
@@ -32,6 +32,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.json.diff.Difference;
 import io.confluent.kafka.schemaregistry.json.diff.SchemaDiff;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -266,6 +267,20 @@ public class JsonSchemaTest {
     TestObj testObj = new TestObj();
     String actual =
         JsonSchemaUtils.getSchema(testObj, SpecificationVersion.DRAFT_4, true, null).toString();
+    String expected = "{\"$schema\":\"http://json-schema.org/draft-04/schema#\","
+        + "\"title\":\"Test Obj\",\"type\":\"object\",\"additionalProperties\":false,"
+        + "\"properties\":{\"prop\":{\"oneOf\":[{\"type\":\"null\",\"title\":\"Not included\"},"
+        + "{\"type\":\"string\"}]}}}";
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testSchemaWithPackageScan() throws Exception {
+    TestObj testObj = new TestObj();
+    String actual =
+        JsonSchemaUtils.getSchema(testObj, SpecificationVersion.DRAFT_4,
+            Arrays.asList("io.confluent.kafka.schemaregistry.json"), true, true,
+            new ObjectMapper(), null).toString();
     String expected = "{\"$schema\":\"http://json-schema.org/draft-04/schema#\","
         + "\"title\":\"Test Obj\",\"type\":\"object\",\"additionalProperties\":false,"
         + "\"properties\":{\"prop\":{\"oneOf\":[{\"type\":\"null\",\"title\":\"Not included\"},"

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaSerializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaSerializer.java
@@ -24,6 +24,7 @@ import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleMode;
 import io.confluent.kafka.schemaregistry.json.SpecificationVersion;
 import java.io.InterruptedIOException;
+import java.util.List;
 import java.util.Optional;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
@@ -52,6 +53,7 @@ public abstract class AbstractKafkaJsonSchemaSerializer<T> extends AbstractKafka
   protected boolean latestCompatStrict;
   protected ObjectMapper objectMapper = Jackson.newObjectMapper();
   protected SpecificationVersion specVersion;
+  protected List<String> scanPackages;
   protected boolean oneofForNullables;
   protected boolean failUnknownProperties;
   protected boolean validate;
@@ -71,6 +73,7 @@ public abstract class AbstractKafkaJsonSchemaSerializer<T> extends AbstractKafka
         SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, !writeDatesAsIso8601);
     this.specVersion = SpecificationVersion.get(
         config.getString(KafkaJsonSchemaSerializerConfig.SCHEMA_SPEC_VERSION));
+    this.scanPackages = config.getList(KafkaJsonSchemaSerializerConfig.SCHEMA_SCAN_PACKAGES);
     this.oneofForNullables = config.getBoolean(KafkaJsonSchemaSerializerConfig.ONEOF_FOR_NULLABLES);
     String inclusion = config.getString(KafkaJsonSchemaSerializerConfig.DEFAULT_PROPERTY_INCLUSION);
     if (inclusion != null) {

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializer.java
@@ -98,7 +98,7 @@ public class KafkaJsonSchemaSerializer<T> extends AbstractKafkaJsonSchemaSeriali
 
   private JsonSchema getSchema(T record) {
     try {
-      return JsonSchemaUtils.getSchema(record, specVersion, oneofForNullables,
+      return JsonSchemaUtils.getSchema(record, specVersion, scanPackages, oneofForNullables,
           failUnknownProperties, objectMapper, schemaRegistry);
     } catch (IOException e) {
       throw new SerializationException(e);

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializerConfig.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializerConfig.java
@@ -47,6 +47,10 @@ public class KafkaJsonSchemaSerializerConfig extends AbstractKafkaSchemaSerDeCon
   public static final String SCHEMA_SPEC_VERSION_DOC = "The specification version to use for JSON "
       + "schemas derived from objects, one of 'draft_4', 'draft_6', 'draft_7', or 'draft_2019_09'";
 
+  public static final String SCHEMA_SCAN_PACKAGES = "json.schema.scan.packages";
+  public static final String SCHEMA_SCAN_PACKAGES_DOC = "A list of packages to scan for Jackson "
+      + "annotations when deriving schemas from objects";
+
   public static final String ONEOF_FOR_NULLABLES = "json.oneof.for.nullables";
   public static final boolean ONEOF_FOR_NULLABLES_DEFAULT = true;
   public static final String ONEOF_FOR_NULLABLES_DOC = "Whether JSON schemas derived from objects "
@@ -85,6 +89,11 @@ public class KafkaJsonSchemaSerializerConfig extends AbstractKafkaSchemaSerDeCon
         EnumRecommender.in(SpecificationVersion.values()),
         ConfigDef.Importance.MEDIUM,
         SCHEMA_SPEC_VERSION_DOC
+    ).define(SCHEMA_SCAN_PACKAGES,
+        ConfigDef.Type.LIST,
+        "",
+        ConfigDef.Importance.LOW,
+        SCHEMA_SCAN_PACKAGES_DOC
     ).define(ONEOF_FOR_NULLABLES,
         ConfigDef.Type.BOOLEAN,
         ONEOF_FOR_NULLABLES_DEFAULT,


### PR DESCRIPTION
Add new config `json.schema.scan.packages` to specify a list of packages to scan when deriving JSON schemas from objects.