### PR TITLE
DGS-19657 Expand semantic check when looking up schemas

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
@@ -17,8 +17,6 @@
 package io.confluent.kafka.schemaregistry;
 
 import static io.confluent.kafka.schemaregistry.AbstractSchemaProvider.canLookupIgnoringVersion;
-import static io.confluent.kafka.schemaregistry.AbstractSchemaProvider.getConfluentVersion;
-import static io.confluent.kafka.schemaregistry.AbstractSchemaProvider.hasLatestVersion;
 import static io.confluent.kafka.schemaregistry.AbstractSchemaProvider.replaceLatestVersion;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
@@ -17,7 +17,6 @@
 package io.confluent.kafka.schemaregistry;
 
 import static io.confluent.kafka.schemaregistry.AbstractSchemaProvider.canLookupIgnoringVersion;
-import static io.confluent.kafka.schemaregistry.AbstractSchemaProvider.getConfluentVersion;
 import static io.confluent.kafka.schemaregistry.AbstractSchemaProvider.replaceLatestVersion;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -327,14 +326,8 @@ public interface ParsedSchema {
     // and the previous schema having matching references when all versions of -1
     // are replaced by the latest version, and the schemas are the same except
     // for the one of the schemas possibly having a confluent:version.
-    String schemaVer = getConfluentVersion(metadata());
-    String prevVer = getConfluentVersion(prev.metadata());
-    boolean nonEmptyRefsEquivalent = !references().isEmpty()
-        && replaceLatestVersion(references(), fetcher).equals(
-            replaceLatestVersion(prev.references(), fetcher));
-    if (schemaVer != null || prevVer != null || nonEmptyRefsEquivalent) {
-      return canLookupIgnoringVersion(this, prev);
-    }
-    return false;
+    boolean areRefsEquivalent = replaceLatestVersion(references(), fetcher)
+        .equals(replaceLatestVersion(prev.references(), fetcher));
+    return areRefsEquivalent && canLookupIgnoringVersion(this, prev);
   }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
@@ -328,15 +328,8 @@ public interface ParsedSchema {
     // and the previous schema having matching references when all versions of -1
     // are replaced by the latest version, and the schemas are the same except
     // for the one of the schemas possibly having a confluent:version.
-    String schemaVer = getConfluentVersion(metadata());
-    String prevVer = getConfluentVersion(prev.metadata());
-    if (schemaVer != null || prevVer != null
-        || hasLatestVersion(this.references())
-        || hasLatestVersion(prev.references())) {
-      boolean areRefsEquivalent = replaceLatestVersion(references(), fetcher)
-          .equals(replaceLatestVersion(prev.references(), fetcher));
-      return areRefsEquivalent && canLookupIgnoringVersion(this, prev);
-    }
-    return false;
+    boolean areRefsEquivalent = replaceLatestVersion(references(), fetcher)
+        .equals(replaceLatestVersion(prev.references(), fetcher));
+    return areRefsEquivalent && canLookupIgnoringVersion(this, prev);
   }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -1320,8 +1320,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
           Schema prev = get(schemaKey.getSubject(), schemaKey.getVersion(), lookupDeletedSchema);
           if (prev != null
               && parsedSchema != null
-              && (MD5.ofSchema(schema).equals(MD5.ofSchema(prev))
-              || parsedSchema.canLookup(parseSchema(prev), this))) {
+              && parsedSchema.canLookup(parseSchema(prev), this)) {
             // This handles the case where a schema is sent with all references resolved
             // or without confluent:version
             return prev;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -1320,7 +1320,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
           Schema prev = get(schemaKey.getSubject(), schemaKey.getVersion(), lookupDeletedSchema);
           if (prev != null
               && parsedSchema != null
-              && parsedSchema.canLookup(parseSchema(prev), this)) {
+              && (MD5.ofSchema(schema).equals(MD5.ofSchema(prev))
+              || parsedSchema.canLookup(parseSchema(prev), this))) {
             // This handles the case where a schema is sent with all references resolved
             // or without confluent:version
             return prev;

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiModeTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiModeTest.java
@@ -441,6 +441,49 @@ public class RestApiModeTest extends ClusterTestHarness {
   }
 
   @Test
+  public void testImportModeWithSameSchemaDifferentIdAndSubject() throws Exception {
+    String subject = "testSubject";
+    String subject2 = "testSubject2";
+    String mode = "IMPORT";
+
+    // set mode to import
+    assertEquals(
+        mode,
+        restApp.restClient.setMode(mode).getMode());
+
+    int expectedIdSchema1 = 100;
+    assertEquals("Registering with id should succeed",
+        expectedIdSchema1,
+        restApp.restClient.registerSchema(SCHEMA_WITH_DECIMAL, subject, 1, expectedIdSchema1));
+
+    assertEquals("Getting schema by id should succeed",
+        SCHEMA_WITH_DECIMAL,
+        restApp.restClient.getVersion(subject, 1).getSchema());
+
+    int versionOfRegisteredSubject1 =
+        restApp.restClient.lookUpSubjectVersion(SCHEMA_WITH_DECIMAL, subject).getVersion();
+    assertEquals(1, versionOfRegisteredSubject1);
+
+    // register equivalent schema with different id
+    expectedIdSchema1 = 200;
+    assertEquals("Registering with id should succeed",
+        expectedIdSchema1,
+        restApp.restClient.registerSchema(SCHEMA_WITH_DECIMAL, subject2, 1, expectedIdSchema1));
+
+    assertEquals("Getting schema by id should succeed",
+        SCHEMA_WITH_DECIMAL,
+        restApp.restClient.getVersion(subject2, 1).getSchema());
+
+    versionOfRegisteredSubject1 =
+        restApp.restClient.lookUpSubjectVersion(SCHEMA_WITH_DECIMAL, subject).getVersion();
+    assertEquals(1, versionOfRegisteredSubject1);
+
+    int versionOfRegisteredSubject2 =
+        restApp.restClient.lookUpSubjectVersion(SCHEMA_WITH_DECIMAL, subject2).getVersion();
+    assertEquals(1, versionOfRegisteredSubject2);
+  }
+
+  @Test
   public void testRegisterIncompatibleSchemaDuringImport() throws Exception {
     String subject = "testSubject";
     String mode = "READWRITE";

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiModeTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiModeTest.java
@@ -452,11 +452,11 @@ public class RestApiModeTest extends ClusterTestHarness {
         restApp.restClient.setMode(mode).getMode());
 
     int expectedIdSchema1 = 100;
-    assertEquals("Registering with id should succeed",
+    assertEquals(
         expectedIdSchema1,
         restApp.restClient.registerSchema(SCHEMA_WITH_DECIMAL, subject, 1, expectedIdSchema1));
 
-    assertEquals("Getting schema by id should succeed",
+    assertEquals(
         SCHEMA_WITH_DECIMAL,
         restApp.restClient.getVersion(subject, 1).getSchema());
 
@@ -466,11 +466,11 @@ public class RestApiModeTest extends ClusterTestHarness {
 
     // register equivalent schema with different id
     expectedIdSchema1 = 200;
-    assertEquals("Registering with id should succeed",
+    assertEquals(
         expectedIdSchema1,
         restApp.restClient.registerSchema(SCHEMA_WITH_DECIMAL, subject2, 1, expectedIdSchema1));
 
-    assertEquals("Getting schema by id should succeed",
+    assertEquals(
         SCHEMA_WITH_DECIMAL,
         restApp.restClient.getVersion(subject2, 1).getSchema());
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -2209,6 +2209,11 @@ public class RestApiTest extends ClusterTestHarness {
     // Register schema with version -1
     request.setVersion(-1);
     request.setMetadata(null);
+    registerAndVerifySchema(restApp.restClient, request, 1, subject);
+
+    // Register schema with version 2
+    request.setVersion(2);
+    request.setMetadata(null);
     registerAndVerifySchema(restApp.restClient, request, 2, subject);
 
     // Register schema with version -1

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/json/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/json/RestApiTest.java
@@ -389,6 +389,11 @@ public class RestApiTest extends ClusterTestHarness {
     // Register schema with version -1
     request.setVersion(-1);
     request.setMetadata(null);
+    registerAndVerifySchema(restApp.restClient, request, 1, subject);
+
+    // Register schema with version 2
+    request.setVersion(2);
+    request.setMetadata(null);
     registerAndVerifySchema(restApp.restClient, request, 2, subject);
 
     // Register schema with version -1

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/protobuf/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/protobuf/RestApiTest.java
@@ -631,6 +631,11 @@ public class RestApiTest extends ClusterTestHarness {
     // Register schema with version -1
     request.setVersion(-1);
     request.setMetadata(null);
+    registerAndVerifySchema(restApp.restClient, request, 1, subject);
+
+    // Register schema with version 2
+    request.setVersion(2);
+    request.setMetadata(null);
     registerAndVerifySchema(restApp.restClient, request, 2, subject);
 
     // Register schema with version -1


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Expand semantic check when looking up schemas.  This will handle the case when a schema is registered under two different IDs and subjects.  In this case the initial lookup using MD5 will fail, but the search will succeed.
 
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes 
  -  Lookups that previously failed with 404 now succeed, and register requests that previously registered a new schema now return the existing schema ID.
- [x] Is this change gated behind feature flag(s)?
    - No
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
    - Yes
- [x] Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - No

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
