### PR TITLE
MINOR fix master build: replace removed kafka-clients Exit with System.exit

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/utils/ShutdownableThread.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/utils/ShutdownableThread.java
@@ -16,7 +16,6 @@
 package io.confluent.kafka.schemaregistry.utils;
 
 import org.apache.kafka.common.internals.FatalExitError;
-import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.LogContext;
 import org.slf4j.Logger;
 
@@ -133,7 +132,7 @@ public abstract class ShutdownableThread extends Thread {
       shutdownInitiated.countDown();
       shutdownComplete.countDown();
       log.info("Stopped");
-      Exit.exit(e.statusCode());
+      System.exit(e.statusCode());
     } catch (Throwable e) {
       if (isRunning()) {
         log.error("Error due to", e);

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/ClusterTestHarness.java
@@ -34,7 +34,6 @@ import kafka.server.KafkaBroker;
 import kafka.server.QuorumTestHarness;
 import org.apache.kafka.common.network.ConnectionMode;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.apache.kafka.common.utils.Java;
 import org.apache.kafka.common.utils.Time;
 
 import java.util.List;
@@ -490,7 +489,9 @@ public class ClusterTestHarness implements SchemaRegistryTestHarness {
     return sslProps;
   }
 
-  private static final boolean IS_IBM_SECURITY = Java.isIbmJdk() && !Java.isIbmJdkSemeru();
+  private static final boolean IS_IBM_SECURITY =
+      System.getProperty("java.vendor", "").contains("IBM")
+      && !System.getProperty("java.runtime.name", "").contains("Semeru");
 
   public static Properties saslConfigs(Optional<Properties> saslProperties) {
     Properties result = saslProperties.orElse(new Properties());

--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -73,6 +73,11 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
     </Match>
 
     <Match>
+        <Class name="io.confluent.kafka.schemaregistry.utils.ShutdownableThread"/>
+        <Bug pattern="DM_EXIT"/>
+    </Match>
+
+    <Match>
         <Class name="io.confluent.connect.avro.AvroData"/>
         <Bug pattern="RC_REF_COMPARISON_BAD_PRACTICE"/>
     </Match>


### PR DESCRIPTION
What
----

Two source files in this repo were importing now-internal Kafka utilities. This PR forward-ports them.

**1. `core/src/main/java/.../utils/ShutdownableThread.java`** — was using `org.apache.kafka.common.utils.Exit` in the `FatalExitError` handler.

* Replaced `Exit.exit(e.statusCode())` with `System.exit(e.statusCode())`.
* Behaviorally identical at runtime: Kafka's `Exit.DEFAULT_EXIT_PROCEDURE` is literally `(s, m) -> System.exit(s)`. This call site does not use Kafka's test-injection hooks (`Exit.setExitProcedure(...)`), so nothing is lost.
* `FatalExitError` is named "fatal" by contract — exiting the JVM is the intended behavior, not a regression.

**2. `findbugs/findbugs-exclude.xml`** — adds a SpotBugs `DM_EXIT` suppression for `ShutdownableThread`.

* The previous `Exit.exit(...)` indirection hid the call from SpotBugs' `DM_EXIT` detector. Now that the call is direct, `spotbugs:check` flags it.
* Mirrors the existing entry for `SchemaRegistryRestApplication` (lines 70-73 of the same file), which has the identical "intentional JVM termination" pattern.

**3. `core/src/test/java/.../ClusterTestHarness.java`** — was using `org.apache.kafka.common.utils.Java` (also moved by the same upstream commit).

* `Java.isIbmJdk()` and `Java.isIbmJdkSemeru()` are two-line wrappers around `System.getProperty(...)`. Inlined the equivalent expression into the only call site (`IS_IBM_SECURITY` in the SASL config helper). No behavior change.

Checklist
---------

- **[N]** Contains customer facing changes? — No, internal refactor only.
- **[N]** Is this change gated behind config(s)? — No.
- **[N]** Did you add sufficient unit test and/or integration test coverage for this PR? — No new tests; existing tests cover both call sites and pass locally.
- **[N]** Does this change require modifying existing system tests or adding new system tests? — No.
- **[N]** Must this be released together with other change(s)? — No.

References
----------

* Upstream Apache Kafka: [apache/kafka#22093](https://github.com/apache/kafka/pull/22093) ([KAFKA-20297](https://issues.apache.org/jira/browse/KAFKA-20297), commit [`0a367aa1`](https://github.com/apache/kafka/commit/0a367aa1ecd7c6aef855281e0b7a8b76b1d689c4))
* Failing master nightly job: https://semaphore.ci.confluent.io/jobs/bf386abc-e08d-4d5d-83dd-c806a57ebfe0
* Slack thread: https://confluent.slack.com/archives/C06SUAPUD47/p1777247187532099
* SR commit that picked up the breaking Kafka version: [`541d8891ccd`](https://github.com/confluentinc/schema-registry/commit/541d8891ccd) "Bump Confluent to 8.4.0-0, Kafka to 8.4.0-0"

Test & Review
-------------

Local verification on this branch (`zma/fix-master-build-kafka-exit`):

```
mvn -pl core -am test-compile -DskipTests   # ✓ exit 0
mvn -pl core -am install -DskipTests -U     # ✓ exit 0
mvn -pl core spotbugs:check -DskipTests     # ✓ BugInstance size is 0 / No errors/warnings found / BUILD SUCCESS
```


