### PR TITLE
DGS-20986 - Modify POST /subjects lookup to fail only if both normalize=true fails

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -135,8 +135,8 @@ public class SubjectsResource {
       if (matchingSchema == null && !normalize) {
         log.debug("No matching schema found with normalize = false,"
                 + " retrying with normalize = true");
-      matchingSchema = schemaRegistry.lookUpSchemaUnderSubjectUsingContexts(
-            subject, schema, true, lookupDeletedSchema);
+        matchingSchema = schemaRegistry.lookUpSchemaUnderSubjectUsingContexts(
+              subject, schema, true, lookupDeletedSchema);
       }
 
       if (matchingSchema == null) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -121,11 +121,10 @@ public class SubjectsResource {
              subject, lookupDeletedSchema, request.getSchemaType());
 
     subject = QualifiedSubject.normalize(schemaRegistry.tenant(), subject);
-
     // returns version if the schema exists. Otherwise returns 404
     Schema schema = new Schema(subject, request);
     io.confluent.kafka.schemaregistry.client.rest.entities.Schema matchingSchema;
-    log.debug("normalize = {}", normalize);
+    log.info("normalize = {}", normalize);
     try {
       if (!normalize) {
         normalize = Boolean.TRUE.equals(schemaRegistry.getConfigInScope(subject).isNormalize());
@@ -133,9 +132,10 @@ public class SubjectsResource {
       matchingSchema = schemaRegistry.lookUpSchemaUnderSubjectUsingContexts(
           subject, schema, normalize, lookupDeletedSchema);
 
-      log.debug("Is matchingSchema null? = {}", matchingSchema == null);
+      log.info("Is matchingSchema null? = {}", matchingSchema == null);
       // If first attempt failed with normalize=false, try again with normalize=true
       if (matchingSchema == null && !normalize) {
+        log.info("No matching schema found with normalize = false, retrying with normalize = true");
         try {
           matchingSchema = schemaRegistry.lookUpSchemaUnderSubjectUsingContexts(
                 subject, schema, true, lookupDeletedSchema);
@@ -144,7 +144,7 @@ public class SubjectsResource {
         }
       }
 
-      log.debug("we have a matching schema with normalize : {} and {}",
+      log.info("we have a matching schema with normalize : {} and {}",
               matchingSchema, normalize);
 
       if (matchingSchema == null) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -124,7 +124,6 @@ public class SubjectsResource {
     // returns version if the schema exists. Otherwise returns 404
     Schema schema = new Schema(subject, request);
     io.confluent.kafka.schemaregistry.client.rest.entities.Schema matchingSchema;
-    log.info("normalize = {}", normalize);
     try {
       if (!normalize) {
         normalize = Boolean.TRUE.equals(schemaRegistry.getConfigInScope(subject).isNormalize());
@@ -132,10 +131,9 @@ public class SubjectsResource {
       matchingSchema = schemaRegistry.lookUpSchemaUnderSubjectUsingContexts(
           subject, schema, normalize, lookupDeletedSchema);
 
-      log.info("Is matchingSchema null? = {}", matchingSchema == null);
       // If first attempt failed with normalize=false, try again with normalize=true
       if (matchingSchema == null && !normalize) {
-        log.info("No matching schema found with normalize = false, retrying with normalize = true");
+        log.debug("No matching schema found with normalize = false, retrying with normalize = true");
         try {
           matchingSchema = schemaRegistry.lookUpSchemaUnderSubjectUsingContexts(
                 subject, schema, true, lookupDeletedSchema);
@@ -143,9 +141,6 @@ public class SubjectsResource {
           throw e;
         }
       }
-
-      log.info("we have a matching schema with normalize : {} and {}",
-              matchingSchema, normalize);
 
       if (matchingSchema == null) {
         if (!schemaRegistry.hasSubjects(subject, lookupDeletedSchema)) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -133,7 +133,8 @@ public class SubjectsResource {
 
       // If first attempt failed with normalize=false, try again with normalize=true
       if (matchingSchema == null && !normalize) {
-        log.debug("No matching schema found with normalize = false, retrying with normalize = true");
+        log.debug("No matching schema found with normalize = false,"
+                + " retrying with normalize = true");
         try {
           matchingSchema = schemaRegistry.lookUpSchemaUnderSubjectUsingContexts(
                 subject, schema, true, lookupDeletedSchema);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -135,12 +135,8 @@ public class SubjectsResource {
       if (matchingSchema == null && !normalize) {
         log.debug("No matching schema found with normalize = false,"
                 + " retrying with normalize = true");
-        try {
-          matchingSchema = schemaRegistry.lookUpSchemaUnderSubjectUsingContexts(
-                subject, schema, true, lookupDeletedSchema);
-        } catch (SchemaRegistryException e) {
-          throw e;
-        }
+      matchingSchema = schemaRegistry.lookUpSchemaUnderSubjectUsingContexts(
+            subject, schema, true, lookupDeletedSchema);
       }
 
       if (matchingSchema == null) {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -1425,6 +1425,39 @@ public class RestApiTest extends ClusterTestHarness {
   }
 
   @Test
+  public void testLookUpSchemaWithNormalizationRetry() throws Exception {
+      String subject = "testSubject";
+
+      String schemaString1 = "{\"type\":\"record\",\"name\":\"User\",\"fields\":[{\"name\":\"id\",\"type\":\"int\"},{\"name\":\"email4\",\"type\":\"string\"}]}";
+  
+      // Register the original schema
+      TestUtils.registerAndVerifySchema(restApp.restClient, schemaString1, 1, subject);
+  
+      // Same schema with different field ordering (semantically equivalent)
+      String schemaString2 = "{\"type\":\"record\",\"name\":\"User\",\"fields\":[{\"type\":\"int\",\"name\":\"id\"},{\"type\":\"string\",\"name\":\"email4\"}]}";
+  
+      RegisterSchemaRequest request = new RegisterSchemaRequest();
+      request.setSchema(schemaString2);
+
+      io.confluent.kafka.schemaregistry.client.rest.entities.Schema schema = 
+          restApp.restClient.lookUpSubjectVersion(request, subject, false, false);
+      assertNotNull(schema);
+      assertEquals(1, schema.getVersion().intValue());
+
+      // Different schema with different field name (not semantically equivalent)
+      String invalidSchema = "{\"type\":\"record\",\"name\":\"User\",\"fields\":[{\"type\":\"int\",\"name\":\"id\"},{\"type\":\"string\",\"name\":\"email6\"}]}";
+      request.setSchema(invalidSchema);
+  
+      // Should fail since schemas are actually different
+      try {
+          restApp.restClient.lookUpSubjectVersion(request, subject, true, false);
+          fail("Should fail as schemas are not semantically equivalent");
+      } catch (RestClientException e) {
+          assertEquals(Errors.SCHEMA_NOT_FOUND_ERROR_CODE, e.getErrorCode());
+      }
+  }
+
+  @Test
   public void testBad() throws Exception {
     String subject1 = "testTopic1";
     List<String> allSubjects = new ArrayList<>();


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
This PR modifies the POST /subjects lookup to handle cases where a client might register a schema with normalize=true while the lookup request is made with normalize=false.

Previously, if a lookup failed with `normalize=false`, the API would immediately return an error. This commit changes that logic. It will now only fail the lookup if it fails with both normalize=false and normalize=true. This ensures that clients, like kSQL, can successfully find schemas that were registered using a different normalization setting.

The new logic is:

1. If a lookup fails with normalize=false, the API will automatically try the lookup again with normalize=true.
2. If the lookup fails with normalize=true, the API will then return an error, as this confirms the schema is genuinely not found under either normalization setting.

<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[n]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[ ]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[ ]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
https://confluentinc.atlassian.net/browse/DGS-20986
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->
I've tested the new lookup logic with two scenarios:

1. Semantically Equivalent Schema: I registered a schema, then changed the field ordering and performed a lookup with normalize=false. As expected, this initial lookup failed. The system then automatically retried with normalize=true and successfully found the schema.

2. Semantically Different Schema: I attempted a lookup with normalize=true using a semantically different schema. This correctly failed, as the system should not find a match.

This behavior is also fully expressed and validated in the unit test cases.

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
