### PR TITLE
fix: correct misleading error messages in getMode and getConfig

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -1236,7 +1236,8 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
     try {
       return lookupCache.mode(subject, true, defaultMode);
     } catch (StoreException e) {
-      throw new SchemaRegistryStoreException("Failed to write new config value to the store", e);
+      throw new SchemaRegistryStoreException(
+          "Failed to get mode in scope for " + subject, e);
     }
   }
 
@@ -1245,7 +1246,7 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
     try {
       return lookupCache.mode(subject, false, defaultMode);
     } catch (StoreException e) {
-      throw new SchemaRegistryStoreException("Failed to write new config value to the store", e);
+      throw new SchemaRegistryStoreException("Failed to get mode for " + subject, e);
     }
   }
 
@@ -1292,7 +1293,8 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
     try {
       return lookupCache.config(subject, true, new Config(defaultCompatibilityLevel.name));
     } catch (StoreException e) {
-      throw new SchemaRegistryStoreException("Failed to write new config value to the store", e);
+      throw new SchemaRegistryStoreException(
+          "Failed to get config in scope for " + subject, e);
     }
   }
 
@@ -1302,7 +1304,7 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
     try {
       return lookupCache.config(subject, false, new Config(defaultCompatibilityLevel.name));
     } catch (StoreException e) {
-      throw new SchemaRegistryStoreException("Failed to write new config value to the store", e);
+      throw new SchemaRegistryStoreException("Failed to get config for " + subject, e);
     }
   }
 


### PR DESCRIPTION
The catch blocks in getConfig() and getMode() were using a copy-pasted error message "Failed to write new config value to the store" despite being read-only operations. This made debugging confusing


<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[N]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[N]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required: just a exception message change
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
