### PR TITLE
DGS-19985 Always override X-Forwarded-For header on follower call

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/RequestHeaderHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/RequestHeaderHandler.java
@@ -47,7 +47,7 @@ public class RequestHeaderHandler extends HandlerWrapper {
     MDC.clear();
     MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(request);
     addXRequestIdToRequest(baseRequest, mutableRequest, response);
-    addXForwardedForToRequest(mutableRequest, request);
+    addXForwardedForToRequest(baseRequest, mutableRequest, request);
 
     // Call the next handler in the chain
     super.handle(target, baseRequest, mutableRequest, response);
@@ -65,10 +65,11 @@ public class RequestHeaderHandler extends HandlerWrapper {
     MDC.put("requestId", requestId);
   }
 
-  protected void addXForwardedForToRequest(MutableHttpServletRequest mutableRequest,
+  protected void addXForwardedForToRequest(Request baseRequest,
+                                           MutableHttpServletRequest mutableRequest,
                                            HttpServletRequest request) {
     // Do not propagate on leader call, or it would override follower IP
-    if (mutableRequest.getHeader(X_FORWARD_HEADER) == null) {
+    if (baseRequest.getHeader(X_FORWARD_HEADER) == null) {
       mutableRequest.putHeader(X_FORWARDED_FOR_HEADER, request.getRemoteAddr());
     }
     log.info("Forwarded for header in RequestHeaderHandler: {}",

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/RequestHeaderHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/RequestHeaderHandler.java
@@ -27,6 +27,8 @@ import javax.servlet.ServletException;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.server.handler.HandlerWrapper;
 import org.eclipse.jetty.server.Request;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import static io.confluent.kafka.schemaregistry.client.rest.RestService.X_FORWARD_HEADER;
@@ -34,6 +36,7 @@ import static io.confluent.kafka.schemaregistry.client.rest.RestService.X_FORWAR
 public class RequestHeaderHandler extends HandlerWrapper {
   public static final String X_REQUEST_ID_HEADER = "X-Request-ID";
   public static final String X_FORWARDED_FOR_HEADER = "X-Forwarded-For";
+  private static final Logger log = LoggerFactory.getLogger(RequestHeaderHandler.class);
 
   @Override
   public void handle(String target,
@@ -65,10 +68,11 @@ public class RequestHeaderHandler extends HandlerWrapper {
   protected void addXForwardedForToRequest(MutableHttpServletRequest mutableRequest,
                                            HttpServletRequest request) {
     // Do not propagate on leader call, or it would override follower IP
-    if (mutableRequest.getHeader(X_FORWARD_HEADER) == null
-        && mutableRequest.getHeader(X_FORWARDED_FOR_HEADER) == null) {
+    if (mutableRequest.getHeader(X_FORWARD_HEADER) == null) {
       mutableRequest.putHeader(X_FORWARDED_FOR_HEADER, request.getRemoteAddr());
     }
+    log.info("Forwarded for header in RequestHeaderHandler: {}",
+        mutableRequest.getHeader(X_FORWARDED_FOR_HEADER));
   }
 
   protected String getRequestId(List<String> headers) {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RequestHeaderHandlerTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RequestHeaderHandlerTest.java
@@ -6,6 +6,7 @@ package io.confluent.kafka.schemaregistry.rest;
 
 
 import org.eclipse.jetty.server.Request;
+import org.glassfish.jersey.internal.inject.Custom;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,6 +27,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.MDC;
 
 import static io.confluent.kafka.schemaregistry.client.rest.RestService.X_FORWARD_HEADER;
+import static io.confluent.kafka.schemaregistry.rest.RequestHeaderHandler.X_FORWARDED_FOR_HEADER;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
@@ -143,6 +145,17 @@ public class RequestHeaderHandlerTest {
     when(request.getRemoteAddr()).thenReturn("should_not_use");
     requestHeaderHandler.addXForwardedForToRequest(mutableRequest, request);
     callerIp = mutableRequest.getHeader(RequestHeaderHandler.X_FORWARDED_FOR_HEADER);
+    Assert.assertEquals("127.0.0.1", callerIp);
+  }
+
+  @Test
+  public void testAddXForwardedForToRequestOverridesHeader() {
+    MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(request);
+    when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+    mutableRequest.putHeader(RequestHeaderHandler.X_FORWARDED_FOR_HEADER, "value");
+
+    requestHeaderHandler.addXForwardedForToRequest(mutableRequest, request);
+    String callerIp = mutableRequest.getHeader(RequestHeaderHandler.X_FORWARDED_FOR_HEADER);
     Assert.assertEquals("127.0.0.1", callerIp);
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RequestHeaderHandlerTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RequestHeaderHandlerTest.java
@@ -141,7 +141,7 @@ public class RequestHeaderHandlerTest {
 
     // Not forwarded request
     when(baseRequest.getHeader(X_FORWARD_HEADER)).thenReturn("true");
-    Mockito.lenient().when(request.getRemoteAddr()).thenReturn("should_not_use");
+    Mockito.lenient().when(request.getRemoteAddr()).thenReturn("192.168.1.10");
     requestHeaderHandler.addXForwardedForToRequest(baseRequest, mutableRequest, request);
     callerIp = mutableRequest.getHeader(RequestHeaderHandler.X_FORWARDED_FOR_HEADER);
     Assert.assertEquals("127.0.0.1", callerIp);
@@ -151,7 +151,7 @@ public class RequestHeaderHandlerTest {
   public void testAddXForwardedForToRequestOverridesHeader() {
     MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(request);
     when(request.getRemoteAddr()).thenReturn("127.0.0.1");
-    mutableRequest.putHeader(RequestHeaderHandler.X_FORWARDED_FOR_HEADER, "value");
+    mutableRequest.putHeader(RequestHeaderHandler.X_FORWARDED_FOR_HEADER, "192.168.1.10");
 
     requestHeaderHandler.addXForwardedForToRequest(baseRequest, mutableRequest, request);
     String callerIp = mutableRequest.getHeader(RequestHeaderHandler.X_FORWARDED_FOR_HEADER);

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RequestHeaderHandlerTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RequestHeaderHandlerTest.java
@@ -6,7 +6,6 @@ package io.confluent.kafka.schemaregistry.rest;
 
 
 import org.eclipse.jetty.server.Request;
-import org.glassfish.jersey.internal.inject.Custom;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,11 +22,11 @@ import java.util.UUID;
 
 import org.mockito.Mock;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.MDC;
 
 import static io.confluent.kafka.schemaregistry.client.rest.RestService.X_FORWARD_HEADER;
-import static io.confluent.kafka.schemaregistry.rest.RequestHeaderHandler.X_FORWARDED_FOR_HEADER;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
@@ -135,15 +134,15 @@ public class RequestHeaderHandlerTest {
     RequestHeaderHandler requestHeaderHandler = new RequestHeaderHandler();
 
     // Forwarded request
-    when(request.getHeader(X_FORWARD_HEADER)).thenReturn(null);
-    requestHeaderHandler.addXForwardedForToRequest(mutableRequest, request);
+    when(baseRequest.getHeader(X_FORWARD_HEADER)).thenReturn(null);
+    requestHeaderHandler.addXForwardedForToRequest(baseRequest, mutableRequest, request);
     String callerIp = mutableRequest.getHeader(RequestHeaderHandler.X_FORWARDED_FOR_HEADER);
     Assert.assertEquals("127.0.0.1", callerIp);
 
     // Not forwarded request
-    when(request.getHeader(X_FORWARD_HEADER)).thenReturn("true");
-    when(request.getRemoteAddr()).thenReturn("should_not_use");
-    requestHeaderHandler.addXForwardedForToRequest(mutableRequest, request);
+    when(baseRequest.getHeader(X_FORWARD_HEADER)).thenReturn("true");
+    Mockito.lenient().when(request.getRemoteAddr()).thenReturn("should_not_use");
+    requestHeaderHandler.addXForwardedForToRequest(baseRequest, mutableRequest, request);
     callerIp = mutableRequest.getHeader(RequestHeaderHandler.X_FORWARDED_FOR_HEADER);
     Assert.assertEquals("127.0.0.1", callerIp);
   }
@@ -154,7 +153,7 @@ public class RequestHeaderHandlerTest {
     when(request.getRemoteAddr()).thenReturn("127.0.0.1");
     mutableRequest.putHeader(RequestHeaderHandler.X_FORWARDED_FOR_HEADER, "value");
 
-    requestHeaderHandler.addXForwardedForToRequest(mutableRequest, request);
+    requestHeaderHandler.addXForwardedForToRequest(baseRequest, mutableRequest, request);
     String callerIp = mutableRequest.getHeader(RequestHeaderHandler.X_FORWARDED_FOR_HEADER);
     Assert.assertEquals("127.0.0.1", callerIp);
   }


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

```
  /**
   * Puts a new header will take precedence over existing header in the HttpServletRequest object.
   */
  public void putHeader(String name, String value) {
    // Value will also overwrite any existing custom header value.
    this.customHeaders.putSingle(name, value);
  }
```

putHeader appears to already overrides the header, we just had a null check before



Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Is this change gated behind feature flag(s)?
    - List the LD flags needed to be set to enable this change
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- [ ] Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
