### PR TITLE
Move replaceAlias to AbstractSchemaRegistry for reuse

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -1296,6 +1296,26 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
     }
   }
 
+  protected QualifiedSubject replaceAlias(String context, String subject) {
+    QualifiedSubject qs = QualifiedSubject.create(tenant(), context, subject);
+    String qualifiedSubject = qs.toQualifiedSubject();
+    Config config = null;
+    try {
+      config = getConfig(qualifiedSubject);
+    } catch (Exception e) {
+      // fall through
+    }
+    if (config == null) {
+      return qs;
+    }
+    String alias = config.getAlias();
+    if (alias != null && !alias.isEmpty()) {
+      return QualifiedSubject.qualifySubjectWithParent(tenant(), qualifiedSubject, alias, true);
+    } else {
+      return qs;
+    }
+  }
+
   @Override
   public Config getConfig(String subject)
           throws SchemaRegistryStoreException {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -1469,26 +1469,6 @@ public class KafkaSchemaRegistry extends AbstractSchemaRegistry implements
     }
   }
 
-  private QualifiedSubject replaceAlias(String context, String subject) {
-    QualifiedSubject qs = QualifiedSubject.create(tenant(), context, subject);
-    String qualifiedSubject = qs.toQualifiedSubject();
-    Config config = null;
-    try {
-      config = getConfig(qualifiedSubject);
-    } catch (Exception e) {
-      // fall through
-    }
-    if (config == null) {
-      return qs;
-    }
-    String alias = config.getAlias();
-    if (alias != null && !alias.isEmpty()) {
-      return QualifiedSubject.qualifySubjectWithParent(tenant(), qualifiedSubject, alias, true);
-    } else {
-      return qs;
-    }
-  }
-
   public AssociationResponse createOrUpdateAssociationOrForward(String context, boolean dryRun,
       AssociationCreateOrUpdateRequest request,
       Map<String, String> headerProperties)


### PR DESCRIPTION
What
----
Move `replaceAlias` from `KafkaSchemaRegistry` (private) to `AbstractSchemaRegistry` (protected) so it can be reused by other subclasses extending `AbstractSchemaRegistry`.

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes
    - No. Internal refactor only, no API or behavior changes.
- [ ] Is this change gated behind feature flag(s)?
    - N/A
- [ ] Did you add sufficient unit test and/or integration test coverage for this PR?
    - No new tests needed — this is a pure method relocation with no logic changes. Existing tests cover the behavior.
- [ ] Does this change require modifying existing system tests or adding new system tests?
    - No

References
----------
JIRA:

Test & Review
------------
Pure refactor: method moved as-is from `KafkaSchemaRegistry` to `AbstractSchemaRegistry`, visibility changed from `private` to `protected`. No logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)