### PR TITLE
remove pin of bouncycastle to favor version defined in common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,6 @@
         <io.confluent.schema-registry.version>7.4.8-0</io.confluent.schema-registry.version>
         <commons.compress.version>1.26.1</commons.compress.version>
         <commons.lang3.version>3.17.0</commons.lang3.version>
-        <bouncycastle.jdk18.version>1.77</bouncycastle.jdk18.version>
         <commons.validator.version>1.7</commons.validator.version>
     </properties>
 


### PR DESCRIPTION
Copy of https://github.com/confluentinc/schema-registry/pull/3394 since I messed up the pint merge