### PR TITLE
Include `subject` when operation fails working with Avro schemas in the registry.

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -184,7 +184,7 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
       // ClassCastException, etc
       throw new SerializationException("Error serializing Avro message", e);
     } catch (RestClientException e) {
-      throw toKafkaException(e, restClientErrorMsg + schema);
+      throw toKafkaException(e, restClientErrorMsg + schema + ", subject: " + subject);
     } finally {
       postOp(object);
     }


### PR DESCRIPTION
# What
Changed the failure messages when an operation fails in the Avro serde to include the subject.

# Why
It can be hard to determine what the subject is otherwise.  Is the failure occurring because the subject is wrong or something else?

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes:
 - No
- [x] Is this change gated behind feature flag(s)?
 -  No
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
 - No: see `Test & Review` below.
- [x] Does this change require modifying existing system tests or adding new system tests?
 -  No.

Test & Review
------------
I'd love to test this and enhance the tests, but I can't get `common` to build locally so I'm unable to run this. 
I realise this is less than ideal, but I don't have the patience or time to work out the maven magic required.
Do with this PR what you will ;). Yes, it would be useful for myself and others. But I appreciate your time is limited to finish off my suggestion.

