### PR TITLE
DGS-23555 Ensure guid is preserved when formatting schema responses

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Schema.java
@@ -334,6 +334,11 @@ public class Schema implements Comparable<Schema> {
     return guid;
   }
 
+  @JsonProperty("guid")
+  public void setGuid(String guid) {
+    this.guid = guid;
+  }
+
   @io.swagger.v3.oas.annotations.media.Schema(
       description = TYPE_DESC + ". " + DESCRIPTION_CONDITION, example = TYPE_EXAMPLE)
   @JsonProperty("schemaType")
@@ -427,11 +432,6 @@ public class Schema implements Comparable<Schema> {
   @JsonProperty("deleted")
   public void setDeleted(Boolean deleted) {
     this.deleted = deleted;
-  }
-
-  @JsonProperty("guid")
-  public void setGuid(String guid) {
-    this.guid = guid;
   }
 
   @Override

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -177,7 +177,9 @@ public class SubjectVersionsResource {
       }
       if (format != null && !format.trim().isEmpty()) {
         ParsedSchema parsedSchema = schemaRegistry.parseSchema(schema, false, false);
+        String originalGuid = schema.getGuid();
         schema.setSchema(parsedSchema.formattedString(format));
+        schema.setGuid(originalGuid);
       }
       QualifiedSubject qs = QualifiedSubject.create(schemaRegistry.tenant(), schema.getSubject());
       boolean isQualifiedSubject = qs != null && !DEFAULT_CONTEXT.equals(qs.getContext());
@@ -485,7 +487,9 @@ public class SubjectVersionsResource {
           schemaRegistry.registerOrForward(subjectName, request, normalize, headerProperties);
       if (result.getSchema() != null && format != null && !format.trim().isEmpty()) {
         ParsedSchema parsedSchema = schemaRegistry.parseSchema(result, false, false);
+        String originalGuid = result.getGuid();
         result.setSchema(parsedSchema.formattedString(format));
+        result.setGuid(originalGuid);
       }
       registerSchemaResponse = new RegisterSchemaResponse(result);
     } catch (IdDoesNotMatchException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -144,7 +144,9 @@ public class SubjectsResource {
       }
       if (format != null && !format.trim().isEmpty()) {
         ParsedSchema parsedSchema = schemaRegistry.parseSchema(matchingSchema, false, false);
+        String originalGuid = matchingSchema.getGuid();
         matchingSchema.setSchema(parsedSchema.formattedString(format));
+        matchingSchema.setGuid(originalGuid);
       }
     } catch (InvalidSchemaException e) {
       throw Errors.invalidSchemaException(e);
@@ -203,7 +205,9 @@ public class SubjectsResource {
       }
       if (format != null && !format.trim().isEmpty()) {
         ParsedSchema parsedSchema = schemaRegistry.parseSchema(matchingSchema, false, false);
+        String originalGuid = matchingSchema.getGuid();
         matchingSchema.setSchema(parsedSchema.formattedString(format));
+        matchingSchema.setGuid(originalGuid);
       }
     } catch (InvalidSchemaException e) {
       throw Errors.invalidSchemaException(e);


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Ensure guid is preserved when formatting schema responses
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
