### PR TITLE
DGS-20498 Ensure AvroConverter does not rely on field order

### DIFF
--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroConverterTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroConverterTest.java
@@ -21,6 +21,7 @@ import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientExcept
 import io.confluent.kafka.serializers.subject.RecordNameStrategy;
 
 import com.google.common.collect.ImmutableMap;
+import io.confluent.kafka.serializers.subject.TopicNameStrategy;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
 import org.apache.kafka.connect.data.SchemaAndValue;
@@ -322,6 +323,55 @@ public class AvroConverterTest {
 
     assertThat(schemaAndValue.schema(), equalTo(schema));
     assertThat(schemaAndValue.value(), equalTo(value));
+  }
+
+  @Test
+  public void testSingleFieldSerialization() throws RestClientException, IOException {
+    SchemaRegistryClient schemaRegistry = new MockSchemaRegistryClient();
+    AvroConverter avroConverter = new AvroConverter(schemaRegistry);
+    Map<String, ?> converterConfig = ImmutableMap.of(
+        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "localhost",
+        AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, false,
+        AbstractKafkaSchemaSerDeConfig.LATEST_COMPATIBILITY_STRICT, false,
+        AbstractKafkaSchemaSerDeConfig.NORMALIZE_SCHEMAS, true,
+        AbstractKafkaSchemaSerDeConfig.USE_LATEST_VERSION, true,
+        AbstractKafkaSchemaSerDeConfig.VALUE_SUBJECT_NAME_STRATEGY, TopicNameStrategy.class.getName());
+    avroConverter.configure(converterConfig, false);
+
+    org.apache.avro.Schema registredSchema = org.apache.avro.SchemaBuilder
+        .record("MySchema")
+        .fields()
+        .requiredString("id")
+        .endRecord();
+
+    schemaRegistry.register("topic-value", new AvroSchema(registredSchema));
+
+    Schema inputSchema1 = SchemaBuilder.struct()
+        .field("foo", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
+        .field("id", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
+        .build();
+
+    Struct inputValue1 = new Struct(inputSchema1)
+        .put("foo", "123")
+        .put("id", "456");
+
+    Schema inputSchema2 = SchemaBuilder.struct()
+        .field("id", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
+        .field("foo", org.apache.kafka.connect.data.Schema.STRING_SCHEMA)
+        .build();
+
+    Struct inputValue2 = new Struct(inputSchema2)
+        .put("id", "456")
+        .put("foo", "123");
+
+    final byte[] bytes1 = avroConverter.fromConnectData("topic", inputSchema1, inputValue1);
+    final SchemaAndValue schemaAndValue1 = avroConverter.toConnectData("topic", bytes1);
+
+    final byte[] bytes2 = avroConverter.fromConnectData("topic", inputSchema2, inputValue2);
+    final SchemaAndValue schemaAndValue2 = avroConverter.toConnectData("topic", bytes2);
+
+
+    assertEquals(schemaAndValue1.value(), schemaAndValue2.value());
   }
 
   private void assertSameSchemaMultipleTopic(AvroConverter converter, SchemaRegistryClient schemaRegistry, boolean isKey) throws IOException, RestClientException {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaUtils.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaUtils.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import org.apache.avro.AvroRuntimeException;
+import org.apache.avro.Conversion;
 import org.apache.avro.Conversions;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.LogicalType;
@@ -49,6 +50,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.DecoderFactory;
@@ -79,16 +81,18 @@ import static io.confluent.kafka.schemaregistry.avro.AvroSchema.NAME_FIELD;
 
 public class AvroSchemaUtils {
 
-  private static final GenericData GENERIC_DATA_INSTANCE = new GenericData();
-  private static final ReflectData REFLECT_DATA_INSTANCE = new ReflectData();
-  private static final ReflectData REFLECT_DATA_ALLOW_NULL_INSTANCE = new AllowNull();
-  private static final SpecificData SPECIFIC_DATA_INSTANCE = new SpecificData();
+  private static final GenericData GENERIC_DATA_INSTANCE =
+      new NameAwareGenericData(GenericData.get());
+  private static final GenericData GENERIC_DATA_INSTANCE_WITH_LOGICAL = new NameAwareGenericData();
+  private static final ReflectData REFLECT_DATA_INSTANCE_WITH_LOGICAL = new ReflectData();
+  private static final ReflectData REFLECT_DATA_ALLOW_NULL_INSTANCE_WITH_LOGICAL = new AllowNull();
+  private static final SpecificData SPECIFIC_DATA_INSTANCE_WITH_LOGICAL = new SpecificData();
 
   static {
-    addLogicalTypeConversion(GENERIC_DATA_INSTANCE);
-    addLogicalTypeConversion(REFLECT_DATA_INSTANCE);
-    addLogicalTypeConversion(REFLECT_DATA_ALLOW_NULL_INSTANCE);
-    addLogicalTypeConversion(SPECIFIC_DATA_INSTANCE);
+    addLogicalTypeConversion(GENERIC_DATA_INSTANCE_WITH_LOGICAL);
+    addLogicalTypeConversion(REFLECT_DATA_INSTANCE_WITH_LOGICAL);
+    addLogicalTypeConversion(REFLECT_DATA_ALLOW_NULL_INSTANCE_WITH_LOGICAL);
+    addLogicalTypeConversion(SPECIFIC_DATA_INSTANCE_WITH_LOGICAL);
   }
 
   private static final ThreadLocal<GenericData> genericData = new ThreadLocal<>();
@@ -120,11 +124,11 @@ public class AvroSchemaUtils {
   }
 
   public static GenericData getGenericData(boolean useLogicalTypes) {
-    return useLogicalTypes ? getGenericData() : GenericData.get();
+    return useLogicalTypes ? getGenericData() : GENERIC_DATA_INSTANCE;
   }
 
   public static GenericData getGenericData() {
-    return GENERIC_DATA_INSTANCE;
+    return GENERIC_DATA_INSTANCE_WITH_LOGICAL;
   }
 
   public static ReflectData getReflectData(boolean useLogicalTypes, boolean allowNull) {
@@ -134,11 +138,11 @@ public class AvroSchemaUtils {
   }
 
   public static ReflectData getReflectData() {
-    return REFLECT_DATA_INSTANCE;
+    return REFLECT_DATA_INSTANCE_WITH_LOGICAL;
   }
 
   public static ReflectData getReflectDataAllowNull() {
-    return REFLECT_DATA_ALLOW_NULL_INSTANCE;
+    return REFLECT_DATA_ALLOW_NULL_INSTANCE_WITH_LOGICAL;
   }
 
   public static SpecificData getSpecificDataForSchema(Schema reader, boolean useLogicalTypes) {
@@ -162,7 +166,7 @@ public class AvroSchemaUtils {
   }
 
   public static SpecificData getSpecificData() {
-    return SPECIFIC_DATA_INSTANCE;
+    return SPECIFIC_DATA_INSTANCE_WITH_LOGICAL;
   }
 
   public static void addLogicalTypeConversion(GenericData avroData) {
@@ -720,6 +724,86 @@ public class AvroSchemaUtils {
       generator.writeNumber((BigDecimal) datum);
     } else {
       throw new AvroRuntimeException("Unknown datum class: " + datum.getClass());
+    }
+  }
+
+  static class NameAwareGenericData extends GenericData {
+    private final GenericData delegate;
+
+    public NameAwareGenericData() {
+      this(null);
+    }
+
+    public NameAwareGenericData(GenericData delegate) {
+      this.delegate = delegate;
+    }
+
+    // The following methods override methods that use position instead of name
+
+    public void setField(Object record, String name, int position, Object value) {
+      if (record instanceof GenericRecord) {
+        ((GenericRecord) record).put(name, value);
+      } else {
+        ((IndexedRecord) record).put(position, value);
+      }
+    }
+
+    public Object getField(Object record, String name, int position) {
+      if (record instanceof GenericRecord) {
+        return ((GenericRecord) record).get(name);
+      } else {
+        return ((IndexedRecord) record).get(position);
+      }
+    }
+
+    // The following methods override all methods that rely on logical conversions
+
+    public Collection<Conversion<?>> getConversions() {
+      if (this.delegate != null) {
+        return this.delegate.getConversions();
+      } else {
+        return super.getConversions();
+      }
+    }
+
+    public void addLogicalTypeConversion(Conversion<?> conversion) {
+      if (this.delegate != null) {
+        this.delegate.addLogicalTypeConversion(conversion);
+      } else {
+        super.addLogicalTypeConversion(conversion);
+      }
+    }
+
+    public <T> Conversion<T> getConversionByClass(Class<T> datumClass) {
+      if (this.delegate != null) {
+        return this.delegate.getConversionByClass(datumClass);
+      } else {
+        return super.getConversionByClass(datumClass);
+      }
+    }
+
+    public <T> Conversion<T> getConversionByClass(Class<T> datumClass, LogicalType logicalType) {
+      if (this.delegate != null) {
+        return this.delegate.getConversionByClass(datumClass, logicalType);
+      } else {
+        return super.getConversionByClass(datumClass, logicalType);
+      }
+    }
+
+    public <T> Conversion<T> getConversionFor(LogicalType logicalType) {
+      if (this.delegate != null) {
+        return this.delegate.getConversionFor(logicalType);
+      } else {
+        return super.getConversionFor(logicalType);
+      }
+    }
+
+    public int resolveUnion(Schema union, Object datum) {
+      if (this.delegate != null) {
+        return this.delegate.resolveUnion(union, datum);
+      } else {
+        return super.resolveUnion(union, datum);
+      }
     }
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaUtils.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaUtils.java
@@ -740,6 +740,7 @@ public class AvroSchemaUtils {
 
     // The following methods override methods that use position instead of name
 
+    @Override
     public void setField(Object record, String name, int position, Object value) {
       if (record instanceof GenericRecord) {
         ((GenericRecord) record).put(name, value);
@@ -748,6 +749,7 @@ public class AvroSchemaUtils {
       }
     }
 
+    @Override
     public Object getField(Object record, String name, int position) {
       if (record instanceof GenericRecord) {
         return ((GenericRecord) record).get(name);
@@ -758,6 +760,7 @@ public class AvroSchemaUtils {
 
     // The following methods override all methods that rely on logical conversions
 
+    @Override
     public Collection<Conversion<?>> getConversions() {
       if (this.delegate != null) {
         return this.delegate.getConversions();
@@ -766,6 +769,7 @@ public class AvroSchemaUtils {
       }
     }
 
+    @Override
     public void addLogicalTypeConversion(Conversion<?> conversion) {
       if (this.delegate != null) {
         this.delegate.addLogicalTypeConversion(conversion);
@@ -774,6 +778,7 @@ public class AvroSchemaUtils {
       }
     }
 
+    @Override
     public <T> Conversion<T> getConversionByClass(Class<T> datumClass) {
       if (this.delegate != null) {
         return this.delegate.getConversionByClass(datumClass);
@@ -782,6 +787,7 @@ public class AvroSchemaUtils {
       }
     }
 
+    @Override
     public <T> Conversion<T> getConversionByClass(Class<T> datumClass, LogicalType logicalType) {
       if (this.delegate != null) {
         return this.delegate.getConversionByClass(datumClass, logicalType);
@@ -790,6 +796,7 @@ public class AvroSchemaUtils {
       }
     }
 
+    @Override
     public <T> Conversion<T> getConversionFor(LogicalType logicalType) {
       if (this.delegate != null) {
         return this.delegate.getConversionFor(logicalType);
@@ -798,6 +805,7 @@ public class AvroSchemaUtils {
       }
     }
 
+    @Override
     public int resolveUnion(Schema union, Object datum) {
       if (this.delegate != null) {
         return this.delegate.resolveUnion(union, datum);


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----

Extend `GenericData` with a subclass `NameAwareGenericData` to use field name instead of field position when accessing instances of `GenericRecord`.  In addition, all methods of `NameAwareGenericData` that access logical types should delegate to the singleton `GenericData.get()` for backward compatibility (when users set logical types on `GenericData.get()`).

<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- [ ] Is this change gated behind feature flag(s)?
    - List the LD flags needed to be set to enable this change
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- [ ] Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
