### PR TITLE
DeleteSubject message handler should only delete non-deleted versions

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaStoreMessageHandler.java
@@ -152,7 +152,7 @@ public class KafkaStoreMessageHandler implements SchemaUpdateHandler {
 
         SchemaKey schemaKey = new SchemaKey(subject, version);
         SchemaValue schemaValue = (SchemaValue) this.lookupCache.get(schemaKey);
-        if (schemaValue != null) {
+        if (schemaValue != null && !schemaValue.isDeleted()) {
           schemaValue.setDeleted(true);
           SchemaValue oldSchemaValue = (SchemaValue) lookupCache.put(schemaKey, schemaValue);
           lookupCache.schemaDeleted(schemaKey, schemaValue, oldSchemaValue);


### PR DESCRIPTION
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
Minor change to prevent `lookup.schemaDeleted()` from being called on schemas that are already soft-deleted.

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[N]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA: [DGS-22102](https://confluentinc.atlassian.net/browse/DGS-22102)
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
