### PR TITLE
Add schema.reject.empty.subject config to reject empty subjects on register

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
@@ -478,13 +478,31 @@ public class QualifiedSubject implements Comparable<QualifiedSubject> {
    */
   public static boolean isValidSubject(
       String tenant, String qualifiedSubject, boolean isConfigOrMode) {
+    return isValidSubject(tenant, qualifiedSubject, isConfigOrMode, true);
+  }
+
+  /**
+   * Validates the given qualified subject for the given tenant, optionally rejecting the
+   * empty-string subject.
+   *
+   * @param tenant the tenant
+   * @param qualifiedSubject the subject with a tenant prefix
+   * @param isConfigOrMode true if the subject is for config or mode settings
+   * @param allowEmpty if false, reject an empty-string subject as invalid
+   * @return true if the qualified subject is valid, false otherwise
+   */
+  public static boolean isValidSubject(
+      String tenant, String qualifiedSubject, boolean isConfigOrMode, boolean allowEmpty) {
     if (qualifiedSubject == null || CharMatcher.javaIsoControl().matchesAnyOf(qualifiedSubject)) {
       return false;
     }
     QualifiedSubject qs = QualifiedSubject.create(tenant, qualifiedSubject);
-    // For backward compatibility, we allow an empty subject
+    // For backward compatibility, we allow an empty subject unless the caller opts out.
     if (qs == null || qs.getSubject().equals(GLOBAL_SUBJECT_NAME)
         || qs.getSubject().equals(EMPTY_SUBJECT_NAME)) {
+      return false;
+    }
+    if (!allowEmpty && qs.getSubject().isEmpty()) {
       return false;
     }
     if (!isConfigOrMode && qs.getContext().equals(GLOBAL_CONTEXT_NAME)) {

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubjectTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubjectTest.java
@@ -217,6 +217,27 @@ public class QualifiedSubjectTest {
   }
 
   @Test
+  public void testSubjectValidationRejectEmpty() {
+    // allowEmpty=true mirrors the legacy overload
+    assertTrue(QualifiedSubject.isValidSubject("default", "foo", false, true));
+    assertTrue(QualifiedSubject.isValidSubject("default", "", false, true));
+    assertTrue(QualifiedSubject.isValidSubject("default", ":.ctx:", false, true));
+
+    // allowEmpty=false rejects the empty-string subject in every context
+    assertTrue(QualifiedSubject.isValidSubject("default", "foo", false, false));
+    assertFalse(QualifiedSubject.isValidSubject("default", "", false, false));
+    assertFalse(QualifiedSubject.isValidSubject("default", ":.ctx:", false, false));
+    assertTrue(QualifiedSubject.isValidSubject("default", ":.ctx:foo", false, false));
+
+    // Pre-existing rules still apply with the new flag
+    assertFalse(QualifiedSubject.isValidSubject("default", null, false, false));
+    assertFalse(QualifiedSubject.isValidSubject(
+        "default", String.valueOf((char) 31), false, false));
+    assertFalse(QualifiedSubject.isValidSubject("default", "__GLOBAL", false, false));
+    assertFalse(QualifiedSubject.isValidSubject("default", "__EMPTY", false, false));
+  }
+
+  @Test
   public void testSubjectInContextCheck() {
     assertTrue(QualifiedSubject.isSubjectInContext(
         "default", "foo", QualifiedSubject.create("default", ":.:")));

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubjectTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubjectTest.java
@@ -223,6 +223,10 @@ public class QualifiedSubjectTest {
     assertTrue(QualifiedSubject.isValidSubject("default", "", false, true));
     assertTrue(QualifiedSubject.isValidSubject("default", ":.ctx:", false, true));
 
+    // Legacy 3-arg overload must still allow the empty-string subject (locks the contract)
+    assertTrue(QualifiedSubject.isValidSubject("default", "", false));
+    assertTrue(QualifiedSubject.isValidSubject("default", ":.ctx:", false));
+
     // allowEmpty=false rejects the empty-string subject in every context
     assertTrue(QualifiedSubject.isValidSubject("default", "foo", false, false));
     assertFalse(QualifiedSubject.isValidSubject("default", "", false, false));

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -199,6 +199,9 @@ public class SchemaRegistryConfig extends RestConfig {
   public static final String SCHEMA_VALIDATE_NEW_SCHEMAS_CONFIG = "schema.validate.new.schemas";
   public static final boolean SCHEMA_VALIDATE_NEW_SCHEMAS_DEFAULT = true;
 
+  public static final String SCHEMA_REJECT_EMPTY_SUBJECT_CONFIG = "schema.reject.empty.subject";
+  public static final boolean SCHEMA_REJECT_EMPTY_SUBJECT_DEFAULT = false;
+
   /**
    * <code>schema.cache.size</code>
    */
@@ -421,6 +424,10 @@ public class SchemaRegistryConfig extends RestConfig {
       + "beginning with $$";
   protected static final String VALIDATE_NEW_SCHEMAS_DOC = "Determines whether validation for new "
       + "schemas is enabled or not. If enabled, it validates both namespaces and defaults in Avro.";
+  protected static final String REJECT_EMPTY_SUBJECT_DOC =
+      "If true, reject schema registration requests whose subject name is the empty string. "
+      + "Defaults to false to preserve backward compatibility with existing deployments that "
+      + "may have schemas registered under an empty subject.";
   protected static final String SCHEMA_CACHE_SIZE_DOC =
       "The maximum size of the schema cache.";
   protected static final String SCHEMA_CACHE_EXPIRY_SECS_DOC =
@@ -656,6 +663,10 @@ public class SchemaRegistryConfig extends RestConfig {
     .define(SCHEMA_VALIDATE_NEW_SCHEMAS_CONFIG, ConfigDef.Type.BOOLEAN,
         SCHEMA_VALIDATE_NEW_SCHEMAS_DEFAULT,
         ConfigDef.Importance.LOW, VALIDATE_NEW_SCHEMAS_DOC
+    )
+    .define(SCHEMA_REJECT_EMPTY_SUBJECT_CONFIG, ConfigDef.Type.BOOLEAN,
+        SCHEMA_REJECT_EMPTY_SUBJECT_DEFAULT,
+        ConfigDef.Importance.LOW, REJECT_EMPTY_SUBJECT_DOC
     )
     .define(SCHEMA_CACHE_SIZE_CONFIG, ConfigDef.Type.INT, SCHEMA_CACHE_SIZE_DEFAULT,
         ConfigDef.Importance.LOW, SCHEMA_CACHE_SIZE_DOC

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -476,7 +476,10 @@ public class SubjectVersionsResource {
       }
     }
     if (subjectName != null
-        && !QualifiedSubject.isValidSubject(schemaRegistry.tenant(), subjectName)) {
+        && !QualifiedSubject.isValidSubject(
+               schemaRegistry.tenant(), subjectName, false, schemaRegistry.allowEmptySubject())) {
+      log.warn("Rejecting register: invalid subject name (tenant={}, subject={})",
+          schemaRegistry.tenant(), subjectName);
       throw Errors.invalidSubjectException(subjectName);
     }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -1807,6 +1807,11 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
   }
 
   @Override
+  public boolean allowEmptySubject() {
+    return !config().getBoolean(SchemaRegistryConfig.SCHEMA_REJECT_EMPTY_SUBJECT_CONFIG);
+  }
+
+  @Override
   public LookupCache<SchemaRegistryKey, SchemaRegistryValue> getLookupCache() {
     return lookupCache;
   }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
@@ -183,6 +183,13 @@ public interface SchemaRegistry extends SchemaVersionFetcher {
   default void setTenant(String tenant) {
   }
 
+  /**
+   * Whether the current registration context allows an empty-string subject name
+   */
+  default boolean allowEmptySubject() {
+    return true;
+  }
+
   SchemaRegistryConfig config();
 
   // Can be used to pass values between extensions

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiRejectEmptySubjectClusterTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiRejectEmptySubjectClusterTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rest;
+
+import io.confluent.kafka.schemaregistry.ClusterTestHarness;
+import java.util.Properties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+
+public class RestApiRejectEmptySubjectClusterTest extends RestApiRejectEmptySubjectTest {
+
+  protected ClusterTestHarness harness;
+
+  public RestApiRejectEmptySubjectClusterTest() {
+    this.harness = new ClusterTestHarness(1, true) {
+      @Override
+      public Properties getSchemaRegistryProperties() throws Exception {
+        Properties props = super.getSchemaRegistryProperties();
+        props.put(SchemaRegistryConfig.SCHEMA_REJECT_EMPTY_SUBJECT_CONFIG, true);
+        return props;
+      }
+    };
+  }
+
+  @BeforeEach
+  public void setUpTest(TestInfo testInfo) throws Exception {
+    harness.setUpTest(testInfo);
+    setRestApp(harness.getRestApp());
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    harness.tearDown();
+  }
+}

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiRejectEmptySubjectClusterTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiRejectEmptySubjectClusterTest.java
@@ -26,14 +26,8 @@ public class RestApiRejectEmptySubjectClusterTest extends RestApiRejectEmptySubj
   protected ClusterTestHarness harness;
 
   public RestApiRejectEmptySubjectClusterTest() {
-    this.harness = new ClusterTestHarness(1, true) {
-      @Override
-      public Properties getSchemaRegistryProperties() throws Exception {
-        Properties props = super.getSchemaRegistryProperties();
-        props.put(SchemaRegistryConfig.SCHEMA_REJECT_EMPTY_SUBJECT_CONFIG, true);
-        return props;
-      }
-    };
+    this.harness = new ClusterTestHarness(1, true);
+    this.harness.injectSchemaRegistryProperties(getSchemaRegistryProperties());
   }
 
   @BeforeEach
@@ -45,5 +39,11 @@ public class RestApiRejectEmptySubjectClusterTest extends RestApiRejectEmptySubj
   @AfterEach
   public void tearDown() throws Exception {
     harness.tearDown();
+  }
+
+  public Properties getSchemaRegistryProperties() {
+    Properties props = new Properties();
+    props.put(SchemaRegistryConfig.SCHEMA_REJECT_EMPTY_SUBJECT_CONFIG, true);
+    return props;
   }
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiRejectEmptySubjectTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiRejectEmptySubjectTest.java
@@ -51,6 +51,7 @@ public abstract class RestApiRejectEmptySubjectTest {
     RestClientException ex = assertThrows(RestClientException.class,
         () -> restApp.restClient.registerSchema(SCHEMA_STRING, EMPTY_SUBJECT_VIA_CONTEXT));
     assertEquals(Errors.INVALID_SUBJECT_ERROR_CODE, ex.getErrorCode());
+    assertEquals(422, ex.getStatus());
   }
 
   @Test

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiRejectEmptySubjectTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiRejectEmptySubjectTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.confluent.kafka.schemaregistry.RestApp;
+import io.confluent.kafka.schemaregistry.avro.AvroUtils;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Shared integration-test shape for schema.reject.empty.subject=true. Assumes the subclass
+ * has configured the registry with that flag set; the subject used for the "register empty"
+ * case is the context-prefix workaround {@code :.:} because Jetty rejects literal empty
+ * path segments.
+ */
+@Tag("IntegrationTest")
+public abstract class RestApiRejectEmptySubjectTest {
+
+  protected static final String EMPTY_SUBJECT_VIA_CONTEXT = ":.:";
+  protected static final String SCHEMA_STRING = AvroUtils.parseSchema(
+      "{\"type\":\"record\",\"name\":\"r\",\"fields\":[{\"name\":\"f\",\"type\":\"string\"}]}"
+  ).canonicalString();
+
+  protected RestApp restApp;
+
+  public void setRestApp(RestApp restApp) {
+    this.restApp = restApp;
+  }
+
+  @Test
+  public void testEmptySubjectRejectedWhenFlagEnabled() {
+    RestClientException ex = assertThrows(RestClientException.class,
+        () -> restApp.restClient.registerSchema(SCHEMA_STRING, EMPTY_SUBJECT_VIA_CONTEXT));
+    assertEquals(Errors.INVALID_SUBJECT_ERROR_CODE, ex.getErrorCode());
+  }
+
+  @Test
+  public void testNonEmptySubjectStillAllowedWhenFlagEnabled() throws Exception {
+    int id = restApp.restClient.registerSchema(SCHEMA_STRING, "normal-subject");
+    assertTrue(id > 0, "non-empty subject registration should still succeed");
+  }
+}


### PR DESCRIPTION
What
----
Adds an opt-in boolean config `schema.reject.empty.subject` (default `false` to preserve existing behavior). When `true`, schema registration under an empty-string subject is rejected with HTTP 422.

Why this shape:
- **Default off, opt-in.** Existing deployments that have schemas registered under an empty subject (which the API has historically allowed and which clients can't always reach round-trip — e.g. Jetty rejects `//` in URLs) keep working unchanged. Operators flip the flag when they're ready to refuse new ones.
- **Single new validation site.** Only `POST /subjects/{subject}/versions` is affected. DELETE, PUT config/mode, and modify-tags paths are intentionally untouched so existing empty-subject owners can still clean up or modify their data.
- **`SchemaRegistry#allowEmptySubject()` mirrors existing config-derived accessors** on the interface (`tenant()`, `config()`, `getConfigInScope(...)`). Concrete impl lives in `AbstractSchemaRegistry` reading the new flag; subclasses can override for finer-grained policy.
- **`QualifiedSubject.isValidSubject(...)` 4-arg overload** keeps the legacy 3-arg signature intact (delegates with `allowEmpty=true`) — no other validation rules change, and no other callers shift behavior.

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes — new config; default off, no behavior change unless enabled
- [x] Is this change gated behind feature flag(s)? — yes, the new `schema.reject.empty.subject` config (default `false`)
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
- [ ] Does this change require modifying existing system tests or adding new system tests?

References
----------
JIRA: [DGS-24014](https://confluentinc.atlassian.net/browse/DGS-24014)

Test & Review
------------
- `QualifiedSubjectTest#testSubjectValidationRejectEmpty` — the new 4-arg overload; legacy 3-arg behavior unchanged.
- `RestApiRejectEmptySubjectClusterTest` (new, integration) — exercises register flow end-to-end with `schema.reject.empty.subject=true`:
  - Empty-subject register → 422 with `INVALID_SUBJECT_ERROR_CODE`.
  - Non-empty subject register still succeeds.

Build/run:

\`\`\`
./mvnw -pl client,core -DskipTests install
./mvnw -pl client -Dtest=QualifiedSubjectTest test
./mvnw -pl core -Dit.test=RestApiRejectEmptySubjectClusterTest -Dtest=NONEXISTENT \\
  -Dsurefire.failIfNoSpecifiedTests=false verify
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DGS-24014]: https://confluentinc.atlassian.net/browse/DGS-24014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ