### PR TITLE
Trying to set SSLSocketFactory for RestService from HttpsUrlConnection, before fallback to global default.

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -369,12 +369,12 @@ public class RestService implements Closeable, Configurable {
     if (!(connection instanceof HttpsURLConnection)) {
       return;
     }
-    HttpsURLConnection httpsURLConnection = (HttpsURLConnection) connection;
+    HttpsURLConnection httpsUrlConnection = (HttpsURLConnection) connection;
     SSLSocketFactory configuredSslSocketFactory;
     if (sslSocketFactory != null) {
       configuredSslSocketFactory = sslSocketFactory;
-    } else if (httpsURLConnection.getSSLSocketFactory() != null) {
-      configuredSslSocketFactory = httpsURLConnection.getSSLSocketFactory();
+    } else if (httpsUrlConnection.getSSLSocketFactory() != null) {
+      configuredSslSocketFactory = httpsUrlConnection.getSSLSocketFactory();
     } else {
       try {
         configuredSslSocketFactory = SSLContext.getDefault().getSocketFactory();
@@ -383,10 +383,10 @@ public class RestService implements Closeable, Configurable {
         throw new RuntimeException(e);
       }
     }
-    httpsURLConnection.setSSLSocketFactory(
+    httpsUrlConnection.setSSLSocketFactory(
         new HostSslSocketFactory(configuredSslSocketFactory, url.getHost()));
     if (hostnameVerifier != null) {
-      httpsURLConnection.setHostnameVerifier(hostnameVerifier);
+      httpsUrlConnection.setHostnameVerifier(hostnameVerifier);
     }
   }
 


### PR DESCRIPTION
- Fix on top of the base PR for the [BouncyCastle issue](https://confluentinc.atlassian.net/wiki/spaces/OAAC/pages/3814982290/LDAPS+AuthN+Failure+in+FIPS+due+to+Bouncy+Castle+Version+Upgrade+from+1.0.2.5+to+2.0.0): https://github.com/confluentinc/schema-registry/pull/3538

