### PR TITLE
DGS-20884 Add referenceFormat param to qualify references

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
@@ -49,6 +49,7 @@ import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -896,7 +897,7 @@ public class AvroSchema implements ParsedSchema {
     }
 
     public static Format get(String symbol) {
-      return lookup.inverse().get(symbol);
+      return lookup.inverse().get(symbol.toLowerCase(Locale.ROOT));
     }
 
     public static Set<String> symbols() {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -1007,9 +1007,16 @@ public class RestService implements Closeable, Configurable {
       throws IOException, RestClientException {
     return getId(requestProperties, id, subject, null, findTags, fetchMaxId);
   }
-  
+
   public SchemaString getId(Map<String, String> requestProperties,
       int id, String subject, String format, Set<String> findTags, boolean fetchMaxId)
+      throws IOException, RestClientException {
+    return getId(requestProperties, id, subject, format, null, findTags, fetchMaxId);
+  }
+
+  public SchemaString getId(Map<String, String> requestProperties,
+      int id, String subject, String format, String referenceFormat,
+      Set<String> findTags, boolean fetchMaxId)
       throws IOException, RestClientException {
     UriBuilder builder = UriBuilder.fromPath("/schemas/ids/{id}")
         .queryParam("fetchMaxId", fetchMaxId);
@@ -1023,6 +1030,9 @@ public class RestService implements Closeable, Configurable {
     }
     if (format != null) {
       builder.queryParam("format", format);
+    }
+    if (referenceFormat != null) {
+      builder.queryParam("referenceFormat", referenceFormat);
     }
     String path = builder.build(id).toString();
 
@@ -1086,6 +1096,13 @@ public class RestService implements Closeable, Configurable {
   public Schema getVersion(Map<String, String> requestProperties,
       String subject, int version, String format, boolean lookupDeletedSchema, Set<String> findTags)
       throws IOException, RestClientException {
+    return getVersion(requestProperties, subject, version, format, null, lookupDeletedSchema, null);
+  }
+
+  public Schema getVersion(Map<String, String> requestProperties,
+      String subject, int version, String format, String referenceFormat,
+      boolean lookupDeletedSchema, Set<String> findTags)
+      throws IOException, RestClientException {
     UriBuilder builder = UriBuilder.fromPath("/subjects/{subject}/versions/{version}")
         .queryParam("deleted", lookupDeletedSchema);
     if (findTags != null && !findTags.isEmpty()) {
@@ -1095,6 +1112,9 @@ public class RestService implements Closeable, Configurable {
     }
     if (format != null) {
       builder.queryParam("format", format);
+    }
+    if (referenceFormat != null) {
+      builder.queryParam("referenceFormat", referenceFormat);
     }
     String path = builder.build(subject, version).toString();
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
@@ -138,6 +138,9 @@ public class QualifiedSubject implements Comparable<QualifiedSubject> {
     }
   }
 
+  /**
+   * Returns the context without the tenant prefix.
+   */
   public String toUnqualifiedContext() {
     return DEFAULT_CONTEXT.equals(context)
         ? ""
@@ -148,6 +151,9 @@ public class QualifiedSubject implements Comparable<QualifiedSubject> {
     return toQualifiedContext() + subject;
   }
 
+  /**
+   * Returns the context and subject without the tenant prefix.
+   */
   public String toUnqualifiedSubject() {
     return toUnqualifiedContext() + subject;
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
@@ -15,11 +15,14 @@
 
 package io.confluent.kafka.schemaregistry.rest.resources;
 
+import static io.confluent.kafka.schemaregistry.utils.QualifiedSubject.DEFAULT_CONTEXT;
+
 import com.google.common.collect.Streams;
 import io.confluent.kafka.schemaregistry.client.rest.Versions;
 import io.confluent.kafka.schemaregistry.client.rest.entities.ContextId;
 import io.confluent.kafka.schemaregistry.client.rest.entities.ErrorMessage;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
 import io.confluent.kafka.schemaregistry.client.rest.entities.ExtendedSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
@@ -29,6 +32,7 @@ import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
 import io.confluent.kafka.schemaregistry.storage.LookupFilter;
+import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
 import io.confluent.rest.annotations.PerformanceMetric;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -154,6 +158,8 @@ public class SchemasResource {
       @QueryParam("subject") String subject,
       @Parameter(description = "Desired output format, dependent on schema type")
       @DefaultValue("") @QueryParam("format") String format,
+      @Parameter(description = "Desired output format for references")
+      @DefaultValue("") @QueryParam("referenceFormat") String referenceFormat,
       @Parameter(description = "Find tagged entities for the given tags or * for all tags")
       @QueryParam("findTags") List<String> tags,
       @Parameter(description = "Whether to fetch the maximum schema identifier that exists")
@@ -170,6 +176,25 @@ public class SchemasResource {
         Schema s = new Schema(null, null, null, schema);
         schemaRegistry.extractSchemaTags(s, tags);
         schema.setSchemaTags(s.getSchemaTags());
+      }
+      QualifiedSubject qs = QualifiedSubject.create(schemaRegistry.tenant(), schema.getSubject());
+      boolean isQualifiedSubject = qs != null && !DEFAULT_CONTEXT.equals(qs.getContext());
+      List<SchemaReference> refs = schema.getReferences();
+      boolean hasRefs = refs != null && !refs.isEmpty();
+      if (isQualifiedSubject
+          && hasRefs
+          && referenceFormat != null
+          && referenceFormat.equals("qualified")) {
+        // Convert references to be qualified with the parent subject
+        List<SchemaReference> qualifiedRefs = refs.stream()
+            .map(ref -> {
+              QualifiedSubject refSubject = QualifiedSubject.qualifySubjectWithParent(
+                  schemaRegistry.tenant(), qs.toQualifiedSubject(), ref.getSubject());
+              return new SchemaReference(
+                  ref.getName(), refSubject.toUnqualifiedSubject(), ref.getVersion());
+            })
+            .collect(Collectors.toList());
+        schema.setReferences(qualifiedRefs);
       }
     } catch (InvalidSchemaException e) {
       throw Errors.invalidSchemaException(e);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -15,11 +15,14 @@
 
 package io.confluent.kafka.schemaregistry.rest.resources;
 
+import static io.confluent.kafka.schemaregistry.utils.QualifiedSubject.DEFAULT_CONTEXT;
+
 import com.google.common.collect.Streams;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.rest.Versions;
 import io.confluent.kafka.schemaregistry.client.rest.entities.ErrorMessage;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.TagSchemaRequest;
@@ -133,6 +136,8 @@ public class SubjectVersionsResource {
       @PathParam("version") String version,
       @Parameter(description = "Desired output format, dependent on schema type")
       @DefaultValue("") @QueryParam("format") String format,
+      @Parameter(description = "Desired output format for references")
+      @DefaultValue("") @QueryParam("referenceFormat") String referenceFormat,
       @Parameter(description = "Whether to include deleted schema")
       @QueryParam("deleted") boolean lookupDeletedSchema,
       @Parameter(description = "Find tagged entities for the given tags or * for all tags")
@@ -168,6 +173,25 @@ public class SubjectVersionsResource {
       if (format != null && !format.trim().isEmpty()) {
         ParsedSchema parsedSchema = schemaRegistry.parseSchema(schema, false, false);
         schema.setSchema(parsedSchema.formattedString(format));
+      }
+      QualifiedSubject qs = QualifiedSubject.create(schemaRegistry.tenant(), schema.getSubject());
+      boolean isQualifiedSubject = qs != null && !DEFAULT_CONTEXT.equals(qs.getContext());
+      List<SchemaReference> refs = schema.getReferences();
+      boolean hasRefs = refs != null && !refs.isEmpty();
+      if (isQualifiedSubject
+          && hasRefs
+          && referenceFormat != null
+          && referenceFormat.equals("qualified")) {
+        // Convert references to be qualified with the parent subject
+        List<SchemaReference> qualifiedRefs = refs.stream()
+            .map(ref -> {
+              QualifiedSubject refSubject = QualifiedSubject.qualifySubjectWithParent(
+                  schemaRegistry.tenant(), qs.toQualifiedSubject(), ref.getSubject());
+              return new SchemaReference(
+                  ref.getName(), refSubject.toUnqualifiedSubject(), ref.getVersion());
+            })
+            .collect(Collectors.toList());
+        schema.setReferences(qualifiedRefs);
       }
     } catch (InvalidSchemaException e) {
       throw Errors.invalidSchemaException(e);
@@ -218,7 +242,7 @@ public class SubjectVersionsResource {
       @DefaultValue("") @QueryParam("format") String format,
       @Parameter(description = "Whether to include deleted schema")
       @QueryParam("deleted") boolean lookupDeletedSchema) {
-    return getSchemaByVersion(subject, version, format, lookupDeletedSchema, null).getSchema();
+    return getSchemaByVersion(subject, version, format, "", lookupDeletedSchema, null).getSchema();
   }
 
   @GET
@@ -259,7 +283,7 @@ public class SubjectVersionsResource {
       @Parameter(description = "Pagination size for results. Ignored if negative")
       @DefaultValue("-1") @QueryParam("limit") int limit) {
 
-    Schema schema = getSchemaByVersion(subject, version, "", true, null);
+    Schema schema = getSchemaByVersion(subject, version, "", "", true, null);
     if (schema == null) {
       return new ArrayList<>();
     }

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -158,6 +158,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -3151,7 +3152,7 @@ public class ProtobufSchema implements ParsedSchema {
     }
 
     public static Format get(String symbol) {
-      return lookup.inverse().get(symbol);
+      return lookup.inverse().get(symbol.toLowerCase(Locale.ROOT));
     }
 
     public static Set<String> symbols() {


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Add referenceFormat param to allow qualify references with the parent context.
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
