### PR TITLE
DGS-20896 Ensure correct GUID when requesting a formatted schema

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
@@ -447,6 +447,16 @@ public class Schema implements Comparable<Schema> {
   }
 
   public void updateHash(MessageDigest md) {
+    updateHash(md, schema, references, metadata, ruleSet);
+  }
+
+  public static void updateHash(
+      MessageDigest md,
+      String schema,
+      List<SchemaReference> references,
+      Metadata metadata,
+      RuleSet ruleSet
+  ) {
     if (schema != null) {
       md.update(schema.getBytes(StandardCharsets.UTF_8));
     }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
@@ -29,7 +29,6 @@ import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
 import io.confluent.kafka.schemaregistry.storage.LookupFilter;
-import io.confluent.kafka.schemaregistry.storage.MD5;
 import io.confluent.rest.annotations.PerformanceMetric;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -172,7 +171,6 @@ public class SchemasResource {
         schemaRegistry.extractSchemaTags(s, tags);
         schema.setSchemaTags(s.getSchemaTags());
       }
-      schema.setGuid(MD5.ofSchema(new Schema(null, null, null, schema)).toString());
     } catch (InvalidSchemaException e) {
       throw Errors.invalidSchemaException(e);
     } catch (SchemaRegistryStoreException e) {
@@ -375,7 +373,6 @@ public class SchemasResource {
       if (schema == null) {
         throw Errors.schemaNotFoundException(guid);
       }
-      schema.setGuid(MD5.ofSchema(new Schema(null, null, null, schema)).toString());
     } catch (InvalidSchemaException e) {
       throw Errors.invalidSchemaException(e);
     } catch (SchemaRegistryStoreException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/MD5.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/MD5.java
@@ -21,7 +21,9 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.HexFormat;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Simple wrapper for 16 byte MD5 hash.
@@ -73,7 +75,31 @@ public class MD5 {
 
   public static MD5 ofSchema(SchemaValue schema) {
     byte[] bytes = schema.getMd5Bytes();
-    return bytes != null ? new MD5(bytes) : ofSchema(schema.toSchemaEntity());
+    return bytes != null
+        ? new MD5(bytes)
+        : ofSchema(
+            schema.getSchema(),
+            schema.getReferences() == null ? null : schema.getReferences().stream()
+                .map(SchemaReference::toRefEntity)
+                .collect(Collectors.toList()),
+            schema.getMetadata() == null ? null : schema.getMetadata().toMetadataEntity() ,
+            schema.getRuleSet() == null ? null : schema.getRuleSet().toRuleSetEntity()
+        );
+  }
+
+  public static MD5 ofSchema(
+      String schema,
+      List<io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference> references,
+      io.confluent.kafka.schemaregistry.client.rest.entities.Metadata metadata,
+      io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet ruleSet
+  ) {
+    try {
+      MessageDigest md = MessageDigest.getInstance("MD5");
+      Schema.updateHash(md, schema, references, metadata, ruleSet);
+      return new MD5(md.digest());
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaValue.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaValue.java
@@ -304,17 +304,29 @@ public class SchemaValue extends SubjectValue implements Comparable<SchemaValue>
   }
 
   public Schema toSchemaEntity() {
+    List<io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference> references =
+        getReferences() == null
+            ? null
+            : getReferences().stream()
+                .map(SchemaReference::toRefEntity)
+                .collect(Collectors.toList());
+    io.confluent.kafka.schemaregistry.client.rest.entities.Metadata metadata =
+        getMetadata() == null ? null : getMetadata().toMetadataEntity();
+    io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet ruleSet =
+        getRuleSet() == null ? null : getRuleSet().toRuleSetEntity();
+    byte[] bytes = getMd5Bytes();
+    MD5 md5 = bytes != null
+        ? new MD5(bytes)
+        : MD5.ofSchema(getSchema(), references, metadata, ruleSet);
     return new Schema(
         getSubject(),
         getVersion(),
         getId(),
-        null,
+        md5.toString(),
         getSchemaType(),
-        getReferences() == null ? null : getReferences().stream()
-            .map(SchemaReference::toRefEntity)
-            .collect(Collectors.toList()),
-        getMetadata() == null ? null : getMetadata().toMetadataEntity(),
-        getRuleSet() == null ? null : getRuleSet().toRuleSetEntity(),
+        references,
+        metadata,
+        ruleSet,
         getSchema(),
         null,
         getTimestamp(),

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -1208,6 +1208,12 @@ public class RestApiTest extends ClusterTestHarness {
         schemaString.getReferences(),
         "Schema references should be found"
     );
+
+    SchemaString schemaString2 = restApp.restClient.getId(
+        RestService.DEFAULT_REQUEST_PROPERTIES,
+        4, "root", "resolved", null, false);
+    // Ensure the guids match even though we are formatting the schema
+    assertEquals(schemaString.getGuid(), schemaString2.getGuid());
   }
 
   @Test


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Ensure correct GUID when requesting a formatted schema via the REST APIs.  To do this, we set the GUID immediately when constructing the schema that will be returned in the REST response (as opposed to setting it lazily after the schema might have been later formatted).
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
