### PR TITLE
Fix master SR oauth to handle AK changes

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/CachedOauthTokenRetriever.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/CachedOauthTokenRetriever.java
@@ -18,15 +18,15 @@ package io.confluent.kafka.schemaregistry.client.security.bearerauth.oauth;
 
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
 import io.confluent.kafka.schemaregistry.client.security.bearerauth.oauth.exceptions.SchemaRegistryOauthTokenRetrieverException;
-import java.io.IOException;
+import org.apache.kafka.common.security.oauthbearer.JwtRetrieverException;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtRetriever;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtValidator;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.ValidateException;
+import org.apache.kafka.common.security.oauthbearer.JwtRetriever;
+import org.apache.kafka.common.security.oauthbearer.JwtValidator;
+import org.apache.kafka.common.security.oauthbearer.JwtValidatorException;
 
 /**
  * <p>
- * <code>CachedOauthTokenRetriever</code> is an wrapper around {@link AccessTokenRetriever} that
+ * <code>CachedOauthTokenRetriever</code> is an wrapper around {@link JwtRetriever} that
  * will communicate with an OAuth/OIDC provider directly via HTTP to post client credentials ({@link
  * SchemaRegistryClientConfig#BEARER_AUTH_CLIENT_ID}/
  * {@link SchemaRegistryClientConfig#BEARER_AUTH_CLIENT_SECRET})
@@ -35,7 +35,7 @@ import org.apache.kafka.common.security.oauthbearer.internals.secured.ValidateEx
  * inorder to fetch an access token.
  * </p>
  * <p>
- * This class adds caching mechanism over {@link AccessTokenRetriever} using {@link
+ * This class adds caching mechanism over {@link JwtRetriever} using {@link
  * OauthTokenCache}
  * </p>
  *
@@ -62,7 +62,7 @@ public class CachedOauthTokenRetriever {
       String token = null;
       try {
         token = tokenRetriever.retrieve();
-      } catch (IOException | RuntimeException e) {
+      } catch (JwtRetrieverException e) {
         throw new SchemaRegistryOauthTokenRetrieverException(
             "Failed to Retrieve OAuth Token for Schema Registry", e);
       }
@@ -70,7 +70,7 @@ public class CachedOauthTokenRetriever {
       OAuthBearerToken oauthBearerToken;
       try {
         oauthBearerToken = tokenValidator.validate(token);
-      } catch (ValidateException e) {
+      } catch (JwtValidatorException e) {
         throw new SchemaRegistryOauthTokenRetrieverException(
             "OAuth Token for Schema Registry is Invalid", e);
       }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/ClientJwtValidator.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/ClientJwtValidator.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This is copy of the class from the Apache Kafka project.
+ */
+
+package io.confluent.kafka.schemaregistry.client.security.bearerauth.oauth;
+
+import org.apache.kafka.common.security.oauthbearer.JwtValidator;
+import org.apache.kafka.common.security.oauthbearer.JwtValidatorException;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.BasicOAuthBearerToken;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.ClaimValidationUtils;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.SerializedJwt;
+import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerIllegalTokenException;
+import org.apache.kafka.common.security.oauthbearer.internals.unsecured.OAuthBearerUnsecuredJws;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.kafka.common.config.SaslConfigs.DEFAULT_SASL_OAUTHBEARER_SCOPE_CLAIM_NAME;
+import static org.apache.kafka.common.config.SaslConfigs.DEFAULT_SASL_OAUTHBEARER_SUB_CLAIM_NAME;
+
+/**
+ * {@code ClientJwtValidator} is an implementation of {@link JwtValidator} that is used
+ * by the client to perform some rudimentary validation of the JWT access token that is received
+ * as part of the response from posting the client credentials to the OAuth/OIDC provider's
+ * token endpoint.
+ *
+ * The validation steps performed are:
+ *
+ * <ol>
+ *     <li>
+ *         Basic structural validation of the <code>b64token</code> value as defined in
+ *         <a href="https://tools.ietf.org/html/rfc6750#section-2.1">RFC 6750 Section 2.1</a>
+ *     </li>
+ *     <li>Basic conversion of the token into an in-memory map</li>
+ *     <li>Presence of <code>scope</code>, <code>exp</code>, <code>subject</code>, and <code>iat</code> claims</li>
+ * </ol>
+ */
+
+public class ClientJwtValidator implements JwtValidator {
+
+  private static final Logger log = LoggerFactory.getLogger(ClientJwtValidator.class);
+
+  public static final String EXPIRATION_CLAIM_NAME = "exp";
+
+  public static final String ISSUED_AT_CLAIM_NAME = "iat";
+
+  private final String scopeClaimName;
+
+  private final String subClaimName;
+
+  /**
+   * Creates a new {@code ClientJwtValidator} that will be used by the client for lightweight
+   * validation of the JWT.
+   *
+   * @param scopeClaimName Name of the scope claim to use; must be non-<code>null</code>
+   * @param subClaimName   Name of the subject claim to use; must be non-<code>null</code>
+   */
+
+  public ClientJwtValidator(String scopeClaimName, String subClaimName) {
+    this.scopeClaimName = ClaimValidationUtils.validateClaimNameOverride(DEFAULT_SASL_OAUTHBEARER_SCOPE_CLAIM_NAME, scopeClaimName);
+    this.subClaimName = ClaimValidationUtils.validateClaimNameOverride(DEFAULT_SASL_OAUTHBEARER_SUB_CLAIM_NAME, subClaimName);
+  }
+
+  /**
+   * Accepts an OAuth JWT access token in base-64 encoded format, validates, and returns an
+   * OAuthBearerToken.
+   *
+   * @param accessToken Non-<code>null</code> JWT access token
+   * @return {@link OAuthBearerToken}
+   * @throws JwtValidatorException Thrown on errors performing validation of given token
+   */
+
+  @SuppressWarnings("unchecked")
+  public OAuthBearerToken validate(String accessToken) throws JwtValidatorException {
+    SerializedJwt serializedJwt = new SerializedJwt(accessToken);
+    Map<String, Object> payload;
+
+    try {
+      payload = OAuthBearerUnsecuredJws.toMap(serializedJwt.getPayload());
+    } catch (OAuthBearerIllegalTokenException e) {
+      throw new JwtValidatorException(String.format("Could not validate the access token: %s", e.getMessage()), e);
+    }
+
+    Object scopeRaw = getClaim(payload, scopeClaimName);
+    Collection<String> scopeRawCollection;
+
+    if (scopeRaw instanceof String)
+      scopeRawCollection = Collections.singletonList((String) scopeRaw);
+    else if (scopeRaw instanceof Collection)
+      scopeRawCollection = (Collection<String>) scopeRaw;
+    else
+      scopeRawCollection = Collections.emptySet();
+
+    Number expirationRaw = (Number) getClaim(payload, EXPIRATION_CLAIM_NAME);
+    String subRaw = (String) getClaim(payload, subClaimName);
+    Number issuedAtRaw = (Number) getClaim(payload, ISSUED_AT_CLAIM_NAME);
+
+    Set<String> scopes = ClaimValidationUtils.validateScopes(scopeClaimName, scopeRawCollection);
+    long expiration = ClaimValidationUtils.validateExpiration(EXPIRATION_CLAIM_NAME,
+        expirationRaw != null ? expirationRaw.longValue() * 1000L : null);
+    String subject = ClaimValidationUtils.validateSubject(subClaimName, subRaw);
+    Long issuedAt = ClaimValidationUtils.validateIssuedAt(ISSUED_AT_CLAIM_NAME,
+        issuedAtRaw != null ? issuedAtRaw.longValue() * 1000L : null);
+
+    return new BasicOAuthBearerToken(accessToken,
+        scopes,
+        expiration,
+        subject,
+        issuedAt);
+  }
+
+  private Object getClaim(Map<String, Object> payload, String claimName) {
+    Object value = payload.get(claimName);
+    log.debug("getClaim - {}: {}", claimName, value);
+    return value;
+  }
+
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/HttpJwtRetriever.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/HttpJwtRetriever.java
@@ -1,0 +1,397 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This is copy of the class from the Apache Kafka project.
+ */
+
+package io.confluent.kafka.schemaregistry.client.security.bearerauth.oauth;
+
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.security.oauthbearer.JwtRetriever;
+import org.apache.kafka.common.security.oauthbearer.JwtRetrieverException;
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.Retry;
+import org.apache.kafka.common.security.oauthbearer.internals.secured.UnretryableException;
+import org.apache.kafka.common.utils.Utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * <code>HttpJwtRetriever</code> is a {@link JwtRetriever} that will communicate with an OAuth/OIDC
+ * provider directly via HTTP to post client credentials
+ * ({@link OAuthBearerLoginCallbackHandler#CLIENT_ID_CONFIG}/{@link OAuthBearerLoginCallbackHandler#CLIENT_SECRET_CONFIG})
+ * to a publicized token endpoint URL ({@link SaslConfigs#SASL_OAUTHBEARER_TOKEN_ENDPOINT_URL}).
+ */
+public class HttpJwtRetriever implements JwtRetriever {
+
+  private static final Logger log = LoggerFactory.getLogger(HttpJwtRetriever.class);
+
+  private static final Set<Integer> UNRETRYABLE_HTTP_CODES;
+
+  private static final int MAX_RESPONSE_BODY_LENGTH = 1000;
+
+  public static final String AUTHORIZATION_HEADER = "Authorization";
+
+  static {
+    // This does not have to be an exhaustive list. There are other HTTP codes that
+    // are defined in different RFCs (e.g. https://datatracker.ietf.org/doc/html/rfc6585)
+    // that we won't worry about yet. The worst case if a status code is missing from
+    // this set is that the request will be retried.
+    UNRETRYABLE_HTTP_CODES = new HashSet<>();
+    UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_BAD_REQUEST);
+    UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_UNAUTHORIZED);
+    UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_PAYMENT_REQUIRED);
+    UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_FORBIDDEN);
+    UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_NOT_FOUND);
+    UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_BAD_METHOD);
+    UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_NOT_ACCEPTABLE);
+    UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_PROXY_AUTH);
+    UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_CONFLICT);
+    UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_GONE);
+    UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_LENGTH_REQUIRED);
+    UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_PRECON_FAILED);
+    UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_ENTITY_TOO_LARGE);
+    UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_REQ_TOO_LONG);
+    UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_UNSUPPORTED_TYPE);
+    UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_NOT_IMPLEMENTED);
+    UNRETRYABLE_HTTP_CODES.add(HttpURLConnection.HTTP_VERSION);
+  }
+
+  private final String clientId;
+
+  private final String clientSecret;
+
+  private final String scope;
+
+  private final SSLSocketFactory sslSocketFactory;
+
+  private final String tokenEndpointUrl;
+
+  private final long loginRetryBackoffMs;
+
+  private final long loginRetryBackoffMaxMs;
+
+  private final Integer loginConnectTimeoutMs;
+
+  private final Integer loginReadTimeoutMs;
+
+  private final boolean urlencodeHeader;
+
+  public HttpJwtRetriever(String clientId,
+      String clientSecret,
+      String scope,
+      SSLSocketFactory sslSocketFactory,
+      String tokenEndpointUrl,
+      long loginRetryBackoffMs,
+      long loginRetryBackoffMaxMs,
+      Integer loginConnectTimeoutMs,
+      Integer loginReadTimeoutMs,
+      boolean urlencodeHeader) {
+    this.clientId = Objects.requireNonNull(clientId);
+    this.clientSecret = Objects.requireNonNull(clientSecret);
+    this.scope = scope;
+    this.sslSocketFactory = sslSocketFactory;
+    this.tokenEndpointUrl = Objects.requireNonNull(tokenEndpointUrl);
+    this.loginRetryBackoffMs = loginRetryBackoffMs;
+    this.loginRetryBackoffMaxMs = loginRetryBackoffMaxMs;
+    this.loginConnectTimeoutMs = loginConnectTimeoutMs;
+    this.loginReadTimeoutMs = loginReadTimeoutMs;
+    this.urlencodeHeader = urlencodeHeader;
+  }
+
+  /**
+   * Retrieves a JWT access token in its serialized three-part form. The implementation
+   * is free to determine how it should be retrieved but should not perform validation
+   * on the result.
+   *
+   * <b>Note</b>: This is a blocking function and callers should be aware that the
+   * implementation communicates over a network. The facility in the
+   * {@link javax.security.auth.spi.LoginModule} from which this is ultimately called
+   * does not provide an asynchronous approach.
+   *
+   * @return Non-<code>null</code> JWT access token string
+   *
+   * @throws JwtRetrieverException Thrown on errors related to IO during retrieval
+   */
+
+  public String retrieve() throws JwtRetrieverException {
+    String authorizationHeader = formatAuthorizationHeader(clientId, clientSecret, urlencodeHeader);
+    String requestBody = formatRequestBody(scope);
+    Retry<String> retry = new Retry<>(loginRetryBackoffMs, loginRetryBackoffMaxMs);
+    Map<String, String> headers = Collections.singletonMap(AUTHORIZATION_HEADER, authorizationHeader);
+
+    String responseBody;
+
+    try {
+      responseBody = retry.execute(() -> {
+        HttpURLConnection con = null;
+
+        try {
+          con = (HttpURLConnection) new URL(tokenEndpointUrl).openConnection();
+
+          if (sslSocketFactory != null && con instanceof HttpsURLConnection)
+            ((HttpsURLConnection) con).setSSLSocketFactory(sslSocketFactory);
+
+          return post(con, headers, requestBody, loginConnectTimeoutMs, loginReadTimeoutMs);
+        } catch (IOException e) {
+          throw new ExecutionException(e);
+        } finally {
+          if (con != null)
+            con.disconnect();
+        }
+      });
+      return parseAccessToken(responseBody);
+    } catch (ExecutionException e) {
+      if (e.getCause() instanceof IOException)
+        throw (JwtRetrieverException) e.getCause();
+      else
+        throw new KafkaException(e.getCause());
+    } catch (IOException e) {
+      throw new JwtRetrieverException(e);
+    }
+  }
+
+  public static String post(HttpURLConnection con,
+      Map<String, String> headers,
+      String requestBody,
+      Integer connectTimeoutMs,
+      Integer readTimeoutMs)
+      throws IOException, UnretryableException {
+    handleInput(con, headers, requestBody, connectTimeoutMs, readTimeoutMs);
+    return handleOutput(con);
+  }
+
+  private static void handleInput(HttpURLConnection con,
+      Map<String, String> headers,
+      String requestBody,
+      Integer connectTimeoutMs,
+      Integer readTimeoutMs)
+      throws IOException, UnretryableException {
+    log.debug("handleInput - starting post for {}", con.getURL());
+    con.setRequestMethod("POST");
+    con.setRequestProperty("Accept", "application/json");
+
+    if (headers != null) {
+      for (Map.Entry<String, String> header : headers.entrySet())
+        con.setRequestProperty(header.getKey(), header.getValue());
+    }
+
+    con.setRequestProperty("Cache-Control", "no-cache");
+
+    if (requestBody != null) {
+      con.setRequestProperty("Content-Length", String.valueOf(requestBody.length()));
+      con.setDoOutput(true);
+    }
+
+    con.setUseCaches(false);
+
+    if (connectTimeoutMs != null)
+      con.setConnectTimeout(connectTimeoutMs);
+
+    if (readTimeoutMs != null)
+      con.setReadTimeout(readTimeoutMs);
+
+    log.debug("handleInput - preparing to connect to {}", con.getURL());
+    con.connect();
+
+    if (requestBody != null) {
+      try (OutputStream os = con.getOutputStream()) {
+        ByteArrayInputStream is = new ByteArrayInputStream(requestBody.getBytes(StandardCharsets.UTF_8));
+        log.debug("handleInput - preparing to write request body to {}", con.getURL());
+        copy(is, os);
+      }
+    }
+  }
+
+  static String handleOutput(final HttpURLConnection con) throws IOException {
+    int responseCode = con.getResponseCode();
+    log.debug("handleOutput - responseCode: {}", responseCode);
+
+    // NOTE: the contents of the response should not be logged so that we don't leak any
+    // sensitive data.
+    String responseBody = null;
+
+    // NOTE: It is OK to log the error response body and/or its formatted version as
+    // per the OAuth spec, it doesn't include sensitive information.
+    // See https://www.ietf.org/rfc/rfc6749.txt, section 5.2
+    String errorResponseBody = null;
+
+    try (InputStream is = con.getInputStream()) {
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+      log.debug("handleOutput - preparing to read response body from {}", con.getURL());
+      copy(is, os);
+      responseBody = os.toString(StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      // there still can be useful error response from the servers, lets get it
+      try (InputStream is = con.getErrorStream()) {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        log.debug("handleOutput - preparing to read error response body from {}", con.getURL());
+        copy(is, os);
+        errorResponseBody = os.toString(StandardCharsets.UTF_8);
+      } catch (Exception e2) {
+        log.warn("handleOutput - error retrieving error information", e2);
+      }
+      log.warn("handleOutput - error retrieving data", e);
+    }
+
+    if (responseCode == HttpURLConnection.HTTP_OK || responseCode == HttpURLConnection.HTTP_CREATED) {
+      log.debug("handleOutput - responseCode: {}, error response: {}", responseCode,
+          errorResponseBody);
+
+      if (responseBody == null || responseBody.isEmpty())
+        throw new IOException(String.format("The token endpoint response was unexpectedly empty despite response code %d from %s and error message %s",
+            responseCode, con.getURL(), formatErrorMessage(errorResponseBody)));
+
+      return responseBody;
+    } else {
+      log.warn("handleOutput - error response code: {}, error response body: {}", responseCode,
+          formatErrorMessage(errorResponseBody));
+
+      if (UNRETRYABLE_HTTP_CODES.contains(responseCode)) {
+        // We know that this is a non-transient error, so let's not keep retrying the
+        // request unnecessarily.
+        throw new UnretryableException(new IOException(String.format("The response code %s and error response %s was encountered reading the token endpoint response; will not attempt further retries",
+            responseCode, formatErrorMessage(errorResponseBody))));
+      } else {
+        // We don't know if this is a transient (retryable) error or not, so let's assume
+        // it is.
+        throw new IOException(String.format("The unexpected response code %s and error message %s was encountered reading the token endpoint response",
+            responseCode, formatErrorMessage(errorResponseBody)));
+      }
+    }
+  }
+
+  static void copy(InputStream is, OutputStream os) throws IOException {
+    byte[] buf = new byte[4096];
+    int b;
+
+    while ((b = is.read(buf)) != -1)
+      os.write(buf, 0, b);
+  }
+
+  static String formatErrorMessage(String errorResponseBody) {
+    // See https://www.ietf.org/rfc/rfc6749.txt, section 5.2 for the format
+    // of this error message.
+    if (errorResponseBody == null || errorResponseBody.trim().isEmpty()) {
+      return "{}";
+    }
+    ObjectMapper mapper = new ObjectMapper();
+    try {
+      JsonNode rootNode = mapper.readTree(errorResponseBody);
+      if (!rootNode.at("/error").isMissingNode()) {
+        return String.format("{%s - %s}", rootNode.at("/error"), rootNode.at("/error_description"));
+      } else if (!rootNode.at("/errorCode").isMissingNode()) {
+        return String.format("{%s - %s}", rootNode.at("/errorCode"), rootNode.at("/errorSummary"));
+      } else {
+        return errorResponseBody;
+      }
+    } catch (Exception e) {
+      log.warn("Error parsing error response", e);
+    }
+    return String.format("{%s}", errorResponseBody);
+  }
+
+  static String parseAccessToken(String responseBody) throws IOException {
+    ObjectMapper mapper = new ObjectMapper();
+    JsonNode rootNode = mapper.readTree(responseBody);
+    JsonNode accessTokenNode = rootNode.at("/access_token");
+
+    if (accessTokenNode == null) {
+      // Only grab the first N characters so that if the response body is huge, we don't
+      // blow up.
+      String snippet = responseBody;
+
+      if (snippet.length() > MAX_RESPONSE_BODY_LENGTH) {
+        int actualLength = responseBody.length();
+        String s = responseBody.substring(0, MAX_RESPONSE_BODY_LENGTH);
+        snippet = String.format("%s (trimmed to first %d characters out of %d total)", s, MAX_RESPONSE_BODY_LENGTH, actualLength);
+      }
+
+      throw new IOException(String.format("The token endpoint response did not contain an access_token value. Response: (%s)", snippet));
+    }
+
+    return sanitizeString("the token endpoint response's access_token JSON attribute", accessTokenNode.textValue());
+  }
+
+  static String formatAuthorizationHeader(String clientId, String clientSecret, boolean urlencode) {
+    clientId = sanitizeString("the token endpoint request client ID parameter", clientId);
+    clientSecret = sanitizeString("the token endpoint request client secret parameter", clientSecret);
+
+    // according to RFC-6749 clientId & clientSecret must be urlencoded, see https://tools.ietf.org/html/rfc6749#section-2.3.1
+    if (urlencode) {
+      clientId = URLEncoder.encode(clientId, StandardCharsets.UTF_8);
+      clientSecret = URLEncoder.encode(clientSecret, StandardCharsets.UTF_8);
+    }
+
+    String s = String.format("%s:%s", clientId, clientSecret);
+    // Per RFC-7617, we need to use the *non-URL safe* base64 encoder. See KAFKA-14496.
+    String encoded = Base64.getEncoder().encodeToString(Utils.utf8(s));
+    return String.format("Basic %s", encoded);
+  }
+
+  static String formatRequestBody(String scope) {
+    StringBuilder requestParameters = new StringBuilder();
+    requestParameters.append("grant_type=client_credentials");
+
+    if (scope != null && !scope.trim().isEmpty()) {
+      scope = scope.trim();
+      String encodedScope = URLEncoder.encode(scope, StandardCharsets.UTF_8);
+      requestParameters.append("&scope=").append(encodedScope);
+    }
+
+    return requestParameters.toString();
+  }
+
+  private static String sanitizeString(String name, String value) {
+    if (value == null)
+      throw new IllegalArgumentException(String.format("The value for %s must be non-null", name));
+
+    if (value.isEmpty())
+      throw new IllegalArgumentException(String.format("The value for %s must be non-empty", name));
+
+    value = value.trim();
+
+    if (value.isEmpty())
+      throw new IllegalArgumentException(String.format("The value for %s must not contain only whitespace", name));
+
+    return value;
+  }
+
+}

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/OauthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/OauthCredentialProvider.java
@@ -24,12 +24,10 @@ import java.util.Map;
 import javax.net.ssl.SSLSocketFactory;
 
 import org.apache.kafka.common.config.SaslConfigs;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtRetriever;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtValidator;
+import org.apache.kafka.common.security.oauthbearer.JwtRetriever;
+import org.apache.kafka.common.security.oauthbearer.JwtValidator;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.ConfigurationUtils;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.HttpJwtRetriever;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.JaasOptionsUtils;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.ClientJwtValidator;
 
 /**
  * <code>OAuthCredentialProvider</code> is a <code>BearerAuthCredentialProvider</code>
@@ -87,7 +85,6 @@ public class OauthCredentialProvider implements BearerAuthCredentialProvider {
   }
 
   private JwtRetriever getTokenRetriever(ConfigurationUtils cu) {
-
     String clientId = cu.validateString(SchemaRegistryClientConfig.BEARER_AUTH_CLIENT_ID);
     String clientSecret = cu.validateString(SchemaRegistryClientConfig.BEARER_AUTH_CLIENT_SECRET);
     String scope = cu.validateString(SchemaRegistryClientConfig.BEARER_AUTH_SCOPE, false);

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/SaslOauthCredentialProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/SaslOauthCredentialProvider.java
@@ -32,13 +32,11 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.security.JaasContext;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtRetriever;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtValidator;
+import org.apache.kafka.common.security.oauthbearer.JwtRetriever;
+import org.apache.kafka.common.security.oauthbearer.JwtValidator;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.ConfigurationUtils;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.HttpJwtRetriever;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.JaasOptionsUtils;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginCallbackHandler;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.ClientJwtValidator;
 
 @SuppressWarnings("checkstyle:ClassDataAbstractionCoupling")
 public class SaslOauthCredentialProvider implements BearerAuthCredentialProvider {

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/CachedOauthTokenRetrieverTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/security/bearerauth/oauth/CachedOauthTokenRetrieverTest.java
@@ -25,10 +25,10 @@ import io.confluent.kafka.schemaregistry.client.security.bearerauth.oauth.except
 import java.io.IOException;
 import java.util.Collections;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtRetriever;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.JwtValidator;
+import org.apache.kafka.common.security.oauthbearer.JwtRetriever;
+import org.apache.kafka.common.security.oauthbearer.JwtValidator;
 import org.apache.kafka.common.security.oauthbearer.internals.secured.BasicOAuthBearerToken;
-import org.apache.kafka.common.security.oauthbearer.internals.secured.ValidateException;
+import org.apache.kafka.common.security.oauthbearer.JwtValidatorException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -132,7 +132,7 @@ public class CachedOauthTokenRetrieverTest {
 
     String validationError = "Malformed JWT provided";
     when(tokenValidator.validate(tokenString1)).thenThrow(
-        new ValidateException(validationError));
+        new JwtValidatorException(validationError));
     Assert.assertThrows(validationError, SchemaRegistryOauthTokenRetrieverException.class, () -> {
       String token = cachedOauthTokenRetriever.getToken();
     });


### PR DESCRIPTION
What
----
Fix master SR oauth to handle AK changes(https://github.com/apache/kafka/commit/1e917906ab2abd87dbf5ae9aaec781538713cf27#diff-b10ee0ca11cf52cba982aee6e0516fd6149b67016257335378dfade05c1d219a). Since this break compatibility, this change pull the earlier versions of ClientJwtValidator and HttpJwtRetriever into the SR repository

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[ ]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes --> NO
- **[ ]** Is this change gated behind config(s)? NO, this is pull in Apache Kafka dependency
    - List the config(s) needed to be set to enable this change
- **[ ]** Did you add sufficient unit test and/or integration test coverage for this PR? Current test sufficient for this change
    - If not, please explain why it is not required
- **[ ]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations --> No
    - If so, include tracking information for the system test changes

References
----------
JIRA: https://confluentinc.atlassian.net/browse/INC-2987

Test & Review
------------
Existing unit tests and integration tests.
