### PR TITLE
Remove ZK from integration tests; upgrade to JUnit 5

### DIFF
--- a/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/GenericAvroSerde.java
+++ b/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/GenericAvroSerde.java
@@ -48,7 +48,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
  * streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, GenericAvroSerde.class);
  * streamsConfiguration.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, GenericAvroSerde.class);
  * streamsConfiguration.put(
- *     AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+ *     AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
  *     "http://confluent-schema-registry-server:8081/");
  * }</pre>
  *
@@ -60,7 +60,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
  * boolean isKeySerde = false;
  * genericAvroSerde.configure(
  *     Collections.singletonMap(
- *         AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+ *         AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
  *         "http://confluent-schema-registry-server:8081/"),
  *     isKeySerde);
  * KStream<String, GenericRecord> stream = ...;

--- a/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/PrimitiveAvroSerde.java
+++ b/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/PrimitiveAvroSerde.java
@@ -56,7 +56,7 @@ import java.util.Map;
  * streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, PrimitiveAvroSerde.class);
  * streamsConfiguration.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, PrimitiveAvroSerde.class);
  * streamsConfiguration.put(
- *     AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+ *     AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
  *     "http://confluent-schema-registry-server:8081/");
  * }</pre>
  *
@@ -72,7 +72,7 @@ import java.util.Map;
  * boolean isKeySerde = true;
  * longAvroSerde.configure(
  *     Collections.singletonMap(
- *         AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+ *         AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
  *         "http://confluent-schema-registry-server:8081/"),
  *     isKeySerde);
  *
@@ -80,7 +80,7 @@ import java.util.Map;
  * isKeySerde = false;
  * genericAvroSerde.configure(
  * Collections.singletonMap(
- * AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+ * AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
  *  "http://confluent-schema-registry-server:8081/"),
  *  isKeySerde);
  *

--- a/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/ReflectionAvroSerde.java
+++ b/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/ReflectionAvroSerde.java
@@ -44,7 +44,7 @@ import org.apache.kafka.common.serialization.Serializer;
  * streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, ReflectionAvroSerde.class);
  * streamsConfiguration.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, ReflectionAvroSerde.class);
  * streamsConfiguration.put(
- *     AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+ *     AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
  *     "http://confluent-schema-registry-server:8081/");
  * }</pre>
  *
@@ -56,7 +56,7 @@ import org.apache.kafka.common.serialization.Serializer;
  * boolean isKeySerde = false;
  * reflectionAvroSerde.configure(
  *     Collections.singletonMap(
- *         AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+ *         AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
  *         "http://confluent-schema-registry-server:8081/"),
  *     isKeySerde);
  * KStream<String, MyJavaClassGeneratedFromAvroSchema> stream = ...;

--- a/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/SpecificAvroSerde.java
+++ b/avro-serde/src/main/java/io/confluent/kafka/streams/serdes/avro/SpecificAvroSerde.java
@@ -47,7 +47,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
  * streamsConfiguration.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, SpecificAvroSerde.class);
  * streamsConfiguration.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, SpecificAvroSerde.class);
  * streamsConfiguration.put(
- *     AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+ *     AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
  *     "http://confluent-schema-registry-server:8081/");
  * }</pre>
  *
@@ -59,7 +59,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
  * boolean isKeySerde = false;
  * specificAvroSerde.configure(
  *     Collections.singletonMap(
- *         AbstractKafkaAvroSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+ *         AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
  *         "http://confluent-schema-registry-server:8081/"),
  *     isKeySerde);
  * KStream<String, MyJavaClassGeneratedFromAvroSchema> stream = ...;

--- a/client-encryption-aws/pom.xml
+++ b/client-encryption-aws/pom.xml
@@ -83,6 +83,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-server-common</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <classifier>test</classifier>
             <scope>test</scope>
@@ -132,6 +139,16 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/client-encryption-azure/pom.xml
+++ b/client-encryption-azure/pom.xml
@@ -83,6 +83,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-server-common</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <classifier>test</classifier>
             <scope>test</scope>
@@ -132,6 +139,16 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/client-encryption-gcp/pom.xml
+++ b/client-encryption-gcp/pom.xml
@@ -83,6 +83,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-server-common</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <classifier>test</classifier>
             <scope>test</scope>
@@ -132,6 +139,16 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/client-encryption-hcvault/pom.xml
+++ b/client-encryption-hcvault/pom.xml
@@ -79,6 +79,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-server-common</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <classifier>test</classifier>
             <scope>test</scope>
@@ -128,6 +135,16 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/client-encryption/pom.xml
+++ b/client-encryption/pom.xml
@@ -79,6 +79,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-server-common</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <classifier>test</classifier>
             <scope>test</scope>
@@ -121,6 +128,16 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/client-encryption/src/test/java/io/confluent/kafka/schemaregistry/encryption/RestApiFieldEncryptionTest.java
+++ b/client-encryption/src/test/java/io/confluent/kafka/schemaregistry/encryption/RestApiFieldEncryptionTest.java
@@ -15,9 +15,9 @@
 package io.confluent.kafka.schemaregistry.encryption;
 
 import static io.confluent.kafka.schemaregistry.encryption.FieldEncryptionExecutor.CLOCK;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -62,8 +62,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class RestApiFieldEncryptionTest extends ClusterTestHarness {
 
@@ -92,8 +91,8 @@ public abstract class RestApiFieldEncryptionTest extends ClusterTestHarness {
     return props;
   }
 
-  @Before
-  public void setUp() throws Exception {
+  @Override
+  protected void setUp() throws Exception {
     super.setUp();
     ((KafkaSchemaRegistry) restApp.schemaRegistry()).setRuleSetHandler(new RuleSetHandler() {
       public void handle(String subject, ConfigUpdateRequest request) {
@@ -300,10 +299,10 @@ public abstract class RestApiFieldEncryptionTest extends ClusterTestHarness {
       int expectedId, String subject)
       throws IOException, RestClientException {
     int registeredId = schemaRegistry.register(subject, schema);
-    assertEquals("Registering a new schema should succeed", expectedId, registeredId);
+    assertEquals(expectedId, registeredId, "Registering a new schema should succeed");
 
     ParsedSchema newSchema = schemaRegistry.getSchemaBySubjectAndId(subject, expectedId);
-    assertNotNull("Registered schema should be found", newSchema);
+    assertNotNull(newSchema, "Registered schema should be found");
   }
 }
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -115,8 +115,30 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${kafka.scala.version}</artifactId>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-server-common</artifactId>
+            <version>${kafka.version}</version>
             <classifier>test</classifier>
             <scope>test</scope>
         </dependency>

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
@@ -195,7 +195,6 @@ public abstract class ClusterTestHarness {
     props.setProperty("auto.create.topics.enable", "false");
     props.setProperty("message.max.bytes", String.valueOf(MAX_MESSAGE_SIZE));
 
-    props.setProperty("auto.create.topics.enable", "true");
     props.setProperty("num.partitions", "1");
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
@@ -192,9 +192,9 @@ public abstract class ClusterTestHarness {
   protected void injectProperties(Properties props) {
     // Make sure that broker only role is "broker"
     props.setProperty("process.roles", "broker");
-    props.setProperty("auto.create.topics.enable", "false");
     props.setProperty("message.max.bytes", String.valueOf(MAX_MESSAGE_SIZE));
 
+    props.setProperty("auto.create.topics.enable", "true");
     props.setProperty("num.partitions", "1");
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
@@ -344,14 +344,18 @@ public abstract class ClusterTestHarness {
           p -> p == protocol).orElse(false);
 
       List<Tuple2<SecurityProtocol, Integer>> protocolAndPorts = new ArrayList<>();
-      if (enablePlaintext || shouldEnable.apply(SecurityProtocol.PLAINTEXT))
+      if (enablePlaintext || shouldEnable.apply(SecurityProtocol.PLAINTEXT)) {
         protocolAndPorts.add(new Tuple2<>(SecurityProtocol.PLAINTEXT, port));
-      if (enableSsl || shouldEnable.apply(SecurityProtocol.SSL))
+      }
+      if (enableSsl || shouldEnable.apply(SecurityProtocol.SSL)) {
         protocolAndPorts.add(new Tuple2<>(SecurityProtocol.SSL, sslPort));
-      if (enableSaslPlaintext || shouldEnable.apply(SecurityProtocol.SASL_PLAINTEXT))
+      }
+      if (enableSaslPlaintext || shouldEnable.apply(SecurityProtocol.SASL_PLAINTEXT)) {
         protocolAndPorts.add(new Tuple2<>(SecurityProtocol.SASL_PLAINTEXT, saslPlaintextPort));
-      if (enableSaslSsl || shouldEnable.apply(SecurityProtocol.SASL_SSL))
+      }
+      if (enableSaslSsl || shouldEnable.apply(SecurityProtocol.SASL_SSL)) {
         protocolAndPorts.add(new Tuple2<>(SecurityProtocol.SASL_SSL, saslSslPort));
+      }
 
       String listeners = protocolAndPorts.stream()
           .map(p -> p._1.name() + "://localhost:" + p._2)
@@ -391,23 +395,25 @@ public abstract class ClusterTestHarness {
       props.put(CleanerConfig.LOG_CLEANER_DEDUPE_BUFFER_SIZE_PROP, "2097152");
       props.put(GroupCoordinatorConfig.OFFSETS_TOPIC_REPLICATION_FACTOR_CONFIG, "1");
       props.put(ServerLogConfigs.LOG_INITIAL_TASK_DELAY_MS_CONFIG, "100");
-      if (!props.containsKey(GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG))
-        ;
-      props.put(GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, "5");
-      if (!props.containsKey(GroupCoordinatorConfig.GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG))
-        ;
-      props.put(GroupCoordinatorConfig.GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, "0");
+      if (!props.containsKey(GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG)) {
+        props.put(GroupCoordinatorConfig.OFFSETS_TOPIC_PARTITIONS_CONFIG, "5");
+      }
+      if (!props.containsKey(GroupCoordinatorConfig.GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG)) {
+        props.put(GroupCoordinatorConfig.GROUP_INITIAL_REBALANCE_DELAY_MS_CONFIG, "0");
+      }
       rack.ifPresent(r -> props.put(ServerConfigs.BROKER_RACK_CONFIG, r));
       // Reduce number of threads per broker
       props.put(SocketServerConfigs.NUM_NETWORK_THREADS_CONFIG, "2");
       props.put(ServerConfigs.BACKGROUND_THREADS_CONFIG, "2");
 
-      if (protocolAndPorts.stream().anyMatch(p -> usesSslTransportLayer(p._1)))
+      if (protocolAndPorts.stream().anyMatch(p -> usesSslTransportLayer(p._1))) {
         props.putAll(sslConfigs(ConnectionMode.SERVER, false, trustStoreFile,
             "server" + nodeId));
+      }
 
-      if (protocolAndPorts.stream().anyMatch(p -> usesSaslAuthentication(p._1)))
+      if (protocolAndPorts.stream().anyMatch(p -> usesSaslAuthentication(p._1))) {
         props.putAll(saslConfigs(saslProperties));
+      }
 
       interBrokerSecurityProtocol.ifPresent(protocol ->
           props.put(ReplicationConfigs.INTER_BROKER_SECURITY_PROTOCOL_CONFIG, protocol.name)
@@ -456,7 +462,7 @@ public abstract class ClusterTestHarness {
   }
 
   public static Properties sslConfigs(ConnectionMode mode, boolean clientCert, Optional<File> trustStoreFile, String certAlias, String certCn, String tlsProtocol) throws Exception {
-    File trustStore = (File)trustStoreFile.orElseThrow(() -> new Exception("SSL enabled but no trustStoreFile provided"));
+    File trustStore = trustStoreFile.orElseThrow(() -> new Exception("SSL enabled but no trustStoreFile provided"));
     Properties sslProps = new Properties();
     sslProps.putAll((new TestSslUtils.SslConfigsBuilder(mode)).useClientCert(clientCert).createNewTrustStore(trustStore).certAlias(certAlias).cn(certCn).tlsProtocol(tlsProtocol).build());
     return sslProps;
@@ -465,7 +471,7 @@ public abstract class ClusterTestHarness {
   private static final boolean IS_IBM_SECURITY = Java.isIbmJdk() && !Java.isIbmJdkSemeru();
 
   public static Properties saslConfigs(Optional<Properties> saslProperties) {
-    Properties result = (Properties)saslProperties.orElse(new Properties());
+    Properties result = saslProperties.orElse(new Properties());
     if (IS_IBM_SECURITY && !result.containsKey("sasl.kerberos.service.name")) {
       result.put("sasl.kerberos.service.name", "kafka");
     }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/LeaderElectorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/LeaderElectorTest.java
@@ -30,7 +30,7 @@ import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.storage.Mode;
 import io.confluent.kafka.schemaregistry.utils.TestUtils;
 import io.confluent.kafka.schemaregistry.storage.SchemaRegistryIdentity;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static io.confluent.kafka.schemaregistry.CompatibilityLevel.FORWARD;
@@ -275,7 +275,7 @@ public class LeaderElectorTest extends ClusterTestHarness {
 
 
   @Test
-  @Ignore("Temporarily disabled since seems flakey with KRaft")
+  @Disabled("Temporarily disabled since seems flakey with KRaft")
   /**
    * Trigger reelection with both a leader cluster and follower cluster present.
    * Ensure that nodes in follower cluster are never elected leader.

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/LeaderElectorTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/LeaderElectorTest.java
@@ -30,6 +30,7 @@ import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.storage.Mode;
 import io.confluent.kafka.schemaregistry.utils.TestUtils;
 import io.confluent.kafka.schemaregistry.storage.SchemaRegistryIdentity;
+import org.junit.Ignore;
 import org.junit.jupiter.api.Test;
 
 import static io.confluent.kafka.schemaregistry.CompatibilityLevel.FORWARD;
@@ -274,6 +275,7 @@ public class LeaderElectorTest extends ClusterTestHarness {
 
 
   @Test
+  @Ignore("Temporarily disabled since seems flakey with KRaft")
   /**
    * Trigger reelection with both a leader cluster and follower cluster present.
    * Ensure that nodes in follower cluster are never elected leader.

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/RestApp.java
@@ -57,9 +57,6 @@ public class RestApp {
       prop.putAll(schemaRegistryProps);
     }
     prop.setProperty(SchemaRegistryConfig.PORT_CONFIG, ((Integer) port).toString());
-    if (zkConnect != null) {
-      prop.setProperty(SchemaRegistryConfig.KAFKASTORE_CONNECTION_URL_CONFIG, zkConnect);
-    }
     if (bootstrapBrokers != null) {
       prop.setProperty(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, bootstrapBrokers);
     }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/SASLClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/SASLClusterTestHarness.java
@@ -97,14 +97,14 @@ public class SASLClusterTestHarness extends ClusterTestHarness {
 
   @Override
   protected KafkaConfig getKafkaConfig(int brokerId) {
-    final Option<File> trustStoreFileOption = scala.Option.apply(null);
-    final Option<SecurityProtocol> saslInterBrokerSecurityProtocol =
-            scala.Option.apply(SecurityProtocol.SASL_PLAINTEXT);
-    Properties props = TestUtils.createBrokerConfig(
+    final Optional<File> trustStoreFileOption = Optional.empty();
+    final Optional<SecurityProtocol> saslInterBrokerSecurityProtocol =
+            Optional.of(SecurityProtocol.SASL_PLAINTEXT);
+    Properties props = createBrokerConfig(
             brokerId, false, false, TestUtils.RandomPort(), saslInterBrokerSecurityProtocol,
             trustStoreFileOption, EMPTY_SASL_PROPERTIES, false, true, TestUtils.RandomPort(),
             false, TestUtils.RandomPort(),
-            false, TestUtils.RandomPort(), Option.<String>empty(), 1, false, 1, (short) 1, false);
+            false, TestUtils.RandomPort(), Optional.empty(), false, 1, (short) 1, false);
 
     injectProperties(props);
     props.setProperty("sasl.mechanism.inter.broker.protocol", "GSSAPI");

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/SASLClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/SASLClusterTestHarness.java
@@ -22,8 +22,7 @@ import kafka.utils.TestUtils;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.security.authenticator.LoginManager;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;
@@ -52,13 +51,12 @@ public class SASLClusterTestHarness extends ClusterTestHarness {
   }
 
   @Override
-  protected SecurityProtocol getSecurityProtocol() {
+  protected SecurityProtocol getBrokerSecurityProtocol() {
     return SecurityProtocol.SASL_PLAINTEXT;
   }
 
-  @Before
   @Override
-  public void setUp() throws Exception {
+  protected void setUp() throws Exception {
     // Important if tests leak consumers, producers or brokers.
     LoginManager.closeAll();
 
@@ -103,20 +101,19 @@ public class SASLClusterTestHarness extends ClusterTestHarness {
     final Option<SecurityProtocol> saslInterBrokerSecurityProtocol =
             scala.Option.apply(SecurityProtocol.SASL_PLAINTEXT);
     Properties props = TestUtils.createBrokerConfig(
-            brokerId, zkConnect, false, false, TestUtils.RandomPort(), saslInterBrokerSecurityProtocol,
+            brokerId, false, false, TestUtils.RandomPort(), saslInterBrokerSecurityProtocol,
             trustStoreFileOption, EMPTY_SASL_PROPERTIES, false, true, TestUtils.RandomPort(),
             false, TestUtils.RandomPort(),
             false, TestUtils.RandomPort(), Option.<String>empty(), 1, false, 1, (short) 1, false);
 
     injectProperties(props);
-    props.setProperty("zookeeper.connection.timeout.ms", "30000");
     props.setProperty("sasl.mechanism.inter.broker.protocol", "GSSAPI");
     props.setProperty(BrokerSecurityConfigs.SASL_ENABLED_MECHANISMS_CONFIG, "GSSAPI");
 
     return KafkaConfig.fromProps(props);
   }
 
-  @After
+  @AfterEach
   @Override
   public void tearDown() throws Exception {
     if (kdc != null) {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/SSLClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/SSLClusterTestHarness.java
@@ -34,7 +34,7 @@ public class SSLClusterTestHarness extends ClusterTestHarness {
   }
 
   @Override
-  protected SecurityProtocol getSecurityProtocol() {
+  protected SecurityProtocol getBrokerSecurityProtocol() {
     return SecurityProtocol.SSL;
   }
 
@@ -49,7 +49,7 @@ public class SSLClusterTestHarness extends ClusterTestHarness {
     final Option<File> trustStoreFileOption = scala.Option.apply(trustStoreFile);
     final Option<SecurityProtocol> sslInterBrokerSecurityProtocol = scala.Option.apply(SecurityProtocol.SSL);
     Properties props = TestUtils.createBrokerConfig(
-            brokerId, zkConnect, false, false, TestUtils.RandomPort(), sslInterBrokerSecurityProtocol,
+            brokerId, false, false, TestUtils.RandomPort(), sslInterBrokerSecurityProtocol,
             trustStoreFileOption, EMPTY_SASL_PROPERTIES, false, false, TestUtils.RandomPort(),
             true, TestUtils.RandomPort(), false, TestUtils.RandomPort(), Option.empty(), 1, false,
             1, (short) 1, false);

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/SSLClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/SSLClusterTestHarness.java
@@ -14,6 +14,7 @@
  */
 package io.confluent.kafka.schemaregistry;
 
+import java.util.Optional;
 import kafka.server.KafkaConfig;
 import kafka.utils.TestUtils;
 import org.apache.kafka.common.network.ConnectionMode;
@@ -46,12 +47,12 @@ public class SSLClusterTestHarness extends ClusterTestHarness {
     } catch (IOException ioe) {
       throw new RuntimeException("Unable to create temporary file for the truststore.");
     }
-    final Option<File> trustStoreFileOption = scala.Option.apply(trustStoreFile);
-    final Option<SecurityProtocol> sslInterBrokerSecurityProtocol = scala.Option.apply(SecurityProtocol.SSL);
-    Properties props = TestUtils.createBrokerConfig(
+    final Optional<File> trustStoreFileOption = Optional.of(trustStoreFile);
+    final Optional<SecurityProtocol> sslInterBrokerSecurityProtocol = Optional.of(SecurityProtocol.SSL);
+    Properties props = createBrokerConfig(
             brokerId, false, false, TestUtils.RandomPort(), sslInterBrokerSecurityProtocol,
             trustStoreFileOption, EMPTY_SASL_PROPERTIES, false, false, TestUtils.RandomPort(),
-            true, TestUtils.RandomPort(), false, TestUtils.RandomPort(), Option.empty(), 1, false,
+            true, TestUtils.RandomPort(), false, TestUtils.RandomPort(), Optional.empty(), false,
             1, (short) 1, false);
 
     // setup client SSL. Needs to happen before the broker is initialized, because the client's cert

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
@@ -32,7 +32,7 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 import java.util.ArrayList;
@@ -42,6 +42,7 @@ import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 
 import static io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig.CONTEXT_NAME_STRATEGY;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThrows;
 
 public class CachedSchemaRegistryClientTest extends ClusterTestHarness {
 
@@ -275,22 +276,24 @@ public class CachedSchemaRegistryClientTest extends ClusterTestHarness {
     assertArrayEquals(objects, recordList.toArray());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testAvroNewProducerUsingInvalidContextStrategy() {
-    String topic = "testAvro";
-    IndexedRecord avroRecord = createAvroRecord();
-    Object[] objects = new Object[]
-        {avroRecord, true, 130, 345L, 1.23f, 2.34d, "abc", "def".getBytes()};
-    Properties producerProps = createNewProducerProps();
-    producerProps.put(CONTEXT_NAME_STRATEGY, InvalidContextNameStrategy.class.getName());
-    KafkaProducer producer = createNewProducer(producerProps);
-    newProduce(producer, topic, objects);
+    assertThrows(IllegalArgumentException.class, () -> {
+      String topic = "testAvro";
+      IndexedRecord avroRecord = createAvroRecord();
+      Object[] objects = new Object[]
+          {avroRecord, true, 130, 345L, 1.23f, 2.34d, "abc", "def".getBytes()};
+      Properties producerProps = createNewProducerProps();
+      producerProps.put(CONTEXT_NAME_STRATEGY, InvalidContextNameStrategy.class.getName());
+      KafkaProducer producer = createNewProducer(producerProps);
+      newProduce(producer, topic, objects);
 
-    Properties consumerProps = createConsumerProps();
-    consumerProps.put(CONTEXT_NAME_STRATEGY, InvalidContextNameStrategy.class.getName());
-    Consumer<String, Object> consumer = createConsumer(consumerProps);
-    ArrayList<Object> recordList = consume(consumer, topic, objects.length);
-    assertArrayEquals(objects, recordList.toArray());
+      Properties consumerProps = createConsumerProps();
+      consumerProps.put(CONTEXT_NAME_STRATEGY, InvalidContextNameStrategy.class.getName());
+      Consumer<String, Object> consumer = createConsumer(consumerProps);
+      ArrayList<Object> recordList = consume(consumer, topic, objects.length);
+      assertArrayEquals(objects, recordList.toArray());
+    });
   }
 
   public static class CustomContextNameStrategy implements ContextNameStrategy {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClientTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClientTest.java
@@ -35,14 +35,14 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Properties;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class MockSchemaRegistryClientTest extends ClusterTestHarness {
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/metrics/CustomSchemaProviderMetricTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/metrics/CustomSchemaProviderMetricTest.java
@@ -21,7 +21,6 @@ import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
-import org.junit.Test;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -29,9 +28,10 @@ import java.lang.management.ManagementFactory;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import org.junit.jupiter.api.Test;
 
 import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_NAME_CUSTOM_SCHEMA_PROVIDER;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CustomSchemaProviderMetricTest extends ClusterTestHarness {
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/metrics/MetricsTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/metrics/MetricsTest.java
@@ -19,12 +19,12 @@ import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.utils.TestUtils;
-import org.junit.Test;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
 import java.util.List;
+import org.junit.jupiter.api.Test;
 
 import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_NAME_API_FAILURE_COUNT;
 import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_NAME_API_SUCCESS_COUNT;
@@ -33,17 +33,12 @@ import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_
 import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_NAME_DELETED_COUNT;
 import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_NAME_MASTER_SLAVE_ROLE;
 import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_NAME_REGISTERED_COUNT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class MetricsTest extends ClusterTestHarness {
 
   public MetricsTest() { super(1, true); }
-
-  @Override
-  public void setUp() throws Exception {
-    super.setUp();
-  }
 
   @Test
   public void testLeaderFollowerMetric() throws Exception {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/MutableHttpServletRequestTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/MutableHttpServletRequestTest.java
@@ -64,8 +64,6 @@ public class MutableHttpServletRequestTest {
     List<String> headerNamesList;
 
     // Mock no header return values from HttpServletRequest
-    when(httpServletRequest.getHeader("header-key-0")).thenReturn(null);
-    when(httpServletRequest.getHeaders("header-key-0")).thenReturn(Collections.emptyEnumeration());
     when(httpServletRequest.getHeaderNames()).thenReturn(Collections.emptyEnumeration());
 
     // Add a "header-key-0" header

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RequestHeaderHandlerTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RequestHeaderHandlerTest.java
@@ -140,7 +140,6 @@ public class RequestHeaderHandlerTest {
 
     // Not forwarded request
     when(request.getHeader(X_FORWARD_HEADER)).thenReturn("true");
-    when(request.getRemoteAddr()).thenReturn("should_not_use");
     requestHeaderHandler.addXForwardedForToRequest(mutableRequest, request);
     callerIp = mutableRequest.getHeader(RequestHeaderHandler.X_FORWARDED_FOR_HEADER);
     Assert.assertEquals("127.0.0.1", callerIp);

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiCompatibilityTest.java
@@ -42,14 +42,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.avro.SchemaCompatibility.SchemaIncompatibilityType.READER_FIELD_MISSING_DEFAULT_VALUE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class RestApiCompatibilityTest extends ClusterTestHarness {
 
@@ -57,8 +56,8 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     super(1, true, CompatibilityLevel.BACKWARD.name);
   }
 
-  @Before
-  public void setUp() throws Exception {
+  @Override
+  protected void setUp() throws Exception {
     super.setUp();
     ((KafkaSchemaRegistry) restApp.schemaRegistry()).setRuleSetHandler(new RuleSetHandler() {
       public void handle(String subject, ConfigUpdateRequest request) {
@@ -85,9 +84,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + "\"fields\":"
         + "[{\"type\":\"string\",\"name\":\"f1\"}]}").canonicalString();
     int expectedIdSchema1 = 1;
-    assertEquals("Registering should succeed",
-            expectedIdSchema1,
-            restApp.restClient.registerSchema(schemaString1, subject));
+    assertEquals(
+        expectedIdSchema1,
+        restApp.restClient.registerSchema(schemaString1, subject),
+        "Registering should succeed"
+    );
 
     // register an incompatible avro
     String incompatibleSchemaString = AvroUtils.parseSchema("{\"type\":\"record\","
@@ -100,11 +101,15 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
       fail("Registering an incompatible schema should fail");
     } catch (RestClientException e) {
       // this is expected.
-      assertEquals("Should get a conflict status",
-                   RestIncompatibleSchemaException.DEFAULT_ERROR_CODE,
-                   e.getStatus());
-      assertTrue("Verifying error message verbosity",
-              e.getMessage().contains(READER_FIELD_MISSING_DEFAULT_VALUE.toString()));
+      assertEquals(
+          RestIncompatibleSchemaException.DEFAULT_ERROR_CODE,
+          e.getStatus(),
+          "Should get a conflict status"
+      );
+      assertTrue(
+          e.getMessage().contains(READER_FIELD_MISSING_DEFAULT_VALUE.toString()),
+          "Verifying error message verbosity"
+      );
     }
 
     // register a non-avro
@@ -114,9 +119,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
       fail("Registering a non-avro schema should fail");
     } catch (RestClientException e) {
       // this is expected.
-      assertEquals("Should get a bad request status",
-                   RestInvalidSchemaException.ERROR_CODE,
-                   e.getErrorCode());
+      assertEquals(
+          RestInvalidSchemaException.ERROR_CODE,
+          e.getErrorCode(),
+          "Should get a bad request status"
+      );
     }
 
     // register a backward compatible avro
@@ -126,9 +133,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + "[{\"type\":\"string\",\"name\":\"f1\"},"
         + " {\"type\":\"string\",\"name\":\"f2\", \"default\": \"foo\"}]}").canonicalString();
     int expectedIdSchema2 = 2;
-    assertEquals("Registering a compatible schema should succeed",
-                 expectedIdSchema2,
-                 restApp.restClient.registerSchema(schemaString2, subject));
+    assertEquals(
+        expectedIdSchema2,
+        restApp.restClient.registerSchema(schemaString2, subject),
+        "Registering a compatible schema should succeed"
+    );
   }
 
   @Test
@@ -141,9 +150,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + "\"fields\":"
         + "[{\"type\":\"string\",\"name\":\"f1\"}]}").canonicalString();
     int expectedIdSchema1 = 1;
-    assertEquals("Registering should succeed",
-            expectedIdSchema1,
-            restApp.restClient.registerSchema(schemaString1, subject));
+    assertEquals(
+        expectedIdSchema1,
+        restApp.restClient.registerSchema(schemaString1, subject),
+        "Registering should succeed"
+    );
 
     // register an incompatible avro
     String incompatibleSchemaString = AvroUtils.parseSchema("{\"type\":\"record\","
@@ -156,17 +167,21 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
       fail("Registering an incompatible schema should fail");
     } catch (RestClientException e) {
       // this is expected.
-      assertEquals("Should get a conflict status",
-                   RestIncompatibleSchemaException.DEFAULT_ERROR_CODE,
-                   e.getStatus());
+      assertEquals(
+          RestIncompatibleSchemaException.DEFAULT_ERROR_CODE,
+          e.getStatus(),
+          "Should get a conflict status"
+      );
     }
 
     // change compatibility level to none and try again
-    assertEquals("Changing compatibility level should succeed",
-            CompatibilityLevel.NONE.name,
-            restApp.restClient
-                    .updateCompatibility(CompatibilityLevel.NONE.name, null)
-                    .getCompatibilityLevel());
+    assertEquals(
+        CompatibilityLevel.NONE.name,
+        restApp.restClient
+            .updateCompatibility(CompatibilityLevel.NONE.name, null)
+            .getCompatibilityLevel(),
+        "Changing compatibility level should succeed"
+    );
 
     try {
       restApp.restClient.registerSchema(incompatibleSchemaString, subject);
@@ -185,24 +200,32 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + "\"fields\":"
         + "[{\"type\":\"string\",\"name\":\"f1\"}]}").canonicalString();
     int expectedIdSchema1 = 1;
-    assertEquals("Registering should succeed",
-            expectedIdSchema1,
-            restApp.restClient.registerSchema(schemaString1, subject));
+    assertEquals(
+        expectedIdSchema1,
+        restApp.restClient.registerSchema(schemaString1, subject),
+        "Registering should succeed"
+    );
     // verify that default compatibility level is backward
-    assertEquals("Default compatibility level should be backward",
-            new Config(CompatibilityLevel.BACKWARD.name),
-            restApp.restClient.getConfig(null));
+    assertEquals(
+        new Config(CompatibilityLevel.BACKWARD.name),
+        restApp.restClient.getConfig(null),
+        "Default compatibility level should be backward"
+    );
     // change it to forward
-    assertEquals("Changing compatibility level should succeed",
-            CompatibilityLevel.FORWARD.name,
-            restApp.restClient
-                    .updateCompatibility(CompatibilityLevel.FORWARD.name, null)
-                    .getCompatibilityLevel());
+    assertEquals(
+        CompatibilityLevel.FORWARD.name,
+        restApp.restClient
+            .updateCompatibility(CompatibilityLevel.FORWARD.name, null)
+            .getCompatibilityLevel(),
+        "Changing compatibility level should succeed"
+    );
 
     // verify that new compatibility level is forward
-    assertEquals("New compatibility level should be forward",
-            new Config(CompatibilityLevel.FORWARD.name),
-            restApp.restClient.getConfig(null));
+    assertEquals(
+        new Config(CompatibilityLevel.FORWARD.name),
+        restApp.restClient.getConfig(null),
+        "New compatibility level should be forward"
+    );
 
     // register schema that is forward compatible with schemaString1
     String schemaString2 = AvroUtils.parseSchema("{\"type\":\"record\","
@@ -211,36 +234,44 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + "[{\"type\":\"string\",\"name\":\"f1\"},"
         + " {\"type\":\"string\",\"name\":\"f2\"}]}").canonicalString();
     int expectedIdSchema2 = 2;
-    assertEquals("Registering should succeed",
-                 expectedIdSchema2,
-                 restApp.restClient.registerSchema(schemaString2, subject));
+    assertEquals(
+        expectedIdSchema2,
+        restApp.restClient.registerSchema(schemaString2, subject),
+        "Registering should succeed"
+    );
 
     // change compatibility to backward
-    assertEquals("Changing compatibility level should succeed",
-            CompatibilityLevel.BACKWARD.name,
-            restApp.restClient.updateCompatibility(CompatibilityLevel.BACKWARD.name,
-                    null).getCompatibilityLevel());
+    assertEquals(
+         CompatibilityLevel.BACKWARD.name,
+         restApp.restClient.updateCompatibility(CompatibilityLevel.BACKWARD.name,
+             null).getCompatibilityLevel(),
+        "Changing compatibility level should succeed"
+    );
 
     // verify that new compatibility level is backward
-    assertEquals("Updated compatibility level should be backward",
-            new Config(CompatibilityLevel.BACKWARD.name),
-            restApp.restClient.getConfig(null));
+    assertEquals(
+        new Config(CompatibilityLevel.BACKWARD.name),
+        restApp.restClient.getConfig(null),
+        "Updated compatibility level should be backward"
+    );
 
-            // register forward compatible schema, which should fail
-            String schemaString3 = AvroUtils.parseSchema("{\"type\":\"record\","
-                + "\"name\":\"myrecord\","
-                + "\"fields\":"
-                + "[{\"type\":\"string\",\"name\":\"f1\"},"
-                + " {\"type\":\"string\",\"name\":\"f2\"},"
-                + " {\"type\":\"string\",\"name\":\"f3\"}]}").canonicalString();
+    // register forward compatible schema, which should fail
+    String schemaString3 = AvroUtils.parseSchema("{\"type\":\"record\","
+        + "\"name\":\"myrecord\","
+        + "\"fields\":"
+        + "[{\"type\":\"string\",\"name\":\"f1\"},"
+        + " {\"type\":\"string\",\"name\":\"f2\"},"
+        + " {\"type\":\"string\",\"name\":\"f3\"}]}").canonicalString();
     try {
       restApp.restClient.registerSchema(schemaString3, subject);
       fail("Registering a forward compatible schema should fail");
     } catch (RestClientException e) {
       // this is expected.
-      assertEquals("Should get a conflict status",
-                   RestIncompatibleSchemaException.DEFAULT_ERROR_CODE,
-                   e.getStatus());
+      assertEquals(
+          RestIncompatibleSchemaException.DEFAULT_ERROR_CODE,
+          e.getStatus(),
+          "Should get a conflict status"
+      );
     }
 
     // now try registering a backward compatible schema (add a field with a default)
@@ -251,9 +282,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + " {\"type\":\"string\",\"name\":\"f2\"},"
         + " {\"type\":\"string\",\"name\":\"f3\", \"default\": \"foo\"}]}").canonicalString();
     int expectedIdSchema4 = 3;
-    assertEquals("Registering should succeed with backwards compatible schema",
-            expectedIdSchema4,
-            restApp.restClient.registerSchema(schemaString4, subject));
+    assertEquals(
+        expectedIdSchema4,
+        restApp.restClient.registerSchema(schemaString4, subject),
+        "Registering should succeed with backwards compatible schema"
+    );
   }
 
   @Test
@@ -269,9 +302,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     config.setCompatibilityGroup("application.version");
     config.setValidateFields(false);
     // add compatibility group
-    assertEquals("Adding compatibility group should succeed",
+    assertEquals(
         config,
-        restApp.restClient.updateConfig(config, null));
+        restApp.restClient.updateConfig(config, null),
+        "Adding compatibility group should succeed"
+    );
 
     Map<String, String> properties = new HashMap<>();
     properties.put("application.version", "1");
@@ -279,13 +314,17 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     RegisterSchemaRequest request1 = new RegisterSchemaRequest(schema1);
     request1.setMetadata(metadata1);
     int expectedIdSchema1 = 1;
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(request1, subject, false).getId());
+        restApp.restClient.registerSchema(request1, subject, false).getId(),
+        "Registering should succeed"
+    );
     // verify that default compatibility level is backward
-    assertEquals("Default compatibility level should be backward",
+    assertEquals(
         CompatibilityLevel.BACKWARD.name,
-        restApp.restClient.getConfig(null).getCompatibilityLevel());
+        restApp.restClient.getConfig(null).getCompatibilityLevel(),
+        "Default compatibility level should be backward"
+    );
 
     // register forward compatible schema, which should fail
     ParsedSchema schema2 = AvroUtils.parseSchema("{\"type\":\"record\","
@@ -299,9 +338,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
       fail("Registering a forward compatible schema should fail");
     } catch (RestClientException e) {
       // this is expected.
-      assertEquals("Should get a conflict status",
+      assertEquals(
           RestIncompatibleSchemaException.DEFAULT_ERROR_CODE,
-          e.getStatus());
+          e.getStatus(),
+          "Should get a conflict status"
+      );
     }
 
     // now try registering a forward compatible schema in a different compatibility group
@@ -310,9 +351,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     Metadata metadata2 = new Metadata(null, properties, null);
     request2.setMetadata(metadata2);
     int expectedIdSchema2 = 2;
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema2,
-        restApp.restClient.registerSchema(request2, subject, false).getId());
+        restApp.restClient.registerSchema(request2, subject, false).getId(),
+        "Registering should succeed"
+    );
   }
 
 
@@ -330,13 +373,17 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     RegisterSchemaRequest request1 = new RegisterSchemaRequest(schema1);
     request1.setMetadata(metadata1);
     int expectedIdSchema1 = 1;
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(request1, subject, false).getId());
+        restApp.restClient.registerSchema(request1, subject, false).getId(),
+        "Registering should succeed"
+    );
     // verify that default compatibility level is backward
-    assertEquals("Default compatibility level should be backward",
+    assertEquals(
         CompatibilityLevel.BACKWARD.name,
-        restApp.restClient.getConfig(null).getCompatibilityLevel());
+        restApp.restClient.getConfig(null).getCompatibilityLevel(),
+        "Default compatibility level should be backward"
+    );
 
     // register forward compatible schema, which should fail
     ParsedSchema schema2 = AvroUtils.parseSchema("{\"type\":\"record\","
@@ -350,9 +397,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
       fail("Registering a forward compatible schema should fail");
     } catch (RestClientException e) {
       // this is expected.
-      assertEquals("Should get a conflict status",
+      assertEquals(
           RestIncompatibleSchemaException.DEFAULT_ERROR_CODE,
-          e.getStatus());
+          e.getStatus(),
+          "Should get a conflict status"
+      );
     }
 
     // Add compatibility group after first schema already registered
@@ -360,9 +409,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     config.setCompatibilityGroup("application.version");
     config.setValidateFields(false);
     // add compatibility group
-    assertEquals("Adding compatibility group should succeed",
+    assertEquals(
         config,
-        restApp.restClient.updateConfig(config, null));
+        restApp.restClient.updateConfig(config, null),
+        "Adding compatibility group should succeed"
+    );
 
     // now try registering a forward compatible schema in a different compatibility group
     properties = new HashMap<>();
@@ -370,9 +421,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     Metadata metadata2 = new Metadata(null, properties, null);
     request2.setMetadata(metadata2);
     int expectedIdSchema2 = 2;
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema2,
-        restApp.restClient.registerSchema(request2, subject, false).getId());
+        restApp.restClient.registerSchema(request2, subject, false).getId(),
+        "Registering should succeed"
+    );
 
     ParsedSchema schema3 = AvroUtils.parseSchema("{\"type\":\"record\","
         + "\"name\":\"myrecord\","
@@ -385,9 +438,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     RegisterSchemaRequest request3 = new RegisterSchemaRequest(schema3);
     request3.setMetadata(metadata3);
     int expectedIdSchema3 = 3;
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema3,
-        restApp.restClient.registerSchema(request3, subject, false).getId());
+        restApp.restClient.registerSchema(request3, subject, false).getId(),
+        "Registering should succeed"
+    );
   }
 
   @Test
@@ -406,9 +461,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     config.setDefaultMetadata(metadata);
     config.setValidateFields(false);
     // add config metadata
-    assertEquals("Adding config with initial metadata should succeed",
+    assertEquals(
         config,
-        restApp.restClient.updateConfig(config, null));
+        restApp.restClient.updateConfig(config, null),
+        "Adding config with initial metadata should succeed"
+    );
 
     properties = new HashMap<>();
     properties.put("subjectKey", "subjectValue");
@@ -417,35 +474,45 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     request1.setMetadata(metadata1);
     int expectedIdSchema1 = 1;
     RegisterSchemaResponse response = restApp.restClient.registerSchema(request1, subject, false);
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema1,
-        response.getId());
+        response.getId(),
+        "Registering should succeed"
+    );
     Metadata metadata2 = response.getMetadata();
     assertEquals("configValue", metadata2.getProperties().get("configKey"));
     assertEquals("subjectValue", metadata2.getProperties().get("subjectKey"));
 
-    assertEquals("Version should match",
+    assertEquals(
         response.getVersion(),
         restApp.restClient.lookUpSubjectVersion(
             new RegisterSchemaRequest(
-                new Schema(subject, response)), subject, false, false).getVersion());
+                new Schema(subject, response)), subject, false, false).getVersion(),
+        "Version should match"
+    );
 
     // verify that default compatibility level is backward
-    assertEquals("Default compatibility level should be backward",
+    assertEquals(
         CompatibilityLevel.BACKWARD.name,
-        restApp.restClient.getConfig(null).getCompatibilityLevel());
+        restApp.restClient.getConfig(null).getCompatibilityLevel(),
+        "Default compatibility level should be backward"
+    );
 
     // change it to forward
-    assertEquals("Changing compatibility level should succeed",
+    assertEquals(
         CompatibilityLevel.FORWARD.name,
         restApp.restClient
             .updateCompatibility(CompatibilityLevel.FORWARD.name, null)
-            .getCompatibilityLevel());
+            .getCompatibilityLevel(),
+        "Changing compatibility level should succeed"
+    );
 
     // verify that new compatibility level is forward
-    assertEquals("New compatibility level should be forward",
+    assertEquals(
         CompatibilityLevel.FORWARD.name,
-        restApp.restClient.getConfig(null).getCompatibilityLevel());
+        restApp.restClient.getConfig(null).getCompatibilityLevel(),
+        "New compatibility level should be forward"
+    );
 
     // register forward compatible schema
     ParsedSchema schema2 = AvroUtils.parseSchema("{\"type\":\"record\","
@@ -456,18 +523,22 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     RegisterSchemaRequest request2 = new RegisterSchemaRequest(schema2);
     int expectedIdSchema2 = 2;
     response = restApp.restClient.registerSchema(request2, subject, false);
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema2,
-        response.getId());
+        response.getId(),
+        "Registering should succeed"
+    );
     metadata2 = response.getMetadata();
     assertEquals("configValue", metadata2.getProperties().get("configKey"));
     assertEquals("subjectValue", metadata2.getProperties().get("subjectKey"));
 
-    assertEquals("Version should match",
+    assertEquals(
         response.getVersion(),
         restApp.restClient.lookUpSubjectVersion(
             new RegisterSchemaRequest(
-                new Schema(subject, response)), subject, false, false).getVersion());
+                new Schema(subject, response)), subject, false, false).getVersion(),
+        "Version should match"
+    );
 
     SchemaString schemaString = restApp.restClient.getId(expectedIdSchema2, subject);
     metadata2 = schemaString.getMetadata();
@@ -476,9 +547,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
 
     // re-register
     response = restApp.restClient.registerSchema(request2, subject, false);
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema2,
-        response.getId());
+        response.getId(),
+        "Registering should succeed"
+    );
     metadata2 = response.getMetadata();
     assertEquals("configValue", metadata2.getProperties().get("configKey"));
     assertEquals("subjectValue", metadata2.getProperties().get("subjectKey"));
@@ -497,19 +570,23 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     request3.setMetadata(metadata3);
     int expectedIdSchema3 = 3;
     response = restApp.restClient.registerSchema(request3, subject, false);
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema3,
-        response.getId());
+        response.getId(),
+        "Registering should succeed"
+    );
     Metadata metadata4 = response.getMetadata();
     assertEquals("configValue", metadata4.getProperties().get("configKey"));
     assertNull(metadata4.getProperties().get("subjectKey"));
     assertEquals("newSubjectValue", metadata4.getProperties().get("newSubjectKey"));
 
-    assertEquals("Version should match",
+    assertEquals(
         response.getVersion(),
         restApp.restClient.lookUpSubjectVersion(
             new RegisterSchemaRequest(
-                new Schema(subject, response)), subject, false, false).getVersion());
+                new Schema(subject, response)), subject, false, false).getVersion(),
+        "Version should match"
+    );
 
     schemaString = restApp.restClient.getId(expectedIdSchema3, subject);
     metadata4 = schemaString.getMetadata();
@@ -534,9 +611,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     config.setDefaultRuleSet(ruleSet);
     config.setValidateFields(false);
     // add config ruleSet
-    assertEquals("Adding config with initial ruleSet should succeed",
+    assertEquals(
         config,
-        restApp.restClient.updateConfig(config, null));
+        restApp.restClient.updateConfig(config, null),
+        "Adding config with initial ruleSet should succeed"
+    );
 
     Rule r2 = new Rule("bar", null, null, RuleMode.UPGRADE, "type1", null, null, null, null, null, false);
     rules = Collections.singletonList(r2);
@@ -545,19 +624,22 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     request1.setRuleSet(ruleSet);
     int expectedIdSchema1 = 1;
     RegisterSchemaResponse response = restApp.restClient.registerSchema(request1, subject, false);
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema1,
-        response.getId());
+        response.getId(),
+        "Registering should succeed"
+    );
     RuleSet ruleSet2 = response.getRuleSet();
     assertEquals("foo", ruleSet2.getMigrationRules().get(0).getName());
     assertEquals("bar", ruleSet2.getMigrationRules().get(1).getName());
 
-    assertEquals("Version should match",
+    assertEquals(
         response.getVersion(),
         restApp.restClient.lookUpSubjectVersion(
             new RegisterSchemaRequest(
-                new Schema(subject, response)), subject, false, false).getVersion());
-
+                new Schema(subject, response)), subject, false, false).getVersion(),
+        "Version should match"
+    );
 
     List<Schema> schemas = restApp.restClient.getSchemas(
         RestService.DEFAULT_REQUEST_PROPERTIES, null, false, false, "type1", null, null);
@@ -567,21 +649,27 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     assertEquals(1, schemas.size());
 
     // verify that default compatibility level is backward
-    assertEquals("Default compatibility level should be backward",
+    assertEquals(
         CompatibilityLevel.BACKWARD.name,
-        restApp.restClient.getConfig(null).getCompatibilityLevel());
+        restApp.restClient.getConfig(null).getCompatibilityLevel(),
+        "Default compatibility level should be backward"
+    );
 
     // change it to forward
-    assertEquals("Changing compatibility level should succeed",
+    assertEquals(
         CompatibilityLevel.FORWARD.name,
         restApp.restClient
             .updateCompatibility(CompatibilityLevel.FORWARD.name, null)
-            .getCompatibilityLevel());
+            .getCompatibilityLevel(),
+        "Changing compatibility level should succeed"
+    );
 
     // verify that new compatibility level is forward
-    assertEquals("New compatibility level should be forward",
+    assertEquals(
         CompatibilityLevel.FORWARD.name,
-        restApp.restClient.getConfig(null).getCompatibilityLevel());
+        restApp.restClient.getConfig(null).getCompatibilityLevel(),
+        "New compatibility level should be forward"
+    );
 
     // register forward compatible schema
     ParsedSchema schema2 = AvroUtils.parseSchema("{\"type\":\"record\","
@@ -592,18 +680,22 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     RegisterSchemaRequest request2 = new RegisterSchemaRequest(schema2);
     int expectedIdSchema2 = 2;
     response = restApp.restClient.registerSchema(request2, subject, false);
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema2,
-        response.getId());
+        response.getId(),
+        "Registering should succeed"
+    );
     ruleSet2 = response.getRuleSet();
     assertEquals("foo", ruleSet2.getMigrationRules().get(0).getName());
     assertEquals("bar", ruleSet2.getMigrationRules().get(1).getName());
 
-    assertEquals("Version should match",
+    assertEquals(
         response.getVersion(),
         restApp.restClient.lookUpSubjectVersion(
             new RegisterSchemaRequest(
-                new Schema(subject, response)), subject, false, false).getVersion());
+                new Schema(subject, response)), subject, false, false).getVersion(),
+        "Version should match"
+    );
 
     SchemaString schemaString = restApp.restClient.getId(expectedIdSchema2, subject);
     ruleSet2 = schemaString.getRuleSet();
@@ -619,9 +711,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
 
     // re-register
     response = restApp.restClient.registerSchema(request2, subject, false);
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema2,
-        response.getId());
+        response.getId(),
+        "Registering should succeed"
+    );
     ruleSet2 = schemaString.getRuleSet();
     assertEquals("foo", ruleSet2.getMigrationRules().get(0).getName());
     assertEquals("bar", ruleSet2.getMigrationRules().get(1).getName());
@@ -640,18 +734,22 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     request3.setRuleSet(ruleSet);
     int expectedIdSchema3 = 3;
     response = restApp.restClient.registerSchema(request3, subject, false);
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema3,
-        response.getId());
+        response.getId(),
+        "Registering should succeed"
+    );
     RuleSet ruleSet3 = response.getRuleSet();
     assertEquals("foo", ruleSet3.getMigrationRules().get(0).getName());
     assertEquals("zap", ruleSet3.getMigrationRules().get(1).getName());
 
-    assertEquals("Version should match",
+    assertEquals(
         response.getVersion(),
         restApp.restClient.lookUpSubjectVersion(
             new RegisterSchemaRequest(
-                new Schema(subject, response)), subject, false, false).getVersion());
+                new Schema(subject, response)), subject, false, false).getVersion(),
+        "Version should match"
+    );
 
     schemaString = restApp.restClient.getId(expectedIdSchema3, subject);
     ruleSet3 = schemaString.getRuleSet();
@@ -683,9 +781,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
 
     RegisterSchemaRequest request1 = new RegisterSchemaRequest(schema1);
     int expectedIdSchema1 = 1;
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(request1, subject, false).getId());
+        restApp.restClient.registerSchema(request1, subject, false).getId(),
+        "Registering should succeed"
+    );
 
     // register just metadata, schema should be inherited from version 1
     RegisterSchemaRequest request2 = new RegisterSchemaRequest();
@@ -694,9 +794,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     Metadata metadata = new Metadata(null, properties, null);
     request2.setMetadata(metadata);
     int expectedIdSchema2 = 2;
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema2,
-        restApp.restClient.registerSchema(request2, subject, false).getId());
+        restApp.restClient.registerSchema(request2, subject, false).getId(),
+        "Registering should succeed"
+    );
 
     SchemaString schemaString = restApp.restClient.getId(expectedIdSchema2, subject);
     assertEquals(schema1.canonicalString(), schemaString.getSchemaString());
@@ -714,9 +816,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
 
     RegisterSchemaRequest request1 = new RegisterSchemaRequest(schema1);
     int expectedIdSchema1 = 1;
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(request1, subject, false).getId());
+        restApp.restClient.registerSchema(request1, subject, false).getId(),
+        "Registering should succeed"
+    );
 
     // register just ruleSet, schema should be inherited from version 1
     RegisterSchemaRequest request2 = new RegisterSchemaRequest();
@@ -725,9 +829,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     RuleSet ruleSet = new RuleSet(rules, null);
     request2.setRuleSet(ruleSet);
     int expectedIdSchema2 = 2;
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema2,
-        restApp.restClient.registerSchema(request2, subject, false).getId());
+        restApp.restClient.registerSchema(request2, subject, false).getId(),
+        "Registering should succeed"
+    );
 
     SchemaString schemaString = restApp.restClient.getId(expectedIdSchema2, subject);
     assertEquals(schema1.canonicalString(), schemaString.getSchemaString());
@@ -744,9 +850,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + "\"fields\":"
         + "[{\"type\":\"string\",\"name\":\"f1\"}]}").canonicalString();
     int expectedIdSchema1 = 1;
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(schemaString1, subject));
+        restApp.restClient.registerSchema(schemaString1, subject),
+        "Registering should succeed"
+    );
 
     // register a backward compatible avro with wrong version number
     ParsedSchema schema2 = AvroUtils.parseSchema("{\"type\":\"record\","
@@ -761,17 +869,21 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
       fail("Registering a wrong version should fail");
     } catch (RestClientException e) {
       // this is expected.
-      assertEquals("Should get a bad request status",
+      assertEquals(
           RestInvalidSchemaException.ERROR_CODE,
-          e.getErrorCode());
+          e.getErrorCode(),
+          "Should get a bad request status"
+      );
     }
 
     // register a backward compatible avro with right version number
     request2.setVersion(2);
     int expectedIdSchema2 = 2;
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema2,
-        restApp.restClient.registerSchema(request2, subject, false).getId());
+        restApp.restClient.registerSchema(request2, subject, false).getId(),
+        "Registering should succeed"
+    );
   }
 
   @Test
@@ -788,9 +900,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
       fail("Registering an invalid ruleSet should fail");
     } catch (RestClientException e) {
       // this is expected.
-      assertEquals("Should get a bad request status",
+      assertEquals(
           RestInvalidRuleSetException.DEFAULT_ERROR_CODE,
-          e.getStatus());
+          e.getStatus(),
+          "Should get a bad request status"
+      );
     }
 
     // Add rule with duplicate name
@@ -805,9 +919,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
       fail("Registering an invalid ruleSet should fail");
     } catch (RestClientException e) {
       // this is expected.
-      assertEquals("Should get a bad request status",
+      assertEquals(
           RestInvalidRuleSetException.DEFAULT_ERROR_CODE,
-          e.getStatus());
+          e.getStatus(),
+          "Should get a bad request status"
+      );
     }
   }
 
@@ -830,9 +946,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
       fail("Registering an invalid ruleSet should fail");
     } catch (RestClientException e) {
       // this is expected.
-      assertEquals("Should get a bad request status",
+      assertEquals(
           RestInvalidRuleSetException.DEFAULT_ERROR_CODE,
-          e.getStatus());
+          e.getStatus(),
+          "Should get a bad request status"
+      );
     }
   }
 
@@ -854,9 +972,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     config.setNormalize(true);
     config.setValidateFields(false);
     // set normalize config
-    assertEquals("Setting normalize config should succeed",
+    assertEquals(
         config,
-        restApp.restClient.updateConfig(config, null));
+        restApp.restClient.updateConfig(config, null),
+        "Setting normalize config should succeed"
+    );
 
     try {
       restApp.restClient.testCompatibility(schema, subject, "latest");
@@ -864,7 +984,7 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
           + Errors.INVALID_SCHEMA_ERROR_CODE
           + " (invalid schema)");
     } catch (RestClientException rce) {
-      assertEquals("Invalid schema", Errors.INVALID_SCHEMA_ERROR_CODE, rce.getErrorCode());
+      assertEquals(Errors.INVALID_SCHEMA_ERROR_CODE, rce.getErrorCode());
     }
 
     try {
@@ -873,7 +993,7 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
           + Errors.INVALID_SCHEMA_ERROR_CODE
           + " (invalid schema)");
     } catch (RestClientException rce) {
-      assertEquals("Invalid schema", Errors.INVALID_SCHEMA_ERROR_CODE, rce.getErrorCode());
+      assertEquals(Errors.INVALID_SCHEMA_ERROR_CODE, rce.getErrorCode());
     }
   }
 
@@ -887,16 +1007,20 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + "\"fields\":"
         + "[{\"type\":\"string\",\"name\":\"f1\"}]}").canonicalString();
     int expectedIdSchema1 = 1;
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(schemaString1, subject));
+        restApp.restClient.registerSchema(schemaString1, subject),
+        "Registering should succeed"
+    );
 
     ConfigUpdateRequest config = new ConfigUpdateRequest();
     config.setAlias("testSubject");
     // set alias config
-    assertEquals("Setting alias config should succeed",
+    assertEquals(
         config,
-        restApp.restClient.updateConfig(config, "testAlias"));
+        restApp.restClient.updateConfig(config, "testAlias"),
+        "Setting alias config should succeed"
+    );
 
     Schema schema = restApp.restClient.getVersion("testAlias", 1);
     assertEquals(schemaString1, schema.getSchema());
@@ -912,16 +1036,20 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + "\"fields\":"
         + "[{\"type\":\"string\",\"name\":\"f1\"}]}").canonicalString();
     int expectedIdSchema1 = 1;
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(schemaString1, subject));
+        restApp.restClient.registerSchema(schemaString1, subject),
+        "Registering should succeed"
+    );
 
     ConfigUpdateRequest config = new ConfigUpdateRequest();
     config.setAlias("testSubject");
     // set alias config
-    assertEquals("Setting alias config should succeed",
+    assertEquals(
         config,
-        restApp.restClient.updateConfig(config, "test/Alias"));
+        restApp.restClient.updateConfig(config, "test/Alias"),
+        "Setting alias config should succeed"
+    );
 
     Schema schema = restApp.restClient.getVersion("test/Alias", 1);
     assertEquals(schemaString1, schema.getSchema());
@@ -938,16 +1066,20 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + "\"fields\":"
         + "[{\"type\":\"string\",\"name\":\"f1\"}]}").canonicalString();
     int expectedIdSchema1 = 1;
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restClient1.registerSchema(schemaString1, "testSubject"));
+        restClient1.registerSchema(schemaString1, "testSubject"),
+        "Registering should succeed"
+    );
 
     ConfigUpdateRequest config = new ConfigUpdateRequest();
     config.setAlias(":.mycontext:testSubject");
     // set alias config
-    assertEquals("Setting alias config should succeed",
+    assertEquals(
         config,
-        restApp.restClient.updateConfig(config, ":.mycontext2:testAlias"));
+        restApp.restClient.updateConfig(config, ":.mycontext2:testAlias"),
+        "Setting alias config should succeed"
+    );
 
     Schema schema = restClient2.getVersion("testAlias", 1);
     assertEquals(schemaString1, schema.getSchema());
@@ -963,17 +1095,21 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + "\"fields\":"
         + "[{\"type\":\"string\",\"name\":\"f1\"}]}").canonicalString();
     int expectedIdSchema1 = 1;
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(schemaString1, subject));
+        restApp.restClient.registerSchema(schemaString1, subject),
+        "Registering should succeed"
+    );
 
     ConfigUpdateRequest config = new ConfigUpdateRequest();
     config.setAlias("badSubject");
     config.setValidateFields(false);
     // set global alias config
-    assertEquals("Setting alias config should succeed",
+    assertEquals(
         config,
-        restApp.restClient.updateConfig(config, null));
+        restApp.restClient.updateConfig(config, null),
+        "Setting alias config should succeed"
+    );
 
     Schema schema = restApp.restClient.getVersion("testSubject", 1);
     assertEquals(schemaString1, schema.getSchema());
@@ -989,9 +1125,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + "\"fields\":"
         + "[{\"type\":\"string\",\"name\":\"f1\"}]}").canonicalString();
     int expectedIdSchema1 = 1;
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(schemaString1, subject));
+        restApp.restClient.registerSchema(schemaString1, subject),
+        "Registering should succeed"
+    );
 
     // register a backward compatible avro
     String schemaString2 = AvroUtils.parseSchema("{\"type\":\"record\","
@@ -1000,9 +1138,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + "[{\"type\":\"string\",\"name\":\"f1\"},"
         + " {\"type\":\"string\",\"name\":\"f2\", \"default\": \"foo\"}]}").canonicalString();
     int expectedIdSchema2 = 2;
-    assertEquals("Registering a compatible schema should succeed",
+    assertEquals(
         expectedIdSchema2,
-        restApp.restClient.registerSchema(schemaString2, subject));
+        restApp.restClient.registerSchema(schemaString2, subject),
+        "Registering a compatible schema should succeed"
+    );
 
     subject = "noTestSubject";
 
@@ -1012,9 +1152,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + "\"fields\":"
         + "[{\"type\":\"string\",\"name\":\"x1\"}]}").canonicalString();
     int expectedIdUnrelated1 = 3;
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdUnrelated1,
-        restApp.restClient.registerSchema(unrelated1, subject));
+        restApp.restClient.registerSchema(unrelated1, subject),
+        "Registering should succeed"
+    );
 
     // register a backward compatible avro
     String unrelated2 = AvroUtils.parseSchema("{\"type\":\"record\","
@@ -1023,16 +1165,20 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + "[{\"type\":\"string\",\"name\":\"x1\"},"
         + " {\"type\":\"string\",\"name\":\"x2\", \"default\": \"foo\"}]}").canonicalString();
     int expectedIdUnrelated2 = 4;
-    assertEquals("Registering a compatible schema should succeed",
+    assertEquals(
         expectedIdUnrelated2,
-        restApp.restClient.registerSchema(unrelated2, subject));
+        restApp.restClient.registerSchema(unrelated2, subject),
+        "Registering a compatible schema should succeed"
+    );
 
     ConfigUpdateRequest config = new ConfigUpdateRequest();
     config.setAlias("testSubject");
     // set alias config
-    assertEquals("Setting alias config should succeed",
+    assertEquals(
         config,
-        restApp.restClient.updateConfig(config, "testAlias"));
+        restApp.restClient.updateConfig(config, "testAlias"),
+        "Setting alias config should succeed"
+    );
 
     List<Schema> schemas = restApp.restClient.getSchemas("testAlias", true, false);
     assertEquals(0, schemas.size());
@@ -1056,9 +1202,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + "[{\"type\":\"string\",\"name\":\"a1\"},"
         + " {\"type\":\"string\",\"name\":\"a2\", \"default\": \"foo\"}]}").canonicalString();
     int expectedIdSchema3 = 5;
-    assertEquals("Registering a schema should succeed",
+    assertEquals(
         expectedIdSchema3,
-        restApp.restClient.registerSchema(schemaString3, subject));
+        restApp.restClient.registerSchema(schemaString3, subject),
+        "Registering a schema should succeed"
+    );
 
     // see if the query picks up the new schema
     schemasWithAliases = restApp.restClient.getSchemas(
@@ -1094,9 +1242,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     config = new ConfigUpdateRequest();
     config.setAlias("testSubject");
     // set alias config
-    assertEquals("Setting alias config should succeed",
+    assertEquals(
         config,
-        restApp.restClient.updateConfig(config, "testAlias2"));
+        restApp.restClient.updateConfig(config, "testAlias2"),
+        "Setting alias config should succeed"
+    );
 
     // see if the query picks up the new schema
     schemasWithAliases = restApp.restClient.getSchemas(
@@ -1141,9 +1291,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
             + "\"fields\":"
             + "[{\"type\":\"string\",\"name\":\"f1\"}]}").canonicalString();
     int expectedIdSchema1 = 1;
-    assertEquals("Registering should succeed",
-            expectedIdSchema1,
-            restApp.restClient.registerSchema(schemaString1, subject));
+    assertEquals(
+        expectedIdSchema1,
+        restApp.restClient.registerSchema(schemaString1, subject),
+        "Registering should succeed"
+    );
 
     // register a backward compatible avro
     String schemaString2 = AvroUtils.parseSchema("{\"type\":\"record\","
@@ -1152,9 +1304,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + "[{\"type\":\"string\",\"name\":\"f1\"},"
         + " {\"type\":\"string\",\"name\":\"f2\", \"default\": \"foo\"}]}").canonicalString();
     int expectedIdSchema2 = 2;
-    assertEquals("Registering a compatible schema should succeed",
+    assertEquals(
         expectedIdSchema2,
-        restApp.restClient.registerSchema(schemaString2, subject));
+        restApp.restClient.registerSchema(schemaString2, subject),
+        "Registering a compatible schema should succeed"
+    );
 
     subject = "noTestSubject";
 
@@ -1164,9 +1318,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + "\"fields\":"
         + "[{\"type\":\"string\",\"name\":\"x1\"}]}").canonicalString();
     int expectedIdUnrelated1 = 3;
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdUnrelated1,
-        restApp.restClient.registerSchema(unrelated1, subject));
+        restApp.restClient.registerSchema(unrelated1, subject),
+        "Registering should succeed"
+    );
 
     // register a backward compatible avro
     String unrelated2 = AvroUtils.parseSchema("{\"type\":\"record\","
@@ -1175,16 +1331,20 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + "[{\"type\":\"string\",\"name\":\"x1\"},"
         + " {\"type\":\"string\",\"name\":\"x2\", \"default\": \"foo\"}]}").canonicalString();
     int expectedIdUnrelated2 = 4;
-    assertEquals("Registering a compatible schema should succeed",
+    assertEquals(
         expectedIdUnrelated2,
-        restApp.restClient.registerSchema(unrelated2, subject));
+        restApp.restClient.registerSchema(unrelated2, subject),
+        "Registering a compatible schema should succeed"
+    );
 
     ConfigUpdateRequest config = new ConfigUpdateRequest();
     config.setAlias("testSubject");
     // set alias config
-    assertEquals("Setting alias config should succeed",
-            config,
-            restApp.restClient.updateConfig(config, "testAlias"));
+    assertEquals(
+        config,
+        restApp.restClient.updateConfig(config, "testAlias"),
+        "Setting alias config should succeed"
+    );
 
     List<Schema> schemas = restApp.restClient.getSchemas("testAlias", true, false);
     assertEquals(0, schemas.size());
@@ -1208,9 +1368,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + "[{\"type\":\"string\",\"name\":\"a1\"},"
         + " {\"type\":\"string\",\"name\":\"a2\", \"default\": \"foo\"}]}").canonicalString();
     int expectedIdSchema3 = 5;
-    assertEquals("Registering a schema should succeed",
+    assertEquals(
         expectedIdSchema3,
-        restApp.restClient.registerSchema(schemaString3, subject));
+        restApp.restClient.registerSchema(schemaString3, subject),
+        "Registering a schema should succeed"
+    );
 
     // see if the query picks up the new schema
     schemasWithAliases = restApp.restClient.getSchemas(
@@ -1229,9 +1391,11 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
     config = new ConfigUpdateRequest();
     config.setAlias("testSubject");
     // set alias config
-    assertEquals("Setting alias config should succeed",
+    assertEquals(
         config,
-        restApp.restClient.updateConfig(config, "testAlias2"));
+        restApp.restClient.updateConfig(config, "testAlias2"),
+        "Setting alias config should succeed"
+    );
 
     // see if the query picks up the new schema
     schemasWithAliases = restApp.restClient.getSchemas(
@@ -1254,17 +1418,21 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
         + "[{\"type\":\"string\",\"name\":\"b1\"},"
         + " {\"type\":\"string\",\"name\":\"b2\", \"default\": \"foo\"}]}").canonicalString();
     int expectedIdSchema4 = 1;
-    assertEquals("Registering a schema should succeed",
+    assertEquals(
         expectedIdSchema4,
-        restApp.restClient.registerSchema(schemaString4, subject));
+        restApp.restClient.registerSchema(schemaString4, subject),
+        "Registering a schema should succeed"
+    );
 
     // another alias to same subject
     config = new ConfigUpdateRequest();
     config.setAlias("testSubject");
     // set alias config
-    assertEquals("Setting alias config should succeed",
+    assertEquals(
         config,
-        restApp.restClient.updateConfig(config, ":.myctx:testAlias3"));
+        restApp.restClient.updateConfig(config, ":.myctx:testAlias3"),
+        "Setting alias config should succeed"
+    );
 
     // see if the query picks up the new schema
     schemasWithAliases = restApp.restClient.getSchemas(

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiContextTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiContextTest.java
@@ -15,8 +15,8 @@
 package io.confluent.kafka.schemaregistry.rest;
 
 import static io.confluent.kafka.schemaregistry.utils.QualifiedSubject.DEFAULT_CONTEXT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.kafka.schemaregistry.ClusterTestHarness;
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RestApiContextTest extends ClusterTestHarness {
 
@@ -63,20 +63,26 @@ public class RestApiContextTest extends ClusterTestHarness {
            + Errors.SUBJECT_NOT_FOUND_ERROR_CODE
            + " (subject not found)");
     } catch (RestClientException rce) {
-      assertEquals("Should get a 404 status for non-existing subject",
-                   Errors.SUBJECT_NOT_FOUND_ERROR_CODE,
-                   rce.getErrorCode());
+      assertEquals(
+          Errors.SUBJECT_NOT_FOUND_ERROR_CODE,
+          rce.getErrorCode(),
+          "Should get a 404 status for non-existing subject"
+      );
     }
 
     // test getAllContexts
-    assertEquals("Getting all subjects should return default context",
+    assertEquals(
         Collections.singletonList(DEFAULT_CONTEXT),
-        restApp.restClient.getAllContexts());
+        restApp.restClient.getAllContexts(),
+        "Getting all subjects should return default context"
+    );
 
     // test getAllSubjects with no existing data
-    assertEquals("Getting all subjects should return empty",
-                 Collections.emptyList(),
-                 restApp.restClient.getAllSubjects());
+    assertEquals(
+        Collections.emptyList(),
+        restApp.restClient.getAllSubjects(),
+        "Getting all subjects should return empty"
+    );
 
     // test registering and verifying new schemas in subject1
     int schemaIdCounter = 1;
@@ -94,8 +100,10 @@ public class RestApiContextTest extends ClusterTestHarness {
       int expectedId = i + 1;
       String schemaString = allSchemasInSubject1.get(i);
       int foundId = restApp.restClient.registerSchema(schemaString, subject1);
-      assertEquals("Re-registering an existing schema should return the existing version",
-                   expectedId, foundId);
+      assertEquals(
+          expectedId, foundId,
+          "Re-registering an existing schema should return the existing version"
+      );
     }
 
     // reset the schema id counter due to a different context
@@ -138,62 +146,86 @@ public class RestApiContextTest extends ClusterTestHarness {
     }
 
     // test getAllVersions with existing data
-    assertEquals("Getting all versions from subject1 should match all registered versions",
-                 allVersionsInSubject1,
-                 restApp.restClient.getAllVersions(subject1));
-    assertEquals("Getting all versions from subject2 should match all registered versions",
-                 allVersionsInSubject2,
-                 restApp.restClient.getAllVersions(subject2));
+    assertEquals(
+        allVersionsInSubject1,
+        restApp.restClient.getAllVersions(subject1),
+        "Getting all versions from subject1 should match all registered versions"
+    );
+    assertEquals(
+        allVersionsInSubject2,
+        restApp.restClient.getAllVersions(subject2),
+        "Getting all versions from subject2 should match all registered versions"
+    );
 
     // test getAllContexts
-    assertEquals("Getting all contexts should return all registered contexts",
-                 ImmutableList.of(DEFAULT_CONTEXT, ".ctx1", ".ctx2", ".ctx3"),
-                 restApp.restClient.getAllContexts());
+    assertEquals(
+        ImmutableList.of(DEFAULT_CONTEXT, ".ctx1", ".ctx2", ".ctx3"),
+        restApp.restClient.getAllContexts(),
+        "Getting all contexts should return all registered contexts"
+    );
 
     // test getAllSubjectsWithPrefix with existing data
-    assertEquals("Getting all subjects should match all registered subjects",
-                 Collections.singletonList(subject1),
-                restApp.restClient.getAllSubjects(":.ctx1:", false));
+    assertEquals(
+        Collections.singletonList(subject1),
+        restApp.restClient.getAllSubjects(":.ctx1:", false),
+        "Getting all subjects should match all registered subjects"
+    );
 
     // test getAllSubjectsWithPrefix with existing data
-    assertEquals("Getting all subjects should match all registered subjects",
-                 Collections.singletonList(subject2),
-                 restApp.restClient.getAllSubjects(":.ctx2:", false));
+    assertEquals(
+        Collections.singletonList(subject2),
+        restApp.restClient.getAllSubjects(":.ctx2:", false),
+        "Getting all subjects should match all registered subjects"
+    );
 
     // test getAllSubjects with existing data
-    assertEquals("Getting all subjects should match default subjects",
-                 Collections.singletonList(subject4),
-                 restApp.restClient.getAllSubjects("", false));
+    assertEquals(
+        Collections.singletonList(subject4),
+        restApp.restClient.getAllSubjects("", false),
+        "Getting all subjects should match default subjects"
+    );
 
     // test getAllSubjectsWithPrefix with context wildcard
-    assertEquals("Getting all subjects should match all registered subjects",
+    assertEquals(
         ImmutableList.of(subject1, subject2, subject3, subject4),
-        restApp.restClient.getAllSubjects(":*:", false));
+        restApp.restClient.getAllSubjects(":*:", false),
+        "Getting all subjects should match all registered subjects"
+    );
 
     // test getSchemas with context wildcard
-    assertEquals("Getting all schemas should match all registered subjects",
+    assertEquals(
         schemasInSubject1 + schemasInSubject2 + schemasInSubject3 + schemasInSubject4,
-        restApp.restClient.getSchemas(":*:", false, false).size());
+        restApp.restClient.getSchemas(":*:", false, false).size(),
+        "Getting all schemas should match all registered subjects"
+    );
 
     // test getSchemas with context wildcard and subject
-    assertEquals("Getting all schemas should match registered subjects",
+    assertEquals(
         schemasInSubject1 + schemasInSubject3 + schemasInSubject4,
-        restApp.restClient.getSchemas(":*:testTopic1", false, false).size());
+        restApp.restClient.getSchemas(":*:testTopic1", false, false).size(),
+        "Getting all schemas should match registered subjects"
+    );
 
     // test getSchemas with context wildcard and subject
-    assertEquals("Getting all schemas should match registered subjects",
+    assertEquals(
         schemasInSubject2,
-        restApp.restClient.getSchemas(":*:testTopic2", false, false).size());
+        restApp.restClient.getSchemas(":*:testTopic2", false, false).size(),
+        "Getting all schemas should match registered subjects"
+    );
 
     Schema schema = restApp.restClient.getVersion("testTopic2", 1);
-    assertEquals("Getting schema by version w/o context should succeed",
+    assertEquals(
         1,
-        schema.getVersion().intValue());
+        schema.getVersion().intValue(),
+        "Getting schema by version w/o context should succeed"
+    );
 
     schema = restApp.restClient.lookUpSubjectVersion(schema.getSchema(), "testTopic2");
-    assertEquals("Getting schema by schema w/o context should succeed",
+    assertEquals(
         1,
-        schema.getVersion().intValue());
+        schema.getVersion().intValue(),
+        "Getting schema by schema w/o context should succeed"
+    );
   }
 
   @Test
@@ -225,9 +257,11 @@ public class RestApiContextTest extends ClusterTestHarness {
           + Errors.SUBJECT_NOT_FOUND_ERROR_CODE
           + " (subject not found)");
     } catch (RestClientException rce) {
-      assertEquals("Should get a 404 status for non-existing subject",
+      assertEquals(
           Errors.SUBJECT_NOT_FOUND_ERROR_CODE,
-          rce.getErrorCode());
+          rce.getErrorCode(),
+          "Should get a 404 status for non-existing subject"
+      );
     }
 
     // test registering and verifying new schemas in subject1
@@ -246,8 +280,10 @@ public class RestApiContextTest extends ClusterTestHarness {
       int expectedId = i + 1;
       String schemaString = allSchemasInSubject1.get(i);
       int foundId = restClient1.registerSchema(schemaString, subject1);
-      assertEquals("Re-registering an existing schema should return the existing version",
-          expectedId, foundId);
+      assertEquals(
+          expectedId, foundId,
+          "Re-registering an existing schema should return the existing version"
+      );
     }
 
     // reset the schema id counter due to a different context
@@ -274,9 +310,11 @@ public class RestApiContextTest extends ClusterTestHarness {
       restClient3.getId(schemaIdCounter);
       fail("Registered schema should not be found in default context");
     } catch (RestClientException rce) {
-      assertEquals("Should get a 404 status for non-existing schema",
+      assertEquals(
           Errors.SCHEMA_NOT_FOUND_ERROR_CODE,
-          rce.getErrorCode());
+          rce.getErrorCode(),
+          "Should get a 404 status for non-existing schema"
+      );
     }
 
     // test registering schemas in subject3
@@ -290,71 +328,97 @@ public class RestApiContextTest extends ClusterTestHarness {
     }
 
     // test getAllVersions with existing data
-    assertEquals("Getting all versions from subject1 should match all registered versions",
+    assertEquals(
         allVersionsInSubject1,
-        restClient1.getAllVersions(subject1));
-    assertEquals("Getting all versions from subject2A should match all registered versions",
+        restClient1.getAllVersions(subject1),
+        "Getting all versions from subject1 should match all registered versions"
+    );
+    assertEquals(
         allVersionsInSubject2,
-        restClient2.getAllVersions(subject2A));
-    assertEquals("Getting all versions from subject3 should match all registered versions",
+        restClient2.getAllVersions(subject2A),
+        "Getting all versions from subject2A should match all registered versions"
+    );
+    assertEquals(
         allVersionsInSubject3,
-        restClient3.getAllVersions(subject3));
-    assertEquals("Getting all versions from subject3 should match all registered versions",
+        restClient3.getAllVersions(subject3),
+        "Getting all versions from subject3 should match all registered versions"
+    );
+    assertEquals(
         allVersionsInSubject3,
-        noCtxRestClient3.getAllVersions(subject3));
-    assertEquals("Getting all versions from subject3 should match all registered versions",
+        noCtxRestClient3.getAllVersions(subject3),
+        "Getting all versions from subject3 should match all registered versions"
+    );
+    assertEquals(
         allVersionsInSubject3,
-        noCtxRestClient3.getAllVersions(":.:" + subject3));
+        noCtxRestClient3.getAllVersions(":.:" + subject3),
+        "Getting all versions from subject3 should match all registered versions"
+    );
 
     // test getAllContexts
-    assertEquals("Getting all contexts should return all registered contexts",
+    assertEquals(
         ImmutableList.of(DEFAULT_CONTEXT, ".ctx1", ".ctx2"),
-        restClient1.getAllContexts());
+        restClient1.getAllContexts(),
+        "Getting all contexts should return all registered contexts"
+    );
 
     // test getAllSubjects with existing data
-    assertEquals("Getting all subjects should match all registered subjects",
+    assertEquals(
         Collections.singletonList(":.ctx1:" + subject1),
-        restClient1.getAllSubjects());
+        restClient1.getAllSubjects(),
+        "Getting all subjects should match all registered subjects"
+    );
 
     // test getAllSubjects with existing data
-    assertEquals("Getting all subjects should match all registered subjects",
+    assertEquals(
         ImmutableList.of(":.ctx2:" + subject2A, ":.ctx2:" + subject2B, ":.ctx2:" + subject2C),
-        restClient2.getAllSubjects());
+        restClient2.getAllSubjects(),
+        "Getting all subjects should match all registered subjects"
+    );
 
     // test getAllSubjects with existing data
-    assertEquals("Getting all subjects should match all registered subjects",
+    assertEquals(
         Collections.singletonList(subject3),
-        restClient3.getAllSubjects());
+        restClient3.getAllSubjects(),
+        "Getting all subjects should match all registered subjects"
+    );
 
     // test getAllSubjects with existing data
-    assertEquals("Getting all subjects should match all registered subjects",
+    assertEquals(
         Collections.singletonList(subject3),
-        noCtxRestClient3.getAllSubjects("", false));
+        noCtxRestClient3.getAllSubjects("", false),
+        "Getting all subjects should match all registered subjects"
+    );
 
     // Now ask for schema id 1 from subject3.
     // This should return schema id 1 from the default context
-    assertEquals("Registered schema should be found",
+    assertEquals(
         allSchemasInSubject3.get(0),
-        noCtxRestClient3.getId(1, subject3).getSchemaString());
+        noCtxRestClient3.getId(1, subject3).getSchemaString(),
+        "Registered schema should be found"
+    );
 
     // Now ask for schema id 1 from subject2A.
     // This should NOT return schema id 1 from the default context
-    assertEquals("Registered schema should be found",
+    assertEquals(
         allSchemasInSubject2.get(0),
-        noCtxRestClient3.getId(1, subject2A).getSchemaString());
+        noCtxRestClient3.getId(1, subject2A).getSchemaString(),
+        "Registered schema should be found"
+    );
   }
 
   static void registerAndVerifySchema(RestService restService, String schemaString,
       int expectedId, String subject)
       throws IOException, RestClientException {
     int registeredId = restService.registerSchema(schemaString, subject);
-    assertEquals("Registering a new schema should succeed", expectedId, registeredId);
+    assertEquals(expectedId, registeredId, "Registering a new schema should succeed");
 
     // the newly registered schema should be immediately readable on the leader
     // Note: this differs from TestUtils in that it passes the subject to getId()
-    assertEquals("Registered schema should be found",
+    assertEquals(
         schemaString,
-        restService.getId(expectedId, subject).getSchemaString());
+        restService.getId(expectedId, subject).getSchemaString(),
+        "Registered schema should be found"
+    );
   }
 }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiMetadataEncoderTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiMetadataEncoderTest.java
@@ -14,9 +14,9 @@
  */
 package io.confluent.kafka.schemaregistry.rest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.kafka.schemaregistry.ClusterTestHarness;
@@ -35,7 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RestApiMetadataEncoderTest extends ClusterTestHarness {
 
@@ -69,9 +69,11 @@ public class RestApiMetadataEncoderTest extends ClusterTestHarness {
     RegisterSchemaRequest request = new RegisterSchemaRequest(schema);
 
     int expectedIdSchema1 = 1;
-    assertEquals("Registering without id should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(request, subject, false).getId());
+        restApp.restClient.registerSchema(request, subject, false).getId(),
+        "Registering without id should succeed"
+    );
 
     List<SubjectVersion> subjectVersions = restApp.restClient.getAllVersionsById(1);
     assertEquals(ImmutableList.of(new SubjectVersion(subject, 1)), subjectVersions);
@@ -92,33 +94,45 @@ public class RestApiMetadataEncoderTest extends ClusterTestHarness {
     RegisterSchemaRequest request = new RegisterSchemaRequest(schema);
 
     int expectedIdSchema1 = 1;
-    assertEquals("Registering without id should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(request, subject, false).getId());
+        restApp.restClient.registerSchema(request, subject, false).getId(),
+        "Registering without id should succeed"
+    );
 
     // Remove encoder
     ((KafkaSchemaRegistry) restApp.schemaRegistry()).getMetadataEncoder().getEncoders()
         .remove(KafkaSchemaRegistry.DEFAULT_TENANT);
 
-    assertThrows("Should fail to get schema",
+    assertThrows(
         RestClientException.class,
-        () -> restApp.restClient.getAllVersionsById(1));
+        () -> restApp.restClient.getAllVersionsById(1),
+        "Should fail to get schema"
+    );
 
-    assertThrows("Should fail to get schema",
+    assertThrows(
         RestClientException.class,
-        () -> restApp.restClient.getId(expectedIdSchema1));
+        () -> restApp.restClient.getId(expectedIdSchema1),
+        "Should fail to get schema"
+    );
 
-    assertThrows("Should fail to get schema",
+    assertThrows(
         RestClientException.class,
-        () -> restApp.restClient.getVersion(subject, 1));
+        () -> restApp.restClient.getVersion(subject, 1),
+        "Should fail to get schema"
+    );
 
-    assertThrows("Should fail to get schema",
+    assertThrows(
         RestClientException.class,
-        () -> restApp.restClient.getLatestVersion(subject));
+        () -> restApp.restClient.getLatestVersion(subject),
+        "Should fail to get schema"
+    );
 
-    assertThrows("Should fail to get schema",
+    assertThrows(
         RestClientException.class,
-        () -> restApp.restClient.getLatestVersion(subject));
+        () -> restApp.restClient.getLatestVersion(subject),
+        "Should fail to get schema"
+    );
 
     List<Schema> schemas = restApp.restClient.getSchemas(subject, true, false);
     assertTrue(schemas.isEmpty());

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiModeTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiModeTest.java
@@ -17,7 +17,6 @@ package io.confluent.kafka.schemaregistry.rest;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
-import org.junit.Test;
 
 import java.util.Collections;
 
@@ -26,9 +25,10 @@ import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.avro.AvroUtils;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.rest.exceptions.RestConstraintViolationException;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class RestApiModeTest extends ClusterTestHarness {
 
@@ -110,9 +110,11 @@ public class RestApiModeTest extends ClusterTestHarness {
       fail("Registering during read-only mode should fail");
     } catch (RestClientException e) {
       // this is expected.
-      assertEquals("Should get a constraint violation",
+      assertEquals(
           RestConstraintViolationException.DEFAULT_ERROR_CODE,
-          e.getStatus());
+          e.getStatus(),
+          "Should get a constraint violation"
+      );
     }
   }
 
@@ -132,15 +134,19 @@ public class RestApiModeTest extends ClusterTestHarness {
       fail("Registering an incompatible schema should fail");
     } catch (RestClientException e) {
       // this is expected.
-      assertEquals("Should get a constraint violation",
+      assertEquals(
           RestConstraintViolationException.DEFAULT_ERROR_CODE,
-          e.getStatus());
+          e.getStatus(),
+          "Should get a constraint violation"
+      );
     }
 
     int expectedIdSchema1 = 1;
-    assertEquals("Registering without id should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(SCHEMA_STRING, subject));
+        restApp.restClient.registerSchema(SCHEMA_STRING, subject),
+        "Registering without id should succeed"
+    );
   }
 
   @Test
@@ -155,9 +161,11 @@ public class RestApiModeTest extends ClusterTestHarness {
 
     // register a valid avro schema
     int expectedIdSchema1 = 1;
-    assertEquals("Registering with id should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(SCHEMA_STRING, subject, 1, expectedIdSchema1));
+        restApp.restClient.registerSchema(SCHEMA_STRING, subject, 1, expectedIdSchema1),
+        "Registering with id should succeed"
+    );
   }
 
   @Test
@@ -176,9 +184,11 @@ public class RestApiModeTest extends ClusterTestHarness {
       fail("Registering a schema without ID should fail");
     } catch (RestClientException e) {
       // this is expected.
-      assertEquals("Should get a constraint violation",
+      assertEquals(
           RestConstraintViolationException.DEFAULT_ERROR_CODE,
-          e.getStatus());
+          e.getStatus(),
+          "Should get a constraint violation"
+      );
     }
   }
 
@@ -189,18 +199,22 @@ public class RestApiModeTest extends ClusterTestHarness {
 
     // register a valid avro schema
     int expectedIdSchema1 = 1;
-    assertEquals("Registering without id should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(SCHEMA_STRING, subject));
+        restApp.restClient.registerSchema(SCHEMA_STRING, subject),
+        "Registering without id should succeed"
+    );
 
     try {
       restApp.restClient.setMode(mode).getMode();
       fail("Setting import mode should fail");
     } catch (RestClientException e) {
       // this is expected.
-      assertEquals("Should get a constraint violation",
+      assertEquals(
           RestConstraintViolationException.DEFAULT_ERROR_CODE,
-          e.getStatus());
+          e.getStatus(),
+          "Should get a constraint violation"
+      );
     }
 
     // set subject mode to import with force=true
@@ -234,14 +248,18 @@ public class RestApiModeTest extends ClusterTestHarness {
         restApp.restClient.setMode(mode).getMode());
 
     int expectedIdSchema1 = 1;
-    assertEquals("Registering with id should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(SCHEMA_STRING, subject, 1, expectedIdSchema1));
+        restApp.restClient.registerSchema(SCHEMA_STRING, subject, 1, expectedIdSchema1),
+        "Registering with id should succeed"
+    );
 
     // register same schema with no id
-    assertEquals("Registering without id should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(SCHEMA_STRING, subject));
+        restApp.restClient.registerSchema(SCHEMA_STRING, subject),
+        "Registering without id should succeed"
+    );
   }
 
   @Test
@@ -255,9 +273,11 @@ public class RestApiModeTest extends ClusterTestHarness {
         restApp.restClient.setMode(mode).getMode());
 
     int expectedIdSchema1 = 1;
-    assertEquals("Registering without id should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(SCHEMA_STRING, subject));
+        restApp.restClient.registerSchema(SCHEMA_STRING, subject),
+        "Registering without id should succeed"
+    );
 
     // delete subject so we can switch to import mode
     restApp.restClient.deleteSubject(Collections.emptyMap(), subject);
@@ -271,9 +291,11 @@ public class RestApiModeTest extends ClusterTestHarness {
 
     // register same schema with different id
     expectedIdSchema1 = 2;
-    assertEquals("Registering with id should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(SCHEMA_STRING, subject, 1, expectedIdSchema1));
+        restApp.restClient.registerSchema(SCHEMA_STRING, subject, 1, expectedIdSchema1),
+        "Registering with id should succeed"
+    );
   }
 
   @Test
@@ -287,9 +309,11 @@ public class RestApiModeTest extends ClusterTestHarness {
             restApp.restClient.setMode(mode).getMode());
 
     int expectedIdSchema1 = 1;
-    assertEquals("Registering without id should succeed",
-            expectedIdSchema1,
-            restApp.restClient.registerSchema(SCHEMA_STRING, subject));
+    assertEquals(
+        expectedIdSchema1,
+        restApp.restClient.registerSchema(SCHEMA_STRING, subject),
+        "Registering without id should succeed"
+    );
 
     // delete subject so we can switch to import mode
     restApp.restClient.deleteSubject(Collections.emptyMap(), subject);
@@ -303,22 +327,28 @@ public class RestApiModeTest extends ClusterTestHarness {
 
     // register same schema with same id
     expectedIdSchema1 = 1;
-    assertEquals("Registering with id should succeed",
-            expectedIdSchema1,
-            restApp.restClient.registerSchema(SCHEMA_STRING, subject, 1, expectedIdSchema1));
+    assertEquals(
+        expectedIdSchema1,
+        restApp.restClient.registerSchema(SCHEMA_STRING, subject, 1, expectedIdSchema1),
+        "Registering with id should succeed"
+    );
 
     // delete subject again
     restApp.restClient.deleteSubject(Collections.emptyMap(), subject);
 
     // register same schema with same id
     expectedIdSchema1 = 1;
-    assertEquals("Registering with id should succeed",
-            expectedIdSchema1,
-            restApp.restClient.registerSchema(SCHEMA_STRING, subject, 1, expectedIdSchema1));
+    assertEquals(
+        expectedIdSchema1,
+        restApp.restClient.registerSchema(SCHEMA_STRING, subject, 1, expectedIdSchema1),
+        "Registering with id should succeed"
+    );
 
-    assertEquals("Getting schema by id should succeed",
-            SCHEMA_STRING,
-            restApp.restClient.getVersion(subject, 1).getSchema());
+    assertEquals(
+        SCHEMA_STRING,
+        restApp.restClient.getVersion(subject, 1).getSchema(),
+        "Getting schema by id should succeed"
+    );
   }
 
   @Test
@@ -332,9 +362,11 @@ public class RestApiModeTest extends ClusterTestHarness {
             restApp.restClient.setMode(mode).getMode());
 
     int expectedIdSchema1 = 1;
-    assertEquals("Registering without id should succeed",
-            expectedIdSchema1,
-            restApp.restClient.registerSchema(SCHEMA_STRING, subject));
+    assertEquals(
+        expectedIdSchema1,
+        restApp.restClient.registerSchema(SCHEMA_STRING, subject),
+        "Registering without id should succeed"
+    );
 
     // delete subject so we can switch to import mode
     restApp.restClient.deleteSubject(Collections.emptyMap(), subject);
@@ -353,13 +385,17 @@ public class RestApiModeTest extends ClusterTestHarness {
     request.setMetadata(new Metadata(null, ImmutableMap.of("foo", "bar"), null));
     request.setVersion(1);
     request.setId(expectedIdSchema1);
-    assertEquals("Registering with id should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(request, subject, false).getId());
+        restApp.restClient.registerSchema(request, subject, false).getId(),
+        "Registering with id should succeed"
+    );
 
-    assertEquals("Getting schema by id should succeed",
+    assertEquals(
         SCHEMA_STRING,
-        restApp.restClient.getVersion(subject, 1).getSchema());
+        restApp.restClient.getVersion(subject, 1).getSchema(),
+        "Getting schema by id should succeed"
+    );
 
     // delete subject again
     restApp.restClient.deleteSubject(Collections.emptyMap(), subject);
@@ -371,13 +407,17 @@ public class RestApiModeTest extends ClusterTestHarness {
     request.setMetadata(new Metadata(null, ImmutableMap.of("foo", "bar"), null));
     request.setVersion(1);
     request.setId(expectedIdSchema1);
-    assertEquals("Registering with id should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(request, subject, false).getId());
+        restApp.restClient.registerSchema(request, subject, false).getId(),
+        "Registering with id should succeed"
+    );
 
-    assertEquals("Getting schema by id should succeed",
+    assertEquals(
         SCHEMA_STRING,
-        restApp.restClient.getVersion(subject, 1).getSchema());
+        restApp.restClient.getVersion(subject, 1).getSchema(),
+        "Getting schema by id should succeed"
+    );
   }
 
   @Test
@@ -391,23 +431,31 @@ public class RestApiModeTest extends ClusterTestHarness {
         restApp.restClient.setMode(mode).getMode());
 
     int expectedIdSchema1 = 100;
-    assertEquals("Registering with id should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(SCHEMA_WITH_DECIMAL, subject, 1, expectedIdSchema1));
+        restApp.restClient.registerSchema(SCHEMA_WITH_DECIMAL, subject, 1, expectedIdSchema1),
+        "Registering with id should succeed"
+    );
 
-    assertEquals("Getting schema by id should succeed",
+    assertEquals(
         SCHEMA_WITH_DECIMAL,
-        restApp.restClient.getVersion(subject, 1).getSchema());
+        restApp.restClient.getVersion(subject, 1).getSchema(),
+        "Getting schema by id should succeed"
+    );
 
     // register equivalent schema with different id
     expectedIdSchema1 = 200;
-    assertEquals("Registering with id should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(SCHEMA_WITH_DECIMAL2, subject, 2, expectedIdSchema1));
+        restApp.restClient.registerSchema(SCHEMA_WITH_DECIMAL2, subject, 2, expectedIdSchema1),
+        "Registering with id should succeed"
+    );
 
-    assertEquals("Getting schema by id should succeed",
+    assertEquals(
         SCHEMA_WITH_DECIMAL2,
-        restApp.restClient.getVersion(subject, 2).getSchema());
+        restApp.restClient.getVersion(subject, 2).getSchema(),
+        "Getting schema by id should succeed"
+    );
   }
 
   @Test
@@ -421,23 +469,31 @@ public class RestApiModeTest extends ClusterTestHarness {
         restApp.restClient.setMode(mode).getMode());
 
     int expectedIdSchema1 = 100;
-    assertEquals("Registering with id should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(SCHEMA_WITH_DECIMAL, subject, 1, expectedIdSchema1));
+        restApp.restClient.registerSchema(SCHEMA_WITH_DECIMAL, subject, 1, expectedIdSchema1),
+        "Registering with id should succeed"
+    );
 
-    assertEquals("Getting schema by id should succeed",
+    assertEquals(
         SCHEMA_WITH_DECIMAL,
-        restApp.restClient.getVersion(subject, 1).getSchema());
+        restApp.restClient.getVersion(subject, 1).getSchema(),
+        "Getting schema by id should succeed"
+    );
 
     // register equivalent schema with different id
     expectedIdSchema1 = 200;
-    assertEquals("Registering with id should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(SCHEMA_WITH_DECIMAL, subject, 2, expectedIdSchema1));
+        restApp.restClient.registerSchema(SCHEMA_WITH_DECIMAL, subject, 2, expectedIdSchema1),
+        "Registering with id should succeed"
+    );
 
-    assertEquals("Getting schema by id should succeed",
+    assertEquals(
         SCHEMA_WITH_DECIMAL,
-        restApp.restClient.getVersion(subject, 2).getSchema());
+        restApp.restClient.getVersion(subject, 2).getSchema(),
+        "Getting schema by id should succeed"
+    );
   }
 
   @Test
@@ -451,9 +507,11 @@ public class RestApiModeTest extends ClusterTestHarness {
         restApp.restClient.setMode(mode).getMode());
 
     int expectedIdSchema1 = 1;
-    assertEquals("Registering without id should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(SCHEMA_STRING, subject));
+        restApp.restClient.registerSchema(SCHEMA_STRING, subject),
+        "Registering without id should succeed"
+    );
 
     // delete subject so we can switch to import mode
     restApp.restClient.deleteSubject(Collections.emptyMap(), subject);
@@ -467,18 +525,24 @@ public class RestApiModeTest extends ClusterTestHarness {
 
     // register same schema with same id
     expectedIdSchema1 = 1;
-    assertEquals("Registering with id should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(SCHEMA_STRING, subject, 1, expectedIdSchema1));
+        restApp.restClient.registerSchema(SCHEMA_STRING, subject, 1, expectedIdSchema1),
+        "Registering with id should succeed"
+    );
 
     // register same schema with same id
     expectedIdSchema1 = 2;
-    assertEquals("Registering with id should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(SCHEMA2_STRING, subject, 2, expectedIdSchema1));
+        restApp.restClient.registerSchema(SCHEMA2_STRING, subject, 2, expectedIdSchema1),
+        "Registering with id should succeed"
+    );
 
-    assertEquals("Getting schema by id should succeed",
+    assertEquals(
         SCHEMA2_STRING,
-        restApp.restClient.getVersion(subject, 2).getSchema());
+        restApp.restClient.getVersion(subject, 2).getSchema(),
+        "Getting schema by id should succeed"
+    );
   }
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiRegisterSchemaTagsTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiRegisterSchemaTagsTest.java
@@ -38,13 +38,12 @@ import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
 import io.confluent.kafka.schemaregistry.storage.RuleSetHandler;
 import io.confluent.kafka.schemaregistry.utils.TestUtils;
 import java.util.List;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RestApiRegisterSchemaTagsTest extends ClusterTestHarness {
 
@@ -58,8 +57,8 @@ public class RestApiRegisterSchemaTagsTest extends ClusterTestHarness {
     super(1, true);
   }
 
-  @Before
-  public void setUp() throws Exception {
+  @Override
+  protected void setUp() throws Exception {
     super.setUp();
     ((KafkaSchemaRegistry) restApp.schemaRegistry()).setRuleSetHandler(new RuleSetHandler() {
       public void handle(String subject, ConfigUpdateRequest request) {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiSchemaTooLargeTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiSchemaTooLargeTest.java
@@ -14,14 +14,14 @@
  */
 package io.confluent.kafka.schemaregistry.rest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import java.util.Properties;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RestApiSchemaTooLargeTest extends ClusterTestHarness {
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiSslTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiSslTest.java
@@ -23,7 +23,6 @@ import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
 import org.apache.avro.Schema;
 import org.apache.kafka.common.config.types.Password;
-import org.junit.Test;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
@@ -37,8 +36,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RestApiSslTest extends ClusterTestHarness {
 
@@ -90,9 +90,9 @@ public class RestApiSslTest extends ClusterTestHarness {
     CachedSchemaRegistryClient schemaRegistryClient = new CachedSchemaRegistryClient(restApp.restClient, 10, clientsslConfigs);
 
     assertEquals(
-        "Registering should succeed",
         expectedIdSchema1,
-        schemaRegistryClient.register(subject, new AvroSchema(schema))
+        schemaRegistryClient.register(subject, new AvroSchema(schema)),
+        "Registering should succeed"
     );
 
   }
@@ -134,9 +134,9 @@ public class RestApiSslTest extends ClusterTestHarness {
     CachedSchemaRegistryClient schemaRegistryClient = new CachedSchemaRegistryClient(restApp.restClient, 10, clientsslConfigs);
 
     assertEquals(
-        "Registering should succeed",
         expectedIdSchema1,
-        schemaRegistryClient.register(subject, new AvroSchema(schema))
+        schemaRegistryClient.register(subject, new AvroSchema(schema)),
+        "Registering should succeed"
     );
 
   }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -18,13 +18,13 @@ import static io.confluent.kafka.schemaregistry.CompatibilityLevel.BACKWARD;
 import static io.confluent.kafka.schemaregistry.CompatibilityLevel.FORWARD;
 import static io.confluent.kafka.schemaregistry.CompatibilityLevel.NONE;
 import static io.confluent.kafka.schemaregistry.utils.QualifiedSubject.DEFAULT_CONTEXT;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.google.common.collect.ImmutableList;
 import io.confluent.kafka.schemaregistry.ClusterTestHarness;
@@ -67,8 +67,7 @@ import java.util.Objects;
 import java.util.Properties;
 import org.apache.avro.Schema.Parser;
 import org.apache.avro.SchemaParseException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RestApiTest extends ClusterTestHarness {
 
@@ -95,20 +94,26 @@ public class RestApiTest extends ClusterTestHarness {
            + Errors.SUBJECT_NOT_FOUND_ERROR_CODE
            + " (subject not found)");
     } catch (RestClientException rce) {
-      assertEquals("Should get a 404 status for non-existing subject",
-                   Errors.SUBJECT_NOT_FOUND_ERROR_CODE,
-                   rce.getErrorCode());
+      assertEquals(
+          Errors.SUBJECT_NOT_FOUND_ERROR_CODE,
+          rce.getErrorCode(),
+          "Should get a 404 status for non-existing subject"
+      );
     }
 
     // test getAllContexts
-    assertEquals("Getting all subjects should return default context",
+    assertEquals(
         Collections.singletonList(DEFAULT_CONTEXT),
-        restApp.restClient.getAllContexts());
+        restApp.restClient.getAllContexts(),
+        "Getting all subjects should return default context"
+    );
 
     // test getAllSubjects with no existing data
-    assertEquals("Getting all subjects should return empty",
-                 allSubjects,
-                 restApp.restClient.getAllSubjects());
+    assertEquals(
+        allSubjects,
+        restApp.restClient.getAllSubjects(),
+        "Getting all subjects should return empty"
+    );
 
     // test registering and verifying new schemas in subject1
     int schemaIdCounter = 1;
@@ -127,8 +132,10 @@ public class RestApiTest extends ClusterTestHarness {
       int expectedId = i + 1;
       String schemaString = allSchemasInSubject1.get(i);
       int foundId = restApp.restClient.registerSchema(schemaString, subject1);
-      assertEquals("Re-registering an existing schema should return the existing version",
-                   expectedId, foundId);
+      assertEquals(
+          expectedId, foundId,
+          "Re-registering an existing schema should return the existing version"
+      );
     }
 
     // test registering schemas in subject2
@@ -143,30 +150,42 @@ public class RestApiTest extends ClusterTestHarness {
     allSubjects.add(subject2);
 
     // test getAllVersions with existing data
-    assertEquals("Getting all versions from subject1 should match all registered versions",
-                 allVersionsInSubject1,
-                 restApp.restClient.getAllVersions(subject1));
-    assertEquals("Getting all versions from subject2 should match all registered versions",
-                 allVersionsInSubject2,
-                 restApp.restClient.getAllVersions(subject2));
+    assertEquals(
+        allVersionsInSubject1,
+        restApp.restClient.getAllVersions(subject1),
+        "Getting all versions from subject1 should match all registered versions"
+    );
+    assertEquals(
+        allVersionsInSubject2,
+        restApp.restClient.getAllVersions(subject2),
+        "Getting all versions from subject2 should match all registered versions"
+    );
 
     // test getAllSubjects with existing data
-    assertEquals("Getting all subjects should match all registered subjects",
-                 allSubjects,
-                 restApp.restClient.getAllSubjects());
+    assertEquals(
+        allSubjects,
+        restApp.restClient.getAllSubjects(),
+        "Getting all subjects should match all registered subjects"
+    );
 
     // test pagination with limit of 1
-    assertEquals("Getting all subjects with pagination offset=0, limit=1 should return first registered subject",
-            ImmutableList.of(allSubjects.get(0)),
-            restApp.restClient.getAllSubjectsWithPagination(0, 1));
-    assertEquals("Getting all subjects with pagination offset=1, limit=1 should return second registered subject",
-            ImmutableList.of(allSubjects.get(1)),
-            restApp.restClient.getAllSubjectsWithPagination(1, 1));
+    assertEquals(
+        ImmutableList.of(allSubjects.get(0)),
+        restApp.restClient.getAllSubjectsWithPagination(0, 1),
+        "Getting all subjects with pagination offset=0, limit=1 should return first registered subject"
+    );
+    assertEquals(
+        ImmutableList.of(allSubjects.get(1)),
+        restApp.restClient.getAllSubjectsWithPagination(1, 1),
+        "Getting all subjects with pagination offset=1, limit=1 should return second registered subject"
+    );
 
     List<Schema> latestSchemas = restApp.restClient.getSchemas(null, false, true);
-    assertEquals("Getting latest schemas should return two schemas",
-                 2,
-                 latestSchemas.size());
+    assertEquals(
+        2,
+        latestSchemas.size(),
+        "Getting latest schemas should return two schemas"
+    );
     assertEquals(Integer.valueOf(10), latestSchemas.get(0).getVersion());
     assertEquals(Integer.valueOf(5), latestSchemas.get(1).getVersion());
   }
@@ -176,8 +195,10 @@ public class RestApiTest extends ClusterTestHarness {
     String schema = TestUtils.getRandomCanonicalAvroString(1).get(0);
     int id1 = restApp.restClient.registerSchema(schema, "subject1");
     int id2 = restApp.restClient.registerSchema(schema, "subject2");
-    assertEquals("Registering the same schema under different subjects should return the same id",
-                 id1, id2);
+    assertEquals(
+        id1, id2,
+        "Registering the same schema under different subjects should return the same id"
+    );
   }
 
   @Test
@@ -197,7 +218,7 @@ public class RestApiTest extends ClusterTestHarness {
           + Errors.INVALID_SCHEMA_ERROR_CODE
           + " (invalid schema)");
     } catch (RestClientException rce) {
-      assertEquals("Invalid schema", Errors.INVALID_SCHEMA_ERROR_CODE, rce.getErrorCode());
+      assertEquals(Errors.INVALID_SCHEMA_ERROR_CODE, rce.getErrorCode());
     }
 
     try {
@@ -206,7 +227,7 @@ public class RestApiTest extends ClusterTestHarness {
           + Errors.INVALID_SCHEMA_ERROR_CODE
           + " (invalid schema)");
     } catch (RestClientException rce) {
-      assertEquals("Invalid schema", Errors.INVALID_SCHEMA_ERROR_CODE, rce.getErrorCode());
+      assertEquals(Errors.INVALID_SCHEMA_ERROR_CODE, rce.getErrorCode());
     }
   }
 
@@ -234,8 +255,8 @@ public class RestApiTest extends ClusterTestHarness {
                 + Errors.INVALID_SCHEMA_ERROR_CODE
                 + " (invalid schema)");
     } catch (RestClientException rce) {
-        assertEquals("Invalid schema", Errors.INVALID_SCHEMA_ERROR_CODE, rce.getErrorCode());
-        assertTrue("Verify error message verbosity", rce.getMessage().contains(expectedErrorMessage));
+        assertEquals(Errors.INVALID_SCHEMA_ERROR_CODE, rce.getErrorCode());
+        assertTrue(rce.getMessage().contains(expectedErrorMessage), "Verify error message verbosity");
     }
   }
 
@@ -257,7 +278,7 @@ public class RestApiTest extends ClusterTestHarness {
               + Errors.INVALID_SCHEMA_ERROR_CODE
               + " (invalid schema)");
     } catch (RestClientException rce) {
-      assertEquals("Invalid schema", Errors.INVALID_SCHEMA_ERROR_CODE, rce.getErrorCode());
+      assertEquals(Errors.INVALID_SCHEMA_ERROR_CODE, rce.getErrorCode());
     }
   }
 
@@ -269,16 +290,14 @@ public class RestApiTest extends ClusterTestHarness {
     String avroSchema = avroSchemas.get(0);
 
     int id1 = restApp.restClient.registerSchema(avroSchema, subject);
-    assertEquals("1st schema registered in first context should have id 1", 1,
-        id1);
+    assertEquals(1, id1, "1st schema registered in first context should have id 1");
 
     // Create another context so that lookup will search it
     String subject2 = ":.ctx:testFoo";
     String avroSchema2 = avroSchemas.get(1);
 
     int id2 = restApp.restClient.registerSchema(avroSchema2, subject2);
-    assertEquals("2nd schema registered in second context should have id 1", 1,
-        id2);
+    assertEquals(1, id2, "2nd schema registered in second context should have id 1");
 
     SchemaReference reference = new SchemaReference("testSubject", "testSubject", 1);
     String schemaString = "{\"type\":\"record\","
@@ -291,7 +310,7 @@ public class RestApiTest extends ClusterTestHarness {
           Collections.singletonList(reference), subject, false);
       fail(String.format("Subject %s should not be found", subject));
     } catch (RestClientException rce) {
-      assertEquals("Subject Not Found", Errors.SCHEMA_NOT_FOUND_ERROR_CODE, rce.getErrorCode());
+      assertEquals(Errors.SCHEMA_NOT_FOUND_ERROR_CODE, rce.getErrorCode());
     }
   }
 
@@ -305,22 +324,19 @@ public class RestApiTest extends ClusterTestHarness {
     restApp.restClient.updateCompatibility(NONE.name, subject);
 
     int id1 = restApp.restClient.registerSchema(avroSchema, subject);
-    assertEquals("1st schema registered globally should have id 1", 1,
-        id1);
+    assertEquals(1, id1, "1st schema registered globally should have id 1");
 
     boolean isCompatible = restApp.restClient.testCompatibility(jsonSchema, "JSON", null, subject, "latest", false).isEmpty();
-    assertTrue("Different schema type is allowed when compatibility is NONE", isCompatible);
+    assertTrue(isCompatible, "Different schema type is allowed when compatibility is NONE");
 
     int id2 = restApp.restClient.registerSchema(jsonSchema, "JSON", null, subject).getId();
-    assertEquals("2nd schema registered globally should have id 2", 2,
-        id2);
+    assertEquals(2, id2, "2nd schema registered globally should have id 2");
 
     isCompatible = restApp.restClient.testCompatibility(protobufSchema, "PROTOBUF", null, subject, "latest", false).isEmpty();
-    assertTrue("Different schema type is allowed when compatibility is NONE", isCompatible);
+    assertTrue(isCompatible, "Different schema type is allowed when compatibility is NONE");
 
     int id3 = restApp.restClient.registerSchema(protobufSchema, "PROTOBUF", null, subject).getId();
-    assertEquals("3rd schema registered globally should have id 3", 3,
-        id3);
+    assertEquals(3, id3, "3rd schema registered globally should have id 3");
   }
 
   @Test
@@ -331,15 +347,13 @@ public class RestApiTest extends ClusterTestHarness {
     String avroSchema = avroSchemas.get(0);
 
     int id1 = restApp.restClient.registerSchema(avroSchema, subject);
-    assertEquals("1st schema registered in first context should have id 1", 1,
-        id1);
+    assertEquals(1, id1, "1st schema registered in first context should have id 1");
 
     String subject2 = ":.ctx:testSubject";
     String avroSchema2 = avroSchemas.get(1);
 
     int id2 = restApp.restClient.registerSchema(avroSchema2, subject2);
-    assertEquals("2nd schema registered in second context should have id 1", 1,
-        id2);
+    assertEquals(1, id2, "2nd schema registered in second context should have id 1");
 
     List<String> subjects = restApp.restClient.getAllSubjects("", false);
     assertEquals(Collections.singletonList(subject), subjects);
@@ -375,8 +389,10 @@ public class RestApiTest extends ClusterTestHarness {
       int id2 = restApp.restClient.registerSchema(schema2, "subject1", 2, 1);
       fail(String.format("Schema2 is registered with id %s, should receive error here", id2));
     } catch (RestClientException e) {
-      assertEquals("Overwrite schema for the same ID is not permitted.",
-          Errors.OPERATION_NOT_PERMITTED_ERROR_CODE, e.getErrorCode());
+      assertEquals(
+          Errors.OPERATION_NOT_PERMITTED_ERROR_CODE, e.getErrorCode(),
+          "Overwrite schema for the same ID is not permitted."
+      );
     }
 
     try {
@@ -385,8 +401,10 @@ public class RestApiTest extends ClusterTestHarness {
       int id2 = restApp.restClient.registerSchema(schema2, "subject2", 1, 1);
       fail(String.format("Schema2 is registered with id %s, should receive error here", id2));
     } catch (RestClientException e) {
-      assertEquals("Overwrite schema for the same ID is not permitted.",
-          Errors.OPERATION_NOT_PERMITTED_ERROR_CODE, e.getErrorCode());
+      assertEquals(
+          Errors.OPERATION_NOT_PERMITTED_ERROR_CODE, e.getErrorCode(),
+          "Overwrite schema for the same ID is not permitted."
+      );
     }
   }
 
@@ -423,7 +441,7 @@ public class RestApiTest extends ClusterTestHarness {
     String schema1 = allSchemas.get(0);
     boolean isCompatible =
         restApp.restClient.testCompatibility(schema1, subject, "latest").isEmpty();
-    assertTrue("First schema registered should be compatible", isCompatible);
+    assertTrue(isCompatible, "First schema registered should be compatible");
 
     for (int i = 0; i < numSchemas; i++) {
       // Test that compatibility check doesn't change the number of versions
@@ -465,7 +483,7 @@ public class RestApiTest extends ClusterTestHarness {
                                                                 String.valueOf(
                                                                     versionOfRegisteredSchema))
                                               .isEmpty();
-    assertFalse("Schema should be incompatible with specified version", isCompatible);
+    assertFalse(isCompatible, "Schema should be incompatible with specified version");
   }
 
   @Test
@@ -497,15 +515,14 @@ public class RestApiTest extends ClusterTestHarness {
 
     //schema3 is compatible with schema2, but not compatible with schema1
     boolean isCompatible = restApp.restClient.testCompatibility(schema3, subject, "latest").isEmpty();
-    assertTrue("Schema is compatible with the latest version", isCompatible);
+    assertTrue(isCompatible, "Schema is compatible with the latest version");
     isCompatible = restApp.restClient.testCompatibility(schema3, subject, null).isEmpty();
-    assertFalse("Schema should be incompatible with FORWARD_TRANSITIVE setting", isCompatible);
+    assertFalse(isCompatible, "Schema should be incompatible with FORWARD_TRANSITIVE setting");
     try {
       restApp.restClient.registerSchema(schema3String, subject);
       fail("Schema register should fail since schema is incompatible");
     } catch (RestClientException e) {
-      assertEquals("Schema register should fail since schema is incompatible",
-          Errors.INCOMPATIBLE_SCHEMA_ERROR_CODE, e.getErrorCode());
+      assertEquals(Errors.INCOMPATIBLE_SCHEMA_ERROR_CODE, e.getErrorCode());
       assertFalse(e.getMessage().isEmpty());
       assertTrue(e.getMessage().contains("oldSchemaVersion:"));
       assertTrue(e.getMessage().contains("oldSchema:"));
@@ -528,9 +545,10 @@ public class RestApiTest extends ClusterTestHarness {
 
     SchemaString schemaString = restApp.restClient.getId(
         RestService.DEFAULT_REQUEST_PROPERTIES, 1, null, "bad-format", null, false);
-    assertEquals("Registered schema should be found",
+    assertEquals(
         schema1,
-        schemaString.getSchemaString()
+        schemaString.getSchemaString(),
+        "Registered schema should be found"
     );
   }
 
@@ -562,45 +580,60 @@ public class RestApiTest extends ClusterTestHarness {
         restApp.restClient.registerSchema(schema1, subject1);
     int versionOfRegisteredSchema1Subject1 =
         restApp.restClient.lookUpSubjectVersion(schema1, subject1).getVersion();
-    assertEquals("1st schema under subject1 should have version 1", 1,
-                 versionOfRegisteredSchema1Subject1);
-    assertEquals("1st schema registered globally should have id 1", 1,
-                 idOfRegisteredSchema1Subject1);
+    assertEquals(
+        1, versionOfRegisteredSchema1Subject1,
+        "1st schema under subject1 should have version 1"
+    );
+    assertEquals(
+        1, idOfRegisteredSchema1Subject1,
+        "1st schema registered globally should have id 1"
+    );
 
     int idOfRegisteredSchema2Subject1 =
         restApp.restClient.registerSchema(schema2, subject1);
     int versionOfRegisteredSchema2Subject1 =
         restApp.restClient.lookUpSubjectVersion(schema2, subject1).getVersion();
-    assertEquals("2nd schema under subject1 should have version 2", 2,
-                 versionOfRegisteredSchema2Subject1);
-    assertEquals("2nd schema registered globally should have id 2", 2,
-                 idOfRegisteredSchema2Subject1);
+    assertEquals(
+        2, versionOfRegisteredSchema2Subject1,
+        "2nd schema under subject1 should have version 2"
+    );
+    assertEquals(
+        2, idOfRegisteredSchema2Subject1,
+        "2nd schema registered globally should have id 2"
+    );
 
     int idOfRegisteredSchema2Subject2 =
         restApp.restClient.registerSchema(schema2, subject2);
     int versionOfRegisteredSchema2Subject2 =
         restApp.restClient.lookUpSubjectVersion(schema2, subject2).getVersion();
     assertEquals(
-        "2nd schema under subject1 should still have version 1 as the first schema under subject2",
         1,
-        versionOfRegisteredSchema2Subject2);
-    assertEquals("Since schema is globally registered but not under subject2, id should not change",
-                 2,
-                 idOfRegisteredSchema2Subject2);
+        versionOfRegisteredSchema2Subject2,
+        "2nd schema under subject1 should still have version 1 as the first schema under subject2"
+    );
+    assertEquals(
+        2,
+        idOfRegisteredSchema2Subject2,
+        "Since schema is globally registered but not under subject2, id should not change"
+    );
   }
 
   @Test
   public void testConfigDefaults() throws Exception {
-    assertEquals("Default compatibility level should be none for this test instance",
-                 NONE.name,
-                 restApp.restClient.getConfig(null).getCompatibilityLevel());
+    assertEquals(
+        NONE.name,
+        restApp.restClient.getConfig(null).getCompatibilityLevel(),
+        "Default compatibility level should be none for this test instance"
+    );
 
     // change it to forward
     restApp.restClient.updateCompatibility(CompatibilityLevel.FORWARD.name, null);
 
-    assertEquals("New compatibility level should be forward for this test instance",
-                 FORWARD.name,
-                 restApp.restClient.getConfig(null).getCompatibilityLevel());
+    assertEquals(
+        FORWARD.name,
+        restApp.restClient.getConfig(null).getCompatibilityLevel(),
+        "New compatibility level should be forward for this test instance"
+    );
   }
 
   @Test
@@ -611,64 +644,82 @@ public class RestApiTest extends ClusterTestHarness {
     } catch (RestClientException e) {
       fail("Changing config for an invalid subject should succeed");
     }
-    assertEquals("New compatibility level for this subject should be forward",
-                 FORWARD.name,
-                 restApp.restClient.getConfig(subject).getCompatibilityLevel());
+    assertEquals(
+        FORWARD.name,
+        restApp.restClient.getConfig(subject).getCompatibilityLevel(),
+        "New compatibility level for this subject should be forward"
+    );
   }
 
   @Test
   public void testSubjectConfigChange() throws Exception {
     String subject = "testSubject";
-    assertEquals("Default compatibility level should be none for this test instance",
-                 NONE.name,
-                 restApp.restClient.getConfig(null).getCompatibilityLevel());
+    assertEquals(
+        NONE.name,
+        restApp.restClient.getConfig(null).getCompatibilityLevel(),
+        "Default compatibility level should be none for this test instance"
+    );
 
     // change subject compatibility to forward
     restApp.restClient.updateCompatibility(CompatibilityLevel.FORWARD.name, subject);
 
-    assertEquals("Global compatibility level should remain none for this test instance",
-                 NONE.name,
-                 restApp.restClient.getConfig(null).getCompatibilityLevel());
+    assertEquals(
+        NONE.name,
+        restApp.restClient.getConfig(null).getCompatibilityLevel(),
+        "Global compatibility level should remain none for this test instance"
+    );
 
-    assertEquals("New compatibility level for this subject should be forward",
-                 FORWARD.name,
-                 restApp.restClient.getConfig(subject).getCompatibilityLevel());
+    assertEquals(
+        FORWARD.name,
+        restApp.restClient.getConfig(subject).getCompatibilityLevel(),
+        "New compatibility level for this subject should be forward"
+    );
 
     // delete subject compatibility
     restApp.restClient.deleteConfig(subject);
 
-    assertEquals("Compatibility level for this subject should be reverted to none",
+    assertEquals(
         NONE.name,
         restApp.restClient
             .getConfig(RestService.DEFAULT_REQUEST_PROPERTIES, subject, true)
-            .getCompatibilityLevel());
+            .getCompatibilityLevel(),
+        "Compatibility level for this subject should be reverted to none"
+    );
   }
 
   @Test
   public void testGlobalConfigChange() throws Exception{
-    assertEquals("Default compatibility level should be none for this test instance",
+    assertEquals(
         NONE.name,
-        restApp.restClient.getConfig(null).getCompatibilityLevel());
+        restApp.restClient.getConfig(null).getCompatibilityLevel(),
+        "Default compatibility level should be none for this test instance"
+    );
 
     // change subject compatibility to forward
     restApp.restClient.updateCompatibility(CompatibilityLevel.FORWARD.name, null);
-    assertEquals("New Global compatibility level should be forward",
+    assertEquals(
         FORWARD.name,
-        restApp.restClient.getConfig(null).getCompatibilityLevel());
+        restApp.restClient.getConfig(null).getCompatibilityLevel(),
+        "New Global compatibility level should be forward"
+    );
 
     // change subject compatibility to backward
     restApp.restClient.updateCompatibility(BACKWARD.name, null);
-    assertEquals("New Global compatibility level should be backward",
+    assertEquals(
         BACKWARD.name,
-        restApp.restClient.getConfig(null).getCompatibilityLevel());
+        restApp.restClient.getConfig(null).getCompatibilityLevel(),
+        "New Global compatibility level should be backward"
+    );
 
     // delete Global compatibility
     restApp.restClient.deleteConfig(null);
-    assertEquals("Global compatibility level should be reverted to none",
+    assertEquals(
         NONE.name,
         restApp.restClient
             .getConfig(RestService.DEFAULT_REQUEST_PROPERTIES, null, true)
-            .getCompatibilityLevel());
+            .getCompatibilityLevel(),
+        "Global compatibility level should be reverted to none"
+    );
   }
 
   @Test
@@ -680,9 +731,11 @@ public class RestApiTest extends ClusterTestHarness {
            + " (schema not found)");
     } catch (RestClientException rce) {
       // this is expected.
-      assertEquals("Should get a 404 status for non-existing id",
-                   Errors.SCHEMA_NOT_FOUND_ERROR_CODE,
-                   rce.getErrorCode());
+      assertEquals(
+          Errors.SCHEMA_NOT_FOUND_ERROR_CODE,
+          rce.getErrorCode(),
+          "Should get a 404 status for non-existing id"
+      );
     }
   }
 
@@ -715,9 +768,11 @@ public class RestApiTest extends ClusterTestHarness {
            + " (subject not found)");
     } catch (RestClientException rce) {
       // this is expected.
-      assertEquals("Should get a 404 status for non-existing subject",
-                   Errors.SUBJECT_NOT_FOUND_ERROR_CODE,
-                   rce.getErrorCode());
+      assertEquals(
+          Errors.SUBJECT_NOT_FOUND_ERROR_CODE,
+          rce.getErrorCode(),
+          "Should get a 404 status for non-existing subject"
+      );
     }
   }
 
@@ -731,9 +786,11 @@ public class RestApiTest extends ClusterTestHarness {
            + " (subject not found)");
     } catch (RestClientException e) {
       // this is expected.
-      assertEquals("Unregistered subject shouldn't be found in getVersion()",
-                   Errors.SUBJECT_NOT_FOUND_ERROR_CODE,
-                   e.getErrorCode());
+      assertEquals(
+          Errors.SUBJECT_NOT_FOUND_ERROR_CODE,
+          e.getErrorCode(),
+          "Unregistered subject shouldn't be found in getVersion()"
+      );
     }
   }
 
@@ -750,8 +807,10 @@ public class RestApiTest extends ClusterTestHarness {
            + " (version not found)");
     } catch (RestClientException e) {
       // this is expected.
-      assertEquals("Unregistered version shouldn't be found",
-                   Errors.VERSION_NOT_FOUND_ERROR_CODE, e.getErrorCode());
+      assertEquals(
+          Errors.VERSION_NOT_FOUND_ERROR_CODE, e.getErrorCode(),
+          "Unregistered version shouldn't be found"
+      );
     }
   }
 
@@ -768,9 +827,11 @@ public class RestApiTest extends ClusterTestHarness {
            + " (invalid version)");
     } catch (RestClientException e) {
       // this is expected.
-      assertEquals("Invalid version shouldn't be found",
-                   RestInvalidVersionException.ERROR_CODE,
-                   e.getErrorCode());
+      assertEquals(
+          RestInvalidVersionException.ERROR_CODE,
+          e.getErrorCode(),
+          "Invalid version shouldn't be found"
+      );
     }
   }
 
@@ -786,9 +847,11 @@ public class RestApiTest extends ClusterTestHarness {
           + " (invalid subject)");
     } catch (RestClientException e) {
       // this is expected.
-      assertEquals("Invalid subject shouldn't be registered",
-                   RestInvalidSubjectException.ERROR_CODE,
-                   e.getErrorCode());
+      assertEquals(
+          RestInvalidSubjectException.ERROR_CODE,
+          e.getErrorCode(),
+          "Invalid subject shouldn't be registered"
+      );
     }
   }
 
@@ -799,16 +862,22 @@ public class RestApiTest extends ClusterTestHarness {
     TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(0), 1, subject);
     TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(1), 2, subject);
 
-    assertEquals("Version 1 schema should match",
-                 schemas.get(0),
-                 restApp.restClient.getVersion(subject, 1).getSchema());
+    assertEquals(
+        schemas.get(0),
+        restApp.restClient.getVersion(subject, 1).getSchema(),
+        "Version 1 schema should match"
+    );
 
-    assertEquals("Version 2 schema should match",
-                 schemas.get(1),
-                 restApp.restClient.getVersion(subject, 2).getSchema());
-    assertEquals("Latest schema should be the same as version 2",
-                 schemas.get(1),
-                 restApp.restClient.getLatestVersion(subject).getSchema());
+    assertEquals(
+        schemas.get(1),
+        restApp.restClient.getVersion(subject, 2).getSchema(),
+        "Version 2 schema should match"
+    );
+    assertEquals(
+        schemas.get(1),
+        restApp.restClient.getLatestVersion(subject).getSchema(),
+        "Latest schema should be the same as version 2"
+    );
   }
 
   @Test
@@ -816,9 +885,11 @@ public class RestApiTest extends ClusterTestHarness {
     String schema = String.valueOf(TestUtils.getRandomCanonicalAvroString(1));
     String subject = "test";
     TestUtils.registerAndVerifySchema(restApp.restClient, schema, 1, subject);
-    assertEquals("Schema with ID 1 should match.",
-            schema,
-            restApp.restClient.getOnlySchemaById(1));
+    assertEquals(
+        schema,
+        restApp.restClient.getOnlySchemaById(1),
+        "Schema with ID 1 should match."
+    );
   }
 
   @Test
@@ -828,9 +899,11 @@ public class RestApiTest extends ClusterTestHarness {
     TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(0), 1, subject);
     TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(1), 2, subject);
 
-    assertEquals("Latest schema should be the same as version 2",
-                 schemas.get(1),
-                 restApp.restClient.getLatestVersionSchemaOnly(subject));
+    assertEquals(
+        schemas.get(1),
+        restApp.restClient.getLatestVersionSchemaOnly(subject),
+        "Latest schema should be the same as version 2"
+    );
   }
 
   @Test
@@ -839,9 +912,11 @@ public class RestApiTest extends ClusterTestHarness {
     String subject = "test";
     TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(0), 1, subject);
 
-    assertEquals("Retrieved schema should be the same as version 1",
-                schemas.get(0),
-                restApp.restClient.getVersionSchemaOnly(subject, 1));
+    assertEquals(
+        schemas.get(0),
+        restApp.restClient.getVersionSchemaOnly(subject, 1),
+        "Retrieved schema should be the same as version 1"
+    );
   }
 
   @Test
@@ -872,17 +947,21 @@ public class RestApiTest extends ClusterTestHarness {
     request.setReferences(Collections.singletonList(ref));
     String subject2 = context + "my_referrer";
     int registeredId = restApp.restClient.registerSchema(request, subject2, false).getId();
-    assertEquals("Registering a new schema should succeed", parentId, registeredId);
+    assertEquals(parentId, registeredId, "Registering a new schema should succeed");
 
     SchemaString schemaString = restApp.restClient.getId(parentId, subject2);
     // the newly registered schema should be immediately readable on the leader
-    assertEquals("Registered schema should be found",
+    assertEquals(
         schemas.get(1),
-        schemaString.getSchemaString());
+        schemaString.getSchemaString(),
+        "Registered schema should be found"
+    );
 
-    assertEquals("Schema references should be found",
+    assertEquals(
         Collections.singletonList(ref),
-        schemaString.getReferences());
+        schemaString.getReferences(),
+        "Schema references should be found"
+    );
 
     List<Integer> refs = restApp.restClient.getReferencedBy(subject, 1);
     assertEquals(parentId, refs.get(0).intValue());
@@ -892,7 +971,10 @@ public class RestApiTest extends ClusterTestHarness {
     // Note that we pass an empty list of refs since SR will perform a deep equality check
     Schema registeredSchema = restApp.restClient.lookUpSubjectVersion(schema.canonicalString(),
         AvroSchema.TYPE, Collections.emptyList(), subject2, false);
-    assertEquals("Registered schema should be found", parentId, registeredSchema.getId().intValue());
+    assertEquals(
+        parentId, registeredSchema.getId().intValue(),
+        "Registered schema should be found"
+    );
 
     try {
       restApp.restClient.deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES,
@@ -901,9 +983,11 @@ public class RestApiTest extends ClusterTestHarness {
       );
       fail("Deleting reference should fail with " + Errors.REFERENCE_EXISTS_ERROR_CODE);
     } catch (RestClientException rce) {
-      assertEquals("Reference found",
+      assertEquals(
           Errors.REFERENCE_EXISTS_ERROR_CODE,
-          rce.getErrorCode());
+          rce.getErrorCode(),
+          "Reference found"
+      );
     }
 
     assertEquals((Integer) 1, restApp.restClient
@@ -973,14 +1057,14 @@ public class RestApiTest extends ClusterTestHarness {
     SchemaReference ref = new SchemaReference("myavro.currencies.Currency", "shared", 1);
     request.setReferences(Collections.singletonList(ref));
     int registeredId = restApp.restClient.registerSchema(request, "ref1", false).getId();
-    assertEquals("Registering a new schema should succeed", 2, registeredId);
+    assertEquals(2, registeredId, "Registering a new schema should succeed");
 
     request = new RegisterSchemaRequest();
     request.setSchema(ref2);
     ref = new SchemaReference("myavro.currencies.Currency", "shared", 1);
     request.setReferences(Collections.singletonList(ref));
     registeredId = restApp.restClient.registerSchema(request, "ref2", false).getId();
-    assertEquals("Registering a new schema should succeed", 3, registeredId);
+    assertEquals(3, registeredId, "Registering a new schema should succeed");
 
     request = new RegisterSchemaRequest();
     request.setSchema(root);
@@ -988,27 +1072,33 @@ public class RestApiTest extends ClusterTestHarness {
     SchemaReference r2 = new SchemaReference("myavro.BudgetUpdated", "ref2", 1);
     request.setReferences(Arrays.asList(r1, r2));
     registeredId = restApp.restClient.registerSchema(request, "root", false).getId();
-    assertEquals("Registering a new schema should succeed", 4, registeredId);
+    assertEquals(4, registeredId, "Registering a new schema should succeed");
 
     SchemaString schemaString = restApp.restClient.getId(4);
     // the newly registered schema should be immediately readable on the leader
-    assertEquals("Registered schema should be found",
+    assertEquals(
         root,
-        schemaString.getSchemaString());
+        schemaString.getSchemaString(),
+        "Registered schema should be found"
+    );
 
-    assertEquals("Schema references should be found",
+    assertEquals(
         Arrays.asList(r1, r2),
-        schemaString.getReferences());
+        schemaString.getReferences(),
+        "Schema references should be found"
+    );
   }
 
-  @Test(expected = RestClientException.class)
+  @Test
   public void testSchemaMissingReferences() throws Exception {
-    List<String> schemas = TestUtils.getAvroSchemaWithReferences();
+    assertThrows(RestClientException.class, () -> {
+      List<String> schemas = TestUtils.getAvroSchemaWithReferences();
 
-    RegisterSchemaRequest request = new RegisterSchemaRequest();
-    request.setSchema(schemas.get(1));
-    request.setReferences(Collections.emptyList());
-    restApp.restClient.registerSchema(request, "referrer", false);
+      RegisterSchemaRequest request = new RegisterSchemaRequest();
+      request.setSchema(schemas.get(1));
+      request.setReferences(Collections.emptyList());
+      restApp.restClient.registerSchema(request, "referrer", false);
+    });
   }
 
   @Test
@@ -1061,10 +1151,14 @@ public class RestApiTest extends ClusterTestHarness {
     lookUpRequest.setReferences(Arrays.asList(ref2, ref1));
     int versionOfRegisteredSchema1Subject1 =
         restApp.restClient.lookUpSubjectVersion(lookUpRequest, subject1, true, false).getVersion();
-    assertEquals("1st schema under subject1 should have version 1", 1,
-        versionOfRegisteredSchema1Subject1);
-    assertEquals("1st schema registered globally should have id 3", 3,
-        idOfRegisteredSchema1Subject1);
+    assertEquals(
+        1, versionOfRegisteredSchema1Subject1,
+        "1st schema under subject1 should have version 1"
+    );
+    assertEquals(
+        3, idOfRegisteredSchema1Subject1,
+        "1st schema registered globally should have id 3"
+    );
 
     // send schema with all references resolved
     lookUpRequest = new RegisterSchemaRequest();
@@ -1075,8 +1169,10 @@ public class RestApiTest extends ClusterTestHarness {
     lookUpRequest.setSchema(resolvedSchema.canonicalString());
     versionOfRegisteredSchema1Subject1 =
         restApp.restClient.lookUpSubjectVersion(lookUpRequest, subject1, true, false).getVersion();
-    assertEquals("1st schema under subject1 should have version 1", 1,
-        versionOfRegisteredSchema1Subject1);
+    assertEquals(
+        1, versionOfRegisteredSchema1Subject1,
+        "1st schema under subject1 should have version 1"
+    );
 
 
     String recordInvalidDefaultSchema =
@@ -1093,9 +1189,11 @@ public class RestApiTest extends ClusterTestHarness {
       restApp.restClient.registerSchema(registerRequest, subject1, true);
       fail("Registering bad schema should fail with " + Errors.INVALID_SCHEMA_ERROR_CODE);
     } catch (RestClientException rce) {
-      assertEquals("Invalid schema",
+      assertEquals(
           Errors.INVALID_SCHEMA_ERROR_CODE,
-          rce.getErrorCode());
+          rce.getErrorCode(),
+          "Invalid schema"
+      );
     }
 
     List<String> messages = restApp.restClient.testCompatibility(
@@ -1109,18 +1207,21 @@ public class RestApiTest extends ClusterTestHarness {
     List<String> allSubjects = new ArrayList<>();
 
     // test getAllSubjects with no existing data
-    assertEquals("Getting all subjects should return empty",
+    assertEquals(
         allSubjects,
-        restApp.restClient.getAllSubjects()
+        restApp.restClient.getAllSubjects(),
+        "Getting all subjects should return empty"
     );
 
     try {
       TestUtils.registerAndVerifySchema(restApp.restClient, TestUtils.getBadSchema(), 1, subject1);
       fail("Registering bad schema should fail with " + Errors.INVALID_SCHEMA_ERROR_CODE);
     } catch (RestClientException rce) {
-      assertEquals("Invalid schema",
+      assertEquals(
           Errors.INVALID_SCHEMA_ERROR_CODE,
-          rce.getErrorCode());
+          rce.getErrorCode(),
+          "Invalid schema"
+      );
     }
 
     try {
@@ -1129,15 +1230,18 @@ public class RestApiTest extends ClusterTestHarness {
           ImmutableList.of(new SchemaReference("bad", "bad", 100)), 1, subject1);
       fail("Registering bad reference should fail with " + Errors.INVALID_SCHEMA_ERROR_CODE);
     } catch (RestClientException rce) {
-      assertEquals("Invalid schema",
+      assertEquals(
           Errors.INVALID_SCHEMA_ERROR_CODE,
-          rce.getErrorCode());
+          rce.getErrorCode(),
+          "Invalid schema"
+      );
     }
 
     // test getAllSubjects with existing data
-    assertEquals("Getting all subjects should match all registered subjects",
+    assertEquals(
         allSubjects,
-        restApp.restClient.getAllSubjects()
+        restApp.restClient.getAllSubjects(),
+        "Getting all subjects should match all registered subjects"
     );
   }
 
@@ -1150,9 +1254,11 @@ public class RestApiTest extends ClusterTestHarness {
            + Errors.SUBJECT_NOT_FOUND_ERROR_CODE
            + " (subject not found)");
     } catch (RestClientException rce) {
-      assertEquals("Subject not found",
-                   Errors.SUBJECT_NOT_FOUND_ERROR_CODE,
-                   rce.getErrorCode());
+      assertEquals(
+          Errors.SUBJECT_NOT_FOUND_ERROR_CODE,
+          rce.getErrorCode(),
+          "Subject not found"
+      );
     }
   }
 
@@ -1169,7 +1275,7 @@ public class RestApiTest extends ClusterTestHarness {
            + Errors.SCHEMA_NOT_FOUND_ERROR_CODE
            + " (schema not found)");
     } catch (RestClientException rce) {
-      assertEquals("Schema not found", Errors.SCHEMA_NOT_FOUND_ERROR_CODE, rce.getErrorCode());
+      assertEquals(Errors.SCHEMA_NOT_FOUND_ERROR_CODE, rce.getErrorCode());
     }
   }
 
@@ -1186,9 +1292,11 @@ public class RestApiTest extends ClusterTestHarness {
     assertEquals(associatedSubjects.size(), 2);
     assertEquals(Arrays.asList(subject1, subject2), associatedSubjects);
 
-    assertEquals("Deleting Schema Version Success", (Integer) 1, restApp.restClient
-        .deleteSchemaVersion
-            (RestService.DEFAULT_REQUEST_PROPERTIES, subject2, "1"));
+    assertEquals(
+        (Integer) 1, restApp.restClient
+            .deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject2, "1"),
+        "Deleting Schema Version Success"
+    );
 
     associatedSubjects = restApp.restClient.getAllSubjectsById(1);
     assertEquals(associatedSubjects.size(), 1);
@@ -1207,9 +1315,11 @@ public class RestApiTest extends ClusterTestHarness {
       fail("Getting all subjects associated with id 1 should fail with "
             + Errors.SCHEMA_NOT_FOUND_ERROR_CODE + " (schema not found)");
     } catch (RestClientException rce) {
-      assertEquals("Should get a 404 status for non-existing schema",
-              Errors.SCHEMA_NOT_FOUND_ERROR_CODE,
-              rce.getErrorCode());
+      assertEquals(
+          Errors.SCHEMA_NOT_FOUND_ERROR_CODE,
+          rce.getErrorCode(),
+          "Should get a 404 status for non-existing schema"
+      );
     }
   }
 
@@ -1227,9 +1337,11 @@ public class RestApiTest extends ClusterTestHarness {
     assertTrue(associatedSubjects.contains(new SubjectVersion(subject1, 1)));
     assertTrue(associatedSubjects.contains(new SubjectVersion(subject2, 1)));
 
-    assertEquals("Deleting Schema Version Success", (Integer) 1, restApp.restClient
-        .deleteSchemaVersion
-            (RestService.DEFAULT_REQUEST_PROPERTIES, subject2, "1"));
+    assertEquals(
+        (Integer) 1, restApp.restClient
+            .deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject2, "1"),
+        "Deleting Schema Version Success"
+    );
 
     associatedSubjects = restApp.restClient.getAllVersionsById(1);
     assertEquals(associatedSubjects.size(), 1);
@@ -1247,11 +1359,11 @@ public class RestApiTest extends ClusterTestHarness {
     String schema = TestUtils.getRandomCanonicalAvroString(1).get(0);
     boolean result = restApp.restClient.testCompatibility(schema, "non-existent-subject", "latest")
                                        .isEmpty();
-    assertTrue("Compatibility succeeds", result);
+    assertTrue(result, "Compatibility succeeds");
 
     result = restApp.restClient.testCompatibility(schema, "non-existent-subject", null)
         .isEmpty();
-    assertTrue("Compatibility succeeds", result);
+    assertTrue(result, "Compatibility succeeds");
   }
 
   @Test
@@ -1265,7 +1377,7 @@ public class RestApiTest extends ClusterTestHarness {
            + Errors.VERSION_NOT_FOUND_ERROR_CODE
            + " (version not found)");
     } catch (RestClientException rce) {
-      assertEquals("Version not found", Errors.VERSION_NOT_FOUND_ERROR_CODE, rce.getErrorCode());
+      assertEquals(Errors.VERSION_NOT_FOUND_ERROR_CODE, rce.getErrorCode());
     }
   }
 
@@ -1280,9 +1392,7 @@ public class RestApiTest extends ClusterTestHarness {
            + RestInvalidVersionException.ERROR_CODE
            + " (version not found)");
     } catch (RestClientException rce) {
-      assertEquals("Version not found",
-                   RestInvalidVersionException.ERROR_CODE,
-                   rce.getErrorCode());
+      assertEquals(RestInvalidVersionException.ERROR_CODE, rce.getErrorCode());
     }
   }
 
@@ -1294,8 +1404,7 @@ public class RestApiTest extends ClusterTestHarness {
            + Errors.SUBJECT_NOT_FOUND_ERROR_CODE
            + " error code (subject not found)");
     } catch (RestClientException rce) {
-      assertEquals("Subject not found",
-                   Errors.SUBJECT_LEVEL_COMPATIBILITY_NOT_CONFIGURED_ERROR_CODE,
+      assertEquals(Errors.SUBJECT_LEVEL_COMPATIBILITY_NOT_CONFIGURED_ERROR_CODE,
                    rce.getErrorCode());
     }
   }
@@ -1305,18 +1414,24 @@ public class RestApiTest extends ClusterTestHarness {
     // schema string with extra white space
     String schema = "{   \"type\":   \"string\"}";
     String subject = "test";
-    assertEquals("Registering a new schema should succeed",
-                 1,
-                 restApp.restClient.registerSchema(schema, subject));
+    assertEquals(
+        1,
+        restApp.restClient.registerSchema(schema, subject),
+        "Registering a new schema should succeed"
+    );
 
-    assertEquals("Registering the same schema should get back the same id",
-                 1,
-                 restApp.restClient.registerSchema(schema, subject));
+    assertEquals(
+        1,
+        restApp.restClient.registerSchema(schema, subject),
+        "Registering the same schema should get back the same id"
+    );
 
-    assertEquals("Lookup the same schema should get back the same id",
-                 1,
-                 restApp.restClient.lookUpSubjectVersion(schema, subject)
-                     .getId().intValue());
+    assertEquals(
+        1,
+        restApp.restClient.lookUpSubjectVersion(schema, subject)
+            .getId().intValue(),
+        "Lookup the same schema should get back the same id"
+    );
   }
 
   @Test
@@ -1327,9 +1442,11 @@ public class RestApiTest extends ClusterTestHarness {
     TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(0), 1, subject);
     TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(1), 2, subject);
 
-    assertEquals("Deleting Schema Version Success", (Integer) 2, restApp.restClient
-        .deleteSchemaVersion
-            (RestService.DEFAULT_REQUEST_PROPERTIES, subject, "2"));
+    assertEquals(
+        (Integer) 2, restApp.restClient
+            .deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject, "2"),
+        "Deleting Schema Version Success"
+    );
 
     assertEquals(Collections.singletonList(1), restApp.restClient.getAllVersions(subject));
 
@@ -1338,9 +1455,11 @@ public class RestApiTest extends ClusterTestHarness {
       fail(String.format("Getting Version %s for subject %s should fail with %s", "2", subject,
                          Errors.VERSION_NOT_FOUND_ERROR_CODE));
     } catch (RestClientException rce) {
-      assertEquals("Version not found",
-                   Errors.VERSION_NOT_FOUND_ERROR_CODE,
-                   rce.getErrorCode());
+      assertEquals(
+          Errors.VERSION_NOT_FOUND_ERROR_CODE,
+          rce.getErrorCode(),
+          "Version not found"
+      );
     }
     try {
       RegisterSchemaRequest request = new RegisterSchemaRequest();
@@ -1351,23 +1470,29 @@ public class RestApiTest extends ClusterTestHarness {
                          subject,
                          Errors.SCHEMA_NOT_FOUND_ERROR_CODE));
     } catch (RestClientException rce) {
-      assertEquals("Schema not found",
-                   Errors.SCHEMA_NOT_FOUND_ERROR_CODE,
-                   rce.getErrorCode());
+      assertEquals(
+          Errors.SCHEMA_NOT_FOUND_ERROR_CODE,
+          rce.getErrorCode(),
+          "Schema not found"
+      );
     }
 
-    assertEquals("Deleting Schema Version Success", (Integer) 1, restApp.restClient
-        .deleteSchemaVersion
-            (RestService.DEFAULT_REQUEST_PROPERTIES, subject, "latest"));
+    assertEquals(
+        (Integer) 1, restApp.restClient
+            .deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject, "latest"),
+        "Deleting Schema Version Success"
+    );
     try {
       List<Integer> versions = restApp.restClient.getAllVersions(subject);
       fail("Getting all versions from non-existing subject1 should fail with "
            + Errors.SUBJECT_NOT_FOUND_ERROR_CODE
            + " (subject not found). Got " + versions);
     } catch (RestClientException rce) {
-      assertEquals("Should get a 404 status for non-existing subject",
-                   Errors.SUBJECT_NOT_FOUND_ERROR_CODE,
-                   rce.getErrorCode());
+      assertEquals(
+          Errors.SUBJECT_NOT_FOUND_ERROR_CODE,
+          rce.getErrorCode(),
+          "Should get a 404 status for non-existing subject"
+      );
     }
 
     //re-register twice and versions should be same
@@ -1395,15 +1520,19 @@ public class RestApiTest extends ClusterTestHarness {
                               true);
       fail("Permanent deleting first time should throw schemaVersionNotSoftDeletedException");
     } catch (RestClientException rce) {
-      assertEquals("Schema version must be soft deleted first",
-              Errors.SCHEMAVERSION_NOT_SOFT_DELETED_ERROR_CODE,
-              rce.getErrorCode());
+      assertEquals(
+          Errors.SCHEMAVERSION_NOT_SOFT_DELETED_ERROR_CODE,
+          rce.getErrorCode(),
+          "Schema version must be soft deleted first"
+      );
     }
 
     //soft delete
-    assertEquals("Deleting Schema Version Success", (Integer) 2, restApp.restClient
-            .deleteSchemaVersion
-                    (RestService.DEFAULT_REQUEST_PROPERTIES, subject, "2"));
+    assertEquals(
+        (Integer) 2, restApp.restClient
+            .deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject, "2"),
+        "Deleting Schema Version Success"
+    );
 
     assertEquals(Collections.singletonList(1), restApp.restClient.getAllVersions(subject));
     assertEquals(Arrays.asList(1,2), restApp.restClient.getAllVersions(
@@ -1416,9 +1545,11 @@ public class RestApiTest extends ClusterTestHarness {
                       (RestService.DEFAULT_REQUEST_PROPERTIES, subject, "2");
       fail("Soft deleting second time should throw schemaVersionSoftDeletedException");
     } catch (RestClientException rce) {
-      assertEquals("Schema version already soft deleted",
-              Errors.SCHEMAVERSION_SOFT_DELETED_ERROR_CODE,
-              rce.getErrorCode());
+      assertEquals(
+          Errors.SCHEMAVERSION_SOFT_DELETED_ERROR_CODE,
+          rce.getErrorCode(),
+          "Schema version already soft deleted"
+      );
     }
 
     try {
@@ -1426,13 +1557,15 @@ public class RestApiTest extends ClusterTestHarness {
       fail(String.format("Getting Version %s for subject %s should fail with %s", "2", subject,
               Errors.VERSION_NOT_FOUND_ERROR_CODE));
     } catch (RestClientException rce) {
-      assertEquals("Version not found",
-              Errors.VERSION_NOT_FOUND_ERROR_CODE,
-              rce.getErrorCode());
+      assertEquals(
+          Errors.VERSION_NOT_FOUND_ERROR_CODE,
+          rce.getErrorCode(),
+          "Version not found"
+      );
     }
 
       Schema schema = restApp.restClient.getVersion(subject, 2, true);
-      assertEquals("Lookup Version Match", (Integer) 2, schema.getVersion());
+      assertEquals((Integer) 2, schema.getVersion());
 
     try {
       RegisterSchemaRequest request = new RegisterSchemaRequest();
@@ -1443,23 +1576,21 @@ public class RestApiTest extends ClusterTestHarness {
               subject,
               Errors.SCHEMA_NOT_FOUND_ERROR_CODE));
     } catch (RestClientException rce) {
-      assertEquals("Schema not found",
-              Errors.SCHEMA_NOT_FOUND_ERROR_CODE,
-              rce.getErrorCode());
+      assertEquals(Errors.SCHEMA_NOT_FOUND_ERROR_CODE, rce.getErrorCode());
     }
     // permanent delete
-    assertEquals("Deleting Schema Version Success", (Integer) 2, restApp.restClient
-            .deleteSchemaVersion
-                    (RestService.DEFAULT_REQUEST_PROPERTIES, subject, "2", true));
+    assertEquals(
+        (Integer) 2, restApp.restClient
+            .deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject, "2", true),
+        "Deleting Schema Version Success"
+    );
     // GET after permanent delete should give exception
     try {
       restApp.restClient.getVersion(subject, 2, true);
       fail(String.format("Getting Version %s for subject %s should fail with %s", "2", subject,
               Errors.VERSION_NOT_FOUND_ERROR_CODE));
     } catch (RestClientException rce) {
-      assertEquals("Version not found",
-              Errors.VERSION_NOT_FOUND_ERROR_CODE,
-              rce.getErrorCode());
+      assertEquals(Errors.VERSION_NOT_FOUND_ERROR_CODE, rce.getErrorCode());
     }
     //permanent delete again
     try {
@@ -1468,14 +1599,14 @@ public class RestApiTest extends ClusterTestHarness {
       fail(String.format("Getting Version %s for subject %s should fail with %s", "2", subject,
               Errors.VERSION_NOT_FOUND_ERROR_CODE));
     } catch (RestClientException rce) {
-      assertEquals("Version not found",
-              Errors.VERSION_NOT_FOUND_ERROR_CODE,
-              rce.getErrorCode());
+      assertEquals(Errors.VERSION_NOT_FOUND_ERROR_CODE, rce.getErrorCode());
     }
 
-    assertEquals("Deleting Schema Version Success", (Integer) 1, restApp.restClient
-            .deleteSchemaVersion
-                    (RestService.DEFAULT_REQUEST_PROPERTIES, subject, "latest"));
+    assertEquals(
+        (Integer) 1, restApp.restClient
+            .deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject, "latest"),
+        "Deleting Schema Version Success"
+    );
 
     try {
       List<Integer> versions = restApp.restClient.getAllVersions(subject);
@@ -1483,9 +1614,11 @@ public class RestApiTest extends ClusterTestHarness {
               + Errors.SUBJECT_NOT_FOUND_ERROR_CODE
               + " (subject not found). Got " + versions);
     } catch (RestClientException rce) {
-      assertEquals("Should get a 404 status for non-existing subject",
-              Errors.SUBJECT_NOT_FOUND_ERROR_CODE,
-              rce.getErrorCode());
+      assertEquals(
+          Errors.SUBJECT_NOT_FOUND_ERROR_CODE,
+          rce.getErrorCode(),
+          "Should get a 404 status for non-existing subject"
+      );
     }
 
     //re-register twice and versions should be same
@@ -1506,9 +1639,11 @@ public class RestApiTest extends ClusterTestHarness {
            + Errors.SUBJECT_NOT_FOUND_ERROR_CODE
            + " error code (subject not found)");
     } catch (RestClientException rce) {
-      assertEquals("Subject not found",
-                   Errors.SUBJECT_NOT_FOUND_ERROR_CODE,
-                   rce.getErrorCode());
+      assertEquals(
+          Errors.SUBJECT_NOT_FOUND_ERROR_CODE,
+          rce.getErrorCode(),
+          "Subject not found"
+      );
     }
   }
 
@@ -1520,31 +1655,38 @@ public class RestApiTest extends ClusterTestHarness {
     TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(0), 1, subject);
     TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(1), 2, subject);
 
-    assertEquals("Deleting Schema Version Success", (Integer) 2, restApp.restClient
-        .deleteSchemaVersion
-            (RestService.DEFAULT_REQUEST_PROPERTIES, subject, "latest"));
+    assertEquals(
+        (Integer) 2, restApp.restClient
+            .deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject, "latest"),
+        "Deleting Schema Version Success"
+    );
 
     Schema schema = restApp.restClient.getLatestVersion(subject);
-    assertEquals("Latest Version Schema", schemas.get(0), schema.getSchema());
+    assertEquals(schemas.get(0), schema.getSchema());
 
-    assertEquals("Deleting Schema Version Success", (Integer) 1, restApp.restClient
-        .deleteSchemaVersion
-            (RestService.DEFAULT_REQUEST_PROPERTIES, subject, "latest"));
+    assertEquals(
+        (Integer) 1, restApp.restClient
+            .deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject, "latest"),
+        "Deleting Schema Version Success"
+    );
     try {
       restApp.restClient.getLatestVersion(subject);
       fail("Getting latest versions from non-existing subject should fail with "
            + Errors.SUBJECT_NOT_FOUND_ERROR_CODE
            + " (subject not found).");
     } catch (RestClientException rce) {
-      assertEquals("Should get a 404 status for non-existing subject",
-                   Errors.SUBJECT_NOT_FOUND_ERROR_CODE,
-                   rce.getErrorCode());
+      assertEquals(
+          Errors.SUBJECT_NOT_FOUND_ERROR_CODE, rce.getErrorCode(),
+          "Should get a 404 status for non-existing subject"
+      );
     }
 
     TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(2), 3, subject);
-    assertEquals("Latest version available after subject re-registration",
-            schemas.get(2),
-            restApp.restClient.getLatestVersion(subject).getSchema());
+    assertEquals(
+        schemas.get(2),
+        restApp.restClient.getLatestVersion(subject).getSchema(),
+        "Latest version available after subject re-registration"
+    );
   }
 
   @Test
@@ -1557,9 +1699,11 @@ public class RestApiTest extends ClusterTestHarness {
               + Errors.SUBJECT_NOT_FOUND_ERROR_CODE
               + " (subject not found).");
     } catch (RestClientException rce) {
-      assertEquals("Should get a 404 status for non-existing subject",
-              Errors.SUBJECT_NOT_FOUND_ERROR_CODE,
-              rce.getErrorCode());
+      assertEquals(
+          Errors.SUBJECT_NOT_FOUND_ERROR_CODE,
+          rce.getErrorCode(),
+          "Should get a 404 status for non-existing subject"
+      );
     }
   }
 
@@ -1571,14 +1715,18 @@ public class RestApiTest extends ClusterTestHarness {
     TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(0), 1, subject);
     TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(1), 2, subject);
 
-    assertEquals("Latest Version Schema", schemas.get(1), restApp.restClient.getLatestVersion(subject).getSchema());
+    assertEquals(schemas.get(1), restApp.restClient.getLatestVersion(subject).getSchema());
 
-    assertEquals("Deleting Schema Older Version Success", (Integer) 1, restApp.restClient
-            .deleteSchemaVersion
-                    (RestService.DEFAULT_REQUEST_PROPERTIES, subject, "1"));
-    assertEquals("Latest Version Schema Still Same",
-            schemas.get(1),
-            restApp.restClient.getLatestVersion(subject).getSchema());
+    assertEquals(
+        (Integer) 1, restApp.restClient
+            .deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject, "1"),
+        "Deleting Schema Older Version Success"
+    );
+    assertEquals(
+        schemas.get(1),
+        restApp.restClient.getLatestVersion(subject).getSchema(),
+        "Latest Version Schema Still Same"
+    );
   }
 
   @Test
@@ -1590,9 +1738,11 @@ public class RestApiTest extends ClusterTestHarness {
     try {
       restApp.restClient.deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject, "2");
     } catch (RestClientException rce) {
-      assertEquals("Should get a 404 status for non-existing subject version",
-                   Errors.VERSION_NOT_FOUND_ERROR_CODE,
-                   rce.getErrorCode());
+      assertEquals(
+          Errors.VERSION_NOT_FOUND_ERROR_CODE,
+          rce.getErrorCode(),
+          "Should get a 404 status for non-existing subject version"
+      );
     }
 
   }
@@ -1604,30 +1754,31 @@ public class RestApiTest extends ClusterTestHarness {
 
     TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(0), 1, subject);
     TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(1), 2, subject);
-    assertEquals("Deleting Schema Version Success", (Integer) 1, restApp.restClient
-        .deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject, "1"));
+    assertEquals(
+        (Integer) 1, restApp.restClient
+            .deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject, "1"),
+        "Deleting Schema Version Success"
+    );
     try {
       restApp.restClient.lookUpSubjectVersion(schemas.get(0), subject, false);
       fail(String.format("Lookup Subject Version %s for subject %s should fail with %s", "2",
                          subject,
                          Errors.SCHEMA_NOT_FOUND_ERROR_CODE));
     } catch (RestClientException rce) {
-      assertEquals("Schema not found",
-                   Errors.SCHEMA_NOT_FOUND_ERROR_CODE,
-                   rce.getErrorCode());
+      assertEquals(Errors.SCHEMA_NOT_FOUND_ERROR_CODE, rce.getErrorCode());
     }
     //verify deleted schema
     Schema schema = restApp.restClient.lookUpSubjectVersion(schemas.get(0), subject, true);
-    assertEquals("Lookup Version Match", (Integer) 1, schema.getVersion());
+    assertEquals((Integer) 1, schema.getVersion());
 
     //re-register schema again and verify we get latest version
     TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(0), 1, subject);
     schema = restApp.restClient.lookUpSubjectVersion(schemas.get(0), subject, true);
-    assertEquals("Lookup Version Match", (Integer) 3, schema.getVersion());
+    assertEquals((Integer) 3, schema.getVersion());
     schema = restApp.restClient.lookUpSubjectVersion(schemas.get(0), subject, false);
-    assertEquals("Lookup Version Match", (Integer) 3, schema.getVersion());
+    assertEquals((Integer) 3, schema.getVersion());
     schema = restApp.restClient.lookUpSubjectVersion(schemas.get(0), subject);
-    assertEquals("Lookup Version Match", (Integer) 3, schema.getVersion());
+    assertEquals((Integer) 3, schema.getVersion());
   }
 
   @Test
@@ -1671,31 +1822,32 @@ public class RestApiTest extends ClusterTestHarness {
 
     boolean isCompatible = restApp.restClient.testCompatibility(wrongSchema2, subject,
                                                                 "latest").isEmpty();
-    assertTrue("Schema should be compatible with specified version", isCompatible);
+    assertTrue(isCompatible, "Schema should be compatible with specified version");
 
     restApp.restClient.registerSchema(wrongSchema2, subject);
 
     isCompatible = restApp.restClient.testCompatibility(correctSchema2, subject,
                                                         "latest").isEmpty();
-    assertFalse("Schema should be incompatible with specified version", isCompatible);
+    assertFalse(isCompatible, "Schema should be incompatible with specified version");
     try {
       restApp.restClient.registerSchema(correctSchema2, subject);
       fail("Schema should be Incompatible");
     } catch (RestClientException rce) {
-      assertEquals("Incompatible Schema",
-                   Errors.INCOMPATIBLE_SCHEMA_ERROR_CODE,
-                   rce.getErrorCode());
+      assertEquals(Errors.INCOMPATIBLE_SCHEMA_ERROR_CODE, rce.getErrorCode());
     }
 
     restApp.restClient.deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject, "latest");
     isCompatible = restApp.restClient.testCompatibility(correctSchema2, subject,
                                                         "latest").isEmpty();
-    assertTrue("Schema should be compatible with specified version", isCompatible);
+    assertTrue(isCompatible, "Schema should be compatible with specified version");
 
     restApp.restClient.registerSchema(correctSchema2, subject);
 
-    assertEquals("Version is same", (Integer) 3, restApp.restClient.lookUpSubjectVersion
-        (correctSchema2String, subject).getVersion());
+    assertEquals(
+        (Integer) 3,
+        restApp.restClient.lookUpSubjectVersion(correctSchema2String, subject).getVersion(),
+        "Version is same"
+    );
 
   }
 
@@ -1728,19 +1880,24 @@ public class RestApiTest extends ClusterTestHarness {
     restApp.restClient.registerSchema(schema2, subject);
 
     restApp.restClient.deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject, "1");
-    assertEquals("Compatibility Level Exists", CompatibilityLevel.BACKWARD.name, restApp
-        .restClient.getConfig(subject).getCompatibilityLevel());
-    assertEquals("Top Compatibility Level Exists", CompatibilityLevel.FULL.name, restApp
-        .restClient.getConfig(null).getCompatibilityLevel());
+    assertEquals(CompatibilityLevel.BACKWARD.name, restApp
+        .restClient.getConfig(subject).getCompatibilityLevel(), "Compatibility Level Exists");
+    assertEquals(CompatibilityLevel.FULL.name, restApp
+        .restClient.getConfig(null).getCompatibilityLevel(), "Top Compatibility Level Exists");
     restApp.restClient.deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject, "2");
     try {
       restApp.restClient.getConfig(subject);
     } catch (RestClientException rce) {
-      assertEquals("Compatibility Level doesn't exist",
-              Errors.SUBJECT_LEVEL_COMPATIBILITY_NOT_CONFIGURED_ERROR_CODE, rce.getErrorCode());
+      assertEquals(
+          Errors.SUBJECT_LEVEL_COMPATIBILITY_NOT_CONFIGURED_ERROR_CODE, rce.getErrorCode(),
+          "Compatibility Level doesn't exist"
+      );
     }
-    assertEquals("Top Compatibility Level Exists", CompatibilityLevel.FULL.name, restApp
-        .restClient.getConfig(null).getCompatibilityLevel());
+    assertEquals(
+        CompatibilityLevel.FULL.name,
+        restApp.restClient.getConfig(null).getCompatibilityLevel(),
+        "Top Compatibility Level Exists"
+    );
 
   }
 
@@ -1754,32 +1911,50 @@ public class RestApiTest extends ClusterTestHarness {
     List<String> expectedResponse = new ArrayList<>();
     expectedResponse.add(subject1);
     expectedResponse.add(subject2);
-    assertEquals("Current Subjects", expectedResponse,
-            restApp.restClient.getAllSubjects());
+    assertEquals(
+        expectedResponse,
+        restApp.restClient.getAllSubjects(),
+        "Current Subjects"
+    );
     List<Integer> deletedResponse = new ArrayList<>();
     deletedResponse.add(1);
-    assertEquals("Versions Deleted Match", deletedResponse,
-            restApp.restClient.deleteSubject(RestService.DEFAULT_REQUEST_PROPERTIES, subject2));
+    assertEquals(
+        deletedResponse,
+        restApp.restClient.deleteSubject(RestService.DEFAULT_REQUEST_PROPERTIES, subject2),
+        "Versions Deleted Match"
+    );
 
     expectedResponse = new ArrayList<>();
     expectedResponse.add(subject1);
-    assertEquals("Current Subjects", expectedResponse,
-            restApp.restClient.getAllSubjects());
+    assertEquals(
+        expectedResponse,
+        restApp.restClient.getAllSubjects(),
+        "Current Subjects"
+    );
 
     expectedResponse = new ArrayList<>();
     expectedResponse.add(subject1);
     expectedResponse.add(subject2);
-    assertEquals("Current Subjects", expectedResponse,
-            restApp.restClient.getAllSubjects(true));
+    assertEquals(
+        expectedResponse,
+        restApp.restClient.getAllSubjects(true),
+        "Current Subjects"
+    );
 
-    assertEquals("Versions Deleted Match", deletedResponse,
-            restApp.restClient.deleteSubject(RestService.DEFAULT_REQUEST_PROPERTIES,
-                    subject2, true));
+    assertEquals(
+        deletedResponse,
+        restApp.restClient.deleteSubject(RestService.DEFAULT_REQUEST_PROPERTIES,
+                    subject2, true),
+        "Versions Deleted Match"
+    );
 
     expectedResponse = new ArrayList<>();
     expectedResponse.add(subject1);
-    assertEquals("Current Subjects", expectedResponse,
-            restApp.restClient.getAllSubjects());
+    assertEquals(
+        expectedResponse,
+        restApp.restClient.getAllSubjects(),
+        "Current Subjects"
+    );
   }
 
   @Test
@@ -1796,19 +1971,36 @@ public class RestApiTest extends ClusterTestHarness {
     assertEquals((Integer) 1,
         restApp.restClient.deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES, subject2, "1"));
 
-    assertEquals("List All Versions Match",
-        Collections.singletonList(2), restApp.restClient.getAllVersions(subject1));
-    assertEquals("List All Versions Include deleted Match",
-        Arrays.asList(1, 2), restApp.restClient.getAllVersions(RestService.DEFAULT_REQUEST_PROPERTIES, subject1, true));
-    assertEquals("List Deleted Versions Match",
-        Collections.singletonList(1), restApp.restClient.getDeletedOnlyVersions(subject1));
+    assertEquals(
+        Collections.singletonList(2), restApp.restClient.getAllVersions(subject1),
+        "List All Versions Match"
+    );
+    assertEquals(
+        Arrays.asList(1, 2),
+        restApp.restClient.getAllVersions(RestService.DEFAULT_REQUEST_PROPERTIES, subject1, true),
+        "List All Versions Include deleted Match"
+    );
+    assertEquals(
+        Collections.singletonList(1),
+        restApp.restClient.getDeletedOnlyVersions(subject1),
+        "List Deleted Versions Match"
+    );
 
-    assertEquals("List All Subjects Match",
-        Collections.singletonList(subject1), restApp.restClient.getAllSubjects());
-    assertEquals("List All Subjects Include deleted Match",
-        Arrays.asList(subject1, subject2), restApp.restClient.getAllSubjects(true));
-    assertEquals("List Deleted Only Subjects Match",
-        Collections.singletonList(subject2), restApp.restClient.getDeletedOnlySubjects(null));
+    assertEquals(
+        Collections.singletonList(subject1),
+        restApp.restClient.getAllSubjects(),
+        "List All Subjects Match"
+    );
+    assertEquals(
+        Arrays.asList(subject1, subject2),
+        restApp.restClient.getAllSubjects(true),
+        "List All Subjects Include deleted Match"
+    );
+    assertEquals(
+        Collections.singletonList(subject2),
+        restApp.restClient.getDeletedOnlySubjects(null),
+        "List Deleted Only Subjects Match"
+    );
   }
 
   @Test
@@ -1820,13 +2012,16 @@ public class RestApiTest extends ClusterTestHarness {
     List<Integer> expectedResponse = new ArrayList<>();
     expectedResponse.add(1);
     expectedResponse.add(2);
-    assertEquals("Versions Deleted Match", expectedResponse,
-        restApp.restClient.deleteSubject(RestService.DEFAULT_REQUEST_PROPERTIES, subject));
+    assertEquals(
+        expectedResponse,
+        restApp.restClient.deleteSubject(RestService.DEFAULT_REQUEST_PROPERTIES, subject),
+        "Versions Deleted Match"
+    );
     try {
       restApp.restClient.getLatestVersion(subject);
       fail(String.format("Subject %s should not be found", subject));
     } catch (RestClientException rce) {
-      assertEquals("Subject Not Found", Errors.SUBJECT_NOT_FOUND_ERROR_CODE, rce.getErrorCode());
+      assertEquals(Errors.SUBJECT_NOT_FOUND_ERROR_CODE, rce.getErrorCode());
     }
 
   }
@@ -1840,8 +2035,11 @@ public class RestApiTest extends ClusterTestHarness {
     List<Integer> expectedResponse = new ArrayList<>();
     expectedResponse.add(1);
     expectedResponse.add(2);
-    assertEquals("Versions Deleted Match", expectedResponse,
-            restApp.restClient.deleteSubject(RestService.DEFAULT_REQUEST_PROPERTIES, subject));
+    assertEquals(
+        expectedResponse,
+        restApp.restClient.deleteSubject(RestService.DEFAULT_REQUEST_PROPERTIES, subject),
+        "Versions Deleted Match"
+    );
 
     Schema schema = restApp.restClient.lookUpSubjectVersion(schemas.get(0), subject, true );
     assertEquals(1, (long)schema.getVersion());
@@ -1852,7 +2050,10 @@ public class RestApiTest extends ClusterTestHarness {
       restApp.restClient.deleteSubject(RestService.DEFAULT_REQUEST_PROPERTIES, subject);
       fail(String.format("Subject %s should not be found", subject));
     } catch (RestClientException rce) {
-      assertEquals("Subject exists in soft deleted format.", Errors.SUBJECT_SOFT_DELETED_ERROR_CODE, rce.getErrorCode());
+      assertEquals(
+          Errors.SUBJECT_SOFT_DELETED_ERROR_CODE, rce.getErrorCode(),
+          "Subject exists in soft deleted format."
+      );
     }
   }
 
@@ -1873,34 +2074,43 @@ public class RestApiTest extends ClusterTestHarness {
               true);
       fail("Delete permanent should not succeed");
     } catch (RestClientException rce) {
-      assertEquals("Subject '%s' was not deleted first before permanent delete", Errors.SUBJECT_NOT_SOFT_DELETED_ERROR_CODE, rce.getErrorCode());
+      assertEquals(
+          Errors.SUBJECT_NOT_SOFT_DELETED_ERROR_CODE,
+          rce.getErrorCode(),
+          "Subject was not deleted first before permanent delete"
+      );
     }
 
-    assertEquals("Versions Deleted Match", expectedResponse,
-            restApp.restClient.deleteSubject(RestService.DEFAULT_REQUEST_PROPERTIES, subject));
+    assertEquals(
+        expectedResponse,
+        restApp.restClient.deleteSubject(RestService.DEFAULT_REQUEST_PROPERTIES, subject),
+        "Versions Deleted Match"
+    );
 
     Schema schema = restApp.restClient.lookUpSubjectVersion(schemas.get(0), subject, true );
     assertEquals(1, (long)schema.getVersion());
     schema = restApp.restClient.lookUpSubjectVersion(schemas.get(1), subject, true );
     assertEquals(2, (long)schema.getVersion());
 
-    assertEquals("Versions Deleted Match", expectedResponse,
-            restApp.restClient.deleteSubject(RestService.DEFAULT_REQUEST_PROPERTIES,
-                    subject,
-                    true));
+    assertEquals(
+        expectedResponse,
+        restApp.restClient
+            .deleteSubject(RestService.DEFAULT_REQUEST_PROPERTIES, subject, true),
+        "Versions Deleted Match"
+    );
     for (Integer i : expectedResponse) {
       try {
         restApp.restClient.lookUpSubjectVersion(schemas.get(0), subject, false);
         fail(String.format("Subject %s should not be found", subject));
       } catch (RestClientException rce) {
-        assertEquals("Subject Not Found", Errors.SUBJECT_NOT_FOUND_ERROR_CODE, rce.getErrorCode());
+        assertEquals(Errors.SUBJECT_NOT_FOUND_ERROR_CODE, rce.getErrorCode());
       }
 
       try {
         restApp.restClient.lookUpSubjectVersion(schemas.get(i-1), subject, true);
         fail(String.format("Subject %s should not be found", subject));
       } catch (RestClientException rce) {
-        assertEquals("Subject Not Found", Errors.SUBJECT_NOT_FOUND_ERROR_CODE, rce.getErrorCode());
+        assertEquals(Errors.SUBJECT_NOT_FOUND_ERROR_CODE, rce.getErrorCode());
       }
     }
   }
@@ -1916,14 +2126,20 @@ public class RestApiTest extends ClusterTestHarness {
     TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(0), 1, subject);
     TestUtils.registerAndVerifySchema(restApp.restClient, schemas.get(1), 2, subject);
 
-    assertEquals("Versions match", Arrays.asList(3, 4),
-                 restApp.restClient.getAllVersions(subject));
+    assertEquals(
+        Arrays.asList(3, 4),
+        restApp.restClient.getAllVersions(subject),
+        "Versions match"
+    );
     try {
       restApp.restClient.getVersion(subject, 1);
       fail("Version 1 should not be found");
     } catch (RestClientException rce) {
-      assertEquals("Version not found", Errors.VERSION_NOT_FOUND_ERROR_CODE,
-                   rce.getErrorCode());
+      assertEquals(
+          Errors.VERSION_NOT_FOUND_ERROR_CODE,
+          rce.getErrorCode(),
+          "Version not found"
+      );
     }
   }
 
@@ -1959,11 +2175,17 @@ public class RestApiTest extends ClusterTestHarness {
     try {
       restApp.restClient.getConfig(subject);
     } catch (RestClientException rce) {
-      assertEquals("Compatibility Level doesn't exist",
-              Errors.SUBJECT_LEVEL_COMPATIBILITY_NOT_CONFIGURED_ERROR_CODE, rce.getErrorCode());
+      assertEquals(
+          Errors.SUBJECT_LEVEL_COMPATIBILITY_NOT_CONFIGURED_ERROR_CODE,
+          rce.getErrorCode(),
+          "Compatibility Level doesn't exist"
+      );
     }
-    assertEquals("Top Compatibility Level Exists", CompatibilityLevel.FULL.name, restApp
-        .restClient.getConfig(null).getCompatibilityLevel());
+    assertEquals(
+        CompatibilityLevel.FULL.name,
+        restApp.restClient.getConfig(null).getCompatibilityLevel(),
+        "Top Compatibility Level Exists"
+    );
 
   }
 
@@ -2028,8 +2250,10 @@ public class RestApiTest extends ClusterTestHarness {
       restApp.restClient.getMode(subject).getMode();
       fail(String.format("Subject %s should not be found when there's no mode override", subject));
     } catch (RestClientException e) {
-      assertEquals(String.format("No mode override for subject %s, get mode should return not configured", subject),
-          Errors.SUBJECT_LEVEL_MODE_NOT_CONFIGURED_ERROR_CODE, e.getErrorCode());
+      assertEquals(
+          Errors.SUBJECT_LEVEL_MODE_NOT_CONFIGURED_ERROR_CODE, e.getErrorCode(),
+          String.format("No mode override for subject %s, get mode should return not configured", subject)
+      );
     }
     assertEquals("READWRITE", restApp.restClient.getMode(subject, true).getMode());
 
@@ -2048,8 +2272,10 @@ public class RestApiTest extends ClusterTestHarness {
       restApp.restClient.registerSchema(schema, "testSubject2");
       fail(String.format("Subject %s is in read-only mode", "testSubject2"));
     } catch (RestClientException rce) {
-      assertEquals("Subject is in read-only mode", Errors.OPERATION_NOT_PERMITTED_ERROR_CODE, rce
-          .getErrorCode());
+      assertEquals(
+          Errors.OPERATION_NOT_PERMITTED_ERROR_CODE, rce.getErrorCode(),
+          "Subject is in read-only mode"
+      );
     }
   }
 
@@ -2089,9 +2315,11 @@ public class RestApiTest extends ClusterTestHarness {
     RegisterSchemaRequest request1 = new RegisterSchemaRequest(schema1);
     request1.setRuleSet(ruleSet);
     int expectedIdSchema1 = 1;
-    assertEquals("Registering should succeed",
+    assertEquals(
         expectedIdSchema1,
-        restApp.restClient.registerSchema(request1, subject, false).getId());
+        restApp.restClient.registerSchema(request1, subject, false).getId(),
+        "Registering should succeed"
+    );
 
     SchemaString schemaString = restApp.restClient.getId(expectedIdSchema1, subject);
     assertNull(schemaString.getRuleSet());
@@ -2117,60 +2345,84 @@ public class RestApiTest extends ClusterTestHarness {
     ConfigUpdateRequest configUpdateRequest = new ConfigUpdateRequest();
     configUpdateRequest.setCompatibilityLevel(BACKWARD.name());
     configUpdateRequest.setValidateFields(true);
-    assertEquals("Updating config should succeed",
+    assertEquals(
         configUpdateRequest,
-        restApp.restClient.updateConfig(configUpdateRequest, null));
-    assertThrows("Fail registering subject0 because of global validateFields",
+        restApp.restClient.updateConfig(configUpdateRequest, null),
+        "Updating config should succeed"
+    );
+    assertThrows(
         RestClientException.class,
-        () -> restApp.restClient.registerSchema(request1, subject0, false));
+        () -> restApp.restClient.registerSchema(request1, subject0, false),
+        "Fail registering subject0 because of global validateFields"
+    );
 
     // global validateFields = false
     configUpdateRequest.setValidateFields(false);
-    assertEquals("Updating config should succeed",
+    assertEquals(
         configUpdateRequest,
-        restApp.restClient.updateConfig(configUpdateRequest, null));
-    assertEquals("Should register despite reserved fields",
+        restApp.restClient.updateConfig(configUpdateRequest, null),
+        "Updating config should succeed"
+    );
+    assertEquals(
         1,
-        restApp.restClient.registerSchema(request1, subject0, false).getId());
+        restApp.restClient.registerSchema(request1, subject0, false).getId(),
+        "Should register despite reserved fields"
+    );
 
     // global validateFields = false; testSubject1 validateFields = true
     String subject1 = "testSubject1";
     configUpdateRequest.setValidateFields(true);
-    assertEquals("Updating config should succeed",
+    assertEquals(
         configUpdateRequest,
-        restApp.restClient.updateConfig(configUpdateRequest, subject1));
-    assertThrows("Fail registering subject1 because of subject1 validateFields",
+        restApp.restClient.updateConfig(configUpdateRequest, subject1),
+        "Updating config should succeed"
+    );
+    assertThrows(
         RestClientException.class,
-        () -> restApp.restClient.registerSchema(request1, subject1, false));
+        () -> restApp.restClient.registerSchema(request1, subject1, false),
+        "Fail registering subject1 because of subject1 validateFields"
+    );
     String subject2 = "testSubject2";
-    assertEquals("Should register despite reserved fields",
+    assertEquals(
         1,
-        restApp.restClient.registerSchema(request1, subject2, false).getId());
+        restApp.restClient.registerSchema(request1, subject2, false).getId(),
+        "Should register despite reserved fields"
+    );
 
     // global validateFields = true; testSubject1 validateFields = false
     configUpdateRequest.setValidateFields(true);
-    assertEquals("Updating config should succeed",
+    assertEquals(
         configUpdateRequest,
-        restApp.restClient.updateConfig(configUpdateRequest, null));
+        restApp.restClient.updateConfig(configUpdateRequest, null),
+        "Updating config should succeed"
+    );
     configUpdateRequest.setValidateFields(false);
-    assertEquals("Updating config should succeed",
+    assertEquals(
         configUpdateRequest,
-        restApp.restClient.updateConfig(configUpdateRequest, subject1));
-    assertEquals("Should register despite reserved fields",
+        restApp.restClient.updateConfig(configUpdateRequest, subject1),
+        "Updating config should succeed"
+    );
+    assertEquals(
         1,
-        restApp.restClient.registerSchema(request1, subject1, false).getId());
+        restApp.restClient.registerSchema(request1, subject1, false).getId(),
+        "Should register despite reserved fields"
+    );
     String subject3 = "testSubject3";
-    assertThrows("Fail registering because of subject3 validateFields",
+    assertThrows(
         RestClientException.class,
-        () -> restApp.restClient.registerSchema(request1, subject3, false));
+        () -> restApp.restClient.registerSchema(request1, subject3, false),
+        "Fail registering because of subject3 validateFields"
+    );
 
     // remove reserved fields for subject1
     request1.setMetadata(new Metadata(Collections.emptyMap(),
         Collections.singletonMap(ParsedSchema.RESERVED, "g"),
         Collections.emptySet()));
-    assertEquals("Should register despite removal of reserved fields",
+    assertEquals(
         2,
-        restApp.restClient.registerSchema(request1, subject1, false).getId());
+        restApp.restClient.registerSchema(request1, subject1, false).getId(),
+        "Should register despite removal of reserved fields"
+    );
 
     // remove reserved fields for subject0
     schema1 = AvroUtils.parseSchema("{\"type\":\"record\","
@@ -2184,9 +2436,11 @@ public class RestApiTest extends ClusterTestHarness {
     request2.setMetadata(new Metadata(Collections.emptyMap(),
         Collections.singletonMap(ParsedSchema.RESERVED, "g"),
         Collections.emptySet()));
-    assertThrows("Fail registering because of removal of reserved fields",
+    assertThrows(
         RestClientException.class,
-        () -> restApp.restClient.registerSchema(request2, subject0, false));
+        () -> restApp.restClient.registerSchema(request2, subject0, false),
+        "Fail registering because of removal of reserved fields"
+    );
   }
 
   @Test
@@ -2299,9 +2553,7 @@ public class RestApiTest extends ClusterTestHarness {
       registerAndVerifySchema(restApp.restClient, request, 3, subject);
       fail("Registering version that is not next version should fail with " + Errors.INVALID_SCHEMA_ERROR_CODE);
     } catch (RestClientException rce) {
-      assertEquals("Invalid schema",
-          Errors.INVALID_SCHEMA_ERROR_CODE,
-          rce.getErrorCode());
+      assertEquals(Errors.INVALID_SCHEMA_ERROR_CODE, rce.getErrorCode());
     }
 
     // Register schema with version 4
@@ -2408,9 +2660,7 @@ public class RestApiTest extends ClusterTestHarness {
       restApp.restClient.lookUpSubjectVersion(request, subject, false, false);
       fail("Looking up version that is not next version should fail with " + Errors.SCHEMA_NOT_FOUND_ERROR_CODE);
     } catch (RestClientException rce) {
-      assertEquals("Schema not found",
-          Errors.SCHEMA_NOT_FOUND_ERROR_CODE,
-          rce.getErrorCode());
+      assertEquals(Errors.SCHEMA_NOT_FOUND_ERROR_CODE, rce.getErrorCode());
     }
   }
 
@@ -2421,15 +2671,15 @@ public class RestApiTest extends ClusterTestHarness {
       String subject
   ) throws IOException, RestClientException {
     int registeredId = restService.registerSchema(request, subject, false).getId();
-    Assert.assertEquals(
-        "Registering a new schema should succeed",
+    assertEquals(
         (long) expectedId,
-        (long) registeredId
+        (long) registeredId,
+        "Registering a new schema should succeed"
     );
-    Assert.assertEquals(
-        "Registered schema should be found",
+    assertEquals(
         request.getSchema().trim(),
-        restService.getId(expectedId).getSchemaString().trim()
+        restService.getId(expectedId).getSchemaString().trim(),
+        "Registered schema should be found"
     );
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTransitiveCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTransitiveCompatibilityTest.java
@@ -19,10 +19,10 @@ import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.avro.AvroUtils;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestIncompatibleSchemaException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class RestApiTransitiveCompatibilityTest extends ClusterTestHarness {
 
@@ -55,16 +55,20 @@ public class RestApiTransitiveCompatibilityTest extends ClusterTestHarness {
 
     // register a valid avro
     int expectedIdSchema1 = 1;
-    assertEquals("Registering should succeed",
-            expectedIdSchema1,
-            restApp.restClient.registerSchema(baseSchema, subject));
+    assertEquals(
+        expectedIdSchema1,
+        restApp.restClient.registerSchema(baseSchema, subject),
+        "Registering should succeed"
+    );
 
     // register a backward compatible avro
     int expectedIdSchema2 = 2;
-    assertEquals("Registering a compatible schema should succeed",
-                 expectedIdSchema2,
-                 restApp.restClient.registerSchema(baseSchemaWithColumnWithDefault, subject));
-    
+    assertEquals(
+        expectedIdSchema2,
+        restApp.restClient.registerSchema(baseSchemaWithColumnWithDefault, subject),
+        "Registering a compatible schema should succeed"
+    );
+
     // register an incompatible avro
     String incompatibleSchemaString = baseSchemaWithColumnNoDefault;
     try {
@@ -72,9 +76,11 @@ public class RestApiTransitiveCompatibilityTest extends ClusterTestHarness {
       fail("Registering an incompatible schema should fail");
     } catch (RestClientException e) {
       // this is expected.
-      assertEquals("Should get a conflict status",
-                   RestIncompatibleSchemaException.DEFAULT_ERROR_CODE,
-                   e.getStatus());
+      assertEquals(
+          RestIncompatibleSchemaException.DEFAULT_ERROR_CODE,
+          e.getStatus(),
+          "Should get a conflict status"
+      );
     }
   }
   
@@ -85,14 +91,18 @@ public class RestApiTransitiveCompatibilityTest extends ClusterTestHarness {
 
     // register a valid avro
     int expectedIdSchema1 = 1;
-    assertEquals("Registering should succeed",
-            expectedIdSchema1,
-            restApp.restClient.registerSchema(baseSchemaWithColumnWithDefault, subject));
+    assertEquals(
+        expectedIdSchema1,
+        restApp.restClient.registerSchema(baseSchemaWithColumnWithDefault, subject),
+        "Registering should succeed"
+    );
 
     // register a backward compatible avro
     int expectedIdSchema2 = 2;
-    assertEquals("Registering a compatible schema should succeed",
-                 expectedIdSchema2,
-                 restApp.restClient.registerSchema(baseSchemaWithColumnNoDefault, subject));
+    assertEquals(
+        expectedIdSchema2,
+        restApp.restClient.registerSchema(baseSchemaWithColumnNoDefault, subject),
+        "Registering a compatible schema should succeed"
+    );
   }
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryErrorHandlerTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryErrorHandlerTest.java
@@ -24,9 +24,6 @@ import io.confluent.kafka.schemaregistry.client.security.basicauth.BasicAuthCred
 import io.confluent.kafka.schemaregistry.client.security.basicauth
     .BasicAuthCredentialProviderFactory;
 import org.apache.kafka.common.security.JaasUtils;
-import org.eclipse.jetty.http.HttpStatus;
-import org.junit.Assert;
-import org.junit.Test;
 
 import javax.security.auth.login.Configuration;
 import java.io.File;
@@ -36,9 +33,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class SchemaRegistryErrorHandlerTest extends ClusterTestHarness {
 
@@ -64,8 +62,8 @@ public class SchemaRegistryErrorHandlerTest extends ClusterTestHarness {
       restApp.restClient.registerSchema(schemaString1, subject);
       fail("Should fail for incorrect password");
     } catch (RestClientException ex) {
-      Assert.assertEquals(401, ex.getStatus());
-      Assert.assertEquals("Unauthorized; error code: 401", ex.getMessage());
+      assertEquals(401, ex.getStatus());
+      assertEquals("Unauthorized; error code: 401", ex.getMessage());
     }
 
   }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryExtensionTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryExtensionTest.java
@@ -15,15 +15,7 @@
 
 package io.confluent.kafka.schemaregistry.rest;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
-
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Properties;
 
 import javax.ws.rs.container.ContainerRequestContext;
@@ -37,24 +29,12 @@ import io.confluent.kafka.schemaregistry.avro.AvroUtils;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.rest.extensions.SchemaRegistryResourceExtension;
 import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
-@RunWith(Parameterized.class)
 public class SchemaRegistryExtensionTest extends ClusterTestHarness {
-
-  @Parameters(name = "{0}")
-  public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][] {
-        { SchemaRegistryConfig.RESOURCE_EXTENSION_CONFIG },
-        { SchemaRegistryConfig.SCHEMAREGISTRY_RESOURCE_EXTENSION_CONFIG },
-        { SchemaRegistryConfig.INIT_RESOURCE_EXTENSION_CONFIG}
-    });
-  }
-
-  @Parameter
-  public String resourceExtensionConfigName;
 
   public SchemaRegistryExtensionTest() {
     super(1, true, CompatibilityLevel.BACKWARD.name);
@@ -70,9 +50,9 @@ public class SchemaRegistryExtensionTest extends ClusterTestHarness {
         + "[{\"type\":\"string\",\"name\":\"f1\"}]}").canonicalString();
     int expectedIdSchema1 = 1;
     assertEquals(
-        "Registering should succeed",
         expectedIdSchema1,
-        restApp.restClient.registerSchema(schemaString1, subject)
+        restApp.restClient.registerSchema(schemaString1, subject),
+        "Registering should succeed"
     );
 
   }
@@ -86,9 +66,9 @@ public class SchemaRegistryExtensionTest extends ClusterTestHarness {
       fail("Getting all versions from non-existing subject1 should fail with 401");
     } catch (RestClientException rce) {
       assertEquals(
-          "Should get a 401 status for GET operations",
           401,
-          rce.getStatus()
+          rce.getStatus(),
+          "Should get a 401 status for GET operations"
       );
     }
   }
@@ -97,7 +77,7 @@ public class SchemaRegistryExtensionTest extends ClusterTestHarness {
   protected Properties getSchemaRegistryProperties() {
     Properties props = new Properties();
     props.put(
-        resourceExtensionConfigName,
+        SchemaRegistryConfig.RESOURCE_EXTENSION_CONFIG,
         TestSchemaRegistryExtension.class.getName()
     );
     return props;

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/json/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/json/RestApiTest.java
@@ -18,8 +18,6 @@ package io.confluent.kafka.schemaregistry.rest.json;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
-import org.junit.Assert;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -43,11 +41,13 @@ import io.confluent.kafka.schemaregistry.json.JsonSchema;
 import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
 import io.confluent.kafka.schemaregistry.json.JsonSchemaUtils;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class RestApiTest extends ClusterTestHarness {
 
@@ -79,9 +79,10 @@ public class RestApiTest extends ClusterTestHarness {
     List<String> allSubjects = new ArrayList<String>();
 
     // test getAllSubjects with no existing data
-    assertEquals("Getting all subjects should return empty",
+    assertEquals(
         allSubjects,
-        restApp.restClient.getAllSubjects()
+        restApp.restClient.getAllSubjects(),
+        "Getting all subjects should return empty"
     );
 
     // test registering and verifying new schemas in subject1
@@ -104,9 +105,10 @@ public class RestApiTest extends ClusterTestHarness {
           Collections.emptyList(),
           subject1
       ).getId();
-      assertEquals("Re-registering an existing schema should return the existing version",
+      assertEquals(
           expectedId,
-          foundId
+          foundId,
+          "Re-registering an existing schema should return the existing version"
       );
     }
 
@@ -122,20 +124,21 @@ public class RestApiTest extends ClusterTestHarness {
 
     // test getAllVersions with existing data
     assertEquals(
-        "Getting all versions from subject1 should match all registered versions",
         allVersionsInSubject1,
-        restApp.restClient.getAllVersions(subject1)
+        restApp.restClient.getAllVersions(subject1),
+        "Getting all versions from subject1 should match all registered versions"
     );
     assertEquals(
-        "Getting all versions from subject2 should match all registered versions",
         allVersionsInSubject2,
-        restApp.restClient.getAllVersions(subject2)
+        restApp.restClient.getAllVersions(subject2),
+        "Getting all versions from subject2 should match all registered versions"
     );
 
     // test getAllSubjects with existing data
-    assertEquals("Getting all subjects should match all registered subjects",
+    assertEquals(
         allSubjects,
-        restApp.restClient.getAllSubjects()
+        restApp.restClient.getAllSubjects(),
+        "Getting all subjects should match all registered subjects"
     );
   }
 
@@ -151,18 +154,20 @@ public class RestApiTest extends ClusterTestHarness {
     SchemaReference ref = new SchemaReference("ref.json", "reference", 1);
     request.setReferences(Collections.singletonList(ref));
     int registeredId = restApp.restClient.registerSchema(request, "referrer", false).getId();
-    assertEquals("Registering a new schema should succeed", 2, registeredId);
+    assertEquals(2, registeredId, "Registering a new schema should succeed");
 
     SchemaString schemaString = restApp.restClient.getId(2);
     // the newly registered schema should be immediately readable on the leader
-    assertEquals("Registered schema should be found",
+    assertEquals(
         MAPPER.readTree(schemas.get("main.json")),
-        MAPPER.readTree(schemaString.getSchemaString())
+        MAPPER.readTree(schemaString.getSchemaString()),
+        "Registered schema should be found"
     );
 
-    assertEquals("Schema references should be found",
+    assertEquals(
         Collections.singletonList(ref),
-        schemaString.getReferences()
+        schemaString.getReferences(),
+        "Schema references should be found"
     );
 
     List<Integer> refs = restApp.restClient.getReferencedBy("reference", 1);
@@ -175,7 +180,7 @@ public class RestApiTest extends ClusterTestHarness {
     JsonSchema schema = JsonSchemaUtils.getSchema(holder, schemaRegistryClient);
     Schema registeredSchema = restApp.restClient.lookUpSubjectVersion(schema.canonicalString(),
             JsonSchema.TYPE, schema.references(), "referrer", false);
-    assertEquals("Registered schema should be found", 2, registeredSchema.getId().intValue());
+    assertEquals(2, registeredSchema.getId().intValue(), "Registered schema should be found");
 
     try {
       restApp.restClient.deleteSchemaVersion(RestService.DEFAULT_REQUEST_PROPERTIES,
@@ -184,9 +189,11 @@ public class RestApiTest extends ClusterTestHarness {
       );
       fail("Deleting reference should fail with " + Errors.REFERENCE_EXISTS_ERROR_CODE);
     } catch (RestClientException rce) {
-      assertEquals("Reference found",
+      assertEquals(
           Errors.REFERENCE_EXISTS_ERROR_CODE,
-          rce.getErrorCode());
+          rce.getErrorCode(),
+          "Reference found"
+      );
     }
 
     assertEquals((Integer) 1, restApp.restClient
@@ -213,15 +220,17 @@ public class RestApiTest extends ClusterTestHarness {
       // This is a dummy schema holder to be used for its annotations
   }
 
-  @Test(expected = RestClientException.class)
+  @Test
   public void testSchemaMissingReferences() throws Exception {
-    Map<String, String> schemas = getJsonSchemaWithReferences();
+    assertThrows(RestClientException.class, () -> {
+      Map<String, String> schemas = getJsonSchemaWithReferences();
 
-    RegisterSchemaRequest request = new RegisterSchemaRequest();
-    request.setSchema(schemas.get("main.json"));
-    request.setSchemaType(JsonSchema.TYPE);
-    request.setReferences(Collections.emptyList());
-    restApp.restClient.registerSchema(request, "referrer", false);
+      RegisterSchemaRequest request = new RegisterSchemaRequest();
+      request.setSchema(schemas.get("main.json"));
+      request.setSchemaType(JsonSchema.TYPE);
+      request.setReferences(Collections.emptyList());
+      restApp.restClient.registerSchema(request, "referrer", false);
+    });
   }
 
   @Test
@@ -268,10 +277,16 @@ public class RestApiTest extends ClusterTestHarness {
     lookUpRequest.setReferences(Arrays.asList(ref2, ref1));
     int versionOfRegisteredSchema1Subject1 =
         restApp.restClient.lookUpSubjectVersion(lookUpRequest, subject1, true, false).getVersion();
-    assertEquals("1st schema under subject1 should have version 1", 1,
-        versionOfRegisteredSchema1Subject1);
-    assertEquals("1st schema registered globally should have id 3", 3,
-        idOfRegisteredSchema1Subject1);
+    assertEquals(
+        1,
+        versionOfRegisteredSchema1Subject1,
+        "1st schema under subject1 should have version 1"
+    );
+    assertEquals(
+        3,
+        idOfRegisteredSchema1Subject1,
+        "1st schema registered globally should have id 3"
+    );
   }
 
   @Test
@@ -280,18 +295,21 @@ public class RestApiTest extends ClusterTestHarness {
     List<String> allSubjects = new ArrayList<String>();
 
     // test getAllSubjects with no existing data
-    assertEquals("Getting all subjects should return empty",
+    assertEquals(
         allSubjects,
-        restApp.restClient.getAllSubjects()
+        restApp.restClient.getAllSubjects(),
+        "Getting all subjects should return empty"
     );
 
     try {
       registerAndVerifySchema(restApp.restClient, getBadSchema(), 1, subject1);
       fail("Registering bad schema should fail with " + Errors.INVALID_SCHEMA_ERROR_CODE);
     } catch (RestClientException rce) {
-      assertEquals("Invalid schema",
+      assertEquals(
           Errors.INVALID_SCHEMA_ERROR_CODE,
-          rce.getErrorCode());
+          rce.getErrorCode(),
+          "Invalid schema"
+      );
     }
 
     try {
@@ -299,15 +317,18 @@ public class RestApiTest extends ClusterTestHarness {
           Arrays.asList(new SchemaReference("bad", "bad", 100)), 1, subject1);
       fail("Registering bad reference should fail with " + Errors.INVALID_SCHEMA_ERROR_CODE);
     } catch (RestClientException rce) {
-      assertEquals("Invalid schema",
+      assertEquals(
           Errors.INVALID_SCHEMA_ERROR_CODE,
-          rce.getErrorCode());
+          rce.getErrorCode(),
+          "Invalid schema"
+      );
     }
 
     // test getAllSubjects with existing data
-    assertEquals("Getting all subjects should match all registered subjects",
+    assertEquals(
         allSubjects,
-        restApp.restClient.getAllSubjects()
+        restApp.restClient.getAllSubjects(),
+        "Getting all subjects should match all registered subjects"
     );
   }
 
@@ -471,9 +492,11 @@ public class RestApiTest extends ClusterTestHarness {
       registerAndVerifySchema(restApp.restClient, request, 3, subject);
       fail("Registering version that is not next version should fail with " + Errors.INVALID_SCHEMA_ERROR_CODE);
     } catch (RestClientException rce) {
-      assertEquals("Invalid schema",
+      assertEquals(
           Errors.INVALID_SCHEMA_ERROR_CODE,
-          rce.getErrorCode());
+          rce.getErrorCode(),
+          "Invalid schema"
+      );
     }
 
     // Register schema with version 4
@@ -587,14 +610,15 @@ public class RestApiTest extends ClusterTestHarness {
         references,
         subject
     ).getId();
-    Assert.assertEquals(
-        "Registering a new schema should succeed",
+    assertEquals(
         expectedId,
-        registeredId
+        registeredId,
+        "Registering a new schema should succeed"
     );
-    Assert.assertEquals("Registered schema should be found",
+    assertEquals(
         MAPPER.readTree(schemaString),
-        MAPPER.readTree(restService.getId(expectedId).getSchemaString())
+        MAPPER.readTree(restService.getId(expectedId).getSchemaString()),
+        "Registered schema should be found"
     );
   }
 
@@ -605,15 +629,15 @@ public class RestApiTest extends ClusterTestHarness {
       String subject
   ) throws IOException, RestClientException {
     int registeredId = restService.registerSchema(request, subject, false).getId();
-    Assert.assertEquals(
-        "Registering a new schema should succeed",
+    assertEquals(
         (long) expectedId,
-        (long) registeredId
+        (long) registeredId,
+        "Registering a new schema should succeed"
     );
-    Assert.assertEquals(
-        "Registered schema should be found",
+    assertEquals(
         request.getSchema().trim(),
-        restService.getId(expectedId).getSchemaString().trim()
+        restService.getId(expectedId).getSchemaString().trim(),
+        "Registered schema should be found"
     );
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/protobuf/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/protobuf/RestApiTest.java
@@ -23,8 +23,6 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaTags;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.TagSchemaRequest;
 import io.confluent.kafka.schemaregistry.utils.ResourceLoader;
-import org.junit.Assert;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -48,11 +46,13 @@ import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.serializers.protobuf.test.Root;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RestApiTest extends ClusterTestHarness {
 
@@ -82,9 +82,10 @@ public class RestApiTest extends ClusterTestHarness {
     List<String> allSubjects = new ArrayList<String>();
 
     // test getAllSubjects with no existing data
-    assertEquals("Getting all subjects should return empty",
+    assertEquals(
         allSubjects,
-        restApp.restClient.getAllSubjects()
+        restApp.restClient.getAllSubjects(),
+        "Getting all subjects should return empty"
     );
 
     // test registering and verifying new schemas in subject1
@@ -107,9 +108,10 @@ public class RestApiTest extends ClusterTestHarness {
           Collections.emptyList(),
           subject1
       ).getId();
-      assertEquals("Re-registering an existing schema should return the existing version",
+      assertEquals(
           expectedId,
-          foundId
+          foundId,
+          "Re-registering an existing schema should return the existing version"
       );
     }
 
@@ -125,20 +127,21 @@ public class RestApiTest extends ClusterTestHarness {
 
     // test getAllVersions with existing data
     assertEquals(
-        "Getting all versions from subject1 should match all registered versions",
         allVersionsInSubject1,
-        restApp.restClient.getAllVersions(subject1)
+        restApp.restClient.getAllVersions(subject1),
+        "Getting all versions from subject1 should match all registered versions"
     );
     assertEquals(
-        "Getting all versions from subject2 should match all registered versions",
         allVersionsInSubject2,
-        restApp.restClient.getAllVersions(subject2)
+        restApp.restClient.getAllVersions(subject2),
+        "Getting all versions from subject2 should match all registered versions"
     );
 
     // test getAllSubjects with existing data
-    assertEquals("Getting all subjects should match all registered subjects",
+    assertEquals(
         allSubjects,
-        restApp.restClient.getAllSubjects()
+        restApp.restClient.getAllSubjects(),
+        "Getting all subjects should match all registered subjects"
     );
   }
 
@@ -158,24 +161,27 @@ public class RestApiTest extends ClusterTestHarness {
     List<SchemaReference> refs = Arrays.asList(ref, meta);
     request.setReferences(refs);
     int registeredId = restApp.restClient.registerSchema(request, "referrer", false).getId();
-    assertEquals("Registering a new schema should succeed", 3, registeredId);
+    assertEquals(3, registeredId, "Registering a new schema should succeed");
 
     SchemaString schemaString = restApp.restClient.getId(3);
     // the newly registered schema should be immediately readable on the leader
-    assertEquals("Registered schema should be found",
+    assertEquals(
         schemas.get("root.proto"),
-        schemaString.getSchemaString()
+        schemaString.getSchemaString(),
+        "Registered schema should be found"
     );
     schemaString = restApp.restClient.getId(RestService.DEFAULT_REQUEST_PROPERTIES, 3, null, "serialized", null, false);
     // the newly registered schema should be immediately readable on the leader
-    assertEquals("Registered schema should be found",
+    assertEquals(
         schemas.get("root.proto"),
-        new ProtobufSchema(schemaString.getSchemaString()).canonicalString()
+        new ProtobufSchema(schemaString.getSchemaString()).canonicalString(),
+        "Registered schema should be found"
     );
 
-    assertEquals("Schema dependencies should be found",
+    assertEquals(
         refs,
-        schemaString.getReferences()
+        schemaString.getReferences(),
+        "Schema dependencies should be found"
     );
 
     Root.ReferrerMessage referrer = Root.ReferrerMessage.newBuilder().build();
@@ -183,24 +189,28 @@ public class RestApiTest extends ClusterTestHarness {
     schema = schema.copy(refs);
     Schema registeredSchema = restApp.restClient.lookUpSubjectVersion(schema.canonicalString(),
             ProtobufSchema.TYPE, schema.references(), "referrer", false);
-    assertEquals("Registered schema should be found", 3, registeredSchema.getId().intValue());
+    assertEquals(3, registeredSchema.getId().intValue(), "Registered schema should be found");
     request = new RegisterSchemaRequest();
     request.setSchema(schema.canonicalString());
     request.setSchemaType(schema.schemaType());
     request.setReferences(schema.references());
     Schema registeredSchema2 = restApp.restClient.lookUpSubjectVersion(
         RestService.DEFAULT_REQUEST_PROPERTIES, request, "referrer", false, "serialized", false);
-    assertEquals("Registered schema should be found",
+    assertEquals(
         registeredSchema.getSchema(),
-        new ProtobufSchema(registeredSchema2.getSchema()).canonicalString());
+        new ProtobufSchema(registeredSchema2.getSchema()).canonicalString(),
+        "Registered schema should be found"
+    );
 
     Schema latestSchema = restApp.restClient.getLatestVersion("referrer");
-    assertEquals("Registered schema should be found", 3, latestSchema.getId().intValue());
+    assertEquals(3, latestSchema.getId().intValue(), "Registered schema should be found");
     Schema latestSchema2 = restApp.restClient.getLatestVersion(
         RestService.DEFAULT_REQUEST_PROPERTIES, "referrer", "serialized", null);
-    assertEquals("Registered schema should be found",
+    assertEquals(
         latestSchema.getSchema(),
-        new ProtobufSchema(latestSchema2.getSchema()).canonicalString());
+        new ProtobufSchema(latestSchema2.getSchema()).canonicalString(),
+        "Registered schema should be found"
+    );
   }
 
   @Test
@@ -240,18 +250,20 @@ public class RestApiTest extends ClusterTestHarness {
     List<SchemaReference> refs = Arrays.asList(meta);
     request.setReferences(refs);
     int registeredId = restApp.restClient.registerSchema(request, subject, false).getId();
-    assertEquals("Registering a new schema should succeed", 2, registeredId);
+    assertEquals(2, registeredId, "Registering a new schema should succeed");
   }
 
-  @Test(expected = RestClientException.class)
+  @Test
   public void testSchemaMissingReferences() throws Exception {
-    Map<String, String> schemas = getProtobufSchemaWithDependencies();
+    assertThrows(RestClientException.class, () -> {
+      Map<String, String> schemas = getProtobufSchemaWithDependencies();
 
-    RegisterSchemaRequest request = new RegisterSchemaRequest();
-    request.setSchema(schemas.get("root.proto"));
-    request.setSchemaType(ProtobufSchema.TYPE);
-    request.setReferences(Collections.emptyList());
-    restApp.restClient.registerSchema(request, "referrer", false);
+      RegisterSchemaRequest request = new RegisterSchemaRequest();
+      request.setSchema(schemas.get("root.proto"));
+      request.setSchemaType(ProtobufSchema.TYPE);
+      request.setReferences(Collections.emptyList());
+      restApp.restClient.registerSchema(request, "referrer", false);
+    });
   }
 
   @Test
@@ -366,7 +378,7 @@ public class RestApiTest extends ClusterTestHarness {
     List<SchemaReference> refs = Arrays.asList(ref1, ref2);
     request.setReferences(refs);
     int registeredId = restApp.restClient.registerSchema(request, subject1, true).getId();
-    assertEquals("Registering a new schema should succeed", 3, registeredId);
+    assertEquals(3, registeredId, "Registering a new schema should succeed");
 
     // Alternate version of same schema
     msg3 = "syntax = \"proto3\";\n" +
@@ -392,10 +404,16 @@ public class RestApiTest extends ClusterTestHarness {
     lookUpRequest.setReferences(Arrays.asList(ref2, ref1));
     int versionOfRegisteredSchema1Subject1 =
         restApp.restClient.lookUpSubjectVersion(lookUpRequest, subject1, true, false).getVersion();
-    assertEquals("1st schema under subject1 should have version 1", 1,
-        versionOfRegisteredSchema1Subject1);
-    assertEquals("1st schema registered globally should have id 3", 3,
-        registeredId);
+    assertEquals(
+        1,
+        versionOfRegisteredSchema1Subject1,
+        "1st schema under subject1 should have version 1"
+    );
+    assertEquals(
+        3,
+        registeredId,
+        "1st schema registered globally should have id 3"
+    );
   }
 
   @Test
@@ -404,18 +422,21 @@ public class RestApiTest extends ClusterTestHarness {
     List<String> allSubjects = new ArrayList<String>();
 
     // test getAllSubjects with no existing data
-    assertEquals("Getting all subjects should return empty",
+    assertEquals(
         allSubjects,
-        restApp.restClient.getAllSubjects()
+        restApp.restClient.getAllSubjects(),
+        "Getting all subjects should return empty"
     );
 
     try {
       registerAndVerifySchema(restApp.restClient, getBadSchema(), 1, subject1);
       fail("Registering bad schema should fail with " + Errors.INVALID_SCHEMA_ERROR_CODE);
     } catch (RestClientException rce) {
-      assertEquals("Invalid schema",
+      assertEquals(
           Errors.INVALID_SCHEMA_ERROR_CODE,
-          rce.getErrorCode());
+          rce.getErrorCode(),
+          "Invalid schema"
+      );
     }
 
     try {
@@ -423,15 +444,18 @@ public class RestApiTest extends ClusterTestHarness {
           Arrays.asList(new SchemaReference("bad", "bad", 100)), 1, subject1);
       fail("Registering bad reference should fail with " + Errors.INVALID_SCHEMA_ERROR_CODE);
     } catch (RestClientException rce) {
-      assertEquals("Invalid schema",
+      assertEquals(
           Errors.INVALID_SCHEMA_ERROR_CODE,
-          rce.getErrorCode());
+          rce.getErrorCode(),
+          "Invalid schema"
+      );
     }
 
     // test getAllSubjects with existing data
-    assertEquals("Getting all subjects should match all registered subjects",
+    assertEquals(
         allSubjects,
-        restApp.restClient.getAllSubjects()
+        restApp.restClient.getAllSubjects(),
+        "Getting all subjects should match all registered subjects"
     );
   }
 
@@ -713,9 +737,11 @@ public class RestApiTest extends ClusterTestHarness {
       registerAndVerifySchema(restApp.restClient, request, 3, subject);
       fail("Registering version that is not next version should fail with " + Errors.INVALID_SCHEMA_ERROR_CODE);
     } catch (RestClientException rce) {
-      assertEquals("Invalid schema",
+      assertEquals(
           Errors.INVALID_SCHEMA_ERROR_CODE,
-          rce.getErrorCode());
+          rce.getErrorCode(),
+          "Invalid schema"
+      );
     }
 
     // Register schema with version 4
@@ -828,15 +854,15 @@ public class RestApiTest extends ClusterTestHarness {
         references,
         subject
     ).getId();
-    Assert.assertEquals(
-        "Registering a new schema should succeed",
+    assertEquals(
         (long) expectedId,
-        (long) registeredId
+        (long) registeredId,
+        "Registering a new schema should succeed"
     );
-    Assert.assertEquals(
-        "Registered schema should be found",
+    assertEquals(
         schemaString.trim(),
-        restService.getId(expectedId).getSchemaString().trim()
+        restService.getId(expectedId).getSchemaString().trim(),
+        "Registered schema should be found"
     );
   }
 
@@ -847,15 +873,15 @@ public class RestApiTest extends ClusterTestHarness {
       String subject
   ) throws IOException, RestClientException {
     int registeredId = restService.registerSchema(request, subject, false).getId();
-    Assert.assertEquals(
-        "Registering a new schema should succeed",
+    assertEquals(
         (long) expectedId,
-        (long) registeredId
+        (long) registeredId,
+        "Registering a new schema should succeed"
     );
-    Assert.assertEquals(
-        "Registered schema should be found",
+    assertEquals(
         request.getSchema().trim(),
-        restService.getId(expectedId).getSchemaString().trim()
+        restService.getId(expectedId).getSchemaString().trim(),
+        "Registered schema should be found"
     );
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThreadTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreReaderThreadTest.java
@@ -17,15 +17,13 @@ package io.confluent.kafka.schemaregistry.storage;
 import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreTimeoutException;
 import io.confluent.kafka.schemaregistry.utils.TestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class KafkaStoreReaderThreadTest extends ClusterTestHarness {
 
@@ -34,16 +32,6 @@ public class KafkaStoreReaderThreadTest extends ClusterTestHarness {
   }
 
   private static final Logger log = LoggerFactory.getLogger(KafkaStoreReaderThreadTest.class);
-
-  @Before
-  public void setup() {
-  }
-
-  @After
-  public void teardown() {
-    log.debug("Shutting down");
-  }
-
 
   @Test
   public void testWaitUntilOffset() throws Exception {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreSASLTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreSASLTest.java
@@ -15,40 +15,41 @@
 package io.confluent.kafka.schemaregistry.storage;
 
 import io.confluent.kafka.schemaregistry.SASLClusterTestHarness;
-import io.confluent.kafka.schemaregistry.storage.exceptions.StoreException;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreInitializationException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 // tests SASL with ZooKeeper and Kafka.
 public class KafkaStoreSASLTest extends SASLClusterTestHarness {
   @Test
   public void testInitialization() throws Exception {
-    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSASLStoreInstance(bootstrapServers);
+    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSASLStoreInstance(brokerList);
     kafkaStore.close();
   }
 
-  @Test(expected = StoreInitializationException.class)
+  @Test
   public void testDoubleInitialization() throws Exception {
-    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSASLStoreInstance(bootstrapServers);
-    try {
-      kafkaStore.init();
-    } finally {
-      kafkaStore.close();
-    }
+    assertThrows(StoreInitializationException.class, () -> {
+      KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSASLStoreInstance(brokerList);
+      try {
+        kafkaStore.init();
+      } finally {
+        kafkaStore.close();
+      }
+    });
   }
 
   @Test
   public void testSimplePut() throws Exception {
-    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSASLStoreInstance(bootstrapServers);
+    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSASLStoreInstance(brokerList);
     String key = "Kafka";
     String value = "Rocks";
     try {
       kafkaStore.put(key, value);
       String retrievedValue = kafkaStore.get(key);
-      assertEquals("Retrieved value should match entered value", value, retrievedValue);
+      assertEquals(value, retrievedValue, "Retrieved value should match entered value");
     } finally {
       kafkaStore.close();
     }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreSSLAuthTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreSSLAuthTest.java
@@ -16,63 +16,61 @@ package io.confluent.kafka.schemaregistry.storage;
 
 import io.confluent.kafka.schemaregistry.SSLClusterTestHarness;
 import io.confluent.kafka.schemaregistry.storage.exceptions.StoreInitializationException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class KafkaStoreSSLAuthTest extends SSLClusterTestHarness {
   private static final Logger log = LoggerFactory.getLogger(KafkaStoreSSLAuthTest.class);
 
-  @Before
-  public void setup() {
-  }
-
-  @After
-  public void teardown() {
-    log.debug("Shutting down");
-  }
 
   @Test
   public void testInitialization() throws Exception {
-    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSSLKafkaStoreInstance(bootstrapServers,
+    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSSLKafkaStoreInstance(
+        brokerList,
             clientSslConfigs, requireSSLClientAuth());
     kafkaStore.close();
   }
 
-  @Test(expected = StoreInitializationException.class)
+  @Test
   public void testInitializationWithoutClientAuth() throws Exception {
-    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSSLKafkaStoreInstance(bootstrapServers,
-            clientSslConfigs, false);
-    kafkaStore.close();
-
-    // TODO: make the timeout shorter so the test fails quicker.
+    assertThrows(StoreInitializationException.class, () -> {
+      KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSSLKafkaStoreInstance(
+          brokerList,
+              clientSslConfigs, false);
+      kafkaStore.close();
+      // TODO: make the timeout shorter so the test fails quicker.
+    });
   }
 
-  @Test(expected = StoreInitializationException.class)
+  @Test
   public void testDoubleInitialization() throws Exception {
-    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSSLKafkaStoreInstance(bootstrapServers,
-            clientSslConfigs, requireSSLClientAuth());
-    try {
-      kafkaStore.init();
-    } finally {
-      kafkaStore.close();
-    }
+    assertThrows(StoreInitializationException.class, () -> {
+      KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSSLKafkaStoreInstance(
+          brokerList,
+              clientSslConfigs, requireSSLClientAuth());
+      try {
+        kafkaStore.init();
+      } finally {
+        kafkaStore.close();
+      }
+    });
   }
 
   @Test
   public void testSimplePut() throws Exception {
-    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSSLKafkaStoreInstance(bootstrapServers,
+    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitSSLKafkaStoreInstance(
+        brokerList,
             clientSslConfigs, requireSSLClientAuth());
     String key = "Kafka";
     String value = "Rocks";
     try {
       kafkaStore.put(key, value);
       String retrievedValue = kafkaStore.get(key);
-      assertEquals("Retrieved value should match entered value", value, retrievedValue);
+      assertEquals(value, retrievedValue, "Retrieved value should match entered value");
     } finally {
       kafkaStore.close();
     }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreSSLNoAuthTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreSSLNoAuthTest.java
@@ -14,7 +14,7 @@
  */
 package io.confluent.kafka.schemaregistry.storage;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class KafkaStoreSSLNoAuthTest extends KafkaStoreSSLAuthTest {
   protected boolean requireSSLClientAuth() {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreTest.java
@@ -14,7 +14,6 @@
  */
 package io.confluent.kafka.schemaregistry.storage;
 
-import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.id.IncrementalIdGenerator;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -24,9 +23,7 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,11 +39,11 @@ import java.util.Iterator;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class KafkaStoreTest extends ClusterTestHarness {
 
@@ -55,40 +52,34 @@ public class KafkaStoreTest extends ClusterTestHarness {
   private static final int ADMIN_TIMEOUT_SEC = 60;
   private static final TopicPartition tp = new TopicPartition("_schemas", 0);
 
-  @Before
-  public void setup() {
-  }
-
-  @After
-  public void teardown() {
-    log.debug("Shutting down");
-  }
-
   @Test
   public void testInitialization() throws Exception {
-    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(bootstrapServers);
+    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(brokerList);
     kafkaStore.close();
   }
 
-  @Test(expected = StoreInitializationException.class)
+  @Test
   public void testDoubleInitialization() throws Exception {
-    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(bootstrapServers);
-    try {
-      kafkaStore.init();
-    } finally {
-      kafkaStore.close();
-    }
+    assertThrows(StoreInitializationException.class, () -> {
+      KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(
+          brokerList);
+      try {
+        kafkaStore.init();
+      } finally {
+        kafkaStore.close();
+      }
+    });
   }
 
   @Test
   public void testSimplePut() throws Exception {
-    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(bootstrapServers);
+    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(brokerList);
     String key = "Kafka";
     String value = "Rocks";
     try {
       kafkaStore.put(key, value);
       String retrievedValue = kafkaStore.get(key);
-      assertEquals("Retrieved value should match entered value", value, retrievedValue);
+      assertEquals(value, retrievedValue, "Retrieved value should match entered value");
     } finally {
       kafkaStore.close();
     }
@@ -130,7 +121,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
   public void testSimpleGetAfterFailure() throws Exception {
     Store<String, String> inMemoryStore = new InMemoryCache<>(StringSerializer.INSTANCE);
     KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(
-        bootstrapServers,
+        brokerList,
         inMemoryStore
     );
     String key = "Kafka";
@@ -147,20 +138,20 @@ public class KafkaStoreTest extends ClusterTestHarness {
       } catch (StoreException e) {
         throw new RuntimeException("Kafka store get(Kafka) operation failed", e);
       }
-      assertEquals("Retrieved value should match entered value", value, retrievedValue);
+      assertEquals(value, retrievedValue, "Retrieved value should match entered value");
     } finally {
       kafkaStore.close();
     }
 
     // recreate kafka store
-    kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(bootstrapServers, inMemoryStore);
+    kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(brokerList, inMemoryStore);
     try {
       try {
         retrievedValue = kafkaStore.get(key);
       } catch (StoreException e) {
         throw new RuntimeException("Kafka store get(Kafka) operation failed", e);
       }
-      assertEquals("Retrieved value should match entered value", value, retrievedValue);
+      assertEquals(value, retrievedValue, "Retrieved value should match entered value");
     } finally {
       kafkaStore.close();
     }
@@ -168,7 +159,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
 
   @Test
   public void testSimpleDelete() throws Exception {
-    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(bootstrapServers);
+    KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(brokerList);
     String key = "Kafka";
     String value = "Rocks";
     try {
@@ -183,7 +174,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
       } catch (StoreException e) {
         throw new RuntimeException("Kafka store get(Kafka) operation failed", e);
       }
-      assertEquals("Retrieved value should match entered value", value, retrievedValue);
+      assertEquals(value, retrievedValue, "Retrieved value should match entered value");
       try {
         kafkaStore.delete(key);
       } catch (StoreException e) {
@@ -195,7 +186,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
       } catch (StoreException e) {
         throw new RuntimeException("Kafka store get(Kafka) operation failed", e);
       }
-      assertNull("Value should have been deleted", retrievedValue);
+      assertNull(retrievedValue, "Value should have been deleted");
     } finally {
       kafkaStore.close();
     }
@@ -205,7 +196,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
   public void testDeleteAfterRestart() throws Exception {
     Store<String, String> inMemoryStore = new InMemoryCache<>(StringSerializer.INSTANCE);
     KafkaStore<String, String> kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(
-        bootstrapServers,
+        brokerList,
         inMemoryStore
     );
     String key = "Kafka";
@@ -222,7 +213,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
       } catch (StoreException e) {
         throw new RuntimeException("Kafka store get(Kafka) operation failed", e);
       }
-      assertEquals("Retrieved value should match entered value", value, retrievedValue);
+      assertEquals(value, retrievedValue, "Retrieved value should match entered value");
       // delete the key
       try {
         kafkaStore.delete(key);
@@ -235,10 +226,10 @@ public class KafkaStoreTest extends ClusterTestHarness {
       } catch (StoreException e) {
         throw new RuntimeException("Kafka store get(Kafka) operation failed", e);
       }
-      assertNull("Value should have been deleted", retrievedValue);
+      assertNull(retrievedValue, "Value should have been deleted");
       kafkaStore.close();
       // recreate kafka store
-      kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(bootstrapServers, inMemoryStore);
+      kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(brokerList, inMemoryStore);
       // verify that key still doesn't exist in the store
       retrievedValue = value;
       try {
@@ -246,7 +237,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
       } catch (StoreException e) {
         throw new RuntimeException("Kafka store get(Kafka) operation failed", e);
       }
-      assertNull("Value should have been deleted", retrievedValue);
+      assertNull(retrievedValue, "Value should have been deleted");
     } finally {
       kafkaStore.close();
     }
@@ -260,7 +251,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
     String groupId = "test-group-id";
     Properties props = new Properties();
     props.put(SchemaRegistryConfig.KAFKASTORE_GROUP_ID_CONFIG, groupId);
-    KafkaStore kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(bootstrapServers, inMemoryStore, props);
+    KafkaStore kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(brokerList, inMemoryStore, props);
 
     assertEquals(kafkaStore.getKafkaStoreReaderThread().getConsumerProperty(org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG), groupId);
   }
@@ -270,49 +261,56 @@ public class KafkaStoreTest extends ClusterTestHarness {
   public void testDefaultGroupIdConfig() throws Exception {
     Store<String, String> inMemoryStore = new InMemoryCache<>(StringSerializer.INSTANCE);
     Properties props = new Properties();
-    KafkaStore kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(bootstrapServers, inMemoryStore, props);
+    KafkaStore kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(brokerList, inMemoryStore, props);
 
     assertTrue(kafkaStore.getKafkaStoreReaderThread().getConsumerProperty(org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG).startsWith("schema-registry-"));
   }
 
-  @Test(expected=StoreInitializationException.class)
+  @Test
   public void testMandatoryCompactionPolicy() throws Exception {
-    Properties kafkaProps = new Properties();
-    Map<String, String> topicProps = new HashMap<>();
-    topicProps.put(TopicConfig.CLEANUP_POLICY_CONFIG, "delete");
+    assertThrows(StoreInitializationException.class, () -> {
+      Properties kafkaProps = new Properties();
+      Map<String, String> topicProps = new HashMap<>();
+      topicProps.put(TopicConfig.CLEANUP_POLICY_CONFIG, "delete");
 
-    NewTopic topic = new NewTopic(SchemaRegistryConfig.DEFAULT_KAFKASTORE_TOPIC, 1, (short) 1);
-    topic.configs(topicProps);
+      NewTopic topic = new NewTopic(SchemaRegistryConfig.DEFAULT_KAFKASTORE_TOPIC, 1, (short) 1);
+      topic.configs(topicProps);
 
-    Properties props = new Properties();
-    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-    try (AdminClient admin = AdminClient.create(props)) {
-      admin.createTopics(Collections.singletonList(topic)).all().get(ADMIN_TIMEOUT_SEC, TimeUnit.SECONDS);
-    }
+      Properties props = new Properties();
+      props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
+      try (AdminClient admin = AdminClient.create(props)) {
+        admin.createTopics(Collections.singletonList(topic)).all()
+            .get(ADMIN_TIMEOUT_SEC, TimeUnit.SECONDS);
+      }
 
-    Store<String, String> inMemoryStore = new InMemoryCache<>(StringSerializer.INSTANCE);
+      Store<String, String> inMemoryStore = new InMemoryCache<>(StringSerializer.INSTANCE);
 
-    KafkaStore kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(bootstrapServers, inMemoryStore, kafkaProps);
+      KafkaStore kafkaStore = StoreUtils.createAndInitKafkaStoreInstance(brokerList, inMemoryStore,
+          kafkaProps);
+    });
   }
 
-  @Test(expected=StoreInitializationException.class)
+  @Test
   public void testTooManyPartitions() throws Exception {
-    Properties kafkaProps = new Properties();
-    Map<String, String> topicProps = new HashMap<>();
-    topicProps.put(TopicConfig.CLEANUP_POLICY_CONFIG, "compact");
+    assertThrows(StoreInitializationException.class, () -> {
+      Properties kafkaProps = new Properties();
+      Map<String, String> topicProps = new HashMap<>();
+      topicProps.put(TopicConfig.CLEANUP_POLICY_CONFIG, "compact");
 
-    NewTopic topic = new NewTopic(SchemaRegistryConfig.DEFAULT_KAFKASTORE_TOPIC, 3, (short) 1);
-    topic.configs(topicProps);
+      NewTopic topic = new NewTopic(SchemaRegistryConfig.DEFAULT_KAFKASTORE_TOPIC, 3, (short) 1);
+      topic.configs(topicProps);
 
-    Properties props = new Properties();
-    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-    try (AdminClient admin = AdminClient.create(props)) {
-      admin.createTopics(Collections.singletonList(topic)).all().get(ADMIN_TIMEOUT_SEC, TimeUnit.SECONDS);
-    }
+      Properties props = new Properties();
+      props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
+      try (AdminClient admin = AdminClient.create(props)) {
+        admin.createTopics(Collections.singletonList(topic)).all()
+            .get(ADMIN_TIMEOUT_SEC, TimeUnit.SECONDS);
+      }
 
-    Store<String, String> inMemoryStore = new InMemoryCache<>(StringSerializer.INSTANCE);
+      Store<String, String> inMemoryStore = new InMemoryCache<>(StringSerializer.INSTANCE);
 
-    StoreUtils.createAndInitKafkaStoreInstance(bootstrapServers, inMemoryStore, kafkaProps);
+      StoreUtils.createAndInitKafkaStoreInstance(brokerList, inMemoryStore, kafkaProps);
+    });
   }
 
   @Test
@@ -321,10 +319,10 @@ public class KafkaStoreTest extends ClusterTestHarness {
     kafkaProps.put("kafkastore.topic.config.delete.retention.ms", "10000");
     kafkaProps.put("kafkastore.topic.config.segment.ms", "10000");
     Store<String, String> inMemoryStore = new InMemoryCache<>(StringSerializer.INSTANCE);
-    StoreUtils.createAndInitKafkaStoreInstance(bootstrapServers, inMemoryStore, kafkaProps);
+    StoreUtils.createAndInitKafkaStoreInstance(brokerList, inMemoryStore, kafkaProps);
 
     Properties props = new Properties();
-    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
 
     ConfigResource configResource = new ConfigResource(
         ConfigResource.Type.TOPIC,
@@ -346,7 +344,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
   @Test
   public void testGetAlwaysTrueHostnameVerifierWhenSslEndpointIdentificationAlgorithmIsNotSet() throws Exception {
     Properties props = new Properties();
-    props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, brokerList);
     props.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG, ClusterTestHarness.KAFKASTORE_TOPIC);
 
     SchemaRegistryConfig config = new SchemaRegistryConfig(props);
@@ -361,7 +359,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
   @Test
   public void testGetAlwaysTrueHostnameVerifierWhenSslEndpointIdentificationAlgorithmIsNone() throws Exception {
     Properties props = new Properties();
-    props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, brokerList);
     props.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG, ClusterTestHarness.KAFKASTORE_TOPIC);
     props.put(SchemaRegistryConfig.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "none");
 
@@ -377,7 +375,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
   @Test
   public void testGetAlwaysTrueHostnameVerifierWhenSslEndpointIdentificationAlgorithmIsEmptyString() throws Exception {
     Properties props = new Properties();
-    props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, brokerList);
     props.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG, ClusterTestHarness.KAFKASTORE_TOPIC);
     props.put(SchemaRegistryConfig.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "");
 
@@ -393,7 +391,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
   @Test
   public void testGetNullHostnameVerifierWhenSslEndpointIdentificationAlgorithmIsHttps() throws Exception {
     Properties props = new Properties();
-    props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, brokerList);
     props.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG, ClusterTestHarness.KAFKASTORE_TOPIC);
     props.put(SchemaRegistryConfig.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "https");
 
@@ -409,7 +407,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
   @Test
   public void testKafkaStoreMessageHandlerSameIdDifferentSchema() throws Exception {
     Properties props = new Properties();
-    props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, brokerList);
     props.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG, ClusterTestHarness.KAFKASTORE_TOPIC);
 
     SchemaRegistryConfig config = new SchemaRegistryConfig(props);
@@ -440,7 +438,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
   @Test
   public void testKafkaStoreMessageHandlerSameIdSameSchema() throws Exception {
     Properties props = new Properties();
-    props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, brokerList);
     props.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG, ClusterTestHarness.KAFKASTORE_TOPIC);
 
     SchemaRegistryConfig config = new SchemaRegistryConfig(props);
@@ -471,7 +469,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
   @Test
   public void testKafkaStoreMessageHandlerSameIdDifferentDeletedSchema() throws Exception {
     Properties props = new Properties();
-    props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, brokerList);
     props.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG, ClusterTestHarness.KAFKASTORE_TOPIC);
 
     SchemaRegistryConfig config = new SchemaRegistryConfig(props);
@@ -505,7 +503,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
   @Test
   public void testKafkaStoreMessageHandlerSameIdSameDeletedSchema() throws Exception {
     Properties props = new Properties();
-    props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, brokerList);
     props.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG, ClusterTestHarness.KAFKASTORE_TOPIC);
 
     SchemaRegistryConfig config = new SchemaRegistryConfig(props);
@@ -540,7 +538,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
   @Test
   public void testKafkaStoreMessageHandlerDeleteSubjectKeyNullValue() throws Exception {
     Properties props = new Properties();
-    props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, brokerList);
     props.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG, ClusterTestHarness.KAFKASTORE_TOPIC);
 
     SchemaRegistryConfig config = new SchemaRegistryConfig(props);
@@ -564,7 +562,7 @@ public class KafkaStoreTest extends ClusterTestHarness {
   @Test
   public void testKafkaStoreMessageHandlerClearSubjectKeyNullValue() throws Exception {
     Properties props = new Properties();
-    props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    props.put(SchemaRegistryConfig.KAFKASTORE_BOOTSTRAP_SERVERS_CONFIG, brokerList);
     props.put(SchemaRegistryConfig.KAFKASTORE_TOPIC_CONFIG, ClusterTestHarness.KAFKASTORE_TOPIC);
 
     SchemaRegistryConfig config = new SchemaRegistryConfig(props);

--- a/dek-registry/pom.xml
+++ b/dek-registry/pom.xml
@@ -58,6 +58,14 @@
 
         <dependency>
             <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-server-common</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <scope>provided</scope>
         </dependency>
@@ -142,6 +150,18 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dek-registry/src/test/java/io/confluent/dekregistry/web/rest/RestApiTest.java
+++ b/dek-registry/src/test/java/io/confluent/dekregistry/web/rest/RestApiTest.java
@@ -54,8 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RestApiTest extends ClusterTestHarness {
 
@@ -80,7 +79,7 @@ public class RestApiTest extends ClusterTestHarness {
     return props;
   }
 
-  @Before
+  @Override
   public void setUp() throws Exception {
     super.setUp();
     fakeTicker = new FakeTicker();

--- a/protobuf-serializer/pom.xml
+++ b/protobuf-serializer/pom.xml
@@ -91,6 +91,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-server-common</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
@@ -98,6 +105,16 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/protobuf-serializer/src/test/java/io/confluent/kafka/schemaregistry/protobuf/rest/RestApiSerializerTest.java
+++ b/protobuf-serializer/src/test/java/io/confluent/kafka/schemaregistry/protobuf/rest/RestApiSerializerTest.java
@@ -48,7 +48,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.junit.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -73,10 +72,12 @@ import io.confluent.kafka.serializers.protobuf.test.NestedTestProto.NestedMessag
 import io.confluent.kafka.serializers.protobuf.test.NestedTestProto.Status;
 import io.confluent.kafka.serializers.protobuf.test.NestedTestProto.UserId;
 import io.confluent.kafka.serializers.protobuf.test.TestMessageProtos.TestMessage;
+import org.junit.jupiter.api.Test;
 
 import static io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializerTest.getField;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RestApiSerializerTest extends ClusterTestHarness {
 
@@ -412,9 +413,11 @@ public class RestApiSerializerTest extends ClusterTestHarness {
     ConfigUpdateRequest config = new ConfigUpdateRequest();
     config.setDefaultMetadata(metadata);
     // add config metadata
-    assertEquals("Adding config with initial metadata should succeed",
+    assertEquals(
         config,
-        restApp.restClient.updateConfig(config, null));
+        restApp.restClient.updateConfig(config, null),
+        "Adding config with initial metadata should succeed"
+    );
 
     SchemaRegistryClient schemaRegistry = new CachedSchemaRegistryClient(restApp.restClient,
         10,
@@ -428,24 +431,27 @@ public class RestApiSerializerTest extends ClusterTestHarness {
 
     RegisterSchemaRequest request = new RegisterSchemaRequest(schema);
     int registeredId = restApp.restClient.registerSchema(request, "referrer", false).getId();
-    assertEquals("Registering a new schema should succeed", 4, registeredId);
+    assertEquals(4, registeredId, "Registering a new schema should succeed");
 
     SchemaString schemaString = restApp.restClient.getId(4);
     // the newly registered schema should be immediately readable on the leader
-    assertNotNull("Registered schema should be found", schemaString);
+    assertNotNull(schemaString, "Registered schema should be found");
 
-    assertEquals("Schema dependencies should be found",
+    assertEquals(
         2,
-        schemaString.getReferences().size()
+        schemaString.getReferences().size(),
+        "Schema dependencies should be found"
     );
   }
 
-  @Test(expected = RestClientException.class)
+  @Test
   public void testInvalidSchema() throws Exception {
-    String schemaString = getInvalidSchema();
-    String subject = "invalid";
-    registerAndVerifySchema(
-        restApp.restClient, schemaString, Collections.emptyList(), 1, subject);
+    assertThrows(RestClientException.class, () -> {
+      String schemaString = getInvalidSchema();
+      String subject = "invalid";
+      registerAndVerifySchema(
+          restApp.restClient, schemaString, Collections.emptyList(), 1, subject);
+    });
   }
 
   private static String getInvalidSchema() {
@@ -486,14 +492,14 @@ public class RestApiSerializerTest extends ClusterTestHarness {
         normalize
     ).getId();
     assertEquals(
-        "Registering a new schema should succeed",
         (long) expectedId,
-        (long) registeredId
+        (long) registeredId,
+        "Registering a new schema should succeed"
     );
     assertEquals(
-        "Registered schema should be found",
         schemaString.trim(),
-        restService.getId(expectedId).getSchemaString().trim()
+        restService.getId(expectedId).getSchemaString().trim(),
+        "Registered schema should be found"
     );
   }
 

--- a/schema-rules/pom.xml
+++ b/schema-rules/pom.xml
@@ -79,6 +79,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-server-common</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <classifier>test</classifier>
             <scope>test</scope>
@@ -115,6 +122,16 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelExecutorIntegrationTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelExecutorIntegrationTest.java
@@ -16,7 +16,7 @@
 
 package io.confluent.kafka.schemaregistry.rules.cel;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
@@ -63,8 +63,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,8 +85,8 @@ public class CelExecutorIntegrationTest extends ClusterTestHarness {
     super(1, true);
   }
 
-  @Before
-  public void setUp() throws Exception {
+  @Override
+  protected void setUp() throws Exception {
     super.setUp();
     ((KafkaSchemaRegistry) restApp.schemaRegistry()).setRuleSetHandler(new RuleSetHandler() {
       public void handle(String subject, ConfigUpdateRequest request) {
@@ -208,7 +207,7 @@ public class CelExecutorIntegrationTest extends ClusterTestHarness {
     value.setAge(45); // rule: > 18
     value.setIBAN("GB33BUKB20201555555555"); // rule: matches regex
     value.setActive(isActive); // rule: is true
-    value.setBalance(new Float(10.0).floatValue()); // rule: >= 0.0
+    value.setBalance(Float.valueOf(10.0f).floatValue()); // rule: >= 0.0
     value.setMode(mode);
     return value;
   }

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/jsonata/JsonataExecutorIntegrationTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/jsonata/JsonataExecutorIntegrationTest.java
@@ -91,8 +91,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,8 +111,8 @@ public class JsonataExecutorIntegrationTest extends ClusterTestHarness {
     super(1, true);
   }
 
-  @Before
-  public void setUp() throws Exception {
+  @Override
+  protected void setUp() throws Exception {
     super.setUp();
     ((KafkaSchemaRegistry) restApp.schemaRegistry()).setRuleSetHandler(new RuleSetHandler() {
       public void handle(String subject, ConfigUpdateRequest request) {


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
The main change is to `ClusterTestHarness`, which now uses the `QuorumTestHarness` from AK 4.0.  AK has also moved from JUnit 4 to JUnit 5, so integration tests that rely on `ClusterTestHarness` have been ported to JUnit 5.  This involved a lot of tedious changes of moving the assertion description parameter from being the first parameter to the last parameter.

<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Is this change gated behind feature flag(s)?
    - List the LD flags needed to be set to enable this change
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- [ ] Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
