### PR TITLE
Quote lang_version in service.yml to fix service-bot validation

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,6 @@
 name: schema-registry
 lang: java
-lang_version: 11
+lang_version: "11"
 codeowners:
   enable: true
 semaphore:


### PR DESCRIPTION
## Summary
- service-bot's pydantic manifest validation expects `lang_version` to be a string, but the unquoted YAML value `11` was being parsed as an integer, causing a `ValidationError` and failing the service-bot CI job
- Quoting the value as `"11"` satisfies the string type constraint
- Also adds a missing newline at end of file

This is safe because the value itself doesn't change — only its YAML type changes from integer to string, which is what the downstream consumer (service-bot) expects.

**Failing job:** https://semaphore.ci.confluent.io/jobs/80f7a716-f8ca-4820-b46b-465eb2ab2f09#L363

**Error:**
```
Invalid service-bot manifest for 'manifest': lang_version: Input should be a valid string [type=string_type, input_value=11, input_type=int]
```

## Test plan
- [ ] Verify service-bot CI job passes on this branch