### PR TITLE
Add toString() to KeyEncryptionKey and DataEncryptionKey

### DIFF
--- a/dek-registry/src/main/java/io/confluent/dekregistry/storage/DataEncryptionKey.java
+++ b/dek-registry/src/main/java/io/confluent/dekregistry/storage/DataEncryptionKey.java
@@ -124,6 +124,17 @@ public class DataEncryptionKey extends EncryptionKey {
   }
 
   @Override
+  public String toString() {
+    return "DEK{kekName=" + kekName
+        + ", subject=" + subject
+        + ", algorithm=" + algorithm
+        + ", version=" + version
+        + ", deleted=" + deleted
+        + ", offset=" + offset
+        + ", ts=" + timestamp + '}';
+  }
+
+  @Override
   public DataEncryptionKeyId toKey(String tenant) {
     return new DataEncryptionKeyId(tenant, kekName, subject, algorithm, version);
   }

--- a/dek-registry/src/main/java/io/confluent/dekregistry/storage/KeyEncryptionKey.java
+++ b/dek-registry/src/main/java/io/confluent/dekregistry/storage/KeyEncryptionKey.java
@@ -127,6 +127,16 @@ public class KeyEncryptionKey extends EncryptionKey {
   }
 
   @Override
+  public String toString() {
+    return "KEK{name=" + name
+        + ", kmsType=" + kmsType
+        + ", shared=" + shared
+        + ", deleted=" + deleted
+        + ", offset=" + offset
+        + ", ts=" + timestamp + '}';
+  }
+
+  @Override
   public KeyEncryptionKeyId toKey(String tenant) {
     return new KeyEncryptionKeyId(tenant, name);
   }

--- a/dek-registry/src/test/java/io/confluent/dekregistry/storage/EncryptionKeyToStringTest.java
+++ b/dek-registry/src/test/java/io/confluent/dekregistry/storage/EncryptionKeyToStringTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.dekregistry.storage;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.confluent.kafka.schemaregistry.encryption.tink.DekFormat;
+import java.util.TreeMap;
+import org.junit.jupiter.api.Test;
+
+class EncryptionKeyToStringTest {
+
+  @Test
+  void kekToStringShouldIncludeIdentifyingFields() {
+    TreeMap<String, String> kmsProps = new TreeMap<>();
+    kmsProps.put("prop1", "value1");
+    KeyEncryptionKey kek = new KeyEncryptionKey(
+        "myKek", "aws-kms", "arn:aws:kms:us-west-2:123:key/abc", kmsProps,
+        "some doc", true, false);
+    kek.setTimestamp(1000L);
+    kek.setOffset(42L);
+
+    String str = kek.toString();
+    assertTrue(str.contains("name=myKek"));
+    assertTrue(str.contains("kmsType=aws-kms"));
+    assertTrue(str.contains("shared=true"));
+    assertTrue(str.contains("deleted=false"));
+    assertTrue(str.contains("offset=42"));
+    assertTrue(str.contains("ts=1000"));
+  }
+
+  @Test
+  void kekToStringShouldExcludeSensitiveFields() {
+    TreeMap<String, String> kmsProps = new TreeMap<>();
+    kmsProps.put("secretProp", "secretValue");
+    KeyEncryptionKey kek = new KeyEncryptionKey(
+        "myKek", "aws-kms", "arn:aws:kms:us-west-2:123:key/abc", kmsProps,
+        "internal documentation", true, false);
+
+    String str = kek.toString();
+    assertFalse(str.contains("arn:aws:kms"), "toString must not contain kmsKeyId");
+    assertFalse(str.contains("secretProp"), "toString must not contain kmsProps keys");
+    assertFalse(str.contains("secretValue"), "toString must not contain kmsProps values");
+    assertFalse(str.contains("internal documentation"), "toString must not contain doc");
+  }
+
+  @Test
+  void dekToStringShouldIncludeIdentifyingFields() {
+    DataEncryptionKey dek = new DataEncryptionKey(
+        "myKek", "mySubject", DekFormat.AES256_GCM, 1,
+        "encryptedMaterial123", false);
+    dek.setTimestamp(2000L);
+    dek.setOffset(43L);
+    dek.setKeyMaterial("rawKeyMaterial");
+
+    String str = dek.toString();
+    assertTrue(str.contains("kekName=myKek"));
+    assertTrue(str.contains("subject=mySubject"));
+    assertTrue(str.contains("algorithm=AES256_GCM"));
+    assertTrue(str.contains("version=1"));
+    assertTrue(str.contains("deleted=false"));
+    assertTrue(str.contains("offset=43"));
+    assertTrue(str.contains("ts=2000"));
+  }
+
+  @Test
+  void dekToStringShouldExcludeSensitiveFields() {
+    DataEncryptionKey dek = new DataEncryptionKey(
+        "myKek", "mySubject", DekFormat.AES256_GCM, 1,
+        "encryptedMaterial123", false);
+    dek.setKeyMaterial("rawKeyMaterial");
+
+    String str = dek.toString();
+    assertFalse(str.contains("encryptedMaterial123"),
+        "toString must not contain encryptedKeyMaterial");
+    assertFalse(str.contains("rawKeyMaterial"),
+        "toString must not contain keyMaterial");
+  }
+}


### PR DESCRIPTION
What
----
Adds `toString()` overrides to `KeyEncryptionKey` and `DataEncryptionKey`. These classes previously used `Object.toString()` which produces opaque hashes (e.g., `KeyEncryptionKey@f9e81e34`) in log output. Now they show identifying fields useful for debugging:

```
KEK{name=myKek, kmsType=aws-kms, shared=false, deleted=false, offset=42, ts=1713100000000}
DEK{kekName=myKek, subject=mySubject, algorithm=AES256_GCM, version=1, deleted=false, offset=43, ts=1713100000001}
```

**Sensitive field exclusion:** `toString()` deliberately excludes fields that could contain secrets or PII:
- **KEK**: `kmsKeyId` (KMS key ARN/ID), `kmsProps` (could contain credentials), `doc` (user-provided content) are all excluded
- **DEK**: `encryptedKeyMaterial` and `keyMaterial` (raw and encrypted key material) are both excluded

**Blast radius validation:** Searched all downstream consumers of these classes. No code calls `.toString()` on `KeyEncryptionKey` or `DataEncryptionKey`, no test assertions rely on their string representation, and no serialization paths use `toString()`. This is a purely additive change that only affects log output.

Checklist
------------------
- **[N]** Contains customer facing changes?
- **[N]** Is this change gated behind config(s)?
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - Added `EncryptionKeyToStringTest` verifying identifying fields are included and sensitive fields are excluded
- **[N]** Does this change require modifying existing system tests or adding new system tests?
- **[N]** Must this be released together with other change(s)?

Test & Review
------------
Unit tests verify:
1. KEK `toString()` includes: name, kmsType, shared, deleted, offset, ts
2. KEK `toString()` excludes: kmsKeyId, kmsProps, doc
3. DEK `toString()` includes: kekName, subject, algorithm, version, deleted, offset, ts
4. DEK `toString()` excludes: encryptedKeyMaterial, keyMaterial

🤖 Generated with [Claude Code](https://claude.com/claude-code)