### PR TITLE
DGS-19763 Send x-forward-port header on forwarded requests

### DIFF
--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RequestHeaderHandlerTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RequestHeaderHandlerTest.java
@@ -147,6 +147,27 @@ public class RequestHeaderHandlerTest {
   }
 
   @Test
+  public void testAddXForwardedPortToRequest() {
+    MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(request);
+    when(request.getLocalPort()).thenReturn(8080);
+    RequestHeaderHandler requestHeaderHandler = new RequestHeaderHandler();
+
+    // Forwarded request
+    when(request.getHeader(X_FORWARD_HEADER)).thenReturn(null);
+    requestHeaderHandler.addXForwardedPortToRequest(mutableRequest, request);
+    String callerPort = mutableRequest.getHeader(RequestHeaderHandler.X_FORWARDED_PORT_HEADER);
+    Assert.assertEquals("8080", callerPort);
+
+    // Not forwarded request
+    when(request.getHeader(X_FORWARD_HEADER)).thenReturn("true");
+    when(request.getLocalPort()).thenReturn(9090);
+    requestHeaderHandler.addXForwardedPortToRequest(mutableRequest, request);
+    callerPort = mutableRequest.getHeader(RequestHeaderHandler.X_FORWARDED_PORT_HEADER);
+    Assert.assertEquals("8080", callerPort);
+  }
+
+
+  @Test
   public void testGetRequestIdWith1RequestId() {
     // A single non-blank request id should be taken as is
     String requestId = requestHeaderHandler.getRequestId(Collections.singletonList("request-ID-1234"));


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

We will send x-forward-port header to use in private link requests so that port information is not lost when forwarding to leader.

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Is this change gated behind feature flag(s)?
    - List the LD flags needed to be set to enable this change
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- [ ] Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
