### PR TITLE
DGS-19289 Add composite deserializer for migration use cases

### DIFF
--- a/core/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
@@ -73,6 +73,23 @@ public class CachedSchemaRegistryClientTest extends ClusterTestHarness {
     return props;
   }
 
+  private Properties createCompositeConsumerProps() {
+    Properties props = new Properties();
+    props.put("bootstrap.servers", brokerList);
+    props.put("group.id", "avroGroup");
+    props.put("session.timeout.ms", "6000"); // default value of group.min.session.timeout.ms.
+    props.put("heartbeat.interval.ms", "2000");
+    props.put("auto.commit.interval.ms", "1000");
+    props.put("auto.offset.reset", "earliest");
+    props.put("key.deserializer", org.apache.kafka.common.serialization.StringDeserializer.class);
+    props.put("value.deserializer",
+        io.confluent.kafka.serializers.migration.CompositeDeserializer.class);
+    props.put("old.deserializer", io.confluent.kafka.serializers.KafkaAvroDeserializer.class);
+    props.put("confluent.deserializer", io.confluent.kafka.serializers.KafkaAvroDeserializer.class);
+    props.put(SCHEMA_REGISTRY_URL, restApp.restConnect);
+    return props;
+  }
+
   private Consumer<String, Object> createConsumer(Properties props) {
     return new KafkaConsumer<>(props);
   }
@@ -149,6 +166,21 @@ public class CachedSchemaRegistryClientTest extends ClusterTestHarness {
     produce(producer, topic, objects);
 
     Properties consumerProps = createConsumerProps();
+    Consumer<String, Object> consumer = createConsumer(consumerProps);
+    ArrayList<Object> recordList = consume(consumer, topic, objects.length);
+    assertArrayEquals(objects, recordList.toArray());
+  }
+
+  @Test
+  public void testAvroProducerWithCompositeDeserializer() {
+    String topic = "testAvro";
+    IndexedRecord avroRecord = createAvroRecord();
+    Object[] objects = new Object[]{avroRecord};
+    Properties producerProps = createProducerProps();
+    Producer<String, Object> producer = createProducer(producerProps);
+    produce(producer, topic, objects);
+
+    Properties consumerProps = createCompositeConsumerProps();
     Consumer<String, Object> consumer = createConsumer(consumerProps);
     ArrayList<Object> recordList = consume(consumer, topic, objects.length);
     assertArrayEquals(objects, recordList.toArray());

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -308,6 +308,10 @@ public abstract class AbstractKafkaSchemaSerDe implements Closeable {
     ruleObject.configure(params);
   }
 
+  public SchemaRegistryClient getSchemaRegistryClient() {
+    return schemaRegistry;
+  }
+
   // Visible for testing
   public Map<String, Map<String, RuleBase>> getRuleExecutors() {
     return ruleExecutors;

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/WrapperKeyDeserializer.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/WrapperKeyDeserializer.java
@@ -42,6 +42,7 @@ public class WrapperKeyDeserializer<T> implements Deserializer<T> {
     }
     this.inner = config.getConfiguredInstance(
         WrapperKeyDeserializerConfig.WRAPPED_KEY_DESERIALIZER, Deserializer.class);
+    this.inner.configure(config.originals(), isKey);
   }
 
   @Override

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/WrapperKeySerializer.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/WrapperKeySerializer.java
@@ -42,6 +42,7 @@ public class WrapperKeySerializer<T> implements Serializer<T> {
     }
     this.inner = config.getConfiguredInstance(
         WrapperKeySerializerConfig.WRAPPED_KEY_SERIALIZER, Serializer.class);
+    this.inner.configure(config.originals(), isKey);
   }
 
   @Override

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/migration/CompositeDeserializer.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/migration/CompositeDeserializer.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2024 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+
+package io.confluent.kafka.serializers.migration;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDe;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import org.apache.commons.lang3.SerializationException;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CompositeDeserializer implements Deserializer<Object> {
+
+  protected Logger log = LoggerFactory.getLogger(CompositeDeserializer.class);
+
+  protected static final byte MAGIC_BYTE = 0x0;
+
+  private Deserializer oldDeserializer;
+  private Deserializer confluentDeserializer;
+  private SchemaRegistryClient schemaRegistryClient;
+
+  /**
+   * Constructor used by Kafka consumer.
+   */
+  public CompositeDeserializer() {
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    configure(new CompositeDeserializerConfig(configs), isKey);
+  }
+
+  @SuppressWarnings("unchecked")
+  protected void configure(CompositeDeserializerConfig config, boolean isKey) {
+    Map<String, Object> originals = config.originals();
+    this.oldDeserializer = config.getConfiguredInstance(
+        CompositeDeserializerConfig.OLD_DESERIALIZER, Deserializer.class);
+    this.oldDeserializer.configure(originals, isKey);
+    this.confluentDeserializer = config.getConfiguredInstance(
+        CompositeDeserializerConfig.CONFLUENT_DESERIALIZER, Deserializer.class);
+    this.confluentDeserializer.configure(originals, isKey);
+    this.schemaRegistryClient = getSchemaRegistryClient();
+  }
+
+  @Override
+  public Object deserialize(String topic, byte[] bytes) {
+    return deserialize(topic, null, bytes);
+  }
+
+  @Override
+  public Object deserialize(String topic, Headers headers, byte[] bytes) {
+    if (bytes == null) {
+      return null;
+    }
+
+    // We assume TopicNameStrategy
+    String subject = topic + "-value";
+
+    int schemaId = getSchemaId(ByteBuffer.wrap(bytes));
+
+    if (isValidSchemaId(subject, schemaId)) {
+      return confluentDeserializer.deserialize(topic, headers, bytes);
+    } else {
+      return oldDeserializer.deserialize(topic, bytes);
+    }
+  }
+
+  private int getSchemaId(ByteBuffer payload) {
+    if (payload == null) {
+      // Skip validation if no strategy is specified or if no data is present.
+      return 0;
+    }
+    if (payload.get() != MAGIC_BYTE) {
+      return 0;
+    }
+    return payload.getInt();
+  }
+
+  protected boolean isValidSchemaId(String subject, int id) {
+    if (id == 0) {
+      return false;
+    }
+
+    try {
+      // Obtain the schema.
+      ParsedSchema schema = schemaRegistryClient.getSchemaBySubjectAndId(subject, id);
+
+      // Get the id of the schema that was saved in the registry.
+      int savedId = schemaRegistryClient.getId(subject, schema);
+
+      return id == savedId;
+    } catch (Exception e) {
+      log.warn("Error while validating schema id", e);
+      return false;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private SchemaRegistryClient getSchemaRegistryClient() {
+    // We use reflection to access the SR client as it is a protected member right now
+    // We should consider making it public in the future
+    try {
+      Field f = AbstractKafkaSchemaSerDe.class.getDeclaredField("schemaRegistry");
+      f.setAccessible(true);
+      return (SchemaRegistryClient) f.get(confluentDeserializer);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+  @Override
+  public void close() {
+    oldDeserializer.close();
+    confluentDeserializer.close();
+  }
+
+}

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/migration/CompositeDeserializerConfig.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/migration/CompositeDeserializerConfig.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ */
+
+package io.confluent.kafka.serializers.migration;
+
+import java.util.Map;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+public class CompositeDeserializerConfig extends AbstractConfig {
+
+  public static final String OLD_DESERIALIZER = "old.deserializer";
+  public static final String OLD_DESERIALIZER_DOC =
+      "Old deserializer that is schema-unaware";
+
+  public static final String CONFLUENT_DESERIALIZER = "confluent.deserializer";
+  public static final String CONFLUENT_DESERIALIZER_DOC =
+      "Confluent deserializer, one of Avro, Protobuf, JSON Schema";
+
+  private static final ConfigDef config;
+
+  static {
+    config = new ConfigDef().define(
+        OLD_DESERIALIZER,
+        ConfigDef.Type.CLASS,
+        Object.class,
+        ConfigDef.Importance.HIGH,
+        OLD_DESERIALIZER_DOC
+    ).define(
+        CONFLUENT_DESERIALIZER,
+        ConfigDef.Type.CLASS,
+        Object.class,
+        ConfigDef.Importance.HIGH,
+        CONFLUENT_DESERIALIZER_DOC
+    );
+  }
+
+  public CompositeDeserializerConfig(Map<?, ?> props) {
+    super(config, props);
+  }
+}


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Add a utility class to help with use cases involving migrating from using a deserializer w/o SR to one with SR.

The composite deserializer takes two configs, the old non-SR deserializer, and a Confluent one (Avro, Protobuf, JSON Schema).  The composite deserializer first tries to determine if the payload corresponds to a schema (using similar logic to the schema validation broker plugin), then calls the appropriate deserializer.
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
    - Yes, adds a new utility class.
- [x] Is this change gated behind feature flag(s)?
    -  No
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
    - Yes
- [x] Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - No

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
