### PR TITLE
USTORAGE-1069: Call close on custom auth provider

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/CustomBearerAuthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/CustomBearerAuthCredentialProvider.java
@@ -17,6 +17,8 @@
 package io.confluent.kafka.schemaregistry.client.security.bearerauth;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
+
+import java.io.IOException;
 import java.net.URL;
 import java.util.Map;
 import org.apache.kafka.common.config.ConfigException;
@@ -74,4 +76,11 @@ public class CustomBearerAuthCredentialProvider implements BearerAuthCredentialP
         SchemaRegistryClientConfig.BEARER_AUTH_IDENTITY_POOL_ID, false);
     this.customBearerAuthCredentialProvider.configure(map);
   }
+
+  @Override
+  public void close() throws IOException {
+    this.customBearerAuthCredentialProvider.close();
+  }
 }
+
+


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

`CustomBearerAuthCredentialProvider` is a wrapper around a `BearerAuthCredentialProvider` that schema registry uses to get authentication credentials for outgoing requests. If you create any resources which need to be closed inside of the wrapped `BearerAuthCredentialProvider`, they need to be closed. 

The `CustomBearerAuthCredentialProvider` was never calling close on the wrapped `BearerAuthCredentialProvider` 


Testing
---------

Test is not required for this change. The interface has a default close function 

https://github.com/confluentinc/schema-registry/blob/8ee8e59415e60330f2cbf24b49ffa0c3527b8594/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/BearerAuthCredentialProvider.java#L50-L52

Therefore this will only add the code path where the user has a custom close function within a custom `BearerAuthCredentialProvider`

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
