### PR TITLE
[DGS-19987] Support new CachedSchemaRegistryClient in SchemaRegistryClientFactory- Port to 7.8.0

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -166,6 +166,15 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   public CachedSchemaRegistryClient(
+          String baseUrls,
+          int cacheCapacity,
+          List<SchemaProvider> providers,
+          Map<String, ?> originals,
+          Map<String, String> httpHeaders) {
+    this(new RestService(baseUrls), cacheCapacity, providers, originals, httpHeaders);
+  }
+
+  public CachedSchemaRegistryClient(
       RestService restService,
       int cacheCapacity,
       Map<String, ?> originals,

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClientFactory.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClientFactory.java
@@ -42,4 +42,24 @@ public class SchemaRegistryClientFactory {
       );
     }
   }
+
+  public static SchemaRegistryClient newClient(
+          String baseUrls,
+          int cacheCapacity,
+          List<SchemaProvider> providers,
+          Map<String, ?> configs,
+          Map<String, String> httpHeaders) {
+    List<String> mockScopes = MockSchemaRegistry.validateAndMaybeGetMockScope(baseUrls);
+    if (mockScopes != null) {
+      return MockSchemaRegistry.getClientForScope(mockScopes, providers);
+    } else {
+      return new CachedSchemaRegistryClient(
+              baseUrls,
+              cacheCapacity,
+              providers,
+              configs,
+              httpHeaders
+      );
+    }
+  }
 }


### PR DESCRIPTION

What
----
Port https://github.com/confluentinc/schema-registry/pull/3636 to 7.8.0 to unblock flink

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Is this change gated behind feature flag(s)? This is just a mocks changes
    - List the LD flags needed to be set to enable this change
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR? This is just a Mocks change
    - If not, please explain why it is not required 
- [ ] Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes

References
----------
JIRA: https://confluentinc.atlassian.net/browse/DGS-19987

Test & Review
------------
Changes to mock. No new unit test
