### PR TITLE
DGS-20411 Handle default context properly for /config and /mode

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
@@ -255,6 +255,12 @@ public class QualifiedSubject implements Comparable<QualifiedSubject> {
     return DEFAULT_CONTEXT.equals(context) ? "" : CONTEXT_DELIMITER + context + CONTEXT_DELIMITER;
   }
 
+  public static boolean isDefaultContext(String tenant, String qualifiedSubject) {
+    QualifiedSubject qs = QualifiedSubject.create(tenant, qualifiedSubject);
+    // For backward compatibility, we allow an empty subject
+    return qs == null || (qs.getContext().equals(DEFAULT_CONTEXT) && qs.getSubject().isEmpty());
+  }
+
   public static boolean isValidSubject(String tenant, String qualifiedSubject) {
     if (qualifiedSubject == null || CharMatcher.javaIsoControl().matchesAnyOf(qualifiedSubject)) {
       return false;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ConfigResource.java
@@ -107,6 +107,10 @@ public class ConfigResource {
       @Parameter(description = "Config Update Request", required = true)
       @NotNull ConfigUpdateRequest request) {
 
+    if (QualifiedSubject.isDefaultContext(schemaRegistry.tenant(), subject)) {
+      return updateTopLevelConfig(headers, request);
+    }
+
     Map<String, String> headerProperties = requestHeaderBuilder.buildRequestHeaders(
         headers, schemaRegistry.config().whitelistHeaders());
     try {
@@ -180,6 +184,10 @@ public class ConfigResource {
           "Whether to return the global compatibility level "
               + " if subject compatibility level not found")
       @QueryParam("defaultToGlobal") boolean defaultToGlobal) {
+
+    if (QualifiedSubject.isDefaultContext(schemaRegistry.tenant(), subject)) {
+      return getTopLevelConfig();
+    }
 
     subject = QualifiedSubject.normalize(schemaRegistry.tenant(), subject);
 
@@ -351,6 +359,11 @@ public class ConfigResource {
       @Parameter(description = "Name of the subject", required = true)
       @PathParam("subject") String subject) {
     log.debug("Deleting compatibility setting for subject {}", subject);
+
+    if (QualifiedSubject.isDefaultContext(schemaRegistry.tenant(), subject)) {
+      deleteTopLevelConfig(asyncResponse, headers);
+      return;
+    }
 
     subject = QualifiedSubject.normalize(schemaRegistry.tenant(), subject);
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/ModeResource.java
@@ -113,7 +113,11 @@ public class ModeResource {
       throw Errors.invalidSubjectException(subject);
     }
 
-    subject = QualifiedSubject.normalize(schemaRegistry.tenant(), subject);
+    if (QualifiedSubject.isDefaultContext(schemaRegistry.tenant(), subject)) {
+      subject = null;
+    } else {
+      subject = QualifiedSubject.normalize(schemaRegistry.tenant(), subject);
+    }
 
     io.confluent.kafka.schemaregistry.storage.Mode mode;
     try {
@@ -169,7 +173,11 @@ public class ModeResource {
       @Parameter(description = "Whether to return the global mode if subject mode not found")
       @QueryParam("defaultToGlobal") boolean defaultToGlobal) {
 
-    subject = QualifiedSubject.normalize(schemaRegistry.tenant(), subject);
+    if (QualifiedSubject.isDefaultContext(schemaRegistry.tenant(), subject)) {
+      subject = null;
+    } else {
+      subject = QualifiedSubject.normalize(schemaRegistry.tenant(), subject);
+    }
 
     try {
       io.confluent.kafka.schemaregistry.storage.Mode mode = defaultToGlobal
@@ -255,6 +263,10 @@ public class ModeResource {
       @Parameter(description = "Name of the subject", required = true)
       @PathParam("subject") String subject) {
     log.debug("Deleting mode for subject {}", subject);
+
+    if (QualifiedSubject.isDefaultContext(schemaRegistry.tenant(), subject)) {
+      throw Errors.invalidSubjectException(subject);
+    }
 
     subject = QualifiedSubject.normalize(schemaRegistry.tenant(), subject);
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -16,7 +16,10 @@ package io.confluent.kafka.schemaregistry.rest;
 
 import static io.confluent.kafka.schemaregistry.CompatibilityLevel.BACKWARD;
 import static io.confluent.kafka.schemaregistry.CompatibilityLevel.FORWARD;
+import static io.confluent.kafka.schemaregistry.CompatibilityLevel.FORWARD_TRANSITIVE;
 import static io.confluent.kafka.schemaregistry.CompatibilityLevel.NONE;
+import static io.confluent.kafka.schemaregistry.storage.Mode.IMPORT;
+import static io.confluent.kafka.schemaregistry.storage.Mode.READONLY;
 import static io.confluent.kafka.schemaregistry.utils.QualifiedSubject.DEFAULT_CONTEXT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -45,6 +48,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
 import io.confluent.kafka.schemaregistry.client.rest.entities.ServerClusterId;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.ConfigUpdateRequest;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.ModeUpdateRequest;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.exceptions.InvalidSchemaException;
@@ -661,6 +665,78 @@ public class RestApiTest extends ClusterTestHarness {
         restApp.restClient
             .getConfig(RestService.DEFAULT_REQUEST_PROPERTIES, null, true)
             .getCompatibilityLevel());
+  }
+
+  @Test
+  public void testDefaultContextConfigAndMode() throws Exception {
+    String defaultContext = ":.:";
+
+    ConfigUpdateRequest configUpdateRequest = new ConfigUpdateRequest();
+    configUpdateRequest.setCompatibilityLevel(FORWARD.name());
+    assertEquals(
+        configUpdateRequest,
+        restApp.restClient.updateConfig(configUpdateRequest, null));
+
+    assertEquals(
+        FORWARD.name,
+        restApp.restClient
+            .getConfig(RestService.DEFAULT_REQUEST_PROPERTIES, ":.:", true)
+            .getCompatibilityLevel()
+    );
+
+    configUpdateRequest = new ConfigUpdateRequest();
+    configUpdateRequest.setCompatibilityLevel(FORWARD_TRANSITIVE.name());
+    assertEquals(
+        configUpdateRequest,
+        restApp.restClient.updateConfig(configUpdateRequest, defaultContext));
+
+    assertEquals(
+        FORWARD_TRANSITIVE.name,
+        restApp.restClient
+            .getConfig(RestService.DEFAULT_REQUEST_PROPERTIES, null, true)
+            .getCompatibilityLevel()
+    );
+
+    restApp.restClient.deleteConfig(defaultContext);
+
+    assertEquals(
+        NONE.name,
+        restApp.restClient
+            .getConfig(RestService.DEFAULT_REQUEST_PROPERTIES, null, true)
+            .getCompatibilityLevel()
+    );
+
+    ModeUpdateRequest modeUpdateRequest = new ModeUpdateRequest();
+    modeUpdateRequest.setMode(IMPORT.name());
+    assertEquals(
+        modeUpdateRequest,
+        restApp.restClient.setMode(IMPORT.name(), null));
+
+    assertEquals(
+        IMPORT.name(),
+        restApp.restClient
+            .getMode(":.:", true)
+            .getMode()
+    );
+
+    modeUpdateRequest = new ModeUpdateRequest();
+    modeUpdateRequest.setMode(READONLY.name());
+    assertEquals(
+        modeUpdateRequest,
+        restApp.restClient.setMode(READONLY.name(), defaultContext));
+
+    assertEquals(
+        READONLY.name(),
+        restApp.restClient
+            .getMode(null, true)
+            .getMode()
+    );
+
+    // We don't support deleting the mode for the default context
+    assertThrows(
+        RestClientException.class,
+        () -> restApp.restClient.deleteSubjectMode(defaultContext)
+    );
   }
 
   @Test


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Handle default context properly for /config and /mode.  Passing the default context (:.:) for the subject should be the same as the top level config/mode.
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Is this change gated behind feature flag(s)?
    - List the LD flags needed to be set to enable this change
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- [ ] Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
