### PR TITLE
Backport pr_ci_gating and status_level to 7.4.x service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -7,6 +7,10 @@ semaphore:
   enable: true
   pipeline_type: cp
   nano_version: true
+  pr_ci_gating:
+    enable: true
+    project_name: schema-registry
+  status_level: block
   execution_time_limit: {"hours": 2}
   downstream_projects: ["kafka-rest", "ksql",
     "confluent-security-plugins", "kafka-connect-replicator",


### PR DESCRIPTION
## Summary

Backports the `pr_ci_gating` and `status_level` fields from master's `service.yml` to 7.4.x. Without these fields, running ServiceBot against 7.4.x removes the "CP Jar Build CI Gating" block from `semaphore.yml`.

This is needed before running ServiceBot to regenerate `semaphore.yml` on 7.4.x (to roll out the `--direct-pom-edit` flag from cc-service-bot#1872).

## Why this is safe

These fields already exist on master and all newer branches. They declare that this repo should have the CP Jar Build CI Gating block, which 7.4.x already has in its `semaphore.yml` — this just ensures `service.yml` matches reality so ServiceBot doesn't remove it.