### PR TITLE
add sr-version to sr client API

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -20,6 +20,7 @@ import com.google.common.base.Ticker;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableMap;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaRegistryServerVersion;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
@@ -832,6 +833,12 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
   public SchemaRegistryDeployment getSchemaRegistryDeployment() 
       throws IOException, RestClientException {
     return restService.getSchemaRegistryDeployment();
+  }
+
+  @Override
+  public SchemaRegistryServerVersion getSchemaRegistryServerVersion()
+      throws IOException, RestClientException {
+    return restService.getSchemaRegistryServerVersion();
   }
 
   @Override

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java
@@ -23,6 +23,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.Config;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaRegistryDeployment;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaRegistryServerVersion;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import java.io.Closeable;
 import java.io.IOException;
@@ -280,6 +281,11 @@ public interface SchemaRegistryClient extends Closeable, SchemaVersionFetcher {
   }
 
   default SchemaRegistryDeployment getSchemaRegistryDeployment() 
+      throws IOException, RestClientException {
+    throw new UnsupportedOperationException();
+  }
+
+  default SchemaRegistryServerVersion getSchemaRegistryServerVersion()
       throws IOException, RestClientException {
     throw new UnsupportedOperationException();
   }

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClientTest.java
@@ -20,6 +20,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.FakeTicker;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaRegistryDeployment;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaRegistryServerVersion;
+import java.util.ArrayList;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -721,6 +724,44 @@ public class CachedSchemaRegistryClientTest {
     fakeTicker.advance(2, TimeUnit.SECONDS);
     Thread.sleep(100);
     client.getId(SUBJECT_0, AVRO_SCHEMA_0);
+  }
+
+  @Test
+  public void testGetSchemaRegistryDeployment() throws Exception {
+    List<String> deploymentAttributes = new ArrayList<>(Collections.singleton("deploymentScope:opensource"));
+    SchemaRegistryDeployment expectedDeployment = new SchemaRegistryDeployment(deploymentAttributes);
+
+    expect(restService.getSchemaRegistryDeployment())
+        .andReturn(expectedDeployment);
+
+    replay(restService);
+
+    SchemaRegistryDeployment deployment = client.getSchemaRegistryDeployment();
+
+    assertNotNull(deployment);
+    assertEquals(expectedDeployment.getAttributes(), deployment.getAttributes());
+
+    verify(restService);
+  }
+
+  @Test
+  public void testGetSchemaRegistryServerVersion() throws Exception {
+    String version = "7.5.0";
+    String commitId = "abc123def456";
+    SchemaRegistryServerVersion expectedVersion = new SchemaRegistryServerVersion(version, commitId);
+
+    expect(restService.getSchemaRegistryServerVersion())
+        .andReturn(expectedVersion);
+
+    replay(restService);
+
+    SchemaRegistryServerVersion serverVersion = client.getSchemaRegistryServerVersion();
+
+    assertNotNull(serverVersion);
+    assertEquals(version, serverVersion.getVersion());
+    assertEquals(commitId, serverVersion.getCommitId());
+
+    verify(restService);
   }
 
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/client/LocalSchemaRegistryClient.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/client/LocalSchemaRegistryClient.java
@@ -662,6 +662,7 @@ public class LocalSchemaRegistryClient implements SchemaRegistryClient {
     return Props.getSchemaRegistryDeployment(schemaRegistry.properties());
   }
 
+  @Override
   public SchemaRegistryServerVersion getSchemaRegistryServerVersion()
       throws IOException, RestClientException {
     return new SchemaRegistryServerVersion(AppInfoParser.getVersion(), AppInfoParser.getCommitId());

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/client/LocalSchemaRegistryClient.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/client/LocalSchemaRegistryClient.java
@@ -29,6 +29,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.Config;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaRegistryDeployment;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaRegistryServerVersion;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
@@ -49,6 +50,7 @@ import io.confluent.kafka.schemaregistry.exceptions.UnknownLeaderException;
 import io.confluent.kafka.schemaregistry.rest.VersionId;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidCompatibilityException;
+import io.confluent.kafka.schemaregistry.utils.AppInfoParser;
 import io.confluent.kafka.schemaregistry.utils.Props;
 import io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidModeException;
 import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
@@ -66,6 +68,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.apache.kafka.common.utils.AppInfoParser.AppInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -657,6 +660,11 @@ public class LocalSchemaRegistryClient implements SchemaRegistryClient {
   public SchemaRegistryDeployment getSchemaRegistryDeployment() 
       throws IOException, RestClientException {
     return Props.getSchemaRegistryDeployment(schemaRegistry.properties());
+  }
+
+  public SchemaRegistryServerVersion getSchemaRegistryServerVersion()
+      throws IOException, RestClientException {
+    return new SchemaRegistryServerVersion(AppInfoParser.getVersion(), AppInfoParser.getCommitId());
   }
 
   @Override

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/utils/Props.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/utils/Props.java
@@ -36,7 +36,7 @@ public class Props {
       List<?> srDeploymentList = (List<?>) srDeployment;
       // Validate and process each element
       List<String> processedList = srDeploymentList.stream().map(
-          item -> item.toString().trim().toLowerCase()
+          item -> item.toString().trim()
       ).collect(Collectors.toList());
       return new SchemaRegistryDeployment(processedList);
     } else {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/client/LocalSchemaRegistryClientTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/client/LocalSchemaRegistryClientTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rest.client;
+
+import static io.confluent.kafka.schemaregistry.storage.SchemaRegistry.DEFAULT_TENANT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+
+import io.confluent.kafka.schemaregistry.SchemaProvider;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaRegistryDeployment;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaRegistryServerVersion;
+import io.confluent.kafka.schemaregistry.storage.KafkaSchemaRegistry;
+import io.confluent.kafka.schemaregistry.utils.Props;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LocalSchemaRegistryClientTest {
+
+  @Mock
+  private KafkaSchemaRegistry mockSchemaRegistry;
+
+  @Mock
+  private SchemaProvider mockSchemaProvider;
+
+  @Mock
+  private AvroSchemaProvider mockAvroProvider;
+
+  private LocalSchemaRegistryClient client;
+  private String testSchemaString;
+
+  @Before
+  public void setUp() {
+    when(mockSchemaRegistry.tenant()).thenReturn(DEFAULT_TENANT);
+    client = new LocalSchemaRegistryClient(mockSchemaRegistry);
+  }
+
+  @Test
+  public void testGetSchemaRegistryDeployment() throws Exception {
+    Map<String, Object> props = new HashMap<>();
+    List<String> deploymentAttributes = new ArrayList<String>(Collections.singleton("deploymentScope:opensource"));
+    props.put(Props.PROPERTY_SCHEMA_REGISTRY_DEPLOYMENT_ATTRIBUTES, deploymentAttributes);
+    when(mockSchemaRegistry.properties()).thenReturn(props);
+
+    SchemaRegistryDeployment deployment = client.getSchemaRegistryDeployment();
+
+    assertNotNull(deployment);
+    assertEquals(deployment.getAttributes(),
+        new ArrayList<String>(Collections.singleton("deploymentScope:opensource"))
+    );
+  }
+
+  @Test
+  public void testGetSchemaRegistryServerVersion() throws Exception {
+    SchemaRegistryServerVersion version = client.getSchemaRegistryServerVersion();
+
+    assertNotNull(version);
+    assertNotNull(version.getVersion());
+    assertNotNull(version.getCommitId());
+  }
+}


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
No breaking changes, adding an existing endpoint to the client interface and implementing in local and cached clients.

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[ Y ]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[ N ]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[ Y ]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[ N ]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[ N ]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->
Adding existing sr version GET to clients for easier access.
https://confluentinc.atlassian.net/browse/DGS-21658

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->
The new code was tested using unit tests.

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->
NA
