### PR TITLE
DGS-19049: Enable semaphore pipeline on SC release branch

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -13,6 +13,7 @@ semaphore:
     - /^\d+\.\d+\.x$/
     - /^gh-readonly-queue.*/
     - /^cc-sr-v0\..+/ # cc-sr-v0.2.414-7.7.2.62-x
+    - /^cc-sc-v0\..+/ # cc-sc-v0.2.414-7.7.2.62-x
   execution_time_limit: {"hours": 2}
   downstream_projects: ["kafka-rest", "ksql", "confluent-security-plugins", "kafka-connect-replicator", "ce-kafka-rest", "confluent-cloud-plugins", "schema-registry-plugins"]
 git:

--- a/service.yml
+++ b/service.yml
@@ -12,8 +12,8 @@ semaphore:
     - main
     - /^\d+\.\d+\.x$/
     - /^gh-readonly-queue.*/
-    - /^cc-sr-v0\..+/ # cc-sr-v0.2.414-7.7.2.62-x
-    - /^cc-sc-v0\..+/ # cc-sc-v0.2.414-7.7.2.62-x
+    - /^cc-sr-v0\..+/
+    - /^cc-sc-v0\..+/
   execution_time_limit: {"hours": 2}
   downstream_projects: ["kafka-rest", "ksql", "confluent-security-plugins", "kafka-connect-replicator", "ce-kafka-rest", "confluent-cloud-plugins", "schema-registry-plugins"]
 git:


### PR DESCRIPTION
- Enables semaphore jobs to run on branches starting with `cc-sc-v0`