### PR TITLE
DGS-19323 Optimization to use confluent:version if available

### DIFF
--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroConverterTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroConverterTest.java
@@ -17,6 +17,7 @@
 package io.confluent.connect.avro;
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.serializers.subject.RecordNameStrategy;
 
@@ -199,7 +200,15 @@ public class AvroConverterTest {
 
     avroConverter.configure(configs, false);
     testVersionExtracted(subject, serializer, avroConverter);
+  }
 
+  @Test
+  public void testVersionExtractedFromMetadata() throws Exception {
+    String subject = TOPIC + "-value";
+    KafkaAvroSerializer serializer = new KafkaAvroSerializer(schemaRegistry);
+    AvroConverter avroConverter = new AvroConverter(schemaRegistry);
+    avroConverter.configure(Collections.singletonMap("schema.registry.url", "http://fake-url"), false);
+    testVersionExtractedFromMetadata(subject, serializer, avroConverter);
   }
 
   private void testVersionExtracted(String subject, KafkaAvroSerializer serializer, AvroConverter avroConverter) throws IOException, RestClientException {
@@ -233,6 +242,42 @@ public class AvroConverterTest {
 
     SchemaAndValue converted2 = avroConverter.toConnectData(TOPIC, serializedRecord2);
     assertEquals(2L, (long) converted2.schema().version());
+  }
+
+  private void testVersionExtractedFromMetadata(String subject, KafkaAvroSerializer serializer,
+      AvroConverter avroConverter) throws IOException, RestClientException {
+    // Pre-register to ensure ordering
+    org.apache.avro.Schema avroSchema1 = org.apache.avro.SchemaBuilder
+        .record("Foo").fields()
+        .requiredInt("key")
+        .endRecord();
+    schemaRegistry.register(subject, new AvroSchema(avroSchema1).copy(
+        new Metadata(null, ImmutableMap.of("confluent:version", "2"), null), null));
+
+    org.apache.avro.Schema avroSchema2 = org.apache.avro.SchemaBuilder
+        .record("Foo").fields()
+        .requiredInt("key")
+        .requiredString("value")
+        .endRecord();
+    schemaRegistry.register(subject, new AvroSchema(avroSchema2).copy(
+        new Metadata(null, ImmutableMap.of("confluent:version", "200"), null), null));
+
+
+    // Get serialized data
+    org.apache.avro.generic.GenericRecord avroRecord1
+        = new org.apache.avro.generic.GenericRecordBuilder(avroSchema1).set("key", 15).build();
+    byte[] serializedRecord1 = serializer.serialize(TOPIC, avroRecord1);
+    org.apache.avro.generic.GenericRecord avroRecord2
+        = new org.apache.avro.generic.GenericRecordBuilder(avroSchema2).set("key", 15).set
+        ("value", "bar").build();
+    byte[] serializedRecord2 = serializer.serialize(TOPIC, avroRecord2);
+
+
+    SchemaAndValue converted1 = avroConverter.toConnectData(TOPIC, serializedRecord1);
+    assertEquals(2L, (long) converted1.schema().version());
+
+    SchemaAndValue converted2 = avroConverter.toConnectData(TOPIC, serializedRecord2);
+    assertEquals(200L, (long) converted2.schema().version());
   }
 
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/AbstractSchemaProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/AbstractSchemaProvider.java
@@ -105,7 +105,7 @@ public abstract class AbstractSchemaProvider implements SchemaProvider {
       // This handles the case where current schema is without confluent:version
       return newSchema.deepEquals(newPrev);
     } else if (schemaVer != null && prevVer == null) {
-      if (!Objects.equals(schemaVer.intValue(), prev.version())) {
+      if (!Objects.equals(schemaVer, prev.version())) {
         // The incoming confluent:version must match the actual version of the prev schema
         return false;
       }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/AbstractSchemaProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/AbstractSchemaProvider.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import io.confluent.kafka.schemaregistry.client.SchemaVersionFetcher;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
-import java.util.Objects;
 import java.util.Set;
 
 public abstract class AbstractSchemaProvider implements SchemaProvider {
@@ -105,7 +104,7 @@ public abstract class AbstractSchemaProvider implements SchemaProvider {
       // This handles the case where current schema is without confluent:version
       return newSchema.deepEquals(newPrev);
     } else if (schemaVer != null && prevVer == null) {
-      if (!Objects.equals(schemaVer, prev.version())) {
+      if (!schemaVer.equals(prev.version())) {
         // The incoming confluent:version must match the actual version of the prev schema
         return false;
       }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/AbstractSchemaProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/AbstractSchemaProvider.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import io.confluent.kafka.schemaregistry.client.SchemaVersionFetcher;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import java.util.Objects;
 import java.util.Set;
 
 public abstract class AbstractSchemaProvider implements SchemaProvider {
@@ -93,8 +94,8 @@ public abstract class AbstractSchemaProvider implements SchemaProvider {
   // have private methods in Java 8.  Move these to ParsedSchema in 8.0.x
   protected static boolean canLookupIgnoringVersion(
       ParsedSchema current, ParsedSchema prev) {
-    String schemaVer = getConfluentVersion(current.metadata());
-    String prevVer = getConfluentVersion(prev.metadata());
+    Integer schemaVer = getConfluentVersionNumber(current.metadata());
+    Integer prevVer = getConfluentVersionNumber(prev.metadata());
     if (schemaVer == null && prevVer != null) {
       ParsedSchema newSchema = current.metadata() != null
           ? current
@@ -104,7 +105,7 @@ public abstract class AbstractSchemaProvider implements SchemaProvider {
       // This handles the case where current schema is without confluent:version
       return newSchema.deepEquals(newPrev);
     } else if (schemaVer != null && prevVer == null) {
-      if (!versionsMatch(schemaVer, prev.version())) {
+      if (!Objects.equals(schemaVer.intValue(), prev.version())) {
         // The incoming confluent:version must match the actual version of the prev schema
         return false;
       }
@@ -118,16 +119,6 @@ public abstract class AbstractSchemaProvider implements SchemaProvider {
     } else {
       return current.deepEquals(prev);
     }
-  }
-
-  private static boolean versionsMatch(String schemaVer, int prevVer) {
-    int schemaVersion = 0;
-    try {
-      schemaVersion = Integer.parseInt(schemaVer);
-    } catch (NumberFormatException e) {
-      // ignore
-    }
-    return schemaVersion == prevVer;
   }
 
   protected static boolean hasLatestVersion(List<SchemaReference> refs) {
@@ -146,6 +137,10 @@ public abstract class AbstractSchemaProvider implements SchemaProvider {
       }
     }
     return result;
+  }
+
+  protected static Integer getConfluentVersionNumber(Metadata metadata) {
+    return metadata != null ? metadata.getConfluentVersionNumber() : null;
   }
 
   protected static String getConfluentVersion(Metadata metadata) {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Metadata.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Metadata.java
@@ -139,6 +139,19 @@ public class Metadata {
   }
 
   @JsonIgnore
+  public Integer getConfluentVersionNumber() {
+    String version = getConfluentVersion();
+    if (version == null) {
+      return null;
+    }
+    try {
+      return Integer.parseInt(version);
+    } catch (NumberFormatException e) {
+      return null;
+    }
+  }
+
+  @JsonIgnore
   public String getConfluentVersion() {
     return getProperties() != null ? getProperties().get(CONFLUENT_VERSION) : null;
   }

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleMode;
 import java.io.InterruptedIOException;
 import java.util.Collections;
@@ -286,12 +287,18 @@ public abstract class AbstractKafkaJsonSchemaDeserializer<T> extends AbstractKaf
   private Integer schemaVersion(
       String topic, boolean isKey, int id, String subject, JsonSchema schema, Object value
   ) throws IOException, RestClientException {
-    Integer version;
+    Integer version = null;
     if (isDeprecatedSubjectNameStrategy(isKey)) {
       subject = getSubjectName(topic, isKey, value, schema);
     }
     JsonSchema subjectSchema = (JsonSchema) schemaRegistry.getSchemaBySubjectAndId(subject, id);
-    version = schemaRegistry.getVersion(subject, subjectSchema);
+    Metadata metadata = subjectSchema.metadata();
+    if (metadata != null) {
+      version = metadata.getConfluentVersionNumber();
+    }
+    if (version == null) {
+      version = schemaRegistry.getVersion(subject, subjectSchema);
+    }
     return version;
   }
 


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
This is a continuation of https://github.com/confluentinc/schema-registry/pull/3458 to add a small optimization to avoid making calls to SR if confluent:version is available.

Also, this fixes an NPE when using the MockSchemaRegistryClient, by using `!schemaVer.equals(prev.version())`, since `prev.version()` may be null during tests.
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes 
  - no
- [x] Is this change gated behind feature flag(s)?
    - no
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
    - yes
- [x] Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - no

References
----------
JIRA: https://confluentinc.atlassian.net/browse/DGS-19323
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
