### PR TITLE
Fix GroupRebalanceConfig to take in rack id as an optional arg 

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java
@@ -81,6 +81,7 @@ final class SchemaRegistryCoordinator extends AbstractCoordinator implements Clo
             heartbeatIntervalMs,
             groupId,
             Optional.empty(),
+            Optional.empty(),
             retryBackoffMs,
             retryBackoffMaxMs,
             true


### PR DESCRIPTION
AK changed the definition of this config - https://issues.apache.org/jira/browse/KAFKA-17747
https://github.com/apache/kafka/blame/trunk/clients/src/main/java/org/apache/kafka/clients/GroupRebalanceConfig.java#L74

