### PR TITLE
DGS-24208 AbstractDekRegistry: add polymorphic getKey/rangeKeys

### DIFF
--- a/dek-registry/src/main/java/io/confluent/dekregistry/storage/AbstractDekRegistry.java
+++ b/dek-registry/src/main/java/io/confluent/dekregistry/storage/AbstractDekRegistry.java
@@ -217,7 +217,6 @@ public abstract class AbstractDekRegistry implements Closeable {
    * @return the keys cache
    * @deprecated callers should use {@link #getKey(EncryptionKeyId)} or
    *     {@link #rangeKeys(EncryptionKeyId, boolean, EncryptionKeyId, boolean)} instead.
-   *     Non-kafka implementations have no kcache to expose.
    */
   @Deprecated
   public Cache<EncryptionKeyId, EncryptionKey> keys() {

--- a/dek-registry/src/main/java/io/confluent/dekregistry/storage/AbstractDekRegistry.java
+++ b/dek-registry/src/main/java/io/confluent/dekregistry/storage/AbstractDekRegistry.java
@@ -228,8 +228,7 @@ public abstract class AbstractDekRegistry implements Closeable {
    * Returns the encryption key for the given id, or {@code null} if not found.
    *
    * <p>The default implementation delegates to {@link #keys()} for kafka-based
-   * subclasses. Non-kafka subclasses (e.g. RM/informer-backed) override this to
-   * read from their own backing store and never need a real {@code keys()}.
+   * subclasses.
    */
   public EncryptionKey getKey(EncryptionKeyId id) {
     return keys().get(id);
@@ -240,8 +239,7 @@ public abstract class AbstractDekRegistry implements Closeable {
    * Caller is responsible for closing the returned iterator.
    *
    * <p>The default implementation delegates to {@link #keys()} for kafka-based
-   * subclasses. Non-kafka subclasses (e.g. RM/informer-backed) override this to
-   * scan their own backing store and never need a real {@code keys()}.
+   * subclasses.
    */
   public KeyValueIterator<EncryptionKeyId, EncryptionKey> rangeKeys(
       EncryptionKeyId start, boolean startInclusive,

--- a/dek-registry/src/main/java/io/confluent/dekregistry/storage/AbstractDekRegistry.java
+++ b/dek-registry/src/main/java/io/confluent/dekregistry/storage/AbstractDekRegistry.java
@@ -49,6 +49,7 @@ import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 import io.confluent.rest.exceptions.RestException;
 import io.kcache.Cache;
 import io.kcache.KeyValue;
+import io.kcache.KeyValueIterator;
 import jakarta.ws.rs.core.UriBuilder;
 import java.io.Closeable;
 import java.io.IOException;
@@ -214,11 +215,39 @@ public abstract class AbstractDekRegistry implements Closeable {
    * Get the underlying keys kcache (only kafka-based implementations override this).
    * Provides backward compatibility for external components relying on direct cache access.
    * @return the keys cache
+   * @deprecated callers should use {@link #getKey(EncryptionKeyId)} or
+   *     {@link #rangeKeys(EncryptionKeyId, boolean, EncryptionKeyId, boolean)} instead.
+   *     Non-kafka implementations have no kcache to expose.
    */
   @Deprecated
   public Cache<EncryptionKeyId, EncryptionKey> keys() {
     throw new UnsupportedOperationException(
         "Direct access to the keys cache is not supported in AbstractDekRegistry");
+  }
+
+  /**
+   * Returns the encryption key for the given id, or {@code null} if not found.
+   *
+   * <p>The default implementation delegates to {@link #keys()} for kafka-based
+   * subclasses. Non-kafka subclasses (e.g. RM/informer-backed) override this to
+   * read from their own backing store and never need a real {@code keys()}.
+   */
+  public EncryptionKey getKey(EncryptionKeyId id) {
+    return keys().get(id);
+  }
+
+  /**
+   * Returns an iterator over the encryption keys whose ids fall in the given range.
+   * Caller is responsible for closing the returned iterator.
+   *
+   * <p>The default implementation delegates to {@link #keys()} for kafka-based
+   * subclasses. Non-kafka subclasses (e.g. RM/informer-backed) override this to
+   * scan their own backing store and never need a real {@code keys()}.
+   */
+  public KeyValueIterator<EncryptionKeyId, EncryptionKey> rangeKeys(
+      EncryptionKeyId start, boolean startInclusive,
+      EncryptionKeyId end, boolean endInclusive) {
+    return keys().range(start, startInclusive, end, endInclusive);
   }
 
   // ==================== Cryptor Management ====================

--- a/dek-registry/src/test/java/io/confluent/dekregistry/storage/AbstractDekRegistryDefaultMethodsTest.java
+++ b/dek-registry/src/test/java/io/confluent/dekregistry/storage/AbstractDekRegistryDefaultMethodsTest.java
@@ -89,7 +89,6 @@ public class AbstractDekRegistryDefaultMethodsTest {
    * If a subclass doesn't have a real {@code keys()}, the default {@code getKey}
    * delegation surfaces the same {@code UnsupportedOperationException} — caller
    * sees a single, consistent failure mode regardless of which method they hit.
-   * This is the canary for "remember to override getKey on RP-mode subclasses."
    */
   @Test
   public void getKey_defaultPropagatesUnsupportedOperationFromKeys() {

--- a/dek-registry/src/test/java/io/confluent/dekregistry/storage/AbstractDekRegistryDefaultMethodsTest.java
+++ b/dek-registry/src/test/java/io/confluent/dekregistry/storage/AbstractDekRegistryDefaultMethodsTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.dekregistry.storage;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import io.confluent.kafka.schemaregistry.encryption.tink.DekFormat;
+import io.kcache.Cache;
+import io.kcache.KeyValueIterator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the default-delegation behavior of {@code AbstractDekRegistry#getKey}
+ * and {@code AbstractDekRegistry#rangeKeys}.
+ *
+ * <p>The defaults route through the (deprecated) {@code keys()} view so kafka-based
+ * subclasses inherit working behavior with no override. Non-kafka subclasses are
+ * expected to override both methods and never need a real {@code keys()} — the
+ * existing {@code UnsupportedOperationException} default for {@code keys()} stays
+ * correct in that case.
+ */
+public class AbstractDekRegistryDefaultMethodsTest {
+
+  @Test
+  public void getKey_defaultDelegatesToKeysGet() {
+    @SuppressWarnings("unchecked")
+    Cache<EncryptionKeyId, EncryptionKey> cache = mock(Cache.class);
+
+    AbstractDekRegistry registry = mock(
+        AbstractDekRegistry.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+    // Use doReturn to stub keys() without invoking the real (UOE-throwing) impl.
+    doReturn(cache).when(registry).keys();
+
+    DataEncryptionKeyId id = new DataEncryptionKeyId(
+        "tenant", "kek", "subject", DekFormat.AES128_GCM, 1);
+    DataEncryptionKey expected = new DataEncryptionKey(
+        "kek", "subject", DekFormat.AES128_GCM, 1, "material", false);
+    when(cache.get(id)).thenReturn(expected);
+
+    assertSame(expected, registry.getKey(id));
+    verify(cache).get(id);
+  }
+
+  @Test
+  public void rangeKeys_defaultDelegatesToKeysRange() {
+    @SuppressWarnings("unchecked")
+    Cache<EncryptionKeyId, EncryptionKey> cache = mock(Cache.class);
+    @SuppressWarnings("unchecked")
+    KeyValueIterator<EncryptionKeyId, EncryptionKey> iter = mock(KeyValueIterator.class);
+
+    AbstractDekRegistry registry = mock(
+        AbstractDekRegistry.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+    doReturn(cache).when(registry).keys();
+    when(cache.range(any(), anyBoolean(), any(), anyBoolean())).thenReturn(iter);
+
+    DataEncryptionKeyId start = new DataEncryptionKeyId(
+        "tenant", "kek", "a", DekFormat.AES128_GCM, 1);
+    DataEncryptionKeyId end = new DataEncryptionKeyId(
+        "tenant", "kek", "z", DekFormat.AES128_GCM, 1);
+
+    assertSame(iter, registry.rangeKeys(start, true, end, false));
+    verify(cache).range(eq(start), eq(true), eq(end), eq(false));
+  }
+
+  /**
+   * If a subclass doesn't have a real {@code keys()}, the default {@code getKey}
+   * delegation surfaces the same {@code UnsupportedOperationException} — caller
+   * sees a single, consistent failure mode regardless of which method they hit.
+   * This is the canary for "remember to override getKey on RP-mode subclasses."
+   */
+  @Test
+  public void getKey_defaultPropagatesUnsupportedOperationFromKeys() {
+    AbstractDekRegistry registry = mock(
+        AbstractDekRegistry.class, withSettings().defaultAnswer(CALLS_REAL_METHODS));
+    DataEncryptionKeyId id = new DataEncryptionKeyId(
+        "tenant", "kek", "subject", DekFormat.AES128_GCM, 1);
+
+    assertThrows(UnsupportedOperationException.class, () -> registry.getKey(id));
+  }
+}


### PR DESCRIPTION
What
----
Adds two polymorphic methods to `AbstractDekRegistry`:

```java
public EncryptionKey getKey(EncryptionKeyId id) { return keys().get(id); }

public KeyValueIterator<EncryptionKeyId, EncryptionKey> rangeKeys(
    EncryptionKeyId start, boolean startInclusive,
    EncryptionKeyId end, boolean endInclusive) {
  return keys().range(start, startInclusive, end, endInclusive);
}
```

The default implementations route through the deprecated `keys()` view, so `KafkaDekRegistry` inherits working behavior with **no override** — its existing `keys()` makes the defaults work transparently.

`keys()` stays `@Deprecated`; deletion deferred until all downstream callers migrate.

No behavior change for existing `KafkaDekRegistry` — the defaults are a 1:1 forwarding to `keys().get` / `keys().range`.

Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes
- [ ] Is this change gated behind feature flag(s)?
    - No flag — non-breaking additive change to a base class.
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
    - New `AbstractDekRegistryDefaultMethodsTest` covers (1) default `getKey` delegation to `keys().get`, (2) default `rangeKeys` delegation to `keys().range`, (3) UOE-propagation through the default `getKey` (the canary that fires if a non-kafka subclass forgets to override).
- [ ] Does this change require modifying existing system tests or adding new system tests?
    - No.

References
----------
JIRA: [DGS-24208](https://confluentinc.atlassian.net/browse/DGS-24208)

Test & Review
------------
- `mvn test -pl dek-registry -Dtest=AbstractDekRegistryDefaultMethodsTest` → 3/3 pass
- `mvn checkstyle:check spotbugs:check -pl dek-registry` → clean
- Existing `KafkaDekRegistry` tests unchanged — the default delegation is byte-for-byte equivalent to the prior `keys().get` / `keys().range` direct calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DGS-24208]: https://confluentinc.atlassian.net/browse/DGS-24208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ