### PR TITLE
DGS-20984 Bump max DEK registry key default

### DIFF
--- a/dek-registry/src/main/java/io/confluent/dekregistry/storage/DekRegistryConfig.java
+++ b/dek-registry/src/main/java/io/confluent/dekregistry/storage/DekRegistryConfig.java
@@ -38,7 +38,7 @@ public class DekRegistryConfig extends SchemaRegistryConfig {
   public static final String DEK_REGISTRY_UPDATE_HANDLERS_CONFIG = "dek.registry.update.handlers";
 
   protected static final String DEK_REGISTRY_TOPIC_DEFAULT = "_dek_registry_keys";
-  protected static final int DEK_REGISTRY_MAX_KEYS_DEFAULT = 10000;
+  protected static final int DEK_REGISTRY_MAX_KEYS_DEFAULT = 20000;
 
   protected static final String DEK_REGISTRY_TOPIC_DOC =
       "The topic used to persist keys for the dek registry.";


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
DGS-20984 Bump max DEK registry key default from 10K to 20K
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[N/A]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N/A]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
