### PR TITLE
Revert "Fix ByteUtils import after Kafka client relocation (#4232)"

### DIFF
--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/MessageIndexes.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/MessageIndexes.java
@@ -15,7 +15,7 @@
 
 package io.confluent.kafka.schemaregistry.protobuf;
 
-import org.apache.kafka.common.utils.internals.ByteUtils;
+import org.apache.kafka.common.utils.ByteUtils;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/schema/id/SchemaId.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/schema/id/SchemaId.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import org.apache.kafka.common.errors.SerializationException;
-import org.apache.kafka.common.utils.internals.ByteUtils;
+import org.apache.kafka.common.utils.ByteUtils;
 
 /**
  * A {@link SchemaId} is used to identify a schema. It can be either an ID or a GUID.


### PR DESCRIPTION
What
----
Revert #4232 ("Fix ByteUtils import after Kafka client relocation").

This restores the original `org.apache.kafka.common.utils.ByteUtils` imports in `MessageIndexes.java` and `SchemaId.java`.

Checklist
------------------
- **[N]** Contains customer facing changes?
- **[N]** Is this change gated behind config(s)?
- **[N/A]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - This is a straightforward revert of an import change; no new tests needed.
- **[N]** Does this change require modifying existing system tests or adding new system tests?
- **[N]** Must this be released together with other change(s), either in this repo or another one?

References
----------
Reverts: #4232

Test & Review
------------
CI should pass with the reverted imports.