### PR TITLE
Remove java-7-jdk dependency from debian build scripts

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: confluent-schema-registry
 Section: misc
 Priority: optional
 Maintainer: Confluent Packaging <packages@confluent.io>
-Build-Depends: debhelper (>= 9), dh-systemd, java7-jdk, javahelper (>= 0.40),
+Build-Depends: debhelper (>= 9), dh-systemd, javahelper (>= 0.40),
  make, maven
 Standards-Version: 3.9.3
 Homepage: http://confluent.io


### PR DESCRIPTION
From CP 8.0, JDK 17 is the JDK that will be used to build CP packages. Hence, remove these dependencies.
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Is this change gated behind feature flag(s)?
    - List the LD flags needed to be set to enable this change
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- [ ] Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
