### PR TITLE
DGS-19032: Added config for not waiting for kafka reader on store init and leader election

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -115,6 +115,11 @@ public class SchemaRegistryConfig extends RestConfig {
    */
   public static final String KAFKASTORE_INIT_TIMEOUT_CONFIG = "kafkastore.init.timeout.ms";
   /**
+   * <code>kafkastore.init.reader.timeout.strict</code>
+   */
+  public static final String KAFKASTORE_INIT_READER_TIMEOUT_STRICT_CONFIG =
+      "kafkastore.init.reader.timeout.strict";
+  /**
    * <code>kafkastore.update.handler</code>
    */
   public static final String KAFKASTORE_UPDATE_HANDLERS_CONFIG = "kafkastore.update.handlers";
@@ -321,6 +326,10 @@ public class SchemaRegistryConfig extends RestConfig {
   protected static final String KAFKASTORE_INIT_TIMEOUT_DOC =
       "The timeout for initialization of the Kafka store, including creation of the Kafka topic "
       + "that stores schema data.";
+  protected static final String KAFKASTORE_INIT_READER_TIMEOUT_STRICT_DOC =
+      "If true, initializing the Kafka store and setting a leader will error if the Kafka reader "
+      + "does not reach the last offset within the timeout configured by the "
+      + KAFKASTORE_INIT_TIMEOUT_CONFIG + " config.";
   protected static final String KAFKASTORE_CHECKPOINT_DIR_DOC =
       "For persistent stores, the directory in which to store offset checkpoints.";
   protected static final String KAFKASTORE_CHECKPOINT_VERSION_DOC =
@@ -531,6 +540,9 @@ public class SchemaRegistryConfig extends RestConfig {
     )
     .define(KAFKASTORE_INIT_TIMEOUT_CONFIG, ConfigDef.Type.INT, 60000, atLeast(0),
         ConfigDef.Importance.MEDIUM, KAFKASTORE_INIT_TIMEOUT_DOC
+    )
+    .define(KAFKASTORE_INIT_READER_TIMEOUT_STRICT_CONFIG, ConfigDef.Type.BOOLEAN, true,
+        ConfigDef.Importance.LOW, KAFKASTORE_INIT_READER_TIMEOUT_STRICT_DOC
     )
     .define(KAFKASTORE_TIMEOUT_CONFIG, ConfigDef.Type.INT, 500, atLeast(0),
         ConfigDef.Importance.MEDIUM, KAFKASTORE_TIMEOUT_DOC

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -115,11 +115,6 @@ public class SchemaRegistryConfig extends RestConfig {
    */
   public static final String KAFKASTORE_INIT_TIMEOUT_CONFIG = "kafkastore.init.timeout.ms";
   /**
-   * <code>kafkastore.init.reader.timeout.strict</code>
-   */
-  public static final String KAFKASTORE_INIT_READER_TIMEOUT_STRICT_CONFIG =
-      "kafkastore.init.reader.timeout.strict";
-  /**
    * <code>kafkastore.update.handler</code>
    */
   public static final String KAFKASTORE_UPDATE_HANDLERS_CONFIG = "kafkastore.update.handlers";
@@ -326,10 +321,6 @@ public class SchemaRegistryConfig extends RestConfig {
   protected static final String KAFKASTORE_INIT_TIMEOUT_DOC =
       "The timeout for initialization of the Kafka store, including creation of the Kafka topic "
       + "that stores schema data.";
-  protected static final String KAFKASTORE_INIT_READER_TIMEOUT_STRICT_DOC =
-      "If true, initializing the Kafka store and setting a leader will error if the Kafka reader "
-      + "does not reach the last offset within the timeout configured by the "
-      + KAFKASTORE_INIT_TIMEOUT_CONFIG + " config.";
   protected static final String KAFKASTORE_CHECKPOINT_DIR_DOC =
       "For persistent stores, the directory in which to store offset checkpoints.";
   protected static final String KAFKASTORE_CHECKPOINT_VERSION_DOC =
@@ -540,9 +531,6 @@ public class SchemaRegistryConfig extends RestConfig {
     )
     .define(KAFKASTORE_INIT_TIMEOUT_CONFIG, ConfigDef.Type.INT, 60000, atLeast(0),
         ConfigDef.Importance.MEDIUM, KAFKASTORE_INIT_TIMEOUT_DOC
-    )
-    .define(KAFKASTORE_INIT_READER_TIMEOUT_STRICT_CONFIG, ConfigDef.Type.BOOLEAN, true,
-        ConfigDef.Importance.LOW, KAFKASTORE_INIT_READER_TIMEOUT_STRICT_DOC
     )
     .define(KAFKASTORE_TIMEOUT_CONFIG, ConfigDef.Type.INT, 500, atLeast(0),
         ConfigDef.Importance.MEDIUM, KAFKASTORE_TIMEOUT_DOC

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -115,6 +115,11 @@ public class SchemaRegistryConfig extends RestConfig {
    */
   public static final String KAFKASTORE_INIT_TIMEOUT_CONFIG = "kafkastore.init.timeout.ms";
   /**
+   * <code>kafkastore.init.wait.for.reader</code>
+   */
+  public static final String KAFKASTORE_INIT_WAIT_FOR_READER_CONFIG =
+      "kafkastore.init.wait.for.reader";
+  /**
    * <code>kafkastore.update.handler</code>
    */
   public static final String KAFKASTORE_UPDATE_HANDLERS_CONFIG = "kafkastore.update.handlers";
@@ -321,6 +326,9 @@ public class SchemaRegistryConfig extends RestConfig {
   protected static final String KAFKASTORE_INIT_TIMEOUT_DOC =
       "The timeout for initialization of the Kafka store, including creation of the Kafka topic "
       + "that stores schema data.";
+  protected static final String KAFKASTORE_INIT_WAIT_FOR_READER_DOC =
+      "If true, Kafka store initialization and leader election will wait for the Kafka reader to "
+      + "reach the last offset.";
   protected static final String KAFKASTORE_CHECKPOINT_DIR_DOC =
       "For persistent stores, the directory in which to store offset checkpoints.";
   protected static final String KAFKASTORE_CHECKPOINT_VERSION_DOC =
@@ -531,6 +539,9 @@ public class SchemaRegistryConfig extends RestConfig {
     )
     .define(KAFKASTORE_INIT_TIMEOUT_CONFIG, ConfigDef.Type.INT, 60000, atLeast(0),
         ConfigDef.Importance.MEDIUM, KAFKASTORE_INIT_TIMEOUT_DOC
+    )
+    .define(KAFKASTORE_INIT_WAIT_FOR_READER_CONFIG, ConfigDef.Type.BOOLEAN, true,
+        ConfigDef.Importance.LOW, KAFKASTORE_INIT_WAIT_FOR_READER_DOC
     )
     .define(KAFKASTORE_TIMEOUT_CONFIG, ConfigDef.Type.INT, 500, atLeast(0),
         ConfigDef.Importance.MEDIUM, KAFKASTORE_TIMEOUT_DOC

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -149,7 +149,6 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   private final Mode defaultMode;
   private final int kafkaStoreTimeoutMs;
   private final int initTimeout;
-  private final boolean initReaderTimeoutStrict;
   private final int kafkaStoreMaxRetries;
   private final int searchDefaultLimit;
   private final int searchMaxLimit;
@@ -207,8 +206,6 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     this.kafkaStoreTimeoutMs =
         config.getInt(SchemaRegistryConfig.KAFKASTORE_TIMEOUT_CONFIG);
     this.initTimeout = config.getInt(SchemaRegistryConfig.KAFKASTORE_INIT_TIMEOUT_CONFIG);
-    this.initReaderTimeoutStrict =
-        config.getBoolean(SchemaRegistryConfig.KAFKASTORE_INIT_READER_TIMEOUT_STRICT_CONFIG);
     this.kafkaStoreMaxRetries =
         config.getInt(SchemaRegistryConfig.KAFKASTORE_WRITE_MAX_RETRIES_CONFIG);
     this.serializer = serializer;
@@ -539,7 +536,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
           //ensure the new leader catches up with the offsets before it gets nextid and assigns
           // leader
           try {
-            kafkaStore.waitUntilKafkaReaderReachesLastOffset(initTimeout, initReaderTimeoutStrict);
+            kafkaStore.waitUntilKafkaReaderReachesLastOffset(initTimeout);
           } catch (StoreException e) {
             throw new SchemaRegistryStoreException("Exception getting latest offset ", e);
           }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -149,6 +149,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   private final Mode defaultMode;
   private final int kafkaStoreTimeoutMs;
   private final int initTimeout;
+  private final boolean initWaitForReader;
   private final int kafkaStoreMaxRetries;
   private final int searchDefaultLimit;
   private final int searchMaxLimit;
@@ -206,6 +207,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     this.kafkaStoreTimeoutMs =
         config.getInt(SchemaRegistryConfig.KAFKASTORE_TIMEOUT_CONFIG);
     this.initTimeout = config.getInt(SchemaRegistryConfig.KAFKASTORE_INIT_TIMEOUT_CONFIG);
+    this.initWaitForReader =
+        config.getBoolean(SchemaRegistryConfig.KAFKASTORE_INIT_WAIT_FOR_READER_CONFIG);
     this.kafkaStoreMaxRetries =
         config.getInt(SchemaRegistryConfig.KAFKASTORE_WRITE_MAX_RETRIES_CONFIG);
     this.serializer = serializer;
@@ -533,12 +536,14 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
           // The new leader may not know the exact last offset in the Kafka log. So, mark the
           // last offset invalid here
           kafkaStore.markLastWrittenOffsetInvalid();
-          //ensure the new leader catches up with the offsets before it gets nextid and assigns
-          // leader
-          try {
-            kafkaStore.waitUntilKafkaReaderReachesLastOffset(initTimeout);
-          } catch (StoreException e) {
-            throw new SchemaRegistryStoreException("Exception getting latest offset ", e);
+          if (initWaitForReader) {
+            //ensure the new leader catches up with the offsets before it gets nextid and assigns
+            // leader
+            try {
+              kafkaStore.waitUntilKafkaReaderReachesLastOffset(initTimeout);
+            } catch (StoreException e) {
+              throw new SchemaRegistryStoreException("Exception getting latest offset ", e);
+            }
           }
           idGenerator.init();
         }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -149,6 +149,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   private final Mode defaultMode;
   private final int kafkaStoreTimeoutMs;
   private final int initTimeout;
+  private final boolean initReaderTimeoutStrict;
   private final int kafkaStoreMaxRetries;
   private final int searchDefaultLimit;
   private final int searchMaxLimit;
@@ -206,6 +207,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     this.kafkaStoreTimeoutMs =
         config.getInt(SchemaRegistryConfig.KAFKASTORE_TIMEOUT_CONFIG);
     this.initTimeout = config.getInt(SchemaRegistryConfig.KAFKASTORE_INIT_TIMEOUT_CONFIG);
+    this.initReaderTimeoutStrict =
+        config.getBoolean(SchemaRegistryConfig.KAFKASTORE_INIT_READER_TIMEOUT_STRICT_CONFIG);
     this.kafkaStoreMaxRetries =
         config.getInt(SchemaRegistryConfig.KAFKASTORE_WRITE_MAX_RETRIES_CONFIG);
     this.serializer = serializer;
@@ -536,7 +539,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
           //ensure the new leader catches up with the offsets before it gets nextid and assigns
           // leader
           try {
-            kafkaStore.waitUntilKafkaReaderReachesLastOffset(initTimeout);
+            kafkaStore.waitUntilKafkaReaderReachesLastOffset(initTimeout, initReaderTimeoutStrict);
           } catch (StoreException e) {
             throw new SchemaRegistryStoreException("Exception getting latest offset ", e);
           }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -69,6 +69,7 @@ public class KafkaStore<K, V> implements Store<K, V> {
   private final AtomicBoolean initialized = new AtomicBoolean(false);
   private final CountDownLatch initLatch = new CountDownLatch(1);
   private final int initTimeout;
+  private final boolean initWaitForReader;
   private final int timeout;
   private final String bootstrapBrokers;
   private final boolean skipSchemaTopicValidation;
@@ -99,6 +100,8 @@ public class KafkaStore<K, V> implements Store<K, V> {
                         config.getString(SchemaRegistryConfig.HOST_NAME_CONFIG), port)
                    : config.getString(SchemaRegistryConfig.KAFKASTORE_GROUP_ID_CONFIG);
     initTimeout = config.getInt(SchemaRegistryConfig.KAFKASTORE_INIT_TIMEOUT_CONFIG);
+    initWaitForReader =
+        config.getBoolean(SchemaRegistryConfig.KAFKASTORE_INIT_WAIT_FOR_READER_CONFIG);
     timeout = config.getInt(SchemaRegistryConfig.KAFKASTORE_TIMEOUT_CONFIG);
     this.storeUpdateHandler = storeUpdateHandler;
     this.serializer = serializer;
@@ -146,10 +149,12 @@ public class KafkaStore<K, V> implements Store<K, V> {
     final Map<TopicPartition, Long> checkpoints = new HashMap<>(kafkaTopicReader.checkpoints());
     this.kafkaTopicReader.start();
 
-    try {
-      waitUntilKafkaReaderReachesLastOffset(initTimeout);
-    } catch (StoreException e) {
-      throw new StoreInitializationException(e);
+    if (initWaitForReader) {
+      try {
+        waitUntilKafkaReaderReachesLastOffset(initTimeout);
+      } catch (StoreException e) {
+        throw new StoreInitializationException(e);
+      }
     }
 
     boolean isInitialized = initialized.compareAndSet(false, true);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStore.java
@@ -69,7 +69,6 @@ public class KafkaStore<K, V> implements Store<K, V> {
   private final AtomicBoolean initialized = new AtomicBoolean(false);
   private final CountDownLatch initLatch = new CountDownLatch(1);
   private final int initTimeout;
-  private final boolean initReaderTimeoutStrict;
   private final int timeout;
   private final String bootstrapBrokers;
   private final boolean skipSchemaTopicValidation;
@@ -100,8 +99,6 @@ public class KafkaStore<K, V> implements Store<K, V> {
                         config.getString(SchemaRegistryConfig.HOST_NAME_CONFIG), port)
                    : config.getString(SchemaRegistryConfig.KAFKASTORE_GROUP_ID_CONFIG);
     initTimeout = config.getInt(SchemaRegistryConfig.KAFKASTORE_INIT_TIMEOUT_CONFIG);
-    initReaderTimeoutStrict =
-        config.getBoolean(SchemaRegistryConfig.KAFKASTORE_INIT_READER_TIMEOUT_STRICT_CONFIG);
     timeout = config.getInt(SchemaRegistryConfig.KAFKASTORE_TIMEOUT_CONFIG);
     this.storeUpdateHandler = storeUpdateHandler;
     this.serializer = serializer;
@@ -150,7 +147,7 @@ public class KafkaStore<K, V> implements Store<K, V> {
     this.kafkaTopicReader.start();
 
     try {
-      waitUntilKafkaReaderReachesLastOffset(initTimeout, initReaderTimeoutStrict);
+      waitUntilKafkaReaderReachesLastOffset(initTimeout);
     } catch (StoreException e) {
       throw new StoreInitializationException(e);
     }
@@ -296,15 +293,13 @@ public class KafkaStore<K, V> implements Store<K, V> {
   /**
    * Wait until the KafkaStore catches up to the last message in the Kafka topic.
    */
-  public void waitUntilKafkaReaderReachesLastOffset(int timeoutMs, boolean strict)
-      throws StoreException {
+  public void waitUntilKafkaReaderReachesLastOffset(int timeoutMs) throws StoreException {
     long offsetOfLastMessage = getLatestOffset(timeoutMs);
-    waitUntilKafkaReaderReachesOffset(offsetOfLastMessage, timeoutMs, strict);
+    waitUntilKafkaReaderReachesOffset(offsetOfLastMessage, timeoutMs);
   }
 
   /**
    * Wait until the KafkaStore catches up to the last message for the given subject.
-   * Throws exception on timeout.
    */
   public void waitUntilKafkaReaderReachesLastOffset(String subject, int timeoutMs)
       throws StoreException {
@@ -317,24 +312,11 @@ public class KafkaStore<K, V> implements Store<K, V> {
 
   /**
    * Wait until the KafkaStore catches up to the given offset in the Kafka topic.
-   * Throws exception on timeout.
    */
-  private void waitUntilKafkaReaderReachesOffset(long offset, int timeoutMs)
-      throws StoreException {
-    waitUntilKafkaReaderReachesOffset(offset, timeoutMs, true);
-  }
-
-  /**
-   * Wait until the KafkaStore catches up to the given offset in the Kafka topic.
-   */
-  private void waitUntilKafkaReaderReachesOffset(long offset, int timeoutMs, boolean strict)
-      throws StoreException {
+  private void waitUntilKafkaReaderReachesOffset(long offset, int timeoutMs) throws StoreException {
     log.info("Wait to catch up until the offset at {}", offset);
-    if (kafkaTopicReader.waitUntilOffset(offset, timeoutMs, TimeUnit.MILLISECONDS, strict)) {
-      log.info("Reached offset at {}", offset);
-    } else {
-      log.warn("Timed out before reaching offset at {}", offset);
-    }
+    kafkaTopicReader.waitUntilOffset(offset, timeoutMs, TimeUnit.MILLISECONDS);
+    log.info("Reached offset at {}", offset);
   }
 
   public void markLastWrittenOffsetInvalid() {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThread.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThread.java
@@ -340,17 +340,7 @@ public class KafkaStoreReaderThread<K, V> extends ShutdownableThread {
     }
   }
 
-  /**
-   * Wait until the specified offset is reached in the Kafka topic.
-   * @param offset Offset to wait for.
-   * @param timeout Timeout before giving up waiting for the offset to be reached.
-   * @param timeUnit Timeout time unit
-   * @param strict if true, throw an exception if the offset is not reached within the timeout.
-   * @return Returns true if the offset is reached within the timeout interval, false otherwise.
-   * @throws StoreException if strict is true and the offset is not reached within the timeout
-   */
-  public boolean waitUntilOffset(long offset, long timeout, TimeUnit timeUnit, boolean strict)
-      throws StoreException {
+  public void waitUntilOffset(long offset, long timeout, TimeUnit timeUnit) throws StoreException {
     if (offset < 0) {
       throw new StoreException("KafkaStoreReaderThread can't wait for a negative offset.");
     }
@@ -373,16 +363,11 @@ public class KafkaStoreReaderThread<K, V> extends ShutdownableThread {
     }
 
     if (offsetInSchemasTopic < offset) {
-      if (strict) {
-        throw new StoreTimeoutException(
-            "KafkaStoreReaderThread failed to reach target offset within the timeout interval. "
-            + "targetOffset: " + offset + ", offsetReached: " + offsetInSchemasTopic
-            + ", timeout(ms): " + TimeUnit.MILLISECONDS.convert(timeout, timeUnit));
-      } else {
-        return false;
-      }
+      throw new StoreTimeoutException(
+          "KafkaStoreReaderThread failed to reach target offset within the timeout interval. "
+          + "targetOffset: " + offset + ", offsetReached: " + offsetInSchemasTopic
+          + ", timeout(ms): " + TimeUnit.MILLISECONDS.convert(timeout, timeUnit));
     }
-    return true;
   }
 
   /* for testing purposes */

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThreadTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThreadTest.java
@@ -18,7 +18,6 @@ import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreTimeoutException;
 import io.confluent.kafka.schemaregistry.utils.TestUtils;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -54,28 +53,16 @@ public class KafkaStoreReaderThreadTest extends ClusterTestHarness {
     KafkaSchemaRegistry sr = (KafkaSchemaRegistry) restApp.schemaRegistry();
     KafkaStoreReaderThread readerThread = sr.getKafkaStore().getKafkaStoreReaderThread();
     try {
-      readerThread.waitUntilOffset(50L, 500L, TimeUnit.MILLISECONDS, true);
+      readerThread.waitUntilOffset(50L, 500L, TimeUnit.MILLISECONDS);
       fail("Should have timed out waiting to reach non-existent offset.");
     } catch (StoreTimeoutException e) {
       // This is expected
     }
     
     try {
-      Assert.assertTrue(readerThread.waitUntilOffset(0L, 5000L, TimeUnit.MILLISECONDS, true));
+      readerThread.waitUntilOffset(0L, 5000L, TimeUnit.MILLISECONDS);
     } catch (StoreTimeoutException e) {
       fail("5 seconds should be more than enough time to reach offset 0 in the log.");
-    }
-
-    try {
-      Assert.assertTrue(readerThread.waitUntilOffset(1L, 5000L, TimeUnit.MILLISECONDS, false));
-    } catch (StoreTimeoutException e) {
-      fail("5 seconds should be more than enough time to reach offset 1 in the log.");
-    }
-
-    try {
-      Assert.assertFalse(readerThread.waitUntilOffset(50L, 500L, TimeUnit.MILLISECONDS, false));
-    } catch (StoreTimeoutException e) {
-      fail("Should not have thrown timeout exception waiting to reach non-existent offset.");
     }
   }
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThreadTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThreadTest.java
@@ -18,6 +18,7 @@ import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreTimeoutException;
 import io.confluent.kafka.schemaregistry.utils.TestUtils;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -53,16 +54,28 @@ public class KafkaStoreReaderThreadTest extends ClusterTestHarness {
     KafkaSchemaRegistry sr = (KafkaSchemaRegistry) restApp.schemaRegistry();
     KafkaStoreReaderThread readerThread = sr.getKafkaStore().getKafkaStoreReaderThread();
     try {
-      readerThread.waitUntilOffset(50L, 500L, TimeUnit.MILLISECONDS);
+      readerThread.waitUntilOffset(50L, 500L, TimeUnit.MILLISECONDS, true);
       fail("Should have timed out waiting to reach non-existent offset.");
     } catch (StoreTimeoutException e) {
       // This is expected
     }
     
     try {
-      readerThread.waitUntilOffset(0L, 5000L, TimeUnit.MILLISECONDS);
+      Assert.assertTrue(readerThread.waitUntilOffset(0L, 5000L, TimeUnit.MILLISECONDS, true));
     } catch (StoreTimeoutException e) {
       fail("5 seconds should be more than enough time to reach offset 0 in the log.");
+    }
+
+    try {
+      Assert.assertTrue(readerThread.waitUntilOffset(1L, 5000L, TimeUnit.MILLISECONDS, false));
+    } catch (StoreTimeoutException e) {
+      fail("5 seconds should be more than enough time to reach offset 1 in the log.");
+    }
+
+    try {
+      Assert.assertFalse(readerThread.waitUntilOffset(50L, 500L, TimeUnit.MILLISECONDS, false));
+    } catch (StoreTimeoutException e) {
+      fail("Should not have thrown timeout exception waiting to reach non-existent offset.");
     }
   }
 }


### PR DESCRIPTION
- Reverted this change: https://github.com/confluentinc/schema-registry/commit/ea7bacbbd13eb2b65bef3976485cc1004aa563c0
- Added config for skipping waiting for the kafka reader on store init and leader election