### PR TITLE
Fix Sonarqube in 8.0.x

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -26,12 +26,10 @@ sonarqube:
     - "**/*.pb.*"
     - "**/mk-include/**/*"
     - "protobuf-serializer/**"
-  java_classes:
-    - "**/target/classes"
-  scanner_config:
-    sonar.java.libraries: "**/target/dependency/*.jar"
-    sonar.java.test.binaries: "**/target/test-classes"
-    sonar.java.test.libraries: "**/target/dependency/*.jar"
+    - "**/generated/**"
+    - "**/target/**"
+    - "**/jacoco-aggregate-*/**"
+    - "**/*.html"
 git:
   enable: true
 code_artifact:

--- a/service.yml
+++ b/service.yml
@@ -26,6 +26,12 @@ sonarqube:
     - "**/*.pb.*"
     - "**/mk-include/**/*"
     - "protobuf-serializer/**"
+  java_classes:
+    - "**/target/classes"
+  scanner_config:
+    sonar.java.libraries: "**/target/dependency/*.jar"
+    sonar.java.test.binaries: "**/target/test-classes"
+    sonar.java.test.libraries: "**/target/dependency/*.jar"
 git:
   enable: true
 code_artifact:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,8 @@
 ### service-bot sonarqube plugin managed file
-sonar.coverage.exclusions=**/test/**/*,**/tests/**/*,**/mock/**/*,**/mocks/**/*,**/*mock*,**/*test*,**/protobuf-types/src/main/java/io/confluent/protobuf/type/*.java
+sonar.coverage.exclusions=**/test/**/*,**/tests/**/*,**/mock/**/*,**/mocks/**/*,**/*mock*,**/*test*
 sonar.coverage.jacoco.xmlReportPaths=**/jacoco.xml
 sonar.cpd.exclusions=**/test/**/*,**/tests/**/*,**/mock/**/*,**/mocks/**/*,**/*mock*,**/*test*
-sonar.exclusions=**/*.pb.*,**/mk-include/**/*,protobuf-serializer/**
+sonar.exclusions=**/*.html,**/*.pb.*,**/generated/**,**/jacoco-aggregate-*/**,**/mk-include/**/*,**/target/**,protobuf-serializer/**
 sonar.java.binaries=.
 sonar.language=java
 sonar.projectKey=schema-registry

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,9 +1,12 @@
 ### service-bot sonarqube plugin managed file
-sonar.coverage.exclusions=**/test/**/*,**/tests/**/*,**/mock/**/*,**/mocks/**/*,**/*mock*,**/*test*,**/protobuf-types/src/main/java/io/confluent/protobuf/type/*.java
+sonar.coverage.exclusions=**/test/**/*,**/tests/**/*,**/mock/**/*,**/mocks/**/*,**/*mock*,**/*test*
 sonar.coverage.jacoco.xmlReportPaths=**/jacoco.xml
 sonar.cpd.exclusions=**/test/**/*,**/tests/**/*,**/mock/**/*,**/mocks/**/*,**/*mock*,**/*test*
 sonar.exclusions=**/*.pb.*,**/mk-include/**/*,protobuf-serializer/**
-sonar.java.binaries=.
+sonar.java.binaries=**/target/classes
+sonar.java.libraries=**/target/dependency/*.jar
+sonar.java.test.binaries=**/target/test-classes
+sonar.java.test.libraries=**/target/dependency/*.jar
 sonar.language=java
 sonar.projectKey=schema-registry
 sonar.sources=.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,12 +1,9 @@
 ### service-bot sonarqube plugin managed file
-sonar.coverage.exclusions=**/test/**/*,**/tests/**/*,**/mock/**/*,**/mocks/**/*,**/*mock*,**/*test*
+sonar.coverage.exclusions=**/test/**/*,**/tests/**/*,**/mock/**/*,**/mocks/**/*,**/*mock*,**/*test*,**/protobuf-types/src/main/java/io/confluent/protobuf/type/*.java
 sonar.coverage.jacoco.xmlReportPaths=**/jacoco.xml
 sonar.cpd.exclusions=**/test/**/*,**/tests/**/*,**/mock/**/*,**/mocks/**/*,**/*mock*,**/*test*
 sonar.exclusions=**/*.pb.*,**/mk-include/**/*,protobuf-serializer/**
-sonar.java.binaries=**/target/classes
-sonar.java.libraries=**/target/dependency/*.jar
-sonar.java.test.binaries=**/target/test-classes
-sonar.java.test.libraries=**/target/dependency/*.jar
+sonar.java.binaries=.
 sonar.language=java
 sonar.projectKey=schema-registry
 sonar.sources=.


### PR DESCRIPTION
What
----
Reduce SonarQube scan time on 8.0.x (was timing out around 21 minutes) by shrinking what the scanner indexes.

The SonarQube job runs in `after_pipeline` on a separate runner that only restores the root `target/` artifact, so configuration must not depend on submodule `*/target/classes` or `*/target/dependency/*.jar` — those don't exist there.

Changes in `service.yml` `coverage_exclusions`:
- `**/generated/**` — swagger-ui HTML/JS/CSS under `core/generated/` and `dek-registry/generated/`
- `**/target/**` — JaCoCo aggregate HTML reports inside the pulled `target/` artifact
- `**/jacoco-aggregate-*/**` — the JaCoCo aggregator module's bulk
- `**/*.html` — stray `.java.html` files SonarQube was indexing as Java-like sources

Then ran `servicebot -m service.yml --plugins sonarqube` to generate the `sonar-project.properties` changes.

Checklist
------------------
- **[N]** Contains customer facing changes? Including API/behavior changes — CI configuration only.
- **[N/A]** Is this change gated behind config(s)? — CI infra change.
- **[N/A]** Did you add sufficient unit test and/or integration test coverage for this PR? — Validation is the SonarQube CI job itself; not unit-testable.
- **[N]** Does this change require modifying existing system tests or adding new system tests?
- **[N]** Must this be released together with other change(s), either in this repo or another one?

Test & Review
------------
Confirm via the next pipeline run that the SonarQube job completes within the execution time limit.

Open questions / Follow-ups
--------------------------
If scan time is still close to the limit after this lands, the next lever is narrowing `sonar.sources` via `scanner_config: { sonar.sources: "<comma-list>" }`.