### PR TITLE
DGS 20675: Expose context name for API errors

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -1127,7 +1127,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     try {
       if (isReadOnlyMode(subject)) {
         String context = QualifiedSubject.qualifiedContextFor(tenant(), subject);
-        throw new OperationNotPermittedException("Subject " + subject + " is in read-only mode"
+        throw new OperationNotPermittedException("Subject " + subject + " is in read-only mode,"
         + " in context " + context);
       }
       SchemaKey key = new SchemaKey(subject, schema.getVersion());
@@ -1195,7 +1195,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     try {
       if (isReadOnlyMode(subject)) {
         String context = QualifiedSubject.qualifiedContextFor(tenant(), subject);
-        throw new OperationNotPermittedException("Subject " + subject + " is in read-only mode"
+        throw new OperationNotPermittedException("Subject " + subject + " is in read-only mode,"
         + " in context " + context);
       }
       kafkaStore.waitUntilKafkaReaderReachesLastOffset(subject, kafkaStoreTimeoutMs);
@@ -1428,7 +1428,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
         if (!existingSchema.equals(schemaCopy)) {
           String context = QualifiedSubject.qualifiedContextFor(tenant(), schema.getSubject());
           throw new OperationNotPermittedException(
-              String.format("Overwrite new schema with id %s is not permitted. (context: %s)", id, context)
+              String.format("Overwrite new schema with id %s is not permitted."
+              +  "(context: %s)", id, context)
           );
         }
       }
@@ -2201,7 +2202,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       throws SchemaRegistryStoreException, OperationNotPermittedException, UnknownLeaderException {
     if (isReadOnlyMode(subject)) {
       String context = QualifiedSubject.qualifiedContextFor(tenant(), subject);
-      throw new OperationNotPermittedException("Subject " + subject + " is in read-only mode"
+      throw new OperationNotPermittedException("Subject " + subject + " is in read-only mode,"
       + " in context " + context);
     }
     ConfigKey configKey = new ConfigKey(subject);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -853,18 +853,24 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   private void checkRegisterMode(
       String subject, Schema schema
   ) throws OperationNotPermittedException, SchemaRegistryStoreException {
+    String context = QualifiedSubject.qualifiedContextFor(tenant(), subject);
     if (isReadOnlyMode(subject)) {
-      throw new OperationNotPermittedException("Subject " + subject + " is in read-only mode");
+      throw new OperationNotPermittedException("Subject " + subject 
+      + " is in read-only mode, in context " 
+      + context);
     }
 
     if (schema.getId() >= 0) {
       if (getModeInScope(subject) != Mode.IMPORT) {
-        throw new OperationNotPermittedException("Subject " + subject + " is not in import mode");
+        throw new OperationNotPermittedException("Subject " + subject 
+        + " is not in import mode, in context " 
+        + context);
       }
     } else {
       if (getModeInScope(subject) != Mode.READWRITE) {
         throw new OperationNotPermittedException(
-            "Subject " + subject + " is not in read-write mode"
+            "Subject " + subject + " is not in read-write mode, in context " 
+            + context
         );
       }
     }
@@ -1120,7 +1126,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
       throws SchemaRegistryException {
     try {
       if (isReadOnlyMode(subject)) {
-        throw new OperationNotPermittedException("Subject " + subject + " is in read-only mode");
+        String context = QualifiedSubject.qualifiedContextFor(tenant(), subject);
+        throw new OperationNotPermittedException("Subject " + subject + " is in read-only mode"
+        + " in context " + context);
       }
       SchemaKey key = new SchemaKey(subject, schema.getVersion());
       if (!lookupCache.referencesSchema(key).isEmpty()) {
@@ -1186,7 +1194,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     // Ensure cache is up-to-date before any potential writes
     try {
       if (isReadOnlyMode(subject)) {
-        throw new OperationNotPermittedException("Subject " + subject + " is in read-only mode");
+        String context = QualifiedSubject.qualifiedContextFor(tenant(), subject);
+        throw new OperationNotPermittedException("Subject " + subject + " is in read-only mode"
+        + " in context " + context);
       }
       kafkaStore.waitUntilKafkaReaderReachesLastOffset(subject, kafkaStoreTimeoutMs);
       List<Integer> deletedVersions = new ArrayList<>();
@@ -1416,8 +1426,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
         schemaCopy.setSubject(existingSchema.getSubject());
         schemaCopy.setVersion(existingSchema.getVersion());
         if (!existingSchema.equals(schemaCopy)) {
+          String context = QualifiedSubject.qualifiedContextFor(tenant(), schema.getSubject());
           throw new OperationNotPermittedException(
-              String.format("Overwrite new schema with id %s is not permitted.", id)
+              String.format("Overwrite new schema with id %s is not permitted. (context: %s)", id, context)
           );
         }
       }
@@ -2189,7 +2200,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   public Config updateConfig(String subject, ConfigUpdateRequest config)
       throws SchemaRegistryStoreException, OperationNotPermittedException, UnknownLeaderException {
     if (isReadOnlyMode(subject)) {
-      throw new OperationNotPermittedException("Subject " + subject + " is in read-only mode");
+      String context = QualifiedSubject.qualifiedContextFor(tenant(), subject);
+      throw new OperationNotPermittedException("Subject " + subject + " is in read-only mode"
+      + " in context " + context);
     }
     ConfigKey configKey = new ConfigKey(subject);
     try {
@@ -2230,7 +2243,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   public void deleteSubjectConfig(String subject)
       throws SchemaRegistryStoreException, OperationNotPermittedException {
     if (isReadOnlyMode(subject)) {
-      throw new OperationNotPermittedException("Subject " + subject + " is in read-only mode");
+      String context = QualifiedSubject.qualifiedContextFor(tenant(), subject);
+      throw new OperationNotPermittedException("Subject " + subject + " is in read-only mode"
+      + " in context " + context);
     }
     try {
       kafkaStore.waitUntilKafkaReaderReachesLastOffset(subject, kafkaStoreTimeoutMs);

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -57,6 +57,7 @@ import io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidSubjectExcep
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidVersionException;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
 import io.confluent.kafka.schemaregistry.utils.AppInfoParser;
+import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
 import io.confluent.kafka.schemaregistry.utils.TestUtils;
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -2135,6 +2136,9 @@ public class RestApiTest extends ClusterTestHarness {
     String schema = TestUtils.getRandomCanonicalAvroString(1).get(0);
     TestUtils.registerAndVerifySchema(restApp.restClient, schema, 1, subject);
 
+    // default context for error message
+    String context = ".";
+
     try {
       restApp.restClient.getMode(subject).getMode();
       fail(String.format("Subject %s should not be found when there's no mode override", subject));
@@ -2157,10 +2161,11 @@ public class RestApiTest extends ClusterTestHarness {
     assertEquals("READONLY_OVERRIDE", restApp.restClient.getMode(subject).getMode());
     try {
       restApp.restClient.registerSchema(schema, "testSubject2");
-      fail(String.format("Subject %s is in read-only mode", "testSubject2"));
+      fail(String.format("Subject %s is in read-only mode, in context %s", "testSubject2", context));
     } catch (RestClientException rce) {
-      assertEquals("Subject is in read-only mode", Errors.OPERATION_NOT_PERMITTED_ERROR_CODE, rce
+      assertEquals("Subject is in read-only mode, in context " + context, Errors.OPERATION_NOT_PERMITTED_ERROR_CODE, rce
           .getErrorCode());
+      assertTrue(rce.getMessage().contains("in context " + context));
     }
   }
 

--- a/protobuf-types/src/main/java/io/confluent/protobuf/type/Decimal.java
+++ b/protobuf-types/src/main/java/io/confluent/protobuf/type/Decimal.java
@@ -59,7 +59,7 @@ private static final long serialVersionUID = 0L;
   private int precision_ = 0;
   /**
    * <pre>
-   * The precision
+   * The precision (zero indicates unlimited precision)
    * </pre>
    *
    * <code>uint32 precision = 2;</code>
@@ -503,7 +503,7 @@ private static final long serialVersionUID = 0L;
     private int precision_ ;
     /**
      * <pre>
-     * The precision
+     * The precision (zero indicates unlimited precision)
      * </pre>
      *
      * <code>uint32 precision = 2;</code>
@@ -515,7 +515,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The precision
+     * The precision (zero indicates unlimited precision)
      * </pre>
      *
      * <code>uint32 precision = 2;</code>
@@ -531,7 +531,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * The precision
+     * The precision (zero indicates unlimited precision)
      * </pre>
      *
      * <code>uint32 precision = 2;</code>

--- a/protobuf-types/src/main/java/io/confluent/protobuf/type/DecimalOrBuilder.java
+++ b/protobuf-types/src/main/java/io/confluent/protobuf/type/DecimalOrBuilder.java
@@ -20,7 +20,7 @@ public interface DecimalOrBuilder extends
 
   /**
    * <pre>
-   * The precision
+   * The precision (zero indicates unlimited precision)
    * </pre>
    *
    * <code>uint32 precision = 2;</code>


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Added the context name to error logging. 
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[ ]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[ ]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[ ]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[ ]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes

References
----------
[JIRA](https://confluentinc.atlassian.net/browse/DGS-20675)
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
