### PR TITLE
DGS-19267 Ensure json-skema validator is called if possible

### DIFF
--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -576,6 +576,7 @@ public class JsonSchema implements ParsedSchema {
   }
 
   public JsonNode validate(JsonNode value) throws JsonProcessingException, ValidationException {
+    // Obtain the raw schema to ensure skemaObj is populated
     Schema rawSchema = rawSchema();
     if (skemaObj != null) {
       return validate(skemaObj, value);

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -576,10 +576,11 @@ public class JsonSchema implements ParsedSchema {
   }
 
   public JsonNode validate(JsonNode value) throws JsonProcessingException, ValidationException {
+    Schema rawSchema = rawSchema();
     if (skemaObj != null) {
       return validate(skemaObj, value);
     } else {
-      return validate(rawSchema(), value);
+      return validate(rawSchema, value);
     }
   }
 

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
@@ -466,6 +466,67 @@ public class JsonSchemaTest {
   }
 
   @Test
+  public void testFoo() throws Exception {
+    String schema = " {\n"
+        + "              \"$schema\": \"https://json-schema.org/draft/2019-09/schema\",\n"
+        + "              \"if\": {\n"
+        + "                \"properties\": {\n"
+        + "                  \"type\": {\n"
+        + "                    \"const\": \"business\"\n"
+        + "                  }\n"
+        + "                },\n"
+        + "                \"required\": [\n"
+        + "                  \"type\"\n"
+        + "                ],\n"
+        + "                \"type\": \"object\"\n"
+        + "              },\n"
+        + "              \"properties\": {\n"
+        + "                \"city\": {\n"
+        + "                  \"type\": \"string\"\n"
+        + "                },\n"
+        + "                \"state\": {\n"
+        + "                  \"type\": \"string\"\n"
+        + "                },\n"
+        + "                \"street_address\": {\n"
+        + "                  \"type\": \"string\"\n"
+        + "                },\n"
+        + "                \"type\": {\n"
+        + "                  \"enum\": [\n"
+        + "                    \"residential\",\n"
+        + "                    \"business\"\n"
+        + "                  ]\n"
+        + "                }\n"
+        + "              },\n"
+        + "              \"required\": [\n"
+        + "                \"street_address\",\n"
+        + "                \"city\",\n"
+        + "                \"state\",\n"
+        + "                \"type\"\n"
+        + "              ],\n"
+        + "              \"then\": {\n"
+        + "                \"properties\": {\n"
+        + "                  \"department\": {\n"
+        + "                    \"type\": \"string\"\n"
+        + "                  }\n"
+        + "                }\n"
+        + "              },\n"
+        + "              \"title\": \"MyTestSchema\",\n"
+        + "              \"type\": \"object\",\n"
+        + "              \"unevaluatedProperties\": false\n"
+        + "            }\n";
+    JsonSchema jsonSchema = new JsonSchema(schema);
+    String json = " {\n"
+        + "              \"street_address\": \"1600 Pennsylvania Avenue NW\",\n"
+        + "              \"city\": \"Washington\",\n"
+        + "              \"state\": \"DC\",\n"
+        + "              \"type\": \"residential\",\n"
+        + "              \"department\": \"HR\"\n"
+        + "            }\n";
+    JsonNode data = new ObjectMapper().readTree(json);
+    jsonSchema.validate(data);
+  }
+
+  @Test
   public void testRecursiveSchema() {
     String schema = "{\n"
         + "  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n"

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
@@ -465,8 +465,8 @@ public class JsonSchemaTest {
     verify(mappings).entrySet();
   }
 
-  @Test
-  public void testFoo() throws Exception {
+  @Test(expected = ValidationException.class)
+  public void testUnevaluatedProperties() throws Exception {
     String schema = " {\n"
         + "              \"$schema\": \"https://json-schema.org/draft/2019-09/schema\",\n"
         + "              \"if\": {\n"


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----

Fix to ensure json-skema validator is used for draft 2019-09 and 2020-12.  The skemaObj is populated when `rawSchema()` is called, so we call it before checking the value of `skemaObj`
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes 
   - No
- [x] Is this change gated behind feature flag(s)?
    - No
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
    - Yes
- [x] Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
   - No
 

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
