### PR TITLE
DGS-22434 Handle multi-tenant default context in isContext()

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
@@ -261,6 +261,7 @@ public class QualifiedSubject implements Comparable<QualifiedSubject> {
   /**
    * Checks if the given qualified subject represents a context (i.e., has no subject part).
    * A context has the format ":.context:" with an empty subject part, or null for default context.
+   * Also returns true for wildcard subject ("*") when tenant is not the default tenant.
    *
    * @param tenant the tenant
    * @param qualifiedSubject the subject with a tenant prefix
@@ -268,7 +269,11 @@ public class QualifiedSubject implements Comparable<QualifiedSubject> {
    */
   public static boolean isContext(String tenant, String qualifiedSubject) {
     QualifiedSubject qs = QualifiedSubject.create(tenant, qualifiedSubject);
-    return qs == null || qs.getSubject().isEmpty();
+    if (qs == null || qs.getSubject().isEmpty()) {
+      return true;
+    }
+    // Check if it's the wildcard subject in non default tenant
+    return tenant != null && !DEFAULT_TENANT.equals(tenant) && WILDCARD.equals(qs.getSubject());
   }
 
   /**

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubjectTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubjectTest.java
@@ -215,4 +215,70 @@ public class QualifiedSubjectTest {
     assertFalse(QualifiedSubject.isValidSubject("default", "__GLOBAL"));
     assertFalse(QualifiedSubject.isValidSubject("default", "__EMPTY"));
   }
+
+   @Test
+  public void testIsContext() {
+    // Test null qualified subject - should return true (default context)
+    assertTrue(QualifiedSubject.isContext("default", null));
+    assertTrue(QualifiedSubject.isContext("tenant1", null));
+
+    // Test empty string qualified subject - should return true (default context)
+    assertTrue(QualifiedSubject.isContext("default", ""));
+    assertTrue(QualifiedSubject.isContext("tenant1", "tenant1_"));
+
+    // Test context with empty subject - should return true
+    assertTrue(QualifiedSubject.isContext("default", ":.ctx1:"));
+    assertTrue(QualifiedSubject.isContext("tenant1", "tenant1_:.ctx1:"));
+    assertTrue(QualifiedSubject.isContext("default", ":.prod:"));
+    assertTrue(QualifiedSubject.isContext("tenant1", "tenant1_:.prod:"));
+
+    // Test context with missing last colon but empty subject - should return true
+    assertTrue(QualifiedSubject.isContext("default", ":.ctx1"));
+    assertTrue(QualifiedSubject.isContext("tenant1", "tenant1_:.ctx1"));
+
+    // Test wildcard subject in non-default tenant - should return true
+    assertTrue(QualifiedSubject.isContext("tenant1", "tenant1_*"));
+    assertTrue(QualifiedSubject.isContext("tenant2", "tenant2_*"));
+
+    // Test wildcard subject in default tenant - should return false
+    assertFalse(QualifiedSubject.isContext("default", "*"));
+    assertFalse(QualifiedSubject.isContext(DEFAULT_TENANT, "*"));
+
+    // Test regular subjects - should return false
+    assertFalse(QualifiedSubject.isContext("default", "subject1"));
+    assertFalse(QualifiedSubject.isContext("tenant1", "tenant1_subject1"));
+    assertFalse(QualifiedSubject.isContext("default", ":.ctx1:subject1"));
+    assertFalse(QualifiedSubject.isContext("tenant1", "tenant1_:.ctx1:subject1"));
+
+    // Test context wildcard (special context) - should return true (empty subject)
+    assertTrue(QualifiedSubject.isContext("tenant1", "tenant1_:*:"));
+
+    // Test invalid context formats with subjects - should return false
+    assertFalse(QualifiedSubject.isContext("default", ":ctx1:subject1"));
+    assertFalse(QualifiedSubject.isContext("tenant1", "tenant1_:ctx1:subject1"));
+  }
+
+  @Test
+  public void testIsContextEdgeCases() {
+    // Test with null tenant
+    assertTrue(QualifiedSubject.isContext(null, null));
+    assertTrue(QualifiedSubject.isContext(null, ""));
+    assertTrue(QualifiedSubject.isContext(null, ":.ctx:"));
+
+    // Wildcard with null tenant (treated as default tenant)
+    assertFalse(QualifiedSubject.isContext(null, "*"));
+
+    // Test with empty context (default context)
+    assertTrue(QualifiedSubject.isContext("default", ":.:"));
+    assertTrue(QualifiedSubject.isContext("tenant1", "tenant1_:.:"));
+
+    // Test subjects that look like contexts but have content after
+    assertFalse(QualifiedSubject.isContext("default", ":.ctx:foo"));
+    assertFalse(QualifiedSubject.isContext("tenant1", "tenant1_:.ctx:foo"));
+
+    // Test with special subjects that are not wildcards
+    assertFalse(QualifiedSubject.isContext("tenant1", "tenant1_**"));
+    assertFalse(QualifiedSubject.isContext("tenant1", "tenant1_*subject"));
+    assertFalse(QualifiedSubject.isContext("default", "**"));
+  }
 }


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Handle multi-tenant default context in isContext()

If MT mode, default context will translate to `tenant1_*`. So a * in subject for a non-default tenant should be treated a context

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[N]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA: https://confluentinc.atlassian.net/browse/DGS-22434

Test & Review
------------
- Unit tests.