### PR TITLE
feat(avro-serializer): Allow providing a custom DatumWriter in AbstractKafkaAvroSerializer

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -209,12 +209,16 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
           throws ExecutionException, IOException {
     BinaryEncoder encoder = encoderFactory.directBinaryEncoder(out, null);
 
-    DatumWriter<Object> writer;
-    writer = datumWriterCache.get(rawSchema,
+    DatumWriter<Object> writer = getDatumWriter();
+    writer.write(value, encoder);
+    encoder.flush();
+  }
+
+  protected DatumWriter<?> getDatumWriter(Schema rawSchema)
+            throws ExecutionException, IOException {
+    return datumWriterCache.get(rawSchema,
         () -> (DatumWriter<Object>) AvroSchemaUtils.getDatumWriter(
             value, rawSchema, avroUseLogicalTypeConverters, avroReflectionAllowNull)
     );
-    writer.write(value, encoder);
-    encoder.flush();
   }
 }


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
I'm the maintainer of Avro4k, a kotlin library allowing (de)serializing kotlin classes to avro bytes, and I'm currently working on integrating it with the confluent schema registry: https://github.com/avro-kotlin/avro4k/issues/218.
There is currently a kind of a mapper implemented to convert kotlin classes to Generic data, then we can use the converted data in the standard apache's library, and vice-versa, to then be used with the `kafka-avro-serializer`. However, doing that is twice less performant, and I would like to directly (de)serialize without this conversion step. Also, this conversion is mainly used to comply with the confluent's serializer, so thanks to this PR, I could remove around 1/3 of the current main codebase.

I would like to make possible providing a custom `DatumWriter` in `AbstractKafkaAvroSerializer`, the same way we can provide a custom `DatumReader` in `AbstractKafkaAvroDeserializer`.

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[N]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes
    - **No breaking change**, just a new protected method to allow override it
- **[N]** Is this change gated behind config(s)?
    - No config to do
- **[N]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required: Not sure if a test is fully relevant here.
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->
N/A

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->
I hesitated to just make protected `writeDatum`, but I felt more consistent to expose `getDatumWriter` the same way as `getDatumReader` in the deserializer.

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
