### PR TITLE
avoid extra copying in protobuf serializer

### DIFF
--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufSerializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufSerializer.java
@@ -165,10 +165,8 @@ public abstract class AbstractKafkaProtobufSerializer<T extends Message>
       MessageIndexes indexes = schema.toMessageIndexes(
           object.getDescriptorForType().getFullName(), normalizeSchema);
       schemaId.setMessageIndexes(indexes.indexes());
-      try (SchemaIdSerializer schemaIdSerializer = schemaIdSerializer(isKey);
-          ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-        object.writeTo(baos);
-        byte[] payload = baos.toByteArray();
+      try (SchemaIdSerializer schemaIdSerializer = schemaIdSerializer(isKey)) {
+        byte[] payload = object.toByteArray();
         payload = (byte[]) executeRules(
             subject, topic, headers, payload, RulePhase.ENCODING, RuleMode.WRITE, null,
             schema, payload

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufSerializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufSerializer.java
@@ -31,7 +31,6 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.errors.SerializationException;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
i noted that the destination type for protobuf is byte[] and that the Message.toByteArray() is optimized for this use case. the ByteArrayOutputStream can/would resize its underlying buffer and the resulting byte array was copied out of its internal buffer. this solution should be cleaner and faster since it eliminates possible resizing and intermediate copying.

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[N]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[N/A]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA: N/A
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->
i was reading through the recent changes related to encryption in https://github.com/confluentinc/schema-registry/pull/3777 and i feel that we could get some good performance if we used an OutputStream approach. that is, we have one outputstream for the actual object serialization (much like that writeTo that is currently done), then that stream feeds optionally into something that does that streaming encryption. additionally, the PrefixSchemaIdSerializer could write its prefix to a single outer ByteArrayOutputStream. also should we use a pooled version of ByteArrayOutputStream. consider this illustration:

```java
ByteArrayOutputStream baos = new ByteArrayOutputStream(); // maybe implement with a pool?
try(OutputStream os = maybeEncryptingOutputStream(schemaIdSerializer.maybePrefixOutputStream(baos))) {
    object.writeTo(os);
}
return baos.toByteArray();
```

but this would require some work and some more investigation along with being beyond the scope of this pr.

here is a memory flame/icicle chart of my use case

<img width="1969" height="419" alt="image" src="https://github.com/user-attachments/assets/042f4680-eb8e-4ff1-98d9-b62ad98d8bc4" />

more immediately: i may try to see if the messageIndices and guid can be cached more, but i will save that for a separate pr.

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
