### PR TITLE
DGS-19323 Enhance lookup match to be more lenient wrt confluent:version

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
@@ -299,7 +299,7 @@ public interface ParsedSchema {
     // This schema can be used to lookup a previous schema if this schema
     // has no references and the previous schema has references,
     // (which can happen with Avro schemas) and the schemas are the same except
-    // for the previous schema possibly having a confluent:version.
+    // for the one of the schemas possibly having a confluent:version.
     if (references().isEmpty() && !prev.references().isEmpty()) {
       if (canLookupIgnoringVersion(this, prev)) {
         // This handles the case where a schema is sent with all references resolved
@@ -309,10 +309,10 @@ public interface ParsedSchema {
     // This schema can be used to lookup a previous schema if this schema
     // and the previous schema having matching references when all versions of -1
     // are replaced by the latest version, and the schemas are the same except
-    // for the previous schema possibly having a confluent:version.
+    // for the one of the schemas possibly having a confluent:version.
     String schemaVer = getConfluentVersion(metadata());
     String prevVer = getConfluentVersion(prev.metadata());
-    if ((schemaVer == null && prevVer != null)
+    if (schemaVer != null || prevVer != null
         || hasLatestVersion(this.references())
         || hasLatestVersion(prev.references())) {
       boolean areRefsEquivalent = replaceLatestVersion(references(), fetcher)

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/protobuf/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/protobuf/RestApiTest.java
@@ -651,6 +651,14 @@ public class RestApiTest extends ClusterTestHarness {
     assertEquals((Integer) 1, result.getVersion());
     assertNull(result.getMetadata());
 
+    // Lookup schema with confluent:version 1 (should return one without metadata)
+    request.setVersion(null);
+    request.setMetadata(new Metadata(null, Collections.singletonMap("confluent:version", "1"), null));
+    result = restApp.restClient.lookUpSubjectVersion(request, subject, false, false);
+    assertEquals(schemaString, result.getSchema());
+    assertEquals((Integer) 1, result.getVersion());
+    assertNull(result.getMetadata());
+
     // Lookup schema with confluent:version 2
     request.setVersion(null);
     request.setMetadata(new Metadata(null, Collections.singletonMap("confluent:version", "2"), null));


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Enhance lookup match to be more lenient w.r.t. confluent:version.

Previously we allowed a match if the schema being passed for lookup did not have a confluent:version.  We would return an existing schema that matches that has a confluent:version.

Now we also allow a match if the schema being passed has a confluent:version.  In this case it will match an existing schema that does not have confluent:version, but has a version that is the same as confluent:version

<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
  - This is an improvement to the API behavior which is more lenient w.r.t. matches
- [x] Is this change gated behind feature flag(s)?
    - No
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
    - Yes
- [x] Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - No
   
References
----------
JIRA: https://confluentinc.atlassian.net/browse/DGS-19323
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
