### PR TITLE
DGS-20647 Ensure SR client cache for CP 8.0 is backward compat with 7.x.x

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -786,13 +786,21 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
 
     RegisterSchemaResponse cachedResponse = schemaResponseMap.get(schema);
     if (cachedResponse != null) {
-      return cachedResponse;
+      // Allow the schema to be looked up again if version is not valid
+      // This is for backward compatibility with versions before CP 8.0
+      if (cachedResponse.getVersion() != null && cachedResponse.getVersion() > 0) {
+        return cachedResponse;
+      }
     }
 
     synchronized (this) {
       cachedResponse = schemaResponseMap.get(schema);
       if (cachedResponse != null) {
-        return cachedResponse;
+        // Allow the schema to be looked up again if version is not valid
+        // This is for backward compatibility with versions before CP 8.0
+        if (cachedResponse.getVersion() != null && cachedResponse.getVersion() > 0) {
+          return cachedResponse;
+        }
       }
 
       final RegisterSchemaResponse retrievedResponse =

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
@@ -236,6 +236,25 @@ public class CachedSchemaRegistryClientTest {
   }
 
   @Test
+  public void testRegisterFollowedByLookupWillSkipCache() throws Exception {
+    expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
+        eq(SUBJECT_0), anyBoolean()))
+        .andReturn(new RegisterSchemaResponse(ID_25))
+        .once();
+    expect(restService.lookUpSubjectVersion(anyObject(RegisterSchemaRequest.class),
+        eq(SUBJECT_0), anyBoolean(), anyBoolean()))
+        .andReturn(new Schema(SUBJECT_0, ID_25))
+        .once();
+
+    replay(restService);
+
+    assertEquals(ID_25, client.register(SUBJECT_0, SCHEMA_WITH_DECIMAL, VERSION_1, ID_25));
+    assertEquals(ID_25, client.getIdWithResponse(SUBJECT_0, SCHEMA_WITH_DECIMAL, false).getId());
+
+    verify(restService);
+  }
+
+  @Test
   public void testRegisterOverCapacity() throws Exception {
     expect(restService.registerSchema(anyObject(RegisterSchemaRequest.class),
         anyString(), anyBoolean()))


### PR DESCRIPTION


<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
For CP 8.0, when registering a schema, the version is returned. However, this is not the case for CP 7.x.x. Therefore when looking up a schema, skip the cached entry if it does not have a version.

Cherry-pick of https://github.com/confluentinc/schema-registry/pull/3714 to 8.0.0
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- \[ ] Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- \[ ] Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- \[x] Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- \[ ] Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
