### PR TITLE
Make AbstractSchemaRegistry tolerate a null metadataEncoder

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -741,7 +741,7 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
       SchemaRegistryKey key1 = keyCreator.apply(start, MIN_VERSION);
       SchemaRegistryKey key2 = keyCreator.apply(end, MAX_VERSION);
       return filter(transform(store.getAll(key1, key2), v -> {
-        if (v instanceof SchemaValue) {
+        if (v instanceof SchemaValue && metadataEncoder != null) {
           try {
             metadataEncoder.decodeMetadata(((SchemaValue) v));
           } catch (SchemaRegistryStoreException e) {
@@ -1660,7 +1660,9 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
 
   @Override
   public Schema toSchemaEntity(SchemaValue schemaValue) throws SchemaRegistryStoreException {
-    metadataEncoder.decodeMetadata(schemaValue);
+    if (metadataEncoder != null) {
+      metadataEncoder.decodeMetadata(schemaValue);
+    }
     return schemaValue.toSchemaEntity();
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
@@ -188,6 +188,9 @@ public interface SchemaRegistry extends SchemaVersionFetcher {
   // Can be used to pass values between extensions
   Map<String, Object> properties();
 
+  /**
+   * Returns the metadata encoder, or {@code null} if SR-level encoding is disabled.
+   */
   MetadataEncoderService getMetadataEncoder();
 
   void addUpdateRequestHandler(UpdateRequestHandler updateRequestHandler);

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistryNullEncoderTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistryNullEncoderTest.java
@@ -16,12 +16,17 @@
 package io.confluent.kafka.schemaregistry.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException;
+import java.lang.reflect.Field;
+import java.util.Iterator;
 import org.junit.jupiter.api.Test;
 
 public class AbstractSchemaRegistryNullEncoderTest {
@@ -30,6 +35,8 @@ public class AbstractSchemaRegistryNullEncoderTest {
 
   @Test
   public void toSchemaEntity_skipsDecodeWhenEncoderIsNull() throws SchemaRegistryStoreException {
+    // CALLS_REAL_METHODS with Mockito bypasses the constructor (Objenesis), so fields
+    // — including metadataEncoder — remain at their default null value.
     AbstractSchemaRegistry registry = mock(AbstractSchemaRegistry.class, CALLS_REAL_METHODS);
     SchemaValue schemaValue = new SchemaValue(
         "subject-1", 1, 42, null, null, SCHEMA_STRING, false);
@@ -41,8 +48,52 @@ public class AbstractSchemaRegistryNullEncoderTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
+  public void allVersions_skipsDecodeWhenEncoderIsNull() throws Exception {
+    AbstractSchemaRegistry registry = mock(AbstractSchemaRegistry.class, CALLS_REAL_METHODS);
+    SchemaValue schemaValue = new SchemaValue(
+        "subject-1", 1, 42, null, null, SCHEMA_STRING, false);
+
+    Store<SchemaRegistryKey, SchemaRegistryValue> store = mock(Store.class);
+    when(store.getAll(any(), any())).thenReturn(singletonIterator(schemaValue));
+    setField(registry, "store", store);
+
+    Iterator<SchemaKey> versions = registry.getAllVersions("subject-1", LookupFilter.DEFAULT);
+
+    assertNotNull(versions);
+    assertEquals(1, versions.next().getVersion());
+  }
+
+  @Test
   public void getMetadataEncoder_returnsNullWhenUnwired() {
     AbstractSchemaRegistry registry = mock(AbstractSchemaRegistry.class, CALLS_REAL_METHODS);
     assertNull(registry.getMetadataEncoder());
+  }
+
+  private static CloseableIterator<SchemaRegistryValue> singletonIterator(SchemaRegistryValue v) {
+    return new CloseableIterator<SchemaRegistryValue>() {
+      private boolean consumed = false;
+
+      @Override
+      public boolean hasNext() {
+        return !consumed;
+      }
+
+      @Override
+      public SchemaRegistryValue next() {
+        consumed = true;
+        return v;
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+
+  private static void setField(Object target, String name, Object value) throws Exception {
+    Field f = AbstractSchemaRegistry.class.getDeclaredField(name);
+    f.setAccessible(true);
+    f.set(target, value);
   }
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistryNullEncoderTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistryNullEncoderTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException;
+import org.junit.jupiter.api.Test;
+
+public class AbstractSchemaRegistryNullEncoderTest {
+
+  private static final String SCHEMA_STRING = "{\"type\":\"string\"}";
+
+  @Test
+  public void toSchemaEntity_skipsDecodeWhenEncoderIsNull() throws SchemaRegistryStoreException {
+    AbstractSchemaRegistry registry = mock(AbstractSchemaRegistry.class, CALLS_REAL_METHODS);
+    SchemaValue schemaValue = new SchemaValue(
+        "subject-1", 1, 42, null, null, SCHEMA_STRING, false);
+
+    Schema entity = registry.toSchemaEntity(schemaValue);
+
+    assertEquals("subject-1", entity.getSubject());
+    assertEquals(42, entity.getId());
+  }
+
+  @Test
+  public void getMetadataEncoder_returnsNullWhenUnwired() {
+    AbstractSchemaRegistry registry = mock(AbstractSchemaRegistry.class, CALLS_REAL_METHODS);
+    assertNull(registry.getMetadataEncoder());
+  }
+}


### PR DESCRIPTION
## Summary

Make SR-level metadata encoding optional. `AbstractSchemaRegistry` today unconditionally dereferences `metadataEncoder` at two sites, so every implementation must wire one (or a no-op stub). This adds null guards so implementations that don't need SR-level metadata encoding can leave it unset.

- Null-guard the two `decodeMetadata` call sites in `AbstractSchemaRegistry` (inside `allVersions()` and `toSchemaEntity()`).
- Document the nullability contract on `SchemaRegistry.getMetadataEncoder()`.
- Add a unit test covering both sites with a null encoder.

`KafkaSchemaRegistry` always wires a non-null `KafkaMetadataEncoderService`, so the Kafka-backed path is unchanged.

JIRA: DGS-23560

## Test plan
- [x] `AbstractSchemaRegistryNullEncoderTest` — new unit test, both cases pass.
- [ ] Existing `RestApiMetadataEncoderTest` remains green (Kafka path, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)