### PR TITLE
Fix SchemaRegistryCoordinator based on upstream Kafka changes

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/SchemaRegistryCoordinator.java
@@ -83,8 +83,7 @@ final class SchemaRegistryCoordinator extends AbstractCoordinator implements Clo
             Optional.empty(),
             "",
             retryBackoffMs,
-            retryBackoffMaxMs,
-            true
+            retryBackoffMaxMs
         ),
         logContext,
         client,


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Fix SchemaRegistryCoordinator based on upstream Kafka changes to GroupRebalanceConfig: https://github.com/apache/kafka/pull/19400

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[N]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[N]** Did you add sufficient unit test and/or integration test coverage for this PR? Existing SchemaRegistryCoordinator covers this class
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

Test & Review
------------
- Unit tests and integration tests

