### PR TITLE
DGS-19032 fix: Config for not throwing timeout exception when waiting for Kafka reader on init

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -115,6 +115,11 @@ public class SchemaRegistryConfig extends RestConfig {
    */
   public static final String KAFKASTORE_INIT_TIMEOUT_CONFIG = "kafkastore.init.timeout.ms";
   /**
+   * <code>kafkastore.init.reader.timeout.strict</code>
+   */
+  public static final String KAFKASTORE_INIT_READER_TIMEOUT_STRICT_CONFIG =
+      "kafkastore.init.reader.timeout.strict";
+  /**
    * <code>kafkastore.update.handler</code>
    */
   public static final String KAFKASTORE_UPDATE_HANDLERS_CONFIG = "kafkastore.update.handlers";
@@ -321,6 +326,10 @@ public class SchemaRegistryConfig extends RestConfig {
   protected static final String KAFKASTORE_INIT_TIMEOUT_DOC =
       "The timeout for initialization of the Kafka store, including creation of the Kafka topic "
       + "that stores schema data.";
+  protected static final String KAFKASTORE_INIT_READER_TIMEOUT_STRICT_DOC =
+      "If true, initializing the Kafka store and setting a leader will error if the Kafka reader "
+      + "does not reach the last offset within the timeout configured by the "
+      + KAFKASTORE_INIT_TIMEOUT_CONFIG + " config.";
   protected static final String KAFKASTORE_CHECKPOINT_DIR_DOC =
       "For persistent stores, the directory in which to store offset checkpoints.";
   protected static final String KAFKASTORE_CHECKPOINT_VERSION_DOC =
@@ -531,6 +540,9 @@ public class SchemaRegistryConfig extends RestConfig {
     )
     .define(KAFKASTORE_INIT_TIMEOUT_CONFIG, ConfigDef.Type.INT, 60000, atLeast(0),
         ConfigDef.Importance.MEDIUM, KAFKASTORE_INIT_TIMEOUT_DOC
+    )
+    .define(KAFKASTORE_INIT_READER_TIMEOUT_STRICT_CONFIG, ConfigDef.Type.BOOLEAN, true,
+        ConfigDef.Importance.LOW, KAFKASTORE_INIT_READER_TIMEOUT_STRICT_DOC
     )
     .define(KAFKASTORE_TIMEOUT_CONFIG, ConfigDef.Type.INT, 500, atLeast(0),
         ConfigDef.Importance.MEDIUM, KAFKASTORE_TIMEOUT_DOC

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -149,6 +149,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   private final Mode defaultMode;
   private final int kafkaStoreTimeoutMs;
   private final int initTimeout;
+  private final boolean initReaderTimeoutStrict;
   private final int kafkaStoreMaxRetries;
   private final int searchDefaultLimit;
   private final int searchMaxLimit;
@@ -206,6 +207,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     this.kafkaStoreTimeoutMs =
         config.getInt(SchemaRegistryConfig.KAFKASTORE_TIMEOUT_CONFIG);
     this.initTimeout = config.getInt(SchemaRegistryConfig.KAFKASTORE_INIT_TIMEOUT_CONFIG);
+    this.initReaderTimeoutStrict =
+        config.getBoolean(SchemaRegistryConfig.KAFKASTORE_INIT_READER_TIMEOUT_STRICT_CONFIG);
     this.kafkaStoreMaxRetries =
         config.getInt(SchemaRegistryConfig.KAFKASTORE_WRITE_MAX_RETRIES_CONFIG);
     this.serializer = serializer;
@@ -536,7 +539,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
           //ensure the new leader catches up with the offsets before it gets nextid and assigns
           // leader
           try {
-            kafkaStore.waitUntilKafkaReaderReachesLastOffset(initTimeout);
+            kafkaStore.waitUntilKafkaReaderReachesLastOffset(initTimeout, initReaderTimeoutStrict);
           } catch (StoreException e) {
             throw new SchemaRegistryStoreException("Exception getting latest offset ", e);
           }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThreadTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThreadTest.java
@@ -18,6 +18,7 @@ import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreTimeoutException;
 import io.confluent.kafka.schemaregistry.utils.TestUtils;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -53,16 +54,28 @@ public class KafkaStoreReaderThreadTest extends ClusterTestHarness {
     KafkaSchemaRegistry sr = (KafkaSchemaRegistry) restApp.schemaRegistry();
     KafkaStoreReaderThread readerThread = sr.getKafkaStore().getKafkaStoreReaderThread();
     try {
-      readerThread.waitUntilOffset(50L, 500L, TimeUnit.MILLISECONDS);
+      readerThread.waitUntilOffset(50L, 500L, TimeUnit.MILLISECONDS, true);
       fail("Should have timed out waiting to reach non-existent offset.");
     } catch (StoreTimeoutException e) {
       // This is expected
     }
     
     try {
-      readerThread.waitUntilOffset(0L, 5000L, TimeUnit.MILLISECONDS);
+      Assert.assertTrue(readerThread.waitUntilOffset(0L, 5000L, TimeUnit.MILLISECONDS, true));
     } catch (StoreTimeoutException e) {
       fail("5 seconds should be more than enough time to reach offset 0 in the log.");
+    }
+
+    try {
+      Assert.assertTrue(readerThread.waitUntilOffset(1L, 5000L, TimeUnit.MILLISECONDS, false));
+    } catch (StoreTimeoutException e) {
+      fail("5 seconds should be more than enough time to reach offset 1 in the log.");
+    }
+
+    try {
+      Assert.assertFalse(readerThread.waitUntilOffset(50L, 500L, TimeUnit.MILLISECONDS, false));
+    } catch (StoreTimeoutException e) {
+      fail("Should not have thrown timeout exception waiting to reach non-existent offset.");
     }
   }
 }


### PR DESCRIPTION
New config allows user to configure whether or not they want a strict timeout when waiting for the kafka reader to reach the last offset during SR initialization and leader setting. 

Strict timeout means that an exception will be thrown if the Kafka reader does not reach the latest offset within the timeout.

The config to enable this is `kafkastore.init.reader.timeout.strict` and is defaulted to true, which is the existing behavior.

No action needs to be taken to maintain old behavior after this change.