### PR TITLE
DGS-24297 Add config to passthru ciphertext if KEK is not shared

### DIFF
--- a/client-encryption/src/main/java/io/confluent/kafka/schemaregistry/encryption/EncryptionExecutor.java
+++ b/client-encryption/src/main/java/io/confluent/kafka/schemaregistry/encryption/EncryptionExecutor.java
@@ -74,6 +74,8 @@ public class EncryptionExecutor implements RuleExecutor {
   public static final String ENCRYPT_DEK_ALGORITHM = "encrypt.dek.algorithm";
   public static final String ENCRYPT_DEK_EXPIRY_DAYS = "encrypt.dek.expiry.days";
   public static final String ENCRYPT_ALTERNATE_KMS_KEY_IDS = "encrypt.alternate.kms.key.ids";
+  public static final String ENCRYPT_NONSHARED_KEK_PASSTHROUGH =
+      "encrypt.nonshared.kek.passthrough";
 
   public static final String KMS_TYPE_SUFFIX = "://";
   public static final byte[] EMPTY_AAD = new byte[0];
@@ -90,6 +92,7 @@ public class EncryptionExecutor implements RuleExecutor {
   private Map<String, ?> configs;
   private int cacheExpirySecs = -1;
   private int cacheSize = 10000;
+  private boolean nonsharedKekPassthrough = false;
   private Clock clock = Clock.systemUTC();
   private DekRegistryClient client;
 
@@ -130,6 +133,10 @@ public class EncryptionExecutor implements RuleExecutor {
     Object clock = configs.get(CLOCK);
     if (clock instanceof Clock) {
       this.clock = (Clock) clock;
+    }
+    Object passthroughConfig = configs.get(ENCRYPT_NONSHARED_KEK_PASSTHROUGH);
+    if (passthroughConfig != null) {
+      this.nonsharedKekPassthrough = Boolean.parseBoolean(passthroughConfig.toString());
     }
     Object url = configs.get(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG);
     if (url == null) {
@@ -262,12 +269,16 @@ public class EncryptionExecutor implements RuleExecutor {
     private String kekName;
     private Kek kek;
     private int dekExpiryDays;
+    private boolean passthroughOnRead;
 
     public void init(RuleContext ctx) throws RuleException {
       cryptor = getCryptor(ctx);
       kekName = getKekName(ctx);
       kek = getOrCreateKek(ctx);
       dekExpiryDays = getDekExpiryDays(ctx);
+      passthroughOnRead = nonsharedKekPassthrough
+          && !kek.isShared()
+          && ctx.ruleMode() == RuleMode.READ;
     }
 
     public boolean isDekRotated() {
@@ -520,6 +531,9 @@ public class EncryptionExecutor implements RuleExecutor {
       try {
         if (value == null) {
           return null;
+        }
+        if (passthroughOnRead) {
+          return value;
         }
         Dek dek;
         byte[] plaintext;

--- a/client-encryption/src/test/java/io/confluent/kafka/schemaregistry/encryption/FieldEncryptionExecutorTest.java
+++ b/client-encryption/src/test/java/io/confluent/kafka/schemaregistry/encryption/FieldEncryptionExecutorTest.java
@@ -415,6 +415,32 @@ public abstract class FieldEncryptionExecutorTest {
   }
 
   @Test
+  public void testKafkaAvroNonsharedKekPassthrough() throws Exception {
+    IndexedRecord avroRecord = createUserRecord();
+    AvroSchema avroSchema = new AvroSchema(createUserSchema());
+    Rule rule = new Rule("rule1", null, null, null,
+        FieldEncryptionExecutor.TYPE, ImmutableSortedSet.of("PII"), null, null, null, null, false);
+    RuleSet ruleSet = new RuleSet(Collections.emptyList(), ImmutableList.of(rule));
+    Metadata metadata = getMetadata("kek1");
+    avroSchema = avroSchema.copy(metadata, ruleSet);
+    schemaRegistry.register(topic + "-value", avroSchema);
+    dekRegistry.createKek("kek1", fieldEncryptionProps.getKmsType(),
+        fieldEncryptionProps.getKmsKeyId(), null, null, false);
+
+    RecordHeaders headers = new RecordHeaders();
+    byte[] bytes = avroSerializer.serialize(topic, headers, avroRecord);
+
+    Map<String, Object> passthroughProps = fieldEncryptionProps.getClientProperties("mock://");
+    passthroughProps.put(EncryptionExecutor.ENCRYPT_NONSHARED_KEK_PASSTHROUGH, "true");
+    KafkaAvroDeserializer passthroughDeserializer =
+        new KafkaAvroDeserializer(schemaRegistry, passthroughProps);
+
+    GenericRecord record = (GenericRecord) passthroughDeserializer.deserialize(
+        topic, headers, bytes);
+    assertNotEquals("testUser", record.get("name").toString());
+  }
+
+  @Test
   public void testKafkaAvroSerializerF1() throws Exception {
     IndexedRecord avroRecord = createF1Record();
     AvroSchema avroSchema = new AvroSchema(createF1Schema());


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Add config to passthru ciphertext if KEK is not shared.  To use set `rule.executors._default_.param.encrypt.nonshared.kek.passthrough=true`
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
