### PR TITLE
DGS-22519 Replace add() with put() in getHeaders to overwrite them

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/MutableRequest.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/MutableRequest.java
@@ -43,7 +43,7 @@ public final class MutableRequest extends Request.Wrapper {
     for (String key : customHeaders.keySet()) {
       List<String> values = customHeaders.get(key);
       for (String value : values) {
-        httpFields.add(key, value);
+        httpFields.put(key, value);
       }
     }
     return httpFields;


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Replace add() with put() in getHeaders to overwrite them. As per mutable request contract, we should be overwriting them

```
  /**
   * Puts a new header will take precedence over existing header in the HttpServletRequest object.
   */
  public void putHeader(String name, String value) {
    // Value will also overwrite any existing custom header value.
    this.customHeaders.putSingle(name, value);
  }
```

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[N]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA: https://confluentinc.atlassian.net/browse/DGS-22519

Test & Review
------------
- Unit tests
