### PR TITLE
ci: one-time cache clear to reduce S3 bucket bloat

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -23,6 +23,7 @@ queue:
 global_job_config:
   prologue:
     commands:
+      - cache clear
       - checkout
       - sem-version java 17
       - . cache-maven restore


### PR DESCRIPTION
## Summary

- Adds `cache clear` as the first command in the Semaphore CI pipeline prologue

## Why this is needed

The prod Semaphore cache S3 bucket (`semaphore-cache-519856050701-us-west-2`) has grown to **137 TB**, up from 58 TB just 3 months ago. Analysis shows that Maven cache entries are being stored with unique-per-build keys (e.g., `cache-maven-8.0.x-1770405615`), creating a new 17-35 GB cache file on every single build instead of overwriting a stable key.

With the 90-day S3 lifecycle, this causes thousands of duplicate cache files to pile up. This project is one of the top contributors to the bucket size.

## What this PR does

Adds `cache clear` as the first prologue command, which deletes all cached entries for this project. This is a **one-time cleanup** -- the change should be **reverted immediately after merging** so that caching resumes normally.

## Why this is safe

- `cache clear` only affects this project cache prefix in S3 (scoped by Semaphore project ID)
- The first build after merge will run without cache (slightly slower), then `cache store` will repopulate it
- No impact on other projects or production systems
- The CI pipeline continues to function normally; it just starts cold once

## Action after merge

**Revert this PR immediately after the first successful pipeline run** so that future builds benefit from caching again.
