### PR TITLE
fix for javadoc failure

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchema.java
@@ -207,8 +207,8 @@ public interface ParsedSchema {
 
   /**
    * Checks the backward compatibility between this schema and the specified schema.
-   * <p/>
-   * Custom providers may choose to modify this schema during this check,
+   *
+   * <p>Custom providers may choose to modify this schema during this check,
    * to ensure that it is compatible with the specified schema.
    *
    * @param previousSchema previous schema
@@ -219,8 +219,8 @@ public interface ParsedSchema {
 
   /**
    * Checks the compatibility between this schema and the specified schemas.
-   * <p/>
-   * Custom providers may choose to modify this schema during this check,
+   *
+   * <p>Custom providers may choose to modify this schema during this check,
    * to ensure that it is compatible with the specified schemas.
    *
    * @param level the compatibility level

--- a/json-serializer/src/main/java/io/confluent/kafka/serializers/KafkaJsonDeserializerConfig.java
+++ b/json-serializer/src/main/java/io/confluent/kafka/serializers/KafkaJsonDeserializerConfig.java
@@ -24,7 +24,7 @@ import java.util.Map;
  * Deserializer configuration for {@link KafkaJsonDeserializer}. It's slightly odd
  * to have this extend {@link KafkaJsonDecoderConfig} (in most other cases the
  * Decoder variants extend from the Deserializer version), but the reason is that
- * {@link kafka.serializer.Decoder} doesn't provide the ability to distinguish
+ * {@link org.apache.kafka.tools.api.Decoder} doesn't provide the ability to distinguish
  * between constructing serializers for keys or for values. So the type configuration
  * options do not work with {@link KafkaJsonDecoder}.
  */


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
mvn -q -e  javadoc:javadoc pass locally 

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[n ]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[ n]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[n ]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[ n]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
