### PR TITLE
DGS-24114 Support public import for empty Proto schemas

### DIFF
--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -2393,8 +2393,8 @@ public class ProtobufSchema implements ParsedSchema {
    * key off this predicate so they treat the same shapes as "delegating"
    * consistently.
    */
-  private boolean hasPublicImport() {
-    return resolvePublicImport() != null;
+  private boolean isPublicImportWrapper() {
+    return resolvePublicImportWrapper() != null;
   }
 
   /**
@@ -2407,7 +2407,7 @@ public class ProtobufSchema implements ParsedSchema {
    * <p>Resolution is depth-1 only: the empty wrapper must directly import a
    * non-empty file. Chains of empty wrappers are not supported.
    */
-  private ProtoFileElement resolvePublicImport() {
+  private ProtoFileElement resolvePublicImportWrapper() {
     if (schemaObj == null) {
       return null;
     }
@@ -2433,7 +2433,7 @@ public class ProtobufSchema implements ParsedSchema {
    * {@link #hasTopLevelField}, etc.
    */
   private ProtoFileElement effectiveFile() {
-    ProtoFileElement leaf = resolvePublicImport();
+    ProtoFileElement leaf = resolvePublicImportWrapper();
     return leaf != null ? leaf : schemaObj;
   }
 
@@ -2633,7 +2633,7 @@ public class ProtobufSchema implements ParsedSchema {
     // null here is honest: callers (toSpecificDescriptor, deserializer) already
     // handle null by skipping the Class.forName lookup or surfacing a clear
     // error rather than building a wrong path.
-    if (hasPublicImport()) {
+    if (isPublicImportWrapper()) {
       return null;
     }
     Map<String, OptionElement> options = mergeOptions(schemaObj.getOptions());

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -2408,13 +2408,15 @@ public class ProtobufSchema implements ParsedSchema {
     if (schemaObj.getPublicImports().size() != 1) {
       return null;
     }
-    // Use the same dep map descriptor resolution uses (well-known protos like
-    // google/protobuf/timestamp.proto live in KNOWN_DEPENDENCIES, not the
-    // user-provided `dependencies`); otherwise an empty wrapper publicly
-    // importing a well-known type would resolve at descriptor-build time but
-    // not be detected as a wrapper here.
-    ProtoFileElement leaf =
-        dependenciesWithLogicalTypes().get(schemaObj.getPublicImports().get(0));
+    // Mirror descriptor resolution: well-known protos (timestamp, struct, etc.)
+    // live in KNOWN_DEPENDENCIES, not user-provided `dependencies`. Two cheap
+    // lookups avoid the HashMap allocation in `dependenciesWithLogicalTypes()`
+    // — important since this method runs on the per-record serialize path.
+    String depName = schemaObj.getPublicImports().get(0);
+    ProtoFileElement leaf = dependencies.get(depName);
+    if (leaf == null) {
+      leaf = KNOWN_DEPENDENCIES.get(depName);
+    }
     if (leaf == null || leaf.getTypes().isEmpty()) {
       return null;
     }

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -2411,6 +2411,9 @@ public class ProtobufSchema implements ParsedSchema {
     if (schemaObj == null) {
       return null;
     }
+    if (!schemaObj.getTypes().isEmpty()) {
+      return null;
+    }
     if (!schemaObj.getImports().isEmpty()) {
       return null;
     }

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -2408,7 +2408,13 @@ public class ProtobufSchema implements ParsedSchema {
     if (schemaObj.getPublicImports().size() != 1) {
       return null;
     }
-    ProtoFileElement leaf = dependencies.get(schemaObj.getPublicImports().get(0));
+    // Use the same dep map descriptor resolution uses (well-known protos like
+    // google/protobuf/timestamp.proto live in KNOWN_DEPENDENCIES, not the
+    // user-provided `dependencies`); otherwise an empty wrapper publicly
+    // importing a well-known type would resolve at descriptor-build time but
+    // not be detected as a wrapper here.
+    ProtoFileElement leaf =
+        dependenciesWithLogicalTypes().get(schemaObj.getPublicImports().get(0));
     if (leaf == null || leaf.getTypes().isEmpty()) {
       return null;
     }

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -2374,14 +2374,99 @@ public class ProtobufSchema implements ParsedSchema {
     if (typeElement == null) {
       typeElement = firstEnum();
     }
-    if (typeElement == null) {
-      throw new IllegalArgumentException("Protobuf schema definition contains no type definitions");
+    if (typeElement != null) {
+      String typeName = typeElement.getName();
+      String packageName = schemaObj.getPackageName();
+      return packageName != null && !packageName.isEmpty()
+          ? packageName + '.' + typeName
+          : typeName;
     }
-    String typeName = typeElement.getName();
-    String packageName = schemaObj.getPackageName();
-    return packageName != null && !packageName.isEmpty()
-        ? packageName + '.' + typeName
-        : typeName;
+    // Fall through to publicly-imported types: an empty public-import file
+    // (`import public "leaf.proto";` with no local messages or enums) takes
+    // its name from the first publicly-imported type. The package on that
+    // name comes from the *imported* file, not this file.
+    String publicImportedName = firstPublicImportedTypeFullName();
+    if (publicImportedName != null) {
+      return publicImportedName;
+    }
+    throw new IllegalArgumentException("Protobuf schema definition contains no type definitions");
+  }
+
+  /**
+   * True iff this file has no local types but declares at least one
+   * {@code import public}. The serialized representation of such a file
+   * delegates index-based message lookup to the publicly-imported file.
+   */
+  private boolean isEmptyPublicImport() {
+    return schemaObj != null
+        && schemaObj.getTypes().isEmpty()
+        && !schemaObj.getPublicImports().isEmpty();
+  }
+
+  /**
+   * For an empty file with exactly one {@code import public} and no private
+   * imports, returns the directly-imported {@link ProtoFileElement} provided
+   * it has at least one local type. Returns null if the shape is malformed
+   * (zero or multiple public imports, any private imports, missing dep, or
+   * the dep itself has no local types).
+   *
+   * <p>Resolution is depth-1 only: the empty wrapper must directly import a
+   * non-empty file. Chains of empty wrappers are not supported.
+   */
+  private ProtoFileElement resolvePublicImportTarget() {
+    if (schemaObj == null) {
+      return null;
+    }
+    if (!schemaObj.getImports().isEmpty()) {
+      return null;
+    }
+    if (schemaObj.getPublicImports().size() != 1) {
+      return null;
+    }
+    ProtoFileElement leaf = dependencies.get(schemaObj.getPublicImports().get(0));
+    if (leaf == null || leaf.getTypes().isEmpty()) {
+      return null;
+    }
+    return leaf;
+  }
+
+  /**
+   * Fully-qualified name (using the imported file's package) of the first
+   * message — or, failing that, the first enum — in the publicly-imported
+   * file. Returns null if the public-import shape is malformed.
+   */
+  private String firstPublicImportedTypeFullName() {
+    ProtoFileElement leaf = resolvePublicImportTarget();
+    if (leaf == null) {
+      return null;
+    }
+    TypeElement first = firstTypeIn(leaf);
+    if (first == null) {
+      return null;
+    }
+    String pkg = leaf.getPackageName();
+    return (pkg != null && !pkg.isEmpty())
+        ? pkg + '.' + first.getName()
+        : first.getName();
+  }
+
+  /**
+   * First {@link MessageElement} in {@code file} (lexical order); failing
+   * that, the first {@link EnumElement}. Returns null if the file has
+   * neither.
+   */
+  private static TypeElement firstTypeIn(ProtoFileElement file) {
+    for (TypeElement t : file.getTypes()) {
+      if (t instanceof MessageElement) {
+        return t;
+      }
+    }
+    for (TypeElement t : file.getTypes()) {
+      if (t instanceof EnumElement) {
+        return t;
+      }
+    }
+    return null;
   }
 
   @Override
@@ -2489,6 +2574,12 @@ public class ProtobufSchema implements ParsedSchema {
   public void validate(boolean strict) {
     // Normalization will try to resolve types
     normalize();
+    if (isEmptyPublicImport() && resolvePublicImportTarget() == null) {
+      throw new IllegalArgumentException(
+          "Empty public-import schema must declare exactly one `import public`, "
+              + "no private imports, and the imported file must contain at least "
+              + "one type");
+    }
   }
 
   @Override
@@ -2660,8 +2751,21 @@ public class ProtobufSchema implements ParsedSchema {
 
   public MessageIndexes toMessageIndexes(String name, boolean normalize) {
     List<Integer> indexes = new ArrayList<>();
-    String[] parts = name.split("\\.");
     List<TypeElement> types = schemaObj.getTypes();
+    // Empty public-import file: index space comes from the publicly-imported
+    // file. Strip its package from `name` so the per-part walk matches local
+    // type names.
+    if (isEmptyPublicImport()) {
+      ProtoFileElement leaf = resolvePublicImportTarget();
+      if (leaf != null) {
+        types = leaf.getTypes();
+        String leafPkg = leaf.getPackageName();
+        if (leafPkg != null && !leafPkg.isEmpty() && name.startsWith(leafPkg + ".")) {
+          name = name.substring(leafPkg.length() + 1);
+        }
+      }
+    }
+    String[] parts = name.split("\\.");
     for (String part : parts) {
       int i = 0;
       for (TypeElement type : types) {
@@ -2689,6 +2793,17 @@ public class ProtobufSchema implements ParsedSchema {
   public String toMessageName(MessageIndexes indexes) {
     StringBuilder sb = new StringBuilder();
     List<TypeElement> types = schemaObj.getTypes();
+    String packageName = schemaObj.getPackageName();
+    // Empty public-import file: types and package come from the publicly-
+    // imported file so the indexes resolve in the same space the serializer
+    // used.
+    if (isEmptyPublicImport()) {
+      ProtoFileElement leaf = resolvePublicImportTarget();
+      if (leaf != null) {
+        types = leaf.getTypes();
+        packageName = leaf.getPackageName();
+      }
+    }
     boolean first = true;
     List<Integer> indexList = indexes.indexes();
     if (indexList.isEmpty()) {
@@ -2709,7 +2824,6 @@ public class ProtobufSchema implements ParsedSchema {
       types = message.getNestedTypes();
     }
     String messageName = sb.toString();
-    String packageName = schemaObj.getPackageName();
     return packageName != null && !packageName.isEmpty()
         ? packageName + '.' + messageName
         : messageName;

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -2386,18 +2386,6 @@ public class ProtobufSchema implements ParsedSchema {
   }
 
   /**
-   * True iff this file is a resolvable empty public-import wrapper —
-   * specifically, no local types, no private imports, exactly one
-   * {@code import public}, and a present dependency with at least one local
-   * type. Delegating methods ({@link #effectiveFile}, {@link #fullName}) all
-   * key off this predicate so they treat the same shapes as "delegating"
-   * consistently.
-   */
-  private boolean isPublicImportWrapper() {
-    return resolvePublicImportWrapper() != null;
-  }
-
-  /**
    * For an empty file with exactly one {@code import public} and no private
    * imports, returns the directly-imported {@link ProtoFileElement} provided
    * it has at least one local type. Returns null if the shape is malformed
@@ -2630,15 +2618,6 @@ public class ProtobufSchema implements ParsedSchema {
   }
 
   public String fullName(String originalPath) {
-    // An empty public-import wrapper has no Java class of its own — codegen
-    // for the resolved type lives in the imported file's namespace, with that
-    // file's java_package / java_outer_classname (not this wrapper's). Returning
-    // null here is honest: callers (toSpecificDescriptor, deserializer) already
-    // handle null by skipping the Class.forName lookup or surfacing a clear
-    // error rather than building a wrong path.
-    if (isPublicImportWrapper()) {
-      return null;
-    }
     Map<String, OptionElement> options = mergeOptions(schemaObj.getOptions());
     OptionElement javaPackageName = options.get(JAVA_PACKAGE);
     OptionElement javaOuterClassname = options.get(JAVA_OUTER_CLASSNAME);

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -2405,6 +2405,12 @@ public class ProtobufSchema implements ParsedSchema {
     if (!schemaObj.getImports().isEmpty()) {
       return null;
     }
+    if (!schemaObj.getServices().isEmpty()) {
+      return null;
+    }
+    if (!schemaObj.getExtendDeclarations().isEmpty()) {
+      return null;
+    }
     if (schemaObj.getPublicImports().size() != 1) {
       return null;
     }

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -2353,7 +2353,7 @@ public class ProtobufSchema implements ParsedSchema {
 
   @Override
   public boolean hasTopLevelField(String field) {
-    return schemaObj != null && schemaObj.getTypes()
+    return schemaObj != null && effectiveFile().getTypes()
             .stream()
             .map(ProtobufSchema::getFieldNames)
             .flatMap(Collection::stream)
@@ -2428,6 +2428,24 @@ public class ProtobufSchema implements ParsedSchema {
       return null;
     }
     return leaf;
+  }
+
+  /**
+   * The {@link ProtoFileElement} whose types and package define this schema's
+   * effective type space. For a normal schema this is {@link #schemaObj}. For
+   * an empty public-import wrapper that resolves to a valid imported file,
+   * this is the imported file. Used to centralize the "look at the imported
+   * file's types instead of mine" logic across {@link #toMessageIndexes},
+   * {@link #toMessageName}, {@link #hasTopLevelField}, etc.
+   */
+  private ProtoFileElement effectiveFile() {
+    if (isEmptyPublicImport()) {
+      ProtoFileElement leaf = resolvePublicImportTarget();
+      if (leaf != null) {
+        return leaf;
+      }
+    }
+    return schemaObj;
   }
 
   /**
@@ -2574,12 +2592,6 @@ public class ProtobufSchema implements ParsedSchema {
   public void validate(boolean strict) {
     // Normalization will try to resolve types
     normalize();
-    if (isEmptyPublicImport() && resolvePublicImportTarget() == null) {
-      throw new IllegalArgumentException(
-          "Empty public-import schema must declare exactly one `import public`, "
-              + "no private imports, and the imported file must contain at least "
-              + "one type");
-    }
   }
 
   @Override
@@ -2665,6 +2677,15 @@ public class ProtobufSchema implements ParsedSchema {
   }
 
   public String fullName(String originalPath) {
+    // An empty public-import wrapper has no Java class of its own — codegen
+    // for the resolved type lives in the imported file's namespace, with that
+    // file's java_package / java_outer_classname (not this wrapper's). Returning
+    // null here is honest: callers (toSpecificDescriptor, deserializer) already
+    // handle null by skipping the Class.forName lookup or surfacing a clear
+    // error rather than building a wrong path.
+    if (isEmptyPublicImport()) {
+      return null;
+    }
     Map<String, OptionElement> options = mergeOptions(schemaObj.getOptions());
     OptionElement javaPackageName = options.get(JAVA_PACKAGE);
     OptionElement javaOuterClassname = options.get(JAVA_OUTER_CLASSNAME);
@@ -2751,18 +2772,14 @@ public class ProtobufSchema implements ParsedSchema {
 
   public MessageIndexes toMessageIndexes(String name, boolean normalize) {
     List<Integer> indexes = new ArrayList<>();
-    List<TypeElement> types = schemaObj.getTypes();
-    // Empty public-import file: index space comes from the publicly-imported
-    // file. Strip its package from `name` so the per-part walk matches local
-    // type names.
-    if (isEmptyPublicImport()) {
-      ProtoFileElement leaf = resolvePublicImportTarget();
-      if (leaf != null) {
-        types = leaf.getTypes();
-        String leafPkg = leaf.getPackageName();
-        if (leafPkg != null && !leafPkg.isEmpty() && name.startsWith(leafPkg + ".")) {
-          name = name.substring(leafPkg.length() + 1);
-        }
+    ProtoFileElement file = effectiveFile();
+    List<TypeElement> types = file.getTypes();
+    // For an empty public-import wrapper, `file` is the imported file. Strip
+    // its package from `name` so the per-part walk matches local type names.
+    if (file != schemaObj) {
+      String pkg = file.getPackageName();
+      if (pkg != null && !pkg.isEmpty() && name.startsWith(pkg + ".")) {
+        name = name.substring(pkg.length() + 1);
       }
     }
     String[] parts = name.split("\\.");
@@ -2792,18 +2809,9 @@ public class ProtobufSchema implements ParsedSchema {
 
   public String toMessageName(MessageIndexes indexes) {
     StringBuilder sb = new StringBuilder();
-    List<TypeElement> types = schemaObj.getTypes();
-    String packageName = schemaObj.getPackageName();
-    // Empty public-import file: types and package come from the publicly-
-    // imported file so the indexes resolve in the same space the serializer
-    // used.
-    if (isEmptyPublicImport()) {
-      ProtoFileElement leaf = resolvePublicImportTarget();
-      if (leaf != null) {
-        types = leaf.getTypes();
-        packageName = leaf.getPackageName();
-      }
-    }
+    ProtoFileElement file = effectiveFile();
+    List<TypeElement> types = file.getTypes();
+    String packageName = file.getPackageName();
     boolean first = true;
     List<Integer> indexList = indexes.indexes();
     if (indexList.isEmpty()) {

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -1509,8 +1509,8 @@ public class ProtobufSchema implements ParsedSchema {
     return toDynamicSchema().getEnumValue(enumTypeName, enumNumber);
   }
 
-  private MessageElement firstMessage() {
-    for (TypeElement typeElement : schemaObj.getTypes()) {
+  private static MessageElement firstMessage(ProtoFileElement file) {
+    for (TypeElement typeElement : file.getTypes()) {
       if (typeElement instanceof MessageElement) {
         return (MessageElement) typeElement;
       }
@@ -1518,8 +1518,8 @@ public class ProtobufSchema implements ParsedSchema {
     return null;
   }
 
-  private EnumElement firstEnum() {
-    for (TypeElement typeElement : schemaObj.getTypes()) {
+  private static EnumElement firstEnum(ProtoFileElement file) {
+    for (TypeElement typeElement : file.getTypes()) {
       if (typeElement instanceof EnumElement) {
         return (EnumElement) typeElement;
       }
@@ -2370,37 +2370,31 @@ public class ProtobufSchema implements ParsedSchema {
     if (name != null) {
       return name;
     }
-    TypeElement typeElement = firstMessage();
+    ProtoFileElement file = effectiveFile();
+    TypeElement typeElement = firstMessage(file);
     if (typeElement == null) {
-      typeElement = firstEnum();
+      typeElement = firstEnum(file);
     }
     if (typeElement != null) {
       String typeName = typeElement.getName();
-      String packageName = schemaObj.getPackageName();
+      String packageName = file.getPackageName();
       return packageName != null && !packageName.isEmpty()
           ? packageName + '.' + typeName
           : typeName;
-    }
-    // Fall through to publicly-imported types: an empty public-import file
-    // (`import public "leaf.proto";` with no local messages or enums) takes
-    // its name from the first publicly-imported type. The package on that
-    // name comes from the *imported* file, not this file.
-    String publicImportedName = firstPublicImportedTypeFullName();
-    if (publicImportedName != null) {
-      return publicImportedName;
     }
     throw new IllegalArgumentException("Protobuf schema definition contains no type definitions");
   }
 
   /**
-   * True iff this file has no local types but declares at least one
-   * {@code import public}. The serialized representation of such a file
-   * delegates index-based message lookup to the publicly-imported file.
+   * True iff this file is a resolvable empty public-import wrapper —
+   * specifically, no local types, no private imports, exactly one
+   * {@code import public}, and a present dependency with at least one local
+   * type. Delegating methods ({@link #effectiveFile}, {@link #fullName}) all
+   * key off this predicate so they treat the same shapes as "delegating"
+   * consistently.
    */
-  private boolean isEmptyPublicImport() {
-    return schemaObj != null
-        && schemaObj.getTypes().isEmpty()
-        && !schemaObj.getPublicImports().isEmpty();
+  private boolean hasPublicImport() {
+    return resolvePublicImport() != null;
   }
 
   /**
@@ -2413,7 +2407,7 @@ public class ProtobufSchema implements ParsedSchema {
    * <p>Resolution is depth-1 only: the empty wrapper must directly import a
    * non-empty file. Chains of empty wrappers are not supported.
    */
-  private ProtoFileElement resolvePublicImportTarget() {
+  private ProtoFileElement resolvePublicImport() {
     if (schemaObj == null) {
       return null;
     }
@@ -2433,58 +2427,14 @@ public class ProtobufSchema implements ParsedSchema {
   /**
    * The {@link ProtoFileElement} whose types and package define this schema's
    * effective type space. For a normal schema this is {@link #schemaObj}. For
-   * an empty public-import wrapper that resolves to a valid imported file,
-   * this is the imported file. Used to centralize the "look at the imported
-   * file's types instead of mine" logic across {@link #toMessageIndexes},
-   * {@link #toMessageName}, {@link #hasTopLevelField}, etc.
+   * a resolvable empty public-import wrapper, this is the imported file.
+   * Used to centralize the "look at the imported file's types instead of
+   * mine" logic across {@link #toMessageIndexes}, {@link #toMessageName},
+   * {@link #hasTopLevelField}, etc.
    */
   private ProtoFileElement effectiveFile() {
-    if (isEmptyPublicImport()) {
-      ProtoFileElement leaf = resolvePublicImportTarget();
-      if (leaf != null) {
-        return leaf;
-      }
-    }
-    return schemaObj;
-  }
-
-  /**
-   * Fully-qualified name (using the imported file's package) of the first
-   * message — or, failing that, the first enum — in the publicly-imported
-   * file. Returns null if the public-import shape is malformed.
-   */
-  private String firstPublicImportedTypeFullName() {
-    ProtoFileElement leaf = resolvePublicImportTarget();
-    if (leaf == null) {
-      return null;
-    }
-    TypeElement first = firstTypeIn(leaf);
-    if (first == null) {
-      return null;
-    }
-    String pkg = leaf.getPackageName();
-    return (pkg != null && !pkg.isEmpty())
-        ? pkg + '.' + first.getName()
-        : first.getName();
-  }
-
-  /**
-   * First {@link MessageElement} in {@code file} (lexical order); failing
-   * that, the first {@link EnumElement}. Returns null if the file has
-   * neither.
-   */
-  private static TypeElement firstTypeIn(ProtoFileElement file) {
-    for (TypeElement t : file.getTypes()) {
-      if (t instanceof MessageElement) {
-        return t;
-      }
-    }
-    for (TypeElement t : file.getTypes()) {
-      if (t instanceof EnumElement) {
-        return t;
-      }
-    }
-    return null;
+    ProtoFileElement leaf = resolvePublicImport();
+    return leaf != null ? leaf : schemaObj;
   }
 
   @Override
@@ -2683,7 +2633,7 @@ public class ProtobufSchema implements ParsedSchema {
     // null here is honest: callers (toSpecificDescriptor, deserializer) already
     // handle null by skipping the Class.forName lookup or surfacing a clear
     // error rather than building a wrong path.
-    if (isEmptyPublicImport()) {
+    if (hasPublicImport()) {
       return null;
     }
     Map<String, OptionElement> options = mergeOptions(schemaObj.getOptions());

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -3343,6 +3343,33 @@ public class ProtobufSchemaTest {
   }
 
   /**
+   * Empty public-import wrapper around a well-known proto (e.g.,
+   * {@code google/protobuf/timestamp.proto}) must be detected as a wrapper.
+   * Well-known types live in {@code KNOWN_DEPENDENCIES}, not user-provided
+   * {@code dependencies}, so wrapper resolution must consult the same
+   * dep map that descriptor resolution uses.
+   */
+  @Test
+  public void testPublicImportOfWellKnownType() {
+    String topProto = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "import public \"google/protobuf/timestamp.proto\";\n";
+
+    ProtobufSchema top = new ProtobufSchema(
+        topProto,
+        Collections.emptyList(),
+        Collections.emptyMap(),
+        1,
+        null);
+
+    // name() should resolve through to the well-known Timestamp type.
+    assertEquals("google.protobuf.Timestamp", top.name());
+    // hasTopLevelField sees Timestamp's fields (seconds, nanos).
+    assertTrue(top.hasTopLevelField("seconds"));
+    assertTrue(top.hasTopLevelField("nanos"));
+  }
+
+  /**
    * A schema with both its own local types AND an {@code import public} is
    * NOT a public-import wrapper — its local types take precedence. The
    * delegating methods ({@link ProtobufSchema#name},

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -33,6 +33,7 @@ import io.confluent.kafka.schemaregistry.SimpleParsedSchemaHolder;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.protobuf.MessageIndexes;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema.Format;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils.FormatContext;
 import io.confluent.kafka.schemaregistry.protobuf.diff.Context;
@@ -3188,5 +3189,195 @@ public class ProtobufSchemaTest {
     ResourceLoader resourceLoader = new ResourceLoader(
         "/io/confluent/kafka/schemaregistry/protobuf/diff/");
     return resourceLoader.toString(fileName);
+  }
+
+  /**
+   * A re-export-only schema (no local messages or enums, just an
+   * {@code import public}) should expose the publicly-imported type as its
+   * canonical name. Without the fall-through, {@link ProtobufSchema#name()}
+   * throws "Protobuf schema definition contains no type definitions".
+   */
+  @Test
+  public void testNameFallsThroughToPublicImport() {
+    String leafProto = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "message Foo {\n"
+        + "  string id = 1;\n"
+        + "}\n";
+    String reExportProto = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "import public \"leaf.proto\";\n";
+
+    Map<String, String> resolved = new HashMap<>();
+    resolved.put("leaf.proto", leafProto);
+    ProtobufSchema reExport = new ProtobufSchema(
+        reExportProto,
+        Collections.singletonList(new SchemaReference("leaf.proto", "leaf-subject", 1)),
+        resolved,
+        1,
+        null);
+
+    // name() must resolve through the public import to com.Foo.
+    assertEquals("com.Foo", reExport.name());
+
+    // canonicalString() preserves the `import public` form (re-emitted by the
+    // existing publicDependency-aware rendering — verifying it isn't broken).
+    assertTrue("expected `import public` in canonical form, got: "
+            + reExport.canonicalString(),
+        reExport.canonicalString().contains("import public \"leaf.proto\""));
+
+    // toDescriptor() should resolve through the public dep and return the
+    // imported type's Descriptor.
+    Descriptor desc = reExport.toDescriptor();
+    assertNotNull("expected a Descriptor for the publicly-imported type", desc);
+    assertEquals("Foo", desc.getName());
+    assertEquals("com.Foo", desc.getFullName());
+  }
+
+  /**
+   * Empty public-import file with multiple {@code import public} declarations
+   * is rejected: the index space for serialize/deserialize must be unambiguous,
+   * which requires a single public import. {@link ProtobufSchema#validate(boolean)}
+   * throws on this shape.
+   */
+  @Test
+  public void testValidateRejectsMultiplePublicImports() {
+    String aProto = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "message Foo {\n"
+        + "  string id = 1;\n"
+        + "}\n";
+    String bProto = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "message Bar {\n"
+        + "  string id = 1;\n"
+        + "}\n";
+    String topProto = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "import public \"a.proto\";\n"
+        + "import public \"b.proto\";\n";
+
+    Map<String, String> resolved = new HashMap<>();
+    resolved.put("a.proto", aProto);
+    resolved.put("b.proto", bProto);
+    ProtobufSchema top = new ProtobufSchema(
+        topProto,
+        Arrays.asList(
+            new SchemaReference("a.proto", "a-subject", 1),
+            new SchemaReference("b.proto", "b-subject", 1)),
+        resolved,
+        1,
+        null);
+
+    IllegalArgumentException ex = assertThrows(
+        IllegalArgumentException.class, () -> top.validate(false));
+    assertTrue("expected empty-public-import error, got: " + ex.getMessage(),
+        ex.getMessage().contains("Empty public-import schema"));
+  }
+
+  /**
+   * Empty public-import file with a private (non-public) import alongside the
+   * public import is rejected: only a single public import and no other imports
+   * are allowed.
+   */
+  @Test
+  public void testValidateRejectsMixedPrivateAndPublicImports() {
+    String leafProto = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "message Foo {\n"
+        + "  string id = 1;\n"
+        + "}\n";
+    String sideProto = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "message Side {\n"
+        + "  string id = 1;\n"
+        + "}\n";
+    String topProto = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "import \"side.proto\";\n"
+        + "import public \"leaf.proto\";\n";
+
+    Map<String, String> resolved = new HashMap<>();
+    resolved.put("side.proto", sideProto);
+    resolved.put("leaf.proto", leafProto);
+    ProtobufSchema top = new ProtobufSchema(
+        topProto,
+        Arrays.asList(
+            new SchemaReference("side.proto", "side-subject", 1),
+            new SchemaReference("leaf.proto", "leaf-subject", 1)),
+        resolved,
+        1,
+        null);
+
+    IllegalArgumentException ex = assertThrows(
+        IllegalArgumentException.class, () -> top.validate(false));
+    assertTrue("expected empty-public-import error, got: " + ex.getMessage(),
+        ex.getMessage().contains("Empty public-import schema"));
+  }
+
+  /**
+   * Empty public-import file pointing at another empty file (no local types
+   * in the imported file) is rejected at validation time.
+   */
+  @Test
+  public void testValidateRejectsEmptyImportedFile() {
+    String emptyLeaf = "syntax = \"proto3\";\n"
+        + "package com;\n";
+    String topProto = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "import public \"empty.proto\";\n";
+
+    Map<String, String> resolved = new HashMap<>();
+    resolved.put("empty.proto", emptyLeaf);
+    ProtobufSchema top = new ProtobufSchema(
+        topProto,
+        Collections.singletonList(new SchemaReference("empty.proto", "empty-subject", 1)),
+        resolved,
+        1,
+        null);
+
+    IllegalArgumentException ex = assertThrows(
+        IllegalArgumentException.class, () -> top.validate(false));
+    assertTrue("expected empty-public-import error, got: " + ex.getMessage(),
+        ex.getMessage().contains("Empty public-import schema"));
+  }
+
+  /**
+   * Index round-trip for an empty public-import file: encoding a leaf type's
+   * fully-qualified name to {@link MessageIndexes} and back must produce the
+   * same name. With two messages in the leaf, a non-zero index ({@code Bar}
+   * at position 1) verifies the wrapper delegates to the leaf's index space
+   * rather than collapsing everything to {@code [0]}.
+   */
+  @Test
+  public void testIndexesRoundTripThroughPublicImport() {
+    String leafProto = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "message Foo {\n"
+        + "  string id = 1;\n"
+        + "}\n"
+        + "message Bar {\n"
+        + "  int32 n = 1;\n"
+        + "}\n";
+    String topProto = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "import public \"leaf.proto\";\n";
+
+    Map<String, String> resolved = new HashMap<>();
+    resolved.put("leaf.proto", leafProto);
+    ProtobufSchema top = new ProtobufSchema(
+        topProto,
+        Collections.singletonList(new SchemaReference("leaf.proto", "leaf-subject", 1)),
+        resolved,
+        1,
+        null);
+
+    MessageIndexes fooIdx = top.toMessageIndexes("com.Foo");
+    assertEquals(Collections.singletonList(0), fooIdx.indexes());
+    assertEquals("com.Foo", top.toMessageName(fooIdx));
+
+    MessageIndexes barIdx = top.toMessageIndexes("com.Bar");
+    assertEquals(Collections.singletonList(1), barIdx.indexes());
+    assertEquals("com.Bar", top.toMessageName(barIdx));
   }
 }

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -3334,4 +3334,45 @@ public class ProtobufSchemaTest {
     assertNull(top.fullName("ignored.proto"));
     assertNull(top.toSpecificDescriptor("ignored.proto"));
   }
+
+  /**
+   * A schema with both its own local types AND an {@code import public} is
+   * NOT a public-import wrapper — its local types take precedence. The
+   * delegating methods ({@link ProtobufSchema#name},
+   * {@link ProtobufSchema#toMessageIndexes}, {@link ProtobufSchema#hasTopLevelField})
+   * must read the wrapper's local types, not the imported file's.
+   */
+  @Test
+  public void testLocalTypesWinOverPublicImport() {
+    String leafProto = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "message Imported {\n"
+        + "  string id = 1;\n"
+        + "}\n";
+    String topProto = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "import public \"leaf.proto\";\n"
+        + "message Local {\n"
+        + "  int32 n = 1;\n"
+        + "}\n";
+
+    Map<String, String> resolved = new HashMap<>();
+    resolved.put("leaf.proto", leafProto);
+    ProtobufSchema top = new ProtobufSchema(
+        topProto,
+        Collections.singletonList(new SchemaReference("leaf.proto", "leaf-subject", 1)),
+        resolved,
+        1,
+        null);
+
+    // name() must return the LOCAL type, not the imported one.
+    assertEquals("com.Local", top.name());
+    // hasTopLevelField must see the local type's fields, not the imported one's.
+    assertTrue(top.hasTopLevelField("n"));
+    assertFalse(top.hasTopLevelField("id"));
+    // toMessageIndexes must encode the local type at index 0.
+    MessageIndexes localIdx = top.toMessageIndexes("com.Local");
+    assertEquals(Collections.singletonList(0), localIdx.indexes());
+    assertEquals("com.Local", top.toMessageName(localIdx));
+  }
 }

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -63,6 +63,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -3235,114 +3236,6 @@ public class ProtobufSchemaTest {
   }
 
   /**
-   * Empty public-import file with multiple {@code import public} declarations
-   * is rejected: the index space for serialize/deserialize must be unambiguous,
-   * which requires a single public import. {@link ProtobufSchema#validate(boolean)}
-   * throws on this shape.
-   */
-  @Test
-  public void testValidateRejectsMultiplePublicImports() {
-    String aProto = "syntax = \"proto3\";\n"
-        + "package com;\n"
-        + "message Foo {\n"
-        + "  string id = 1;\n"
-        + "}\n";
-    String bProto = "syntax = \"proto3\";\n"
-        + "package com;\n"
-        + "message Bar {\n"
-        + "  string id = 1;\n"
-        + "}\n";
-    String topProto = "syntax = \"proto3\";\n"
-        + "package com;\n"
-        + "import public \"a.proto\";\n"
-        + "import public \"b.proto\";\n";
-
-    Map<String, String> resolved = new HashMap<>();
-    resolved.put("a.proto", aProto);
-    resolved.put("b.proto", bProto);
-    ProtobufSchema top = new ProtobufSchema(
-        topProto,
-        Arrays.asList(
-            new SchemaReference("a.proto", "a-subject", 1),
-            new SchemaReference("b.proto", "b-subject", 1)),
-        resolved,
-        1,
-        null);
-
-    IllegalArgumentException ex = assertThrows(
-        IllegalArgumentException.class, () -> top.validate(false));
-    assertTrue("expected empty-public-import error, got: " + ex.getMessage(),
-        ex.getMessage().contains("Empty public-import schema"));
-  }
-
-  /**
-   * Empty public-import file with a private (non-public) import alongside the
-   * public import is rejected: only a single public import and no other imports
-   * are allowed.
-   */
-  @Test
-  public void testValidateRejectsMixedPrivateAndPublicImports() {
-    String leafProto = "syntax = \"proto3\";\n"
-        + "package com;\n"
-        + "message Foo {\n"
-        + "  string id = 1;\n"
-        + "}\n";
-    String sideProto = "syntax = \"proto3\";\n"
-        + "package com;\n"
-        + "message Side {\n"
-        + "  string id = 1;\n"
-        + "}\n";
-    String topProto = "syntax = \"proto3\";\n"
-        + "package com;\n"
-        + "import \"side.proto\";\n"
-        + "import public \"leaf.proto\";\n";
-
-    Map<String, String> resolved = new HashMap<>();
-    resolved.put("side.proto", sideProto);
-    resolved.put("leaf.proto", leafProto);
-    ProtobufSchema top = new ProtobufSchema(
-        topProto,
-        Arrays.asList(
-            new SchemaReference("side.proto", "side-subject", 1),
-            new SchemaReference("leaf.proto", "leaf-subject", 1)),
-        resolved,
-        1,
-        null);
-
-    IllegalArgumentException ex = assertThrows(
-        IllegalArgumentException.class, () -> top.validate(false));
-    assertTrue("expected empty-public-import error, got: " + ex.getMessage(),
-        ex.getMessage().contains("Empty public-import schema"));
-  }
-
-  /**
-   * Empty public-import file pointing at another empty file (no local types
-   * in the imported file) is rejected at validation time.
-   */
-  @Test
-  public void testValidateRejectsEmptyImportedFile() {
-    String emptyLeaf = "syntax = \"proto3\";\n"
-        + "package com;\n";
-    String topProto = "syntax = \"proto3\";\n"
-        + "package com;\n"
-        + "import public \"empty.proto\";\n";
-
-    Map<String, String> resolved = new HashMap<>();
-    resolved.put("empty.proto", emptyLeaf);
-    ProtobufSchema top = new ProtobufSchema(
-        topProto,
-        Collections.singletonList(new SchemaReference("empty.proto", "empty-subject", 1)),
-        resolved,
-        1,
-        null);
-
-    IllegalArgumentException ex = assertThrows(
-        IllegalArgumentException.class, () -> top.validate(false));
-    assertTrue("expected empty-public-import error, got: " + ex.getMessage(),
-        ex.getMessage().contains("Empty public-import schema"));
-  }
-
-  /**
    * Index round-trip for an empty public-import file: encoding a leaf type's
    * fully-qualified name to {@link MessageIndexes} and back must produce the
    * same name. With two messages in the leaf, a non-zero index ({@code Bar}
@@ -3379,5 +3272,66 @@ public class ProtobufSchemaTest {
     MessageIndexes barIdx = top.toMessageIndexes("com.Bar");
     assertEquals(Collections.singletonList(1), barIdx.indexes());
     assertEquals("com.Bar", top.toMessageName(barIdx));
+  }
+
+  /**
+   * {@link ProtobufSchema#hasTopLevelField} for an empty public-import wrapper
+   * must report fields from the publicly-imported file, not from the wrapper's
+   * (empty) local types.
+   */
+  @Test
+  public void testHasTopLevelFieldThroughPublicImport() {
+    String leafProto = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "message Foo {\n"
+        + "  string id = 1;\n"
+        + "}\n";
+    String topProto = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "import public \"leaf.proto\";\n";
+
+    Map<String, String> resolved = new HashMap<>();
+    resolved.put("leaf.proto", leafProto);
+    ProtobufSchema top = new ProtobufSchema(
+        topProto,
+        Collections.singletonList(new SchemaReference("leaf.proto", "leaf-subject", 1)),
+        resolved,
+        1,
+        null);
+
+    assertTrue(top.hasTopLevelField("id"));
+    assertFalse(top.hasTopLevelField("nonexistent"));
+  }
+
+  /**
+   * {@link ProtobufSchema#fullName} returns null for an empty public-import
+   * wrapper. The wrapper has no Java class of its own — codegen lives in the
+   * imported file under that file's java options. Returning null is honest;
+   * existing callers (toSpecificDescriptor, derive-type deserializer) handle
+   * null cleanly.
+   */
+  @Test
+  public void testFullNameReturnsNullForEmptyPublicImport() {
+    String leafProto = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "message Foo {\n"
+        + "  string id = 1;\n"
+        + "}\n";
+    String topProto = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "import public \"leaf.proto\";\n";
+
+    Map<String, String> resolved = new HashMap<>();
+    resolved.put("leaf.proto", leafProto);
+    ProtobufSchema top = new ProtobufSchema(
+        topProto,
+        Collections.singletonList(new SchemaReference("leaf.proto", "leaf-subject", 1)),
+        resolved,
+        1,
+        null);
+
+    assertNull(top.fullName());
+    assertNull(top.fullName("ignored.proto"));
+    assertNull(top.toSpecificDescriptor("ignored.proto"));
   }
 }

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -3304,14 +3304,16 @@ public class ProtobufSchemaTest {
   }
 
   /**
-   * {@link ProtobufSchema#fullName} returns null for an empty public-import
-   * wrapper. The wrapper has no Java class of its own — codegen lives in the
-   * imported file under that file's java options. Returning null is honest;
-   * existing callers (toSpecificDescriptor, derive-type deserializer) handle
-   * null cleanly.
+   * {@link ProtobufSchema#fullName} for an empty public-import wrapper returns
+   * the wrapper file's own generated class name (e.g.,
+   * {@code com.LeafWrapper}), not the imported type's class. This matches
+   * what {@code protoc} generates for an empty {@code import public} file —
+   * a real Java class with a {@code getDescriptor()} returning the
+   * {@link FileDescriptor}. {@code toSpecificDescriptor} can then load that
+   * class and return the file descriptor.
    */
   @Test
-  public void testFullNameReturnsNullForEmptyPublicImport() {
+  public void testFullNameOfEmptyPublicImportWrapper() {
     String leafProto = "syntax = \"proto3\";\n"
         + "package com;\n"
         + "message Foo {\n"
@@ -3330,9 +3332,14 @@ public class ProtobufSchemaTest {
         1,
         null);
 
+    // Without a path or java_outer_classname there's nothing to derive the
+    // class name from, so fullName() with no path returns null (existing
+    // contract for any schema with no java_outer_classname).
     assertNull(top.fullName());
-    assertNull(top.fullName("ignored.proto"));
-    assertNull(top.toSpecificDescriptor("ignored.proto"));
+    // With an originalPath, fullName derives the outer class name from the
+    // file name — for an empty wrapper that's the file-level class protoc
+    // generates (e.g. "Wrapper" → "com.Wrapper").
+    assertEquals("com.Wrapper", top.fullName("Wrapper.proto"));
   }
 
   /**

--- a/protobuf-serializer/src/test/java/io/confluent/kafka/schemaregistry/protobuf/rest/RestApiSerializerTest.java
+++ b/protobuf-serializer/src/test/java/io/confluent/kafka/schemaregistry/protobuf/rest/RestApiSerializerTest.java
@@ -79,6 +79,7 @@ import static io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializerTes
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RestApiSerializerTest extends ClusterTestHarness {
 
@@ -579,6 +580,181 @@ public class RestApiSerializerTest extends ClusterTestHarness {
     );
 
     checkNormalization(schemaRegistry, "EnumReference.proto");
+  }
+
+  /**
+   * A schema that consists of nothing but {@code import public "..."} should:
+   *   1. register successfully against the SR server,
+   *   2. be usable through {@code KafkaProtobufSerializer} /
+   *      {@code KafkaProtobufDeserializer} (the resolved Descriptor flows
+   *      through the publicly-imported file in both directions), and
+   *   3. pass backward-compat checks against an identical public-import file.
+   *
+   * <p>Pattern mirrors {@code testEnumRoot}: pre-register the imported file
+   * and the public-import wrapper, then drive serialize/deserialize through
+   * Kafka serializers with {@code USE_LATEST_VERSION} so the serializer picks
+   * up the pre-registered wrapper schema for the topic's subject.
+   */
+  @Test
+  public void testImportPublic() throws Exception {
+    // 1. Pre-register the imported schema (`com.Foo`) at "leaf-subject".
+    String leafSchemaText = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "message Foo {\n"
+        + "  string id = 1;\n"
+        + "}\n";
+    int leafId = restApp.restClient.registerSchema(leafSchemaText,
+        ProtobufSchema.TYPE,
+        Collections.emptyList(),
+        "leaf-subject",
+        false).getId();
+    assertNotNull(restApp.restClient.getId(leafId));
+
+    // 2. Pre-register an empty public-import wrapper at "test-value" (the
+    // topic's subject) that pulls in the imported schema via `import public`.
+    // No local types — just package + public import. This is the schema the
+    // serializer will use.
+    String wrapperSchemaText = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "import public \"leaf.proto\";\n";
+    List<SchemaReference> refs = Collections.singletonList(
+        new SchemaReference("leaf.proto", "leaf-subject", 1));
+    int wrapperId = restApp.restClient.registerSchema(wrapperSchemaText,
+        ProtobufSchema.TYPE,
+        refs,
+        topic + "-value",
+        false).getId();
+    assertNotNull(restApp.restClient.getId(wrapperId));
+
+    // 3. Configure a serializer that USES the pre-registered wrapper
+    // (USE_LATEST_VERSION + AUTO_REGISTER off). Without this, the serializer
+    // would try to auto-register the message's own schema and bypass the
+    // wrapper entirely.
+    Properties serializerConfig = new Properties();
+    serializerConfig.put(KafkaProtobufSerializerConfig.AUTO_REGISTER_SCHEMAS, false);
+    serializerConfig.put(KafkaProtobufSerializerConfig.USE_LATEST_VERSION, true);
+    // The strict-latest check structurally diffs the message's schema against
+    // the registered latest. For an empty public-import wrapper, that diff
+    // sees a gap (message has Foo, registered file has no types) and refuses.
+    // Disabling the strict check is the supported way to use a public-import
+    // wrapper as the registered latest.
+    serializerConfig.put(KafkaProtobufSerializerConfig.LATEST_COMPATIBILITY_STRICT, false);
+    serializerConfig.put(KafkaProtobufSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "bogus");
+    SchemaRegistryClient schemaRegistry = new CachedSchemaRegistryClient(restApp.restClient,
+        10,
+        Collections.singletonList(new ProtobufSchemaProvider()),
+        Collections.emptyMap(),
+        Collections.emptyMap()
+    );
+    KafkaProtobufSerializer protobufSerializer = new KafkaProtobufSerializer(schemaRegistry,
+        new HashMap(serializerConfig));
+
+    KafkaProtobufDeserializer protobufDeserializer = new KafkaProtobufDeserializer(schemaRegistry);
+
+    // 4. Build a `com.Foo` DynamicMessage via the wrapper's resolved
+    // Descriptor (a generated Java class isn't available since `Foo` is
+    // declared inline in the test).
+    ProtobufSchema wrapper =
+        (ProtobufSchema) schemaRegistry.getSchemaBySubjectAndId(topic + "-value", wrapperId);
+    Descriptor desc = wrapper.toDescriptor();
+    assertEquals("com.Foo", desc.getFullName());
+    DynamicMessage.Builder builder = DynamicMessage.newBuilder(desc);
+    builder.setField(desc.findFieldByName("id"), "test-id");
+    DynamicMessage fooMessage = builder.build();
+
+    // 5. Round-trip through the serializer/deserializer. Bytes carry the
+    // wrapper's schema ID; on read, the deserializer fetches the wrapper,
+    // resolves its Descriptor through the public import, and parses bytes
+    // against `com.Foo`.
+    byte[] bytes = protobufSerializer.serialize(topic, fooMessage);
+    DynamicMessage roundTripped =
+        (DynamicMessage) protobufDeserializer.deserialize(topic, bytes);
+    assertEquals("test-id", getField(roundTripped, "id"));
+
+    // 6. Backward compat: re-registering an identical wrapper must succeed
+    // (no diff at the file level since both sides have empty local types).
+    List<String> compatErrors = restApp.restClient.testCompatibility(
+        wrapperSchemaText,
+        ProtobufSchema.TYPE,
+        refs,
+        topic + "-value",
+        "latest",
+        false);
+    assertTrue(compatErrors.isEmpty(),
+        "re-registering an identical public-import wrapper should be compatible, got: "
+            + compatErrors);
+  }
+
+  /**
+   * Same shape as {@link #testImportPublic}, but the leaf has two messages and
+   * the test serializes the *second* one. Confirms the wrapper's
+   * {@code toDescriptor(name)} can find non-first leaf types and that the
+   * serializer/deserializer index round-trip lands on the right message.
+   */
+  @Test
+  public void testImportPublicNonFirstMessage() throws Exception {
+    String leafSchemaText = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "message Foo {\n"
+        + "  string id = 1;\n"
+        + "}\n"
+        + "message Bar {\n"
+        + "  int32 n = 1;\n"
+        + "}\n";
+    int leafId = restApp.restClient.registerSchema(leafSchemaText,
+        ProtobufSchema.TYPE,
+        Collections.emptyList(),
+        "leaf-subject",
+        false).getId();
+    assertNotNull(restApp.restClient.getId(leafId));
+
+    String reExportSchemaText = "syntax = \"proto3\";\n"
+        + "package com;\n"
+        + "import public \"leaf.proto\";\n";
+    List<SchemaReference> refs = Collections.singletonList(
+        new SchemaReference("leaf.proto", "leaf-subject", 1));
+    int reExportId = restApp.restClient.registerSchema(reExportSchemaText,
+        ProtobufSchema.TYPE,
+        refs,
+        topic + "-value",
+        false).getId();
+    assertNotNull(restApp.restClient.getId(reExportId));
+
+    Properties serializerConfig = new Properties();
+    serializerConfig.put(KafkaProtobufSerializerConfig.AUTO_REGISTER_SCHEMAS, false);
+    serializerConfig.put(KafkaProtobufSerializerConfig.USE_LATEST_VERSION, true);
+    serializerConfig.put(KafkaProtobufSerializerConfig.LATEST_COMPATIBILITY_STRICT, false);
+    serializerConfig.put(KafkaProtobufSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "bogus");
+    SchemaRegistryClient schemaRegistry = new CachedSchemaRegistryClient(restApp.restClient,
+        10,
+        Collections.singletonList(new ProtobufSchemaProvider()),
+        Collections.emptyMap(),
+        Collections.emptyMap()
+    );
+    KafkaProtobufSerializer protobufSerializer = new KafkaProtobufSerializer(schemaRegistry,
+        new HashMap(serializerConfig));
+    KafkaProtobufDeserializer protobufDeserializer = new KafkaProtobufDeserializer(schemaRegistry);
+
+    // Build a com.Bar (the *second* message in the leaf). toDescriptor(name)
+    // must find Bar through the public import — name() would only return Foo.
+    ProtobufSchema reExport =
+        (ProtobufSchema) schemaRegistry.getSchemaBySubjectAndId(topic + "-value", reExportId);
+    Descriptor barDesc = reExport.toDescriptor("com.Bar");
+    assertNotNull(barDesc,
+        "expected toDescriptor(\"com.Bar\") to resolve via public import");
+    assertEquals("com.Bar", barDesc.getFullName());
+    DynamicMessage.Builder builder = DynamicMessage.newBuilder(barDesc);
+    builder.setField(barDesc.findFieldByName("n"), 42);
+    DynamicMessage barMessage = builder.build();
+
+    // Round-trip. The serializer encodes index [1] (Bar's position in the
+    // leaf); the deserializer decodes it back to com.Bar and parses the bytes
+    // against the right descriptor.
+    byte[] bytes = protobufSerializer.serialize(topic, barMessage);
+    DynamicMessage roundTripped =
+        (DynamicMessage) protobufDeserializer.deserialize(topic, bytes);
+    assertEquals("com.Bar", roundTripped.getDescriptorForType().getFullName());
+    assertEquals(42, getField(roundTripped, "n"));
   }
 
   private static void checkNormalization(SchemaRegistryClient schemaRegistry, String fileName)


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Support public import for empty Proto schemas.  SR serdes can now support schemas of the following form, which is simply a reference to another Proto schema.
```
syntax = "proto3";

import public "com.example.demo.Address";
```
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
