### PR TITLE
Add display name generator to ensure Kraft is used in integration tests

### DIFF
--- a/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
@@ -17,8 +17,10 @@ package io.confluent.kafka.schemaregistry;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.stream.Collectors.toList;
 
+import io.confluent.kafka.schemaregistry.ClusterTestHarness.AddKraftQuorum;
 import io.vavr.Tuple2;
 import java.io.File;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Optional;
@@ -56,6 +58,8 @@ import org.apache.kafka.storage.internals.log.CleanerConfig;
 import org.apache.kafka.test.TestSslUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestInfo;
 import org.slf4j.Logger;
@@ -70,6 +74,7 @@ import scala.collection.Seq;
  * the addition of the REST proxy. Defaults to a 1-ZK, 3-broker, 1 REST proxy cluster.
  */
 @Tag("IntegrationTest")
+@DisplayNameGeneration(AddKraftQuorum.class)
 public abstract class ClusterTestHarness {
 
   private static final Logger log = LoggerFactory.getLogger(ClusterTestHarness.class);
@@ -477,5 +482,26 @@ public abstract class ClusterTestHarness {
     }
 
     return result;
+  }
+
+  static class AddKraftQuorum extends DisplayNameGenerator.Standard {
+    @Override
+    public String generateDisplayNameForClass(Class<?> testClass) {
+      return addKraftQuorum(super.generateDisplayNameForClass(testClass));
+    }
+
+    @Override
+    public String generateDisplayNameForNestedClass(Class<?> nestedClass) {
+      return addKraftQuorum(super.generateDisplayNameForNestedClass(nestedClass));
+    }
+
+    @Override
+    public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
+      return this.addKraftQuorum(super.generateDisplayNameForMethod(testClass, testMethod));
+    }
+
+    String addKraftQuorum(String name) {
+      return name + ",quorum=kraft";
+    }
   }
 }


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Add display name generator to ensure Kraft is used in integration tests, since the underlying QuorumTestHarness keys off of the display name.
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Is this change gated behind feature flag(s)?
    - List the LD flags needed to be set to enable this change
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- [ ] Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
