### PR TITLE
DGS-23945 - add strict validation for empty metadata encoder secret

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -272,6 +272,10 @@ public class SchemaRegistryConfig extends RestConfig {
   public static final String METADATA_ENCODER_TOPIC_CONFIG = "metadata.encoder.topic";
   public static final String METADATA_ENCODER_TOPIC_DEFAULT = "_schema_encoders";
 
+  public static final String METADATA_ENCODER_SECRET_STRICT_VALIDATION_CONFIG =
+      "metadata.encoder.secret.strict.validation";
+  public static final boolean METADATA_ENCODER_SECRET_STRICT_VALIDATION_DEFAULT = false;
+
   public static final String ENABLE_STORE_HEALTH_CHECK = "enable.store.health.check";
   public static final boolean DEFAULT_ENABLE_STORE_HEALTH_CHECK = false;
 
@@ -448,6 +452,10 @@ public class SchemaRegistryConfig extends RestConfig {
       + "old secret and re-encrypted using the new secret.";
   protected static final String METADATA_ENCODER_TOPIC_DOC =
       "The durable single partition topic that acts as the durable log for the encoder keysets.";
+  protected static final String METADATA_ENCODER_SECRET_STRICT_VALIDATION_DOC =
+      "When true, treat an empty encoder secret the same as a missing secret (disable the encoder "
+      + "service). This prevents silent data corruption when the secret file is not yet mounted "
+      + "at startup.";
   protected static final String LEADER_ELIGIBILITY_DOC =
       "If true, this node can participate in leader election. In a multi-colo setup, turn this off "
       + "for clusters in the follower data center.";
@@ -698,6 +706,10 @@ public class SchemaRegistryConfig extends RestConfig {
     )
     .define(METADATA_ENCODER_TOPIC_CONFIG, ConfigDef.Type.STRING, METADATA_ENCODER_TOPIC_DEFAULT,
         ConfigDef.Importance.HIGH, METADATA_ENCODER_TOPIC_DOC
+    )
+    .define(METADATA_ENCODER_SECRET_STRICT_VALIDATION_CONFIG, ConfigDef.Type.BOOLEAN,
+        METADATA_ENCODER_SECRET_STRICT_VALIDATION_DEFAULT,
+        ConfigDef.Importance.LOW, METADATA_ENCODER_SECRET_STRICT_VALIDATION_DOC
     )
     .define(MASTER_ELIGIBILITY, ConfigDef.Type.BOOLEAN, null,
         ConfigDef.Importance.MEDIUM, LEADER_ELIGIBILITY_DOC

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/encoder/MetadataEncoderService.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/encoder/MetadataEncoderService.java
@@ -77,7 +77,15 @@ public abstract class MetadataEncoderService implements Closeable {
 
   public MetadataEncoderService(SchemaRegistry schemaRegistry) {
     this.schemaRegistry = schemaRegistry;
-    this.encoderSecret = encoderSecret(schemaRegistry.config());
+    String secret = encoderSecret(schemaRegistry.config());
+    boolean strictValidation = schemaRegistry.config().getBoolean(
+        SchemaRegistryConfig.METADATA_ENCODER_SECRET_STRICT_VALIDATION_CONFIG);
+    if (secret != null && strictValidation && secret.isEmpty()) {
+      log.warn("Encoder secret is empty and strict validation is enabled, "
+          + "treating as missing");
+      secret = null;
+    }
+    this.encoderSecret = secret;
     if (encoderSecret == null) {
       log.warn("No value specified for {}, sensitive metadata will not be encoded",
           SchemaRegistryConfig.METADATA_ENCODER_SECRET_CONFIG);

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/encoder/MetadataEncoderServiceStrictValidationTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/encoder/MetadataEncoderServiceStrictValidationTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.storage.encoder;
+
+import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
+import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
+import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
+import io.confluent.kafka.schemaregistry.storage.SchemaValue;
+import io.kcache.Cache;
+import io.kcache.utils.InMemoryCache;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MetadataEncoderServiceStrictValidationTest {
+
+  private SchemaRegistry createMockRegistry(String secret, boolean strictValidation)
+      throws Exception {
+    SchemaRegistry registry = mock(SchemaRegistry.class);
+    Properties props = new Properties();
+    if (secret != null) {
+      props.setProperty(SchemaRegistryConfig.METADATA_ENCODER_SECRET_CONFIG, secret);
+    }
+    props.setProperty(
+        SchemaRegistryConfig.METADATA_ENCODER_SECRET_STRICT_VALIDATION_CONFIG,
+        String.valueOf(strictValidation));
+    SchemaRegistryConfig config = new SchemaRegistryConfig(props);
+    when(registry.config()).thenReturn(config);
+    return registry;
+  }
+
+  private KafkaMetadataEncoderService createService(SchemaRegistry registry) {
+    Cache<String, KeysetWrapper> encoders = new InMemoryCache<>();
+    return new KafkaMetadataEncoderService(registry, encoders);
+  }
+
+  private SchemaValue createSchemaWithSensitiveMetadata() {
+    Map<String, String> properties = new HashMap<>();
+    properties.put("description", "test");
+    properties.put("api_secret", "sensitive-value");
+    Metadata metadata = new Metadata(null, properties, Collections.singleton("api_secret"));
+    return new SchemaValue(
+        "mysubject", null, null, null, null, null,
+        new io.confluent.kafka.schemaregistry.storage.Metadata(metadata), null, "true", false);
+  }
+
+  @Test
+  public void testEmptySecret_StrictDisabled_EncoderServiceInitializes() throws Exception {
+    // With strict validation disabled (default), empty secret should still initialize
+    // the encoder service (backward compatible behavior)
+    SchemaRegistry registry = createMockRegistry("", false);
+    KafkaMetadataEncoderService service = createService(registry);
+    service.init();
+
+    SchemaValue schema = createSchemaWithSensitiveMetadata();
+    service.encodeMetadata(schema);
+
+    // Encoder initialized with empty secret — metadata IS encoded (with wrong key, but functional)
+    assertNotNull(schema.getMetadata().getProperties().get(SchemaValue.ENCODED_PROPERTY));
+
+    service.close();
+  }
+
+  @Test
+  public void testEmptySecret_StrictEnabled_EncoderServiceDisabled() throws Exception {
+    // With strict validation enabled, empty secret should disable the encoder service
+    SchemaRegistry registry = createMockRegistry("", true);
+    KafkaMetadataEncoderService service = createService(registry);
+    service.init();
+
+    SchemaValue schema = createSchemaWithSensitiveMetadata();
+    service.encodeMetadata(schema);
+
+    // Encoder disabled — metadata should NOT be encoded (no-op)
+    assertNull(schema.getMetadata().getProperties().get(SchemaValue.ENCODED_PROPERTY));
+    assertEquals("sensitive-value", schema.getMetadata().getProperties().get("api_secret"));
+
+    service.close();
+  }
+
+  @Test
+  public void testValidSecret_StrictEnabled_EncoderServiceInitializes() throws Exception {
+    // With strict validation enabled, a non-empty secret should still work normally
+    SchemaRegistry registry = createMockRegistry("mysecret", true);
+    KafkaMetadataEncoderService service = createService(registry);
+    service.init();
+
+    SchemaValue schema = createSchemaWithSensitiveMetadata();
+    service.encodeMetadata(schema);
+
+    // Encoder initialized — metadata IS encoded
+    assertNotNull(schema.getMetadata().getProperties().get(SchemaValue.ENCODED_PROPERTY));
+
+    service.close();
+  }
+
+  @Test
+  public void testNullSecret_StrictEnabled_EncoderServiceDisabled() throws Exception {
+    // Null secret should disable the encoder regardless of strict validation
+    SchemaRegistry registry = createMockRegistry(null, true);
+    KafkaMetadataEncoderService service = createService(registry);
+    service.init();
+
+    SchemaValue schema = createSchemaWithSensitiveMetadata();
+    service.encodeMetadata(schema);
+
+    // Encoder disabled — metadata should NOT be encoded
+    assertNull(schema.getMetadata().getProperties().get(SchemaValue.ENCODED_PROPERTY));
+    assertEquals("sensitive-value", schema.getMetadata().getProperties().get("api_secret"));
+
+    service.close();
+  }
+}


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
Add config metadata.encoder.secret.strict.validation (default false). When enabled, treat an empty encoder secret the same as null, disabling the encoder service. This prevents silent data corruption when the K8s secret volume mount is not ready at pod startup and FileConfigProvider resolves the secret to an empty string.

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[N]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[Y]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change `metadata.encoder.secret.strict.validation` default false means no behavior change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
