### PR TITLE
DGS-22600 Ensure canonicalString() method is thread-safe

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
@@ -251,6 +251,7 @@ public class AvroSchema implements ParsedSchema {
       return null;
     }
     if (canonicalString == null) {
+      // Use double-checked locking to avoid unnecessary synchronization
       synchronized (this) {
         if (canonicalString == null) {
           Schema.Parser parser = getParser();

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -347,6 +347,7 @@ public class JsonSchema implements ParsedSchema {
       return null;
     }
     if (canonicalString == null) {
+      // Use double-checked locking to avoid unnecessary synchronization
       synchronized (this) {
         if (canonicalString == null) {
           try {

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -1943,6 +1943,7 @@ public class ProtobufSchema implements ParsedSchema {
       return null;
     }
     if (canonicalString == null) {
+      // Use double-checked locking to avoid unnecessary synchronization
       synchronized (this) {
         if (canonicalString == null) {
           canonicalString = ProtobufSchemaUtils.toString(schemaObj);


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Ensure canonicalString() method is thread-safe by using double-checked locking
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[N]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - Covered by existing tests
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
