### PR TITLE
DGS-24271 Ensure dry-run checks during mutateAssoc are idempotent

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -2030,7 +2030,7 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
         request.getResourceId(), request.getResourceType(),
         new ArrayList<>(infosByType.keySet()), null);
 
-    if (associations.isEmpty() && dryRun && request.getResourceId() == null) {
+    if (associations.isEmpty() && isCreate && dryRun && request.getResourceId() == null) {
       // At validate-phase the caller may not yet have a resourceId.
       // Fall back to (name, namespace, type) so the equivalence check below can recognize an
       // idempotent retry.
@@ -2039,8 +2039,23 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
           request.getResourceType(), new ArrayList<>(infosByType.keySet()), null);
     }
 
+    // The name-based fallback can return entries from multiple resourceIds sharing
+    // (name, namespace, type) — e.g. an orphan from a deleted topic alongside a live one.
+    // Keep the most-recently-updated entry per type so equivalence compares against the
+    // live association and toMap doesn't throw on duplicate keys.
     Map<String, Association> assocsByType = associations.stream()
-        .collect(Collectors.toMap(Association::getAssociationType, a -> a));
+        .collect(Collectors.toMap(Association::getAssociationType, a -> a,
+            (a, b) -> {
+              Long timestampA = a.getUpdateTimestamp();
+              Long timestampB = b.getUpdateTimestamp();
+              if (timestampA == null) {
+                return b;
+              }
+              if (timestampB == null) {
+                return a;
+              }
+              return timestampA >= timestampB ? a : b;
+            }));
     Set<String> assocTypesToSkip = new HashSet<>();
     for (AssociationCreateOrUpdateInfo info : request.getAssociations()) {
       String associationType = info.getAssociationType();

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -2030,6 +2030,15 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
         request.getResourceId(), request.getResourceType(),
         new ArrayList<>(infosByType.keySet()), null);
 
+    if (associations.isEmpty() && dryRun && request.getResourceId() == null) {
+      // At validate-phase the caller may not yet have a resourceId.
+      // Fall back to (name, namespace, type) so the equivalence check below can recognize an
+      // idempotent retry.
+      associations = getAssociationsByResourceName(
+          request.getResourceName(), request.getResourceNamespace(),
+          request.getResourceType(), new ArrayList<>(infosByType.keySet()), null);
+    }
+
     Map<String, Association> assocsByType = associations.stream()
         .collect(Collectors.toMap(Association::getAssociationType, a -> a));
     Set<String> assocTypesToSkip = new HashSet<>();

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -2030,32 +2030,35 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
         request.getResourceId(), request.getResourceType(),
         new ArrayList<>(infosByType.keySet()), null);
 
+    Map<String, Association> assocsByType;
     if (associations.isEmpty() && isCreate && dryRun && request.getResourceId() == null) {
       // At validate-phase the caller may not yet have a resourceId.
       // Fall back to (name, namespace, type) so the equivalence check below can recognize an
       // idempotent retry.
-      associations = getAssociationsByResourceName(
+      List<Association> fallback = getAssociationsByResourceName(
           request.getResourceName(), request.getResourceNamespace(),
           request.getResourceType(), new ArrayList<>(infosByType.keySet()), null);
+      // The fallback can return entries from multiple resourceIds sharing (name, namespace,
+      // type) — e.g. an orphan from a deleted topic alongside a live one. Keep the
+      // most-recently-updated entry per type so equivalence compares against the live one.
+      assocsByType = fallback.stream()
+          .collect(Collectors.toMap(Association::getAssociationType, a -> a,
+              (a, b) -> {
+                Long timestampA = a.getUpdateTimestamp();
+                Long timestampB = b.getUpdateTimestamp();
+                if (timestampA == null) {
+                  return b;
+                }
+                if (timestampB == null) {
+                  return a;
+                }
+                return timestampA >= timestampB ? a : b;
+              }));
+    } else {
+      // By-resourceId guarantees one row per associationType. Keep fail-fast on duplicates
+      assocsByType = associations.stream()
+          .collect(Collectors.toMap(Association::getAssociationType, a -> a));
     }
-
-    // The name-based fallback can return entries from multiple resourceIds sharing
-    // (name, namespace, type) — e.g. an orphan from a deleted topic alongside a live one.
-    // Keep the most-recently-updated entry per type so equivalence compares against the
-    // live association and toMap doesn't throw on duplicate keys.
-    Map<String, Association> assocsByType = associations.stream()
-        .collect(Collectors.toMap(Association::getAssociationType, a -> a,
-            (a, b) -> {
-              Long timestampA = a.getUpdateTimestamp();
-              Long timestampB = b.getUpdateTimestamp();
-              if (timestampA == null) {
-                return b;
-              }
-              if (timestampB == null) {
-                return a;
-              }
-              return timestampA >= timestampB ? a : b;
-            }));
     Set<String> assocTypesToSkip = new HashSet<>();
     for (AssociationCreateOrUpdateInfo info : request.getAssociations()) {
       String associationType = info.getAssociationType();

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
@@ -681,6 +681,88 @@ public class RestApiAssociationTest extends ClusterTestHarness {
   }
 
   @Test
+  public void testIdempotentValidateAndCreateRetry() throws Exception {
+    // Simulates the CreateTopics retry pattern: callers cannot supply a resourceId
+    // at validate-phase because Kafka assigns the topic UUID at create time, strictly
+    // after validate. The validate-phase call on retry must be idempotent when the
+    // requested association is content-equivalent to the existing one.
+    String subject1 = "subject1";
+    String resourceName = "topic1";
+    String resourceNamespace = "default";
+    String resourceId = "resource-uuid-123";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(1);
+
+    restApp.restClient.registerSchema(allSchemas.get(0), subject1);
+
+    AssociationCreateOrUpdateRequest validateRequest = new AssociationCreateOrUpdateRequest(
+        resourceName,
+        resourceNamespace,
+        null,
+        "topic",
+        ImmutableList.of(
+            new AssociationCreateOrUpdateInfo(
+                subject1,
+                "value",
+                LifecyclePolicy.STRONG,
+                false,
+                null,
+                null
+            )
+        )
+    );
+    AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
+        resourceName,
+        resourceNamespace,
+        resourceId,
+        "topic",
+        ImmutableList.of(
+            new AssociationCreateOrUpdateInfo(
+                subject1,
+                "value",
+                LifecyclePolicy.STRONG,
+                false,
+                null,
+                null
+            )
+        )
+    );
+
+    // 1. Initial validate (dryRun=true, resourceId=null)
+    AssociationResponse response = restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, true, validateRequest);
+    assertNull(response.getResourceId());
+    assertNull(response.getAssociations());
+
+    // 2. Initial commit (dryRun=false, resourceId=UUID) — creates association
+    response = restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
+    assertEquals(resourceId, response.getResourceId());
+    assertEquals(1, response.getAssociations().size());
+
+    // 3. Retry validate (dryRun=true, resourceId=null) — must be idempotent.
+    // Before the fix this threw 40904: by-resourceId lookup returned empty, the
+    // equivalence check was skipped, and the strong-uniqueness check fired against
+    // the association created in step 2.
+    response = restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, true, validateRequest);
+    assertNull(response.getResourceId());
+    assertNull(response.getAssociations());
+
+    // 4. Retry commit (dryRun=false, resourceId=UUID) — idempotent via existing
+    // by-resourceId equivalence path; confirms the fallback didn't break it.
+    // The response carries no associations because the existing one is equivalent
+    // and gets added to assocTypesToSkip; verify state via a follow-up query.
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
+    List<Association> existing = restApp.restClient.getAssociationsByResourceId(
+        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
+        ImmutableList.of("value"), null, 0, -1);
+    assertEquals(1, existing.size());
+    assertEquals("value", existing.get(0).getAssociationType());
+    assertEquals(LifecyclePolicy.STRONG, existing.get(0).getLifecycle());
+  }
+
+  @Test
   public void testWeakAssociationCannotBeFrozen() throws Exception {
     String subject1 = "subject1";
     String resourceName = "topic1";


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Ensure dry-run checks during mutateAssoc are idempotent
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
