### PR TITLE
DGS-22434 Add support for recursive mode delete

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -1117,9 +1117,23 @@ public class RestService implements Closeable, Configurable {
 
   public Mode deleteSubjectMode(Map<String, String> requestProperties, String subject)
       throws IOException, RestClientException {
+    return deleteSubjectMode(requestProperties, subject, false);
+  }
+
+  public Mode deleteSubjectMode(Map<String, String> requestProperties, String subject,
+                                boolean recursive)
+      throws IOException, RestClientException {
+    UriBuilder builder = subject != null
+            ? UriBuilder.fromPath("/mode/{subject}")
+            : UriBuilder.fromPath("/mode");
+
+    if (recursive) {
+      builder.queryParam("recursive", "true");
+    }
+
     String path = subject != null
-            ? UriBuilder.fromPath("/mode/{subject}").build(subject).toString()
-            : "/mode";
+            ? builder.build(subject).toString()
+            : builder.build().toString();
 
     Mode response = httpRequest(path, "DELETE", null, requestProperties,
         DELETE_SUBJECT_MODE_RESPONSE_TYPE);

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
@@ -362,6 +362,19 @@ public class QualifiedSubject implements Comparable<QualifiedSubject> {
   }
 
   /**
+   * Checks if the given qualified subject represents a context (i.e., has no subject part).
+   * A context has the format ":.context:" with an empty subject part, or null for default context.
+   *
+   * @param tenant the tenant
+   * @param qualifiedSubject the subject with a tenant prefix
+   * @return true if the qualified subject is a context, false otherwise
+   */
+  public static boolean isContext(String tenant, String qualifiedSubject) {
+    QualifiedSubject qs = QualifiedSubject.create(tenant, qualifiedSubject);
+    return qs == null || qs.getSubject().isEmpty();
+  }
+
+  /**
    * Checks if the given qualified subject is the default context for the given tenant.
    * The default context is the context with name "." and an empty subject.
    *
@@ -456,4 +469,3 @@ public class QualifiedSubject implements Comparable<QualifiedSubject> {
     }
   }
 }
-

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -15,6 +15,8 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
+import static io.confluent.kafka.schemaregistry.utils.QualifiedSubject.CONTEXT_DELIMITER;
+import static io.confluent.kafka.schemaregistry.utils.QualifiedSubject.CONTEXT_PREFIX;
 import static io.confluent.kafka.schemaregistry.utils.QualifiedSubject.DEFAULT_CONTEXT;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -64,6 +66,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -993,13 +996,15 @@ public class KafkaSchemaRegistry extends AbstractSchemaRegistry implements
 
   private void forwardDeleteSubjectModeRequestToLeader(
       String subject,
+      boolean recursive,
       Map<String, String> headerProperties)
       throws SchemaRegistryRequestForwardingException {
     UrlList baseUrl = leaderRestService.getBaseUrls();
 
-    log.debug("Forwarding delete subject mode request {} to {}", subject, baseUrl);
+    log.debug("Forwarding delete subject mode request {} to {} with recursive={}",
+        subject, baseUrl, recursive);
     try {
-      leaderRestService.deleteSubjectMode(headerProperties, subject);
+      leaderRestService.deleteSubjectMode(headerProperties, subject, recursive);
     } catch (IOException e) {
       throw new SchemaRegistryRequestForwardingException(
           String.format(
@@ -1247,37 +1252,117 @@ public class KafkaSchemaRegistry extends AbstractSchemaRegistry implements
 
   public void deleteSubjectMode(String subject)
       throws SchemaRegistryStoreException, OperationNotPermittedException {
+    deleteSubjectMode(subject, false);
+  }
+
+  public void deleteSubjectMode(String subject, boolean recursive)
+      throws SchemaRegistryStoreException, OperationNotPermittedException {
     if (!allowModeChanges) {
       throw new OperationNotPermittedException("Mode changes are not allowed");
     }
     try {
       kafkaStore.waitUntilKafkaReaderReachesLastOffset(subject, kafkaStoreTimeoutMs);
       deleteMode(subject);
+
+      // If recursive and subject is a context, delete modes for all subjects under it
+      if (recursive && QualifiedSubject.isContext(tenant(), subject)) {
+        log.info("Recursively deleting mode for all subjects under context: {}", subject);
+        try {
+          deleteModesForSubjectsUnderContext(subject);
+        } catch (SchemaRegistryException e) {
+          throw new SchemaRegistryStoreException(
+              "Failed to recursively delete modes for subjects under context", e);
+        }
+      }
     } catch (StoreException e) {
       throw new SchemaRegistryStoreException("Failed to delete subject config value from store",
           e);
     }
   }
 
-  public void deleteSubjectModeOrForward(String subject, Map<String, String> headerProperties)
+  public void deleteSubjectModeOrForward(String subject, boolean recursive,
+                                         Map<String, String> headerProperties)
       throws SchemaRegistryStoreException, SchemaRegistryRequestForwardingException,
       OperationNotPermittedException, UnknownLeaderException {
     kafkaStore.lockFor(subject).lock();
     try {
       if (isLeader()) {
-        deleteSubjectMode(subject);
+        // Delete the subject/context mode itself (and recursively if requested)
+        deleteSubjectMode(subject, recursive);
       } else {
-        // forward delete subject config request to the leader
+        // forward delete subject mode request to the leader (with recursive flag)
         if (leaderIdentity != null) {
-          forwardDeleteSubjectModeRequestToLeader(subject, headerProperties);
+          forwardDeleteSubjectModeRequestToLeader(subject, recursive, headerProperties);
         } else {
-          throw new UnknownLeaderException("Delete config request failed since leader is "
+          throw new UnknownLeaderException("Delete mode request failed since leader is "
               + "unknown");
         }
       }
     } finally {
       kafkaStore.lockFor(subject).unlock();
     }
+  }
+
+  /**
+   * List all subjects that have a mode configured under the given prefix.
+   * This is different from listSubjectsWithPrefix which only returns subjects with schemas.
+   *
+   * @param prefix The subject prefix to match (e.g., ":.context:" for a context)
+   * @return Set of subject names that have modes configured under the prefix
+   * @throws SchemaRegistryException if there's an error accessing the store
+   */
+  private Set<String> listSubjectsWithModePrefix(String prefix)
+      throws SchemaRegistryException {
+    try {
+      ModeKey startKey = new ModeKey(prefix + Character.MIN_VALUE);
+      ModeKey endKey = new ModeKey(prefix + Character.MAX_VALUE);
+
+      Set<String> subjects = new LinkedHashSet<>();
+      try (CloseableIterator<SchemaRegistryValue> iterator =
+               kafkaStore.getAll(startKey, endKey)) {
+        while (iterator.hasNext()) {
+          SchemaRegistryValue value = iterator.next();
+          if (value instanceof ModeValue) {
+            ModeValue modeValue = (ModeValue) value;
+            String subject = modeValue.getSubject();
+            // Only include subjects that match our prefix
+            if (subject != null && subject.startsWith(prefix)) {
+              subjects.add(subject);
+            }
+          }
+        }
+      }
+      return subjects;
+    } catch (StoreException e) {
+      throw new SchemaRegistryStoreException(
+          "Error while retrieving subjects with modes under prefix: " + prefix, e);
+    }
+  }
+
+  private void deleteModesForSubjectsUnderContext(String context)
+      throws SchemaRegistryException {
+    // Context is already normalized and includes the trailing delimiter
+    // For default context: context would be like ":tenant:"
+    // For named context: context would be like ":.production:"
+    String subjectPrefix = context != null ? context :
+            QualifiedSubject.normalize(tenant(), CONTEXT_PREFIX + CONTEXT_DELIMITER);
+
+    // Get all subjects with modes under this context
+    // This includes subjects that have modes set but no schemas registered
+    Set<String> subjects = listSubjectsWithModePrefix(subjectPrefix);
+
+    log.info("Found {} subjects with modes under context '{}' for recursive mode deletion with"
+                    +  " subjectPrefix={}", subjects.size(), context, subjectPrefix);
+
+    // Delete mode for each subject (locally on leader)
+    int successCount = 0;
+    for (String subjectName : subjects) {
+      log.debug("Deleting mode for subject: {}", subjectName);
+      deleteSubjectMode(subjectName);
+      successCount++;
+    }
+
+    log.info("Recursive mode deletion completed successfully for {} subjects", successCount);
   }
 
   @Override

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
@@ -263,6 +263,9 @@ public interface SchemaRegistry extends SchemaVersionFetcher {
   void deleteSubjectMode(String subject) throws SchemaRegistryStoreException,
           OperationNotPermittedException;
 
+  void deleteSubjectMode(String subject, boolean recursive) throws SchemaRegistryStoreException,
+          OperationNotPermittedException;
+
   RuleSetHandler getRuleSetHandler();
 
   void setRuleSetHandler(RuleSetHandler ruleSetHandler);
@@ -297,7 +300,8 @@ public interface SchemaRegistry extends SchemaVersionFetcher {
     return null;
   }
 
-  default void deleteSubjectModeOrForward(String subject, Map<String, String> headerProperties)
+  default void deleteSubjectModeOrForward(String subject, boolean recursive,
+                                          Map<String, String> headerProperties)
           throws SchemaRegistryStoreException, SchemaRegistryRequestForwardingException,
           OperationNotPermittedException, UnknownLeaderException {}
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiModeTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiModeTest.java
@@ -699,4 +699,425 @@ public class RestApiModeTest extends ClusterTestHarness {
             globalMode,
             restApp.restClient.getMode(subject, true).getMode());
   }
+
+  @Test
+  public void testRecursiveDeleteContextMode() throws Exception {
+    String context = ":.mycontext:";
+    String subject1 = ":.mycontext:subject1";
+    String subject2 = ":.mycontext:subject2";
+    String subject3 = ":.mycontext:subject3";
+    String mode = "READONLY";
+
+    // set mode for context
+    assertEquals(
+            mode,
+            restApp.restClient.setMode(mode, context).getMode());
+
+    // set mode for subjects under the context
+    assertEquals(
+            mode,
+            restApp.restClient.setMode(mode, subject1).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.setMode(mode, subject2).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.setMode(mode, subject3).getMode());
+
+    // verify modes are set
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(context, false).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(subject1, false).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(subject2, false).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(subject3, false).getMode());
+
+    // recursive delete context mode
+    Mode deletedMode = restApp.restClient.deleteSubjectMode(Collections.emptyMap(), context, true);
+    assertEquals(
+            mode,
+            deletedMode.getMode(),
+            "Deleted mode should return the old context mode");
+
+    // verify context mode is deleted
+    try {
+      restApp.restClient.getMode(context, false);
+      fail("Should throw exception for deleted context mode");
+    } catch (RestClientException e) {
+      assertEquals(40409, e.getErrorCode(),
+              "Should get mode not configured error");
+    }
+
+    // verify all subject modes under the context are also deleted
+    try {
+      restApp.restClient.getMode(subject1, false);
+      fail("Should throw exception for deleted subject1 mode");
+    } catch (RestClientException e) {
+      assertEquals(40409, e.getErrorCode(),
+              "Should get mode not configured error");
+    }
+
+    try {
+      restApp.restClient.getMode(subject2, false);
+      fail("Should throw exception for deleted subject2 mode");
+    } catch (RestClientException e) {
+      assertEquals(40409, e.getErrorCode(),
+              "Should get mode not configured error");
+    }
+
+    try {
+      restApp.restClient.getMode(subject3, false);
+      fail("Should throw exception for deleted subject3 mode");
+    } catch (RestClientException e) {
+      assertEquals(40409, e.getErrorCode(),
+              "Should get mode not configured error");
+    }
+  }
+
+  @Test
+  public void testNonRecursiveDeleteContextModeDoesNotAffectSubjects() throws Exception {
+    String context = ":.mycontext:";
+    String subject1 = ":.mycontext:subject1";
+    String subject2 = ":.mycontext:subject2";
+    String mode = "READONLY";
+
+    // set mode for context
+    assertEquals(
+            mode,
+            restApp.restClient.setMode(mode, context).getMode());
+
+    // set mode for subjects under the context
+    assertEquals(
+            mode,
+            restApp.restClient.setMode(mode, subject1).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.setMode(mode, subject2).getMode());
+
+    // verify modes are set
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(context, false).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(subject1, false).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(subject2, false).getMode());
+
+    // non-recursive delete context mode (recursive = false)
+    Mode deletedMode = restApp.restClient.deleteSubjectMode(Collections.emptyMap(), context, false);
+    assertEquals(
+            mode,
+            deletedMode.getMode(),
+            "Deleted mode should return the old context mode");
+
+    // verify context mode is deleted
+    try {
+      restApp.restClient.getMode(context, false);
+      fail("Should throw exception for deleted context mode");
+    } catch (RestClientException e) {
+      assertEquals(40409, e.getErrorCode(),
+              "Should get mode not configured error");
+    }
+
+    // verify subject modes are NOT deleted (still exist)
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(subject1, false).getMode(),
+            "Subject1 mode should still exist");
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(subject2, false).getMode(),
+            "Subject2 mode should still exist");
+  }
+
+  @Test
+  public void testRecursiveDeleteGlobalMode() throws Exception {
+    String subject1 = "subject1";
+    String subject2 = "subject2";
+    String subject3 = "subject3";
+    String mode = "READONLY";
+
+    // set global mode
+    assertEquals(
+            mode,
+            restApp.restClient.setMode(mode).getMode());
+
+    // set mode for subjects in default context
+    assertEquals(
+            mode,
+            restApp.restClient.setMode(mode, subject1).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.setMode(mode, subject2).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.setMode(mode, subject3).getMode());
+
+    // verify modes are set
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(null, false).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(subject1, false).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(subject2, false).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(subject3, false).getMode());
+
+    // recursive delete global mode
+    Mode deletedMode = restApp.restClient.deleteSubjectMode(Collections.emptyMap(), null, true);
+    assertEquals(
+            mode,
+            deletedMode.getMode(),
+            "Deleted mode should return the old global mode");
+
+    // verify global mode is deleted (reverts to default)
+    assertEquals(
+            "READWRITE",
+            restApp.restClient.getMode(null, false).getMode(),
+            "Global mode should revert to default READWRITE");
+
+    // verify all subject modes in default context are also deleted
+    try {
+      restApp.restClient.getMode(subject1, false);
+      fail("Should throw exception for deleted subject1 mode");
+    } catch (RestClientException e) {
+      assertEquals(40409, e.getErrorCode(),
+              "Should get mode not configured error");
+    }
+
+    try {
+      restApp.restClient.getMode(subject2, false);
+      fail("Should throw exception for deleted subject2 mode");
+    } catch (RestClientException e) {
+      assertEquals(40409, e.getErrorCode(),
+              "Should get mode not configured error");
+    }
+
+    try {
+      restApp.restClient.getMode(subject3, false);
+      fail("Should throw exception for deleted subject3 mode");
+    } catch (RestClientException e) {
+      assertEquals(40409, e.getErrorCode(),
+              "Should get mode not configured error");
+    }
+  }
+
+  @Test
+  public void testRecursiveDeleteContextModeWhenContextModeNotSet() throws Exception {
+    String context = ":.mycontext:";
+    String subject1 = ":.mycontext:subject1";
+    String subject2 = ":.mycontext:subject2";
+    String mode = "READONLY";
+
+    // set mode for subjects under the context (but NOT for the context itself)
+    assertEquals(
+            mode,
+            restApp.restClient.setMode(mode, subject1).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.setMode(mode, subject2).getMode());
+
+    // verify subject modes are set
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(subject1, false).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(subject2, false).getMode());
+
+    // verify context mode is not set
+    try {
+      restApp.restClient.getMode(context, false);
+      fail("Context mode should not be set");
+    } catch (RestClientException e) {
+      assertEquals(40409, e.getErrorCode(),
+              "Should get mode not configured error");
+    }
+
+    // recursive delete context mode (should succeed even though context mode is not set)
+    // and should delete modes for subjects under the context
+    Mode deletedMode = restApp.restClient.deleteSubjectMode(Collections.emptyMap(), context, true);
+    assertEquals(
+            null,
+            deletedMode.getMode(),
+            "Deleted mode should return null as context mode was not set");
+
+    // verify subject modes are deleted
+    try {
+      restApp.restClient.getMode(subject1, false);
+      fail("Should throw exception for deleted subject1 mode");
+    } catch (RestClientException e) {
+      assertEquals(40409, e.getErrorCode(),
+              "Should get mode not configured error");
+    }
+
+    try {
+      restApp.restClient.getMode(subject2, false);
+      fail("Should throw exception for deleted subject2 mode");
+    } catch (RestClientException e) {
+      assertEquals(40409, e.getErrorCode(),
+              "Should get mode not configured error");
+    }
+  }
+
+  @Test
+  public void testRecursiveDeleteMixedContextAndSubjects() throws Exception {
+    String context = ":.mycontext:";
+    String subject1 = ":.mycontext:subject1";
+    String subject2 = ":.mycontext:subject2";
+    String subject3 = ":.mycontext:subject3";
+    String contextMode = "IMPORT";
+    String subject1Mode = "READONLY";
+    String subject2Mode = "READWRITE";
+    // subject3 has no mode set
+
+    // set mode for context
+    assertEquals(
+            contextMode,
+            restApp.restClient.setMode(contextMode, context).getMode());
+
+    // set different modes for subjects
+    assertEquals(
+            subject1Mode,
+            restApp.restClient.setMode(subject1Mode, subject1).getMode());
+    assertEquals(
+            subject2Mode,
+            restApp.restClient.setMode(subject2Mode, subject2).getMode());
+    // subject3 has no explicit mode
+
+    // verify modes are set
+    assertEquals(
+            contextMode,
+            restApp.restClient.getMode(context, false).getMode());
+    assertEquals(
+            subject1Mode,
+            restApp.restClient.getMode(subject1, false).getMode());
+    assertEquals(
+            subject2Mode,
+            restApp.restClient.getMode(subject2, false).getMode());
+
+    // recursive delete context mode
+    Mode deletedMode = restApp.restClient.deleteSubjectMode(Collections.emptyMap(), context, true);
+    assertEquals(
+            contextMode,
+            deletedMode.getMode(),
+            "Deleted mode should return the old context mode");
+
+    // verify all modes are deleted
+    try {
+      restApp.restClient.getMode(context, false);
+      fail("Should throw exception for deleted context mode");
+    } catch (RestClientException e) {
+      assertEquals(40409, e.getErrorCode(),
+              "Should get mode not configured error");
+    }
+
+    try {
+      restApp.restClient.getMode(subject1, false);
+      fail("Should throw exception for deleted subject1 mode");
+    } catch (RestClientException e) {
+      assertEquals(40409, e.getErrorCode(),
+              "Should get mode not configured error");
+    }
+
+    try {
+      restApp.restClient.getMode(subject2, false);
+      fail("Should throw exception for deleted subject2 mode");
+    } catch (RestClientException e) {
+      assertEquals(40409, e.getErrorCode(),
+              "Should get mode not configured error");
+    }
+
+    // subject3 still has no mode (should not be affected)
+    try {
+      restApp.restClient.getMode(subject3, false);
+      fail("Subject3 should still have no mode");
+    } catch (RestClientException e) {
+      assertEquals(40409, e.getErrorCode(),
+              "Should get mode not configured error");
+    }
+  }
+
+  @Test
+  public void testRecursiveDeleteDoesNotAffectOtherContexts() throws Exception {
+    String context1 = ":.context1:";
+    String context2 = ":.context2:";
+    String subject1 = ":.context1:subject1";
+    String subject2 = ":.context2:subject2";
+    String mode = "READONLY";
+
+    // set mode for both contexts and subjects
+    assertEquals(
+            mode,
+            restApp.restClient.setMode(mode, context1).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.setMode(mode, context2).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.setMode(mode, subject1).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.setMode(mode, subject2).getMode());
+
+    // verify modes are set
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(context1, false).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(context2, false).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(subject1, false).getMode());
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(subject2, false).getMode());
+
+    // recursive delete context1 mode
+    Mode deletedMode = restApp.restClient.deleteSubjectMode(Collections.emptyMap(), context1, true);
+    assertEquals(
+            mode,
+            deletedMode.getMode(),
+            "Deleted mode should return the old context1 mode");
+
+    // verify context1 and subject1 modes are deleted
+    try {
+      restApp.restClient.getMode(context1, false);
+      fail("Should throw exception for deleted context1 mode");
+    } catch (RestClientException e) {
+      assertEquals(40409, e.getErrorCode(),
+              "Should get mode not configured error");
+    }
+
+    try {
+      restApp.restClient.getMode(subject1, false);
+      fail("Should throw exception for deleted subject1 mode");
+    } catch (RestClientException e) {
+      assertEquals(40409, e.getErrorCode(),
+              "Should get mode not configured error");
+    }
+
+    // verify context2 and subject2 modes are NOT affected
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(context2, false).getMode(),
+            "Context2 mode should still exist");
+    assertEquals(
+            mode,
+            restApp.restClient.getMode(subject2, false).getMode(),
+            "Subject2 mode should still exist");
+  }
 }


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Add support for recursive mode delete /mode API.  This add a new options parameter recursive, which when set to true and subject is a context, will update mode for the given context and all subjects under the context.
This is defaulted to false to maintain existing behavior

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA: https://confluentinc.atlassian.net/browse/DGS-22434

Test & Review
------------
- Unit tests
- Manual tests in local SR


