### PR TITLE
DGS-24065 Make $ref: #/$defs/X resolve consistently across JSON Schema drafts

### DIFF
--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -295,26 +295,6 @@ public class JsonSchema implements ParsedSchema {
     }
   }
 
-  public JsonSchema(
-      Schema schemaObj,
-      Integer version,
-      List<SchemaReference> references,
-      Map<String, String> resolvedReferences
-  ) {
-    try {
-      this.jsonNode = schemaObj != null ? objectMapper.readTree(schemaObj.toString()) : null;
-      this.schemaObj = schemaObj;
-      this.version = version;
-      this.references = references;
-      this.resolvedReferences = resolvedReferences;
-      this.metadata = null;
-      this.ruleSet = null;
-      this.ignoreModernDialects = false;
-    } catch (IOException e) {
-      throw new IllegalArgumentException("Invalid JSON schema", e);
-    }
-  }
-
   private JsonSchema(
       JsonNode jsonNode,
       com.github.erosb.jsonsKema.Schema skemaObj,
@@ -490,6 +470,11 @@ public class JsonSchema implements ParsedSchema {
       String content = mergeDefBuckets(dep.getValue(), "definitions", "$defs");
       URI uri = new URI(dep.getKey());
       mappings.put(uri, content);
+      // Also register under the base-resolved absolute URI. json-sKema resolves a
+      // cross-document ref like `$ref: "external.json#/$defs/X"` against the document
+      // base (`mem://input`) before looking it up, producing
+      // `mem://input/external.json`. Without this entry, the relative form above
+      // wouldn't be matched and the ref would fail to resolve.
       mappings.put(base.resolve(dep.getKey()), content);
       if (!uri.isAbsolute() && !dep.getKey().startsWith(".")) {
         // For backward compatibility

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -295,6 +295,26 @@ public class JsonSchema implements ParsedSchema {
     }
   }
 
+  public JsonSchema(
+      Schema schemaObj,
+      Integer version,
+      List<SchemaReference> references,
+      Map<String, String> resolvedReferences
+  ) {
+    try {
+      this.jsonNode = schemaObj != null ? objectMapper.readTree(schemaObj.toString()) : null;
+      this.schemaObj = schemaObj;
+      this.version = version;
+      this.references = references;
+      this.resolvedReferences = resolvedReferences;
+      this.metadata = null;
+      this.ruleSet = null;
+      this.ignoreModernDialects = false;
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Invalid JSON schema", e);
+    }
+  }
+
   private JsonSchema(
       JsonNode jsonNode,
       com.github.erosb.jsonsKema.Schema skemaObj,
@@ -459,23 +479,92 @@ public class JsonSchema implements ParsedSchema {
     return prepopulatedMetaSchemas;
   }
 
-  private void loadLatestDraft() throws URISyntaxException {
+  private void loadLatestDraft() throws URISyntaxException, IOException {
     Map<URI, String> mappings = new HashMap<>(getPrepopulatedMappings());
+    URI base = URI.create(DEFAULT_BASE_URI);
     for (Map.Entry<String, String> dep : resolvedReferences.entrySet()) {
+      // Bridge top-level draft-7 `definitions` into `$defs` so json-sKema's
+      // JSON Pointer resolver can locate entries inside them. The original
+      // content is left untouched in resolvedReferences; only the in-memory
+      // copy passed to the loader is augmented.
+      String content = mergeDefBuckets(dep.getValue(), "definitions", "$defs");
       URI uri = new URI(dep.getKey());
-      mappings.put(uri, dep.getValue());
+      mappings.put(uri, content);
+      mappings.put(base.resolve(dep.getKey()), content);
       if (!uri.isAbsolute() && !dep.getKey().startsWith(".")) {
         // For backward compatibility
-        mappings.put(new URI("./" + dep.getKey()), dep.getValue());
+        mappings.put(new URI("./" + dep.getKey()), content);
       }
     }
     SchemaLoaderConfig config = SchemaLoaderConfig.createDefaultConfig(mappings);
-    JsonValue schemaJson = objectMapper.convertValue(jsonNode, JsonObject.class);
+    // Apply the same bridge to the root document so refs like `#/$defs/X` resolve
+    // when the body lives in `definitions`.
+    String rootJson = mergeDefBuckets(
+        objectMapper.writeValueAsString(jsonNode), "definitions", "$defs");
+    JsonValue schemaJson = objectMapper.convertValue(
+        objectMapper.readTree(rootJson), JsonObject.class);
     skemaObj = new com.github.erosb.jsonsKema.SchemaLoader(schemaJson, config).load();
     SchemaTranslator.SchemaContext ctx = skemaObj.accept(new SchemaTranslator());
     assert ctx != null;
     ctx.close();
     schemaObj = ctx.schema();
+  }
+
+  /**
+   * Copies any top-level entries under {@code fromKey} into {@code toKey}.
+   *
+   * <p>Used by both load paths to bridge {@code definitions} entries into {@code $defs} so
+   * that {@code $ref: "#/$defs/X"} resolves regardless of which bucket the body lives in.
+   * The keys are parameterized to keep the helper algorithmically symmetric and easy to test
+   * in isolation; in production both call sites pass {@code ("definitions", "$defs")}.
+   *
+   * <p>Existing {@code toKey} entries take precedence on key collision (the target keyword
+   * wins). Returns the original string when:
+   * <ul>
+   *   <li>{@code json} is null or empty,</li>
+   *   <li>{@code json} parses to a non-object (e.g. a boolean schema),</li>
+   *   <li>{@code fromKey} is absent, its value is not an object, or its value is empty,</li>
+   *   <li>{@code toKey} is present but not an object (preserved rather than overwritten),</li>
+   *   <li>parsing fails (best-effort fallback).</li>
+   * </ul>
+   *
+   * <p>Top-level only — nested {@code definitions}/{@code $defs} inside subschemas are not
+   * bridged.
+   */
+  static String mergeDefBuckets(String json, String fromKey, String toKey) {
+    if (json == null || json.isEmpty()) {
+      return json;
+    }
+    try {
+      JsonNode root = objectMapper.readTree(json);
+      if (!root.isObject()) {
+        return json;
+      }
+      JsonNode source = root.get(fromKey);
+      if (source == null || !source.isObject() || source.size() == 0) {
+        // Nothing to copy — return as-is to avoid creating a stray empty target.
+        return json;
+      }
+      // Preserve a non-object target unchanged rather than overwriting it.
+      JsonNode existingTarget = root.get(toKey);
+      if (existingTarget != null && !existingTarget.isObject()) {
+        return json;
+      }
+      ObjectNode mut = (ObjectNode) root;
+      ObjectNode target = existingTarget != null
+          ? (ObjectNode) existingTarget
+          : mut.putObject(toKey);
+      java.util.Iterator<Map.Entry<String, JsonNode>> it = source.fields();
+      while (it.hasNext()) {
+        Map.Entry<String, JsonNode> entry = it.next();
+        if (!target.has(entry.getKey())) {
+          target.set(entry.getKey(), entry.getValue());
+        }
+      }
+      return objectMapper.writeValueAsString(mut);
+    } catch (IOException e) {
+      return json;
+    }
   }
 
   private void loadPreviousDraft(SpecificationVersion spec)
@@ -507,10 +596,22 @@ public class JsonSchema implements ParsedSchema {
     SchemaLoader.SchemaLoaderBuilder builder = SchemaLoader.builder()
         .useDefaults(true).draftV7Support();
     for (Map.Entry<String, String> dep : resolvedReferences.entrySet()) {
+      // Bridge top-level `definitions` into `$defs` so a `$ref: "#/$defs/X"`
+      // resolves via Everit's literal JSON Pointer fallback even when the
+      // schema author placed the body under draft-7's native `definitions`
+      // bucket. The asymmetric direction (definitions → $defs, not the
+      // reverse) makes `$defs` the canonical "forgiving" ref form across both
+      // drafts: a `$ref: "#/$defs/X"` always finds its target, regardless of
+      // which bucket the body actually lives in. The original content in
+      // resolvedReferences is left untouched; only the in-memory copy passed
+      // to the loader is augmented.
+      String content = mergeDefBuckets(dep.getValue(), "definitions", "$defs");
       URI child = ReferenceResolver.resolve(idUri, dep.getKey());
-      builder.registerSchemaByURI(child, new JSONObject(dep.getValue()));
+      builder.registerSchemaByURI(child, new JSONObject(content));
     }
-    JSONObject jsonObject = objectMapper.treeToValue(jsonNode, JSONObject.class);
+    String rootJson = mergeDefBuckets(
+        objectMapper.writeValueAsString(jsonNode), "definitions", "$defs");
+    JSONObject jsonObject = new JSONObject(rootJson);
     builder.schemaJson(jsonObject);
     SchemaLoader loader = builder.build();
     schemaObj = loader.load().build();

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -463,10 +463,10 @@ public class JsonSchema implements ParsedSchema {
     Map<URI, String> mappings = new HashMap<>(getPrepopulatedMappings());
     URI base = URI.create(DEFAULT_BASE_URI);
     for (Map.Entry<String, String> dep : resolvedReferences.entrySet()) {
-      // Bridge top-level draft-7 `definitions` into `$defs` so json-sKema's
-      // JSON Pointer resolver can locate entries inside them. The original
-      // content is left untouched in resolvedReferences; only the in-memory
-      // copy passed to the loader is augmented.
+      // Bridge top-level `definitions` entries into `$defs` so json-sKema (which
+      // only walks `$defs`) can resolve a `$ref: "#/$defs/X"` regardless of which
+      // bucket the body lives in. The original content is left untouched in
+      // resolvedReferences; only the in-memory copy passed to the loader is augmented.
       String content = mergeDefBuckets(dep.getValue(), "definitions", "$defs");
       URI uri = new URI(dep.getKey());
       mappings.put(uri, content);

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaDefBridgeTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaDefBridgeTest.java
@@ -247,6 +247,57 @@ public class JsonSchemaDefBridgeTest {
     schema.validate(true);
   }
 
+  /**
+   * Cross-draft: a draft-7 root imports a draft-2020-12 schema. The whole load is routed
+   * through Everit (the root's draft picks the loader), but the bridge is still applied to the
+   * imported content — so a body in {@code definitions} inside the import is reachable via
+   * {@code #/$defs/X}.
+   */
+  @Test
+  public void crossDraft_draft7Root_importsDraft2020Schema_resolves() {
+    String draft2020Import = "{"
+        + "\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\","
+        + "\"properties\":{\"x\":{\"$ref\":\"#/$defs/X\"}},"
+        + "\"definitions\":{\"X\":{\"type\":\"integer\"}}"
+        + "}";
+    String draft7Root = "{"
+        + "\"$schema\":\"http://json-schema.org/draft-07/schema#\","
+        + "\"type\":\"object\","
+        + "\"properties\":{\"item\":{\"$ref\":\"external.json\"}}"
+        + "}";
+    SchemaReference ref = new SchemaReference("external.json", "external", 1);
+    JsonSchema schema = new JsonSchema(draft7Root, ImmutableList.of(ref),
+        ImmutableMap.of("external.json", draft2020Import), null);
+    assertNotNull(schema.rawSchema());
+    schema.validate(true);
+  }
+
+  /**
+   * Cross-draft: a draft-2020-12 root imports a draft-7 schema. The whole load is routed
+   * through json-sKema, but the bridge is still applied to the imported content — so a body in
+   * {@code definitions} inside the import is reachable via {@code #/$defs/X}.
+   */
+  @Test
+  public void crossDraft_draft2020Root_importsDraft7Schema_resolves() {
+    String draft7Import = "{"
+        + "\"$schema\":\"http://json-schema.org/draft-07/schema#\","
+        + "\"type\":\"object\","
+        + "\"properties\":{\"x\":{\"$ref\":\"#/$defs/X\"}},"
+        + "\"definitions\":{\"X\":{\"type\":\"integer\"}}"
+        + "}";
+    String draft2020Root = "{"
+        + "\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\","
+        + "\"properties\":{\"item\":{\"$ref\":\"external.json\"}}"
+        + "}";
+    SchemaReference ref = new SchemaReference("external.json", "external", 1);
+    JsonSchema schema = new JsonSchema(draft2020Root, ImmutableList.of(ref),
+        ImmutableMap.of("external.json", draft7Import), null);
+    assertNotNull(schema.rawSchema());
+    schema.validate(true);
+  }
+
   // -----------------------------------------------------------------------------------------
   // Round-trip / no-mutation: bridging must not leak into the canonical form.
   // -----------------------------------------------------------------------------------------

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaDefBridgeTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaDefBridgeTest.java
@@ -248,6 +248,33 @@ public class JsonSchemaDefBridgeTest {
   }
 
   /**
+   * Cross-document fragment ref: a draft-2020-12 root with {@code $ref:
+   * "external.json#/$defs/X"} must resolve into the imported schema's {@code $defs} entry.
+   * Pins the {@code base.resolve(dep.getKey())} mapping in {@code loadLatestDraft} — without
+   * that registration, json-sKema would resolve the document part {@code external.json}
+   * against the document base ({@code mem://input}) into {@code mem://input/external.json},
+   * miss the un-resolved entry, and fail the lookup.
+   */
+  @Test
+  public void crossDocumentFragmentRef_resolvesViaBaseResolvedMapping() {
+    String external = "{"
+        + "\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\","
+        + "\"$defs\":{\"X\":{\"type\":\"integer\"}}"
+        + "}";
+    String root = "{"
+        + "\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\","
+        + "\"properties\":{\"item\":{\"$ref\":\"external.json#/$defs/X\"}}"
+        + "}";
+    SchemaReference ref = new SchemaReference("external.json", "external", 1);
+    JsonSchema schema = new JsonSchema(root, ImmutableList.of(ref),
+        ImmutableMap.of("external.json", external), null);
+    assertNotNull(schema.rawSchema());
+    schema.validate(true);
+  }
+
+  /**
    * Cross-draft: a draft-7 root imports a draft-2020-12 schema. The whole load is routed
    * through Everit (the root's draft picks the loader), but the bridge is still applied to the
    * imported content — so a body in {@code definitions} inside the import is reachable via

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaDefBridgeTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaDefBridgeTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import org.everit.json.schema.ObjectSchema;
+import org.everit.json.schema.ReferenceSchema;
+import org.everit.json.schema.Schema;
+import org.junit.Test;
+
+/**
+ * Tests for the {@code definitions → $defs} bridging inside {@link JsonSchema}.
+ *
+ * <p>Both load paths copy {@code definitions} entries into {@code $defs}, making {@code $defs}
+ * the canonical "forgiving" reference form across both drafts. The user-facing rule is:
+ *
+ * <ul>
+ *   <li>{@code $ref: "#/$defs/X"} always resolves, regardless of which bucket the body lives in.</li>
+ *   <li>{@code $ref: "#/definitions/X"} resolves only when the body is actually in
+ *       {@code definitions}.</li>
+ * </ul>
+ *
+ * <p>This trade-off is deliberate: schema authors and tooling can pick {@code $defs} as the
+ * single canonical ref form without worrying about draft compatibility, at the cost of one
+ * inverse pattern (body in {@code $defs}, ref via {@code #/definitions/X}) not working in
+ * draft 7. {@link #draft7_bodyInDefs_refViaDefinitions_fails} pins that gap as intentional.
+ */
+public class JsonSchemaDefBridgeTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  // -----------------------------------------------------------------------------------------
+  // Unit tests on JsonSchema.mergeDefBuckets — exercise the in-production direction.
+  // The helper is algorithmically symmetric in (fromKey, toKey); testing one direction is
+  // sufficient since the algorithm doesn't branch on the keyword names.
+  // -----------------------------------------------------------------------------------------
+
+  @Test
+  public void mergeDefBuckets_emptyOrAbsentSource_returnsUnchanged() throws Exception {
+    // Source key absent entirely.
+    String absent = "{\"type\":\"object\"}";
+    assertJsonEquals(absent, JsonSchema.mergeDefBuckets(absent, "definitions", "$defs"));
+
+    // Source key present but empty object — nothing to copy, target unchanged.
+    String empty = "{\"definitions\":{}}";
+    assertJsonEquals(empty, JsonSchema.mergeDefBuckets(empty, "definitions", "$defs"));
+  }
+
+  @Test
+  public void mergeDefBuckets_emptyOrAbsentTarget_copiesAllEntries() throws Exception {
+    // Target absent — copied wholesale.
+    String absentTarget = "{\"definitions\":{\"Foo\":{\"type\":\"string\"}}}";
+    JsonNode out = MAPPER.readTree(
+        JsonSchema.mergeDefBuckets(absentTarget, "definitions", "$defs"));
+    assertNotNull(out.get("$defs"));
+    assertEquals("string", out.get("$defs").get("Foo").get("type").asText());
+
+    // Target present but empty — entries copied in.
+    String emptyTarget = "{\"definitions\":{\"Foo\":{\"type\":\"string\"}},\"$defs\":{}}";
+    out = MAPPER.readTree(JsonSchema.mergeDefBuckets(emptyTarget, "definitions", "$defs"));
+    assertEquals("string", out.get("$defs").get("Foo").get("type").asText());
+  }
+
+  @Test
+  public void mergeDefBuckets_disjointKeys_merged() throws Exception {
+    String json = "{\"definitions\":{\"Foo\":{\"type\":\"string\"}},"
+        + "\"$defs\":{\"Bar\":{\"type\":\"integer\"}}}";
+    JsonNode out = MAPPER.readTree(JsonSchema.mergeDefBuckets(json, "definitions", "$defs"));
+    assertEquals("string", out.get("$defs").get("Foo").get("type").asText());
+    assertEquals("integer", out.get("$defs").get("Bar").get("type").asText());
+  }
+
+  @Test
+  public void mergeDefBuckets_collision_targetWins() throws Exception {
+    String json = "{\"definitions\":{\"Foo\":{\"type\":\"string\"}},"
+        + "\"$defs\":{\"Foo\":{\"type\":\"integer\"}}}";
+    JsonNode out = MAPPER.readTree(JsonSchema.mergeDefBuckets(json, "definitions", "$defs"));
+    // Target wins: "integer" should remain, not be overwritten by source's "string".
+    assertEquals("integer", out.get("$defs").get("Foo").get("type").asText());
+  }
+
+  @Test
+  public void mergeDefBuckets_nonObjectSourceOrTarget_ignored() throws Exception {
+    // Non-object source (e.g. `definitions: 42`): nothing to merge, return as-is.
+    String nonObjectSource = "{\"definitions\":42}";
+    assertJsonEquals(nonObjectSource,
+        JsonSchema.mergeDefBuckets(nonObjectSource, "definitions", "$defs"));
+
+    // Non-object target (e.g. `$defs: []`): preserved unchanged, don't overwrite with object.
+    String nonObjectTarget = "{\"definitions\":{\"Foo\":{\"type\":\"string\"}},\"$defs\":[]}";
+    JsonNode out = MAPPER.readTree(
+        JsonSchema.mergeDefBuckets(nonObjectTarget, "definitions", "$defs"));
+    assertTrue("non-object target preserved", out.get("$defs").isArray());
+
+    // Malformed JSON: best-effort fallback returns input unchanged (same instance).
+    String malformed = "{not-valid-json";
+    assertSame(malformed, JsonSchema.mergeDefBuckets(malformed, "definitions", "$defs"));
+  }
+
+  @Test
+  public void mergeDefBuckets_booleanSchemaRoot_unchanged() throws Exception {
+    assertJsonEquals("true", JsonSchema.mergeDefBuckets("true", "definitions", "$defs"));
+    assertJsonEquals("false", JsonSchema.mergeDefBuckets("false", "definitions", "$defs"));
+  }
+
+  // -----------------------------------------------------------------------------------------
+  // End-to-end tests on JsonSchema — exercise the full load path through Everit / json-sKema.
+  // -----------------------------------------------------------------------------------------
+
+  /**
+   * For every combination of draft and bucket keyword, a schema whose body lives in that bucket
+   * and whose ref uses the matching JSON Pointer keyword must resolve. Covers the "natural" cases
+   * across both load paths — native walks for the loader's preferred bucket, literal JSON Pointer
+   * fallback for the other.
+   */
+  @Test
+  public void bucketMatchingRef_resolvesAcrossDrafts() {
+    String[][] cases = new String[][]{
+        // {draft URI, bucket keyword}
+        {"http://json-schema.org/draft-04/schema#", "$defs"},
+        {"http://json-schema.org/draft-06/schema#", "$defs"},
+        {"http://json-schema.org/draft-07/schema#", "$defs"},
+        {"http://json-schema.org/draft-07/schema#", "definitions"},
+        {"https://json-schema.org/draft/2020-12/schema", "$defs"},
+        {"https://json-schema.org/draft/2020-12/schema", "definitions"},
+    };
+    for (String[] c : cases) {
+      String draftUri = c[0];
+      String bucket = c[1];
+      String schemaStr = "{"
+          + "\"$schema\":\"" + draftUri + "\","
+          + "\"type\":\"object\","
+          + "\"properties\":{\"thing\":{\"$ref\":\"#/" + bucket + "/Thing\"}},"
+          + "\"" + bucket + "\":{\"Thing\":{\"type\":\"integer\"}}"
+          + "}";
+      JsonSchema schema = new JsonSchema(schemaStr);
+      assertReferredPropertyResolves(schema, "thing", draftUri + " / " + bucket);
+    }
+  }
+
+  /**
+   * Draft-7 case 3: body in {@code definitions}, ref via {@code #/$defs/X}. The
+   * {@code definitions → $defs} bridge in {@code loadPreviousDraft} is what makes this work —
+   * after bridging the body is also at {@code root.$defs.Thing}, and Everit's literal JSON
+   * Pointer fallback resolves the ref.
+   */
+  @Test
+  public void draft7_bodyInDefinitions_refViaDefs_resolvesRefs() {
+    String schemaStr = "{"
+        + "\"$schema\":\"http://json-schema.org/draft-07/schema#\","
+        + "\"type\":\"object\","
+        + "\"properties\":{\"thing\":{\"$ref\":\"#/$defs/Thing\"}},"
+        + "\"definitions\":{\"Thing\":{\"type\":\"integer\"}}"
+        + "}";
+    JsonSchema schema = new JsonSchema(schemaStr);
+    assertReferredPropertyResolves(schema, "thing", "draft-7 body-in-definitions, ref via $defs");
+  }
+
+  /**
+   * Draft-7 case 1: body in {@code $defs}, ref via {@code #/definitions/X}. <b>Intentional
+   * gap.</b> The bridge direction (definitions → $defs) does not cover this combination — the
+   * body never lands in {@code definitions}, so neither the URI registry nor the literal
+   * fallback can find it. Pinned as a regression marker so the gap doesn't change silently.
+   *
+   * <p>Schema authors should use {@code #/$defs/X} as the canonical ref form — that always
+   * resolves regardless of body location.
+   */
+  @Test
+  public void draft7_bodyInDefs_refViaDefinitions_fails() {
+    String schemaStr = "{"
+        + "\"$schema\":\"http://json-schema.org/draft-07/schema#\","
+        + "\"type\":\"object\","
+        + "\"properties\":{\"thing\":{\"$ref\":\"#/definitions/Thing\"}},"
+        + "\"$defs\":{\"Thing\":{\"type\":\"integer\"}}"
+        + "}";
+    try {
+      new JsonSchema(schemaStr).rawSchema();
+      fail("Expected IllegalArgumentException for draft-7 body-in-$defs + ref-via-definitions");
+    } catch (IllegalArgumentException expected) {
+      // Pinned: this combination is intentionally unsupported.
+    }
+  }
+
+  /**
+   * Draft-2020-12 case 1: body in {@code definitions}, ref via {@code #/$defs/X}. The
+   * {@code definitions → $defs} bridge in {@code loadLatestDraft} is what makes this work —
+   * after bridging json-sKema sees {@code $defs.Thing} in its native walk and registers the URI.
+   */
+  @Test
+  public void draft2020_bodyInDefinitions_refViaDefs_resolvesRefs() {
+    String schemaStr = "{"
+        + "\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\","
+        + "\"properties\":{\"thing\":{\"$ref\":\"#/$defs/Thing\"}},"
+        + "\"definitions\":{\"Thing\":{\"type\":\"integer\"}}"
+        + "}";
+    JsonSchema schema = new JsonSchema(schemaStr);
+    assertReferredPropertyResolves(schema, "thing", "draft-2020-12 body-in-definitions, ref via $defs");
+  }
+
+  /**
+   * The bridge applies to {@code resolvedReferences} content too: an external schema brought in
+   * via SR references that uses the non-native bucket must remain reachable from the importing
+   * root.
+   */
+  @Test
+  public void externalRef_via_resolvedReferences_resolves() {
+    String externalSchema = "{"
+        + "\"$schema\":\"http://json-schema.org/draft-07/schema#\","
+        + "\"type\":\"object\","
+        + "\"properties\":{\"x\":{\"$ref\":\"#/$defs/X\"}},"
+        + "\"definitions\":{\"X\":{\"type\":\"integer\"}}"
+        + "}";
+    String rootSchema = "{"
+        + "\"$schema\":\"http://json-schema.org/draft-07/schema#\","
+        + "\"type\":\"object\","
+        + "\"properties\":{\"item\":{\"$ref\":\"external.json\"}}"
+        + "}";
+    SchemaReference ref = new SchemaReference("external.json", "external", 1);
+    JsonSchema schema = new JsonSchema(rootSchema, ImmutableList.of(ref),
+        ImmutableMap.of("external.json", externalSchema), null);
+    // Schema loads without error — the bridged external schema's body was reachable.
+    assertNotNull(schema.rawSchema());
+    schema.validate(true);
+  }
+
+  // -----------------------------------------------------------------------------------------
+  // Round-trip / no-mutation: bridging must not leak into the canonical form.
+  // -----------------------------------------------------------------------------------------
+
+  /**
+   * Bridging mutates an in-memory copy passed to the loader, never the source representation.
+   * The schema's canonical form should still reflect the original keyword set, so persisted /
+   * fingerprinted schemas don't shift.
+   */
+  @Test
+  public void canonicalForm_unchangedByBridging() throws Exception {
+    String schemaStr = "{"
+        + "\"$schema\":\"http://json-schema.org/draft-07/schema#\","
+        + "\"type\":\"object\","
+        + "\"properties\":{\"thing\":{\"$ref\":\"#/$defs/Thing\"}},"
+        + "\"definitions\":{\"Thing\":{\"type\":\"integer\"}}"
+        + "}";
+    JsonSchema schema = new JsonSchema(schemaStr);
+    schema.rawSchema(); // force load — triggers bridging
+    JsonNode canonical = MAPPER.readTree(schema.canonicalString());
+    // The bridge must not have copied entries into `$defs` in the canonical form.
+    assertTrue("definitions preserved", canonical.has("definitions"));
+    assertTrue("$defs not introduced by bridging", !canonical.has("$defs"));
+  }
+
+  // -----------------------------------------------------------------------------------------
+  // Helpers
+  // -----------------------------------------------------------------------------------------
+
+  private static void assertJsonEquals(String expected, String actual) throws Exception {
+    assertEquals(MAPPER.readTree(expected), MAPPER.readTree(actual));
+  }
+
+  /**
+   * Walk to the named property, follow any {@code ReferenceSchema}, and assert the body is
+   * present and resolved (i.e. {@code getReferredSchema()} is non-null). The {@code label}
+   * is included in failure messages to identify which case failed.
+   */
+  private static void assertReferredPropertyResolves(
+      JsonSchema schema, String propertyName, String label) {
+    Schema raw = schema.rawSchema();
+    assertNotNull("rawSchema() returned null for " + label, raw);
+    assertTrue("expected ObjectSchema root for " + label, raw instanceof ObjectSchema);
+    Schema property = ((ObjectSchema) raw).getPropertySchemas().get(propertyName);
+    assertNotNull("property '" + propertyName + "' missing for " + label, property);
+    if (property instanceof ReferenceSchema) {
+      assertNotNull(
+          "ReferenceSchema for '" + propertyName + "' is unresolved for " + label,
+          ((ReferenceSchema) property).getReferredSchema());
+    }
+  }
+
+}


### PR DESCRIPTION
In JsonSchema, handling of both JSON Schema draft 7 and JSON Schema draft 2020-12 now copy definitions entries into $defs during processing (the source representation is left untouched).  This allows schemas for both drafts to use $ref: #/$defs/X consistently.

<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
