### PR TITLE
DGS-19838 Fix message reader to allow for interactive usage

### DIFF
--- a/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageReader.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/formatter/SchemaMessageReader.java
@@ -23,9 +23,9 @@ import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDe;
 import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
 import java.io.InputStream;
 import java.util.AbstractMap;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -377,58 +377,83 @@ public abstract class SchemaMessageReader<T> implements RecordReader {
 
   @Override
   public Iterator<ProducerRecord<byte[], byte[]>> readRecords(InputStream inputStream) {
-    List<ProducerRecord<byte[], byte[]>> records = new ArrayList<>();
-    try (BufferedReader reader =
-        new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
-      while (true) {
-        String line = reader.readLine();
-        if (line == null) {
-          break;
-        }
+    return new Iterator<ProducerRecord<byte[], byte[]>>() {
+      private final BufferedReader reader =
+          new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+      private ProducerRecord<byte[], byte[]> current;
 
-        String headersString = parse(parseHeaders, line, 0, headersDelimiter, "headers delimiter");
-        int headersOffset = headersString == null
-            ? 0
-            : headersString.length() + headersDelimiter.length();
-        Headers headers = new RecordHeaders();
-        if (headersString != null && !headersString.equals(nullMarker)) {
-          splitHeaders(headersString, line).forEach(
-              header -> headers.add(header.getKey(), header.getValue()));
-        }
+      @Override
+      public boolean hasNext() {
+        if (current != null) {
+          return true;
+        } else {
+          String line;
+          try {
+            line = reader.readLine();
+          } catch (IOException e) {
+            throw new KafkaException(e);
+          }
 
-        String keyString = parse(parseKey, line, headersOffset, keySeparator, "key separator");
-        int keyOffset = keyString == null ? 0 : keyString.length() + keySeparator.length();
-        byte[] serializedKey = null;
-        if (keyString != null && !keyString.equals(nullMarker)) {
-          if (serializer.getKeySerializer() != null) {
-            serializedKey = serializeNonSchemaKey(headers, keyString);
+          if (line == null) {
+            current = null;
           } else {
-            T key = readFrom(keyString, keySchema);
-            serializedKey = serializer.serialize(keySubject, topic, true, headers, key, keySchema);
+            String headers = parse(parseHeaders, line, 0, headersDelimiter, "headers delimiter");
+            int headerOffset = headers == null ? 0 : headers.length() + headersDelimiter.length();
+            Headers recordHeaders = new RecordHeaders();
+            if (headers != null && !headers.equals(nullMarker)) {
+              splitHeaders(headers, line).forEach(
+                  header -> recordHeaders.add(header.getKey(), header.getValue()));
+            }
+
+            String key = parse(parseKey, line, headerOffset, keySeparator, "key separator");
+            int keyOffset = key == null ? 0 : key.length() + keySeparator.length();
+            byte[] serializedKey = null;
+            if (key != null && !key.equals(nullMarker)) {
+              if (serializer.getKeySerializer() != null) {
+                serializedKey = serializeNonSchemaKey(recordHeaders, key);
+              } else {
+                T keyObj = readFrom(key, keySchema);
+                serializedKey = serializer.serialize(
+                    keySubject, topic, true, recordHeaders, keyObj, keySchema);
+              }
+            }
+
+            String value = line.substring(headerOffset + keyOffset);
+            byte[] serializedValue = null;
+            if (value != null && !value.equals(nullMarker)) {
+              T valueObj = readFrom(value, valueSchema);
+              serializedValue = serializer.serialize(
+                  valueSubject, topic, false, recordHeaders, valueObj, valueSchema);
+            }
+
+            ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(
+                topic,
+                null,
+                serializedKey,
+                serializedValue,
+                recordHeaders
+            );
+
+            current = record;
+          }
+
+          return current != null;
+        }
+      }
+
+      @Override
+      public ProducerRecord<byte[], byte[]> next() {
+        if (!hasNext()) {
+          throw new NoSuchElementException("no more record");
+        } else {
+          try {
+            return current;
+          } finally {
+            current = null;
           }
         }
-
-        String valueString = line.substring(headersOffset + keyOffset);
-        byte[] serializedValue = null;
-        if (valueString != null && !valueString.equals(nullMarker)) {
-          T value = readFrom(valueString, valueSchema);
-          serializedValue = serializer.serialize(valueSubject, topic, false, headers,
-              value, valueSchema);
-        }
-
-        ProducerRecord<byte[], byte[]> record = new ProducerRecord<>(
-            topic,
-            null,
-            serializedKey,
-            serializedValue,
-            headers);
-
-        records.add(record);
       }
-    } catch (IOException e) {
-      throw new KafkaException("Error reading from input", e);
-    }
-    return records.iterator();
+    };
   }
 
   private String parse(


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
A previous fix for KIP-641 did not accommodate interactive usage with the console, whereas this one is a minor refactoring that does accommodate such usage.

This affects CP 7.9.0
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Is this change gated behind feature flag(s)?
    - List the LD flags needed to be set to enable this change
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
    - This is a refactoring covered by existing tests
- [ ] Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
