### PR TITLE
DGS-19699 Ensure lookup by schema logic matches logic during register

### DIFF
--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiCompatibilityTest.java
@@ -1283,4 +1283,27 @@ public class RestApiCompatibilityTest extends ClusterTestHarness {
       }
     }
   }
+
+  @Test
+  public void testRegisterEmptyRuleSet() throws Exception {
+    String subject = "testSubject";
+
+    ParsedSchema schema1 = AvroUtils.parseSchema("{\"type\":\"record\","
+        + "\"name\":\"myrecord\","
+        + "\"fields\":"
+        + "[{\"type\":\"string\",\"name\":\"f1\"}]}");
+
+    List<Rule> rules = Collections.emptyList();
+    RuleSet ruleSet = new RuleSet(null, rules);
+    RegisterSchemaRequest request1 = new RegisterSchemaRequest(schema1);
+    request1.setRuleSet(ruleSet);
+    int expectedIdSchema1 = 1;
+    assertEquals(
+        expectedIdSchema1,
+        restApp.restClient.registerSchema(request1, subject, false).getId());
+
+    request1.setRuleSet(null);
+    Schema s = restApp.restClient.lookUpSubjectVersion(request1, subject, false, false);
+    assertEquals(expectedIdSchema1, s.getId().intValue());
+  }
 }


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
When registering a schema, a lookup is performed to see if an existing schema matches.  In certain cases, this lookup logic would succeed while a lookup by schema (when not registering) would fail.  This was the case with a persisted schema with an empty ruleSet, when the lookup is using a schema with a null ruleSet. This PR ensures the logic of the two different types of lookups (one during registration and one not) match.
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Is this change gated behind feature flag(s)?
    - List the LD flags needed to be set to enable this change
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
    - Yes
- [ ] Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
