### PR TITLE
CPSEC-628: Setting default SSLSocketFactory from HttpsURLConnection in RestService.

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -51,7 +51,6 @@ import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
@@ -60,7 +59,6 @@ import java.util.Map;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.CompatibilityCheckResponse;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -369,12 +369,7 @@ public class RestService implements Closeable, Configurable {
     if (connection instanceof HttpsURLConnection) {
       SSLSocketFactory configuredSslSocketFactory = sslSocketFactory;
       if (configuredSslSocketFactory == null) {
-        try {
-          configuredSslSocketFactory = SSLContext.getDefault().getSocketFactory();
-        } catch (NoSuchAlgorithmException e) {
-          log.error("Error while getting default SSLContext: ", e);
-          throw new RuntimeException(e);
-        }
+        configuredSslSocketFactory = HttpsURLConnection.getDefaultSSLSocketFactory();
       }
       ((HttpsURLConnection) connection).setSSLSocketFactory(
               new HostSslSocketFactory(configuredSslSocketFactory, url.getHost()));


### PR DESCRIPTION
- Fix on top of the base PR for the [BouncyCastle issue](https://confluentinc.atlassian.net/wiki/spaces/OAAC/pages/3814982290/LDAPS+AuthN+Failure+in+FIPS+due+to+Bouncy+Castle+Version+Upgrade+from+1.0.2.5+to+2.0.0): https://github.com/confluentinc/schema-registry/pull/3538