### PR TITLE
Add Confluent Cloud promotional banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Try Confluent Cloud - The Data Streaming Platform](https://images.ctfassets.net/8vofjvai1hpv/10bgcSfn5MzmvS4nNqr94J/af43dd2336e3f9e0c0ca4feef4398f6f/confluent-banner-v2.svg)](https://confluent.cloud/signup?utm_source=github&utm_medium=banner&utm_campaign=oss-repos&utm_term=schema-registry)
+
 Schema Registry
 ================
 


### PR DESCRIPTION
## Summary
- Adds promotional banner for Confluent Cloud at the top of README
- Banner includes call-to-action for $400 free credits
- Uses centrally managed SVG from Contentful CMS

## Changes
- Added banner as first element in README
- Includes UTM parameters for tracking (utm_term=schema-registry)