### PR TITLE
DGS-24035 Validate protobuf type references at registration time

### DIFF
--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/protobuf/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/protobuf/RestApiTest.java
@@ -22,6 +22,7 @@ import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaTags;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.ConfigUpdateRequest;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaResponse;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.TagSchemaRequest;
 import io.confluent.kafka.schemaregistry.utils.ResourceLoader;
@@ -958,6 +959,156 @@ public abstract class RestApiTest {
         restService.getId(expectedId).getSchemaString().trim(),
         "Registered schema should be found"
     );
+  }
+
+  @Test
+  public void testValidateFieldsRejectsBrokenReference() throws Exception {
+    // Schema that defines FeatureDataFloatArray
+    String floatArraySchema = "syntax = \"proto3\";\n"
+        + "package com.example;\n"
+        + "\n"
+        + "message FeatureDataFloatArray {\n"
+        + "  repeated float values = 1;\n"
+        + "}\n";
+
+    // Schema that uses FeatureDataFloatArray but does NOT import it
+    String brokenSchema = "syntax = \"proto3\";\n"
+        + "package com.example;\n"
+        + "\n"
+        + "message FeatureData {\n"
+        + "  map<string, FeatureDataFloatArray> float_array_features = 1;\n"
+        + "}\n";
+
+    // Register the dependency schema
+    String depSubject = "float_array.proto";
+    registerAndVerifySchema(restApp.restClient, floatArraySchema, expectedSchemaId(1), depSubject);
+
+    // Enable validateFields
+    ConfigUpdateRequest configUpdateRequest = new ConfigUpdateRequest();
+    configUpdateRequest.setValidateFields(true);
+    restApp.restClient.updateConfig(configUpdateRequest, null);
+
+    // Register the broken schema with SR-level reference but missing proto import
+    RegisterSchemaRequest request = new RegisterSchemaRequest();
+    request.setSchema(brokenSchema);
+    request.setSchemaType(ProtobufSchema.TYPE);
+    SchemaReference ref = new SchemaReference("float_array.proto", depSubject, 1);
+    request.setReferences(Collections.singletonList(ref));
+
+    try {
+      restApp.restClient.registerSchema(request, "broken_referrer", false);
+      fail("Registration should fail with INVALID_SCHEMA_ERROR_CODE");
+    } catch (RestClientException rce) {
+      assertEquals(Errors.INVALID_SCHEMA_ERROR_CODE, rce.getErrorCode());
+    }
+  }
+
+  @Test
+  public void testValidateFieldsAcceptsValidReference() throws Exception {
+    // Schema that defines FeatureDataFloatArray
+    String floatArraySchema = "syntax = \"proto3\";\n"
+        + "package com.example;\n"
+        + "\n"
+        + "message FeatureDataFloatArray {\n"
+        + "  repeated float values = 1;\n"
+        + "}\n";
+
+    // Schema that uses FeatureDataFloatArray AND properly imports it
+    String validSchema = "syntax = \"proto3\";\n"
+        + "package com.example;\n"
+        + "\n"
+        + "import \"float_array.proto\";\n"
+        + "\n"
+        + "message FeatureData {\n"
+        + "  map<string, FeatureDataFloatArray> float_array_features = 1;\n"
+        + "}\n";
+
+    // Register the dependency schema
+    String depSubject = "float_array.proto";
+    registerAndVerifySchema(restApp.restClient, floatArraySchema, expectedSchemaId(1), depSubject);
+
+    // Enable validateFields
+    ConfigUpdateRequest configUpdateRequest = new ConfigUpdateRequest();
+    configUpdateRequest.setValidateFields(true);
+    restApp.restClient.updateConfig(configUpdateRequest, null);
+
+    // Register the valid schema — should succeed
+    RegisterSchemaRequest request = new RegisterSchemaRequest();
+    request.setSchema(validSchema);
+    request.setSchemaType(ProtobufSchema.TYPE);
+    SchemaReference ref = new SchemaReference("float_array.proto", depSubject, 1);
+    request.setReferences(Collections.singletonList(ref));
+
+    int registeredId = restApp.restClient.registerSchema(request, "valid_referrer", false).getId();
+    assertEquals(expectedSchemaId(2), registeredId, "Valid schema with references should register");
+  }
+
+  @Test
+  public void testValidateFieldsAcceptsWellKnownImports() throws Exception {
+    // Schema that imports well-known types — no SR references needed
+    String schemaWithWellKnown = "syntax = \"proto3\";\n"
+        + "package com.example;\n"
+        + "\n"
+        + "import \"google/protobuf/timestamp.proto\";\n"
+        + "import \"google/protobuf/duration.proto\";\n"
+        + "\n"
+        + "message Event {\n"
+        + "  string name = 1;\n"
+        + "  google.protobuf.Timestamp created_at = 2;\n"
+        + "  google.protobuf.Duration ttl = 3;\n"
+        + "}\n";
+
+    // Enable validateFields
+    ConfigUpdateRequest configUpdateRequest = new ConfigUpdateRequest();
+    configUpdateRequest.setValidateFields(true);
+    restApp.restClient.updateConfig(configUpdateRequest, null);
+
+    RegisterSchemaRequest request = new RegisterSchemaRequest();
+    request.setSchema(schemaWithWellKnown);
+    request.setSchemaType(ProtobufSchema.TYPE);
+
+    int registeredId = restApp.restClient.registerSchema(request, "wellknown_subject", false).getId();
+    assertEquals(expectedSchemaId(1), registeredId,
+        "Schema with well-known imports should register");
+  }
+
+  @Test
+  public void testValidateFieldsDisabledAcceptsBrokenReference() throws Exception {
+    // Schema that defines FeatureDataFloatArray
+    String floatArraySchema = "syntax = \"proto3\";\n"
+        + "package com.example;\n"
+        + "\n"
+        + "message FeatureDataFloatArray {\n"
+        + "  repeated float values = 1;\n"
+        + "}\n";
+
+    // Schema that uses FeatureDataFloatArray but does NOT import it
+    String brokenSchema = "syntax = \"proto3\";\n"
+        + "package com.example;\n"
+        + "\n"
+        + "message FeatureData {\n"
+        + "  map<string, FeatureDataFloatArray> float_array_features = 1;\n"
+        + "}\n";
+
+    // Register the dependency schema
+    String depSubject = "float_array.proto";
+    registerAndVerifySchema(restApp.restClient, floatArraySchema, expectedSchemaId(1), depSubject);
+
+    // Explicitly disable validateFields (CP default)
+    ConfigUpdateRequest configUpdateRequest = new ConfigUpdateRequest();
+    configUpdateRequest.setValidateFields(false);
+    restApp.restClient.updateConfig(configUpdateRequest, null);
+
+    // Register the broken schema — should succeed when validation is disabled
+    RegisterSchemaRequest request = new RegisterSchemaRequest();
+    request.setSchema(brokenSchema);
+    request.setSchemaType(ProtobufSchema.TYPE);
+    SchemaReference ref = new SchemaReference("float_array.proto", depSubject, 1);
+    request.setReferences(Collections.singletonList(ref));
+
+    int registeredId = restApp.restClient.registerSchema(request, "broken_referrer", false).getId();
+    assertEquals(expectedSchemaId(2), registeredId,
+        "Broken schema should register when validateFields is disabled");
   }
 
   public static List<String> getRandomProtobufSchemas(int num) {

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -2595,6 +2595,9 @@ public class ProtobufSchema implements ParsedSchema {
   public void validate(boolean strict) {
     // Normalization will try to resolve types
     normalize();
+    if (strict) {
+      toDynamicSchema();
+    }
   }
 
   @Override


### PR DESCRIPTION
## Summary

- When `schema.validate.fields` is `true` (strict mode), call `toDynamicSchema()` during `validate()` to trigger `FileDescriptor.buildFrom()`, which cross-links all type references against declared imports
- Catches broken protobuf schemas (e.g. using a type without importing the file that defines it) at registration time with HTTP 422, instead of silently accepting them and failing on the read side in downstream services like Metastore/Tableflow
- Gated behind the existing `schema.validate.fields` config — `true` in CC (via cc-spec), `false` by default in CP

## What

During [INC-10296](https://confluentinc.atlassian.net/browse/INC-10296) (SEV-2, Faire), a customer registered a protobuf schema where a sub-schema (`FeatureData.proto`) used types (`FeatureDataFloatArray`, `FeatureDataStringArray`) without importing the files that define them. SR accepted the broken schema — producing worked fine — but downstream consumers (Metastore/Tableflow) failed with `DescriptorValidationException` when they tried to build the protobuf descriptor.

Existing fixes addressed related but different gaps:
- **DGS-20135** — Validates that referenced subjects exist in SR
- **DGS-21829** — Prevents re-registering a schema whose referenced subject was deleted
- **DGS-24024** — Changed exception type from `IllegalStateException` to `IllegalArgumentException`

None of these validate **proto source-level consistency** — whether types used in the proto text are actually resolvable via declared imports. This PR closes that gap.

## How

In `ProtobufSchema.validate()`, when `strict=true`, we now call `toDynamicSchema()` which triggers `FileDescriptor.buildFrom()` — the same code path that fails on the read side. This surfaces the error at registration time as a clean HTTP 422 instead of letting it through.

```java
@Override
public void validate(boolean strict) {
    normalize();
    if (strict) {
        toDynamicSchema();
    }
}
```

## Backward compatibility

- **CC**: `schema.validate.fields` is `true` in cc-spec, so validation is on by default. Existing broken schemas would fail on lookup/re-registration — this is the desired behavior (they're already broken on the read side)
- **CP**: Default is `false`, so no impact unless customers opt in via config. Escape hatch: `PUT /config/{subject} {"validateFields": false}`

## Checklist

- **[Y]** Contains customer facing changes? Including API/behavior changes
- **[Y]** Is this change gated behind config(s)?
  - `schema.validate.fields` (true in CC via cc-spec, false by default in CP)
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
- **[N]** Does this change require modifying existing system tests or adding new system tests?
- **[N]** Must this be released together with other change(s)?

## References

- JIRA: [DGS-24035](https://confluentinc.atlassian.net/browse/DGS-24035)
- Incident: [INC-10296](https://confluentinc.atlassian.net/browse/INC-10296)
- Related: [DGS-24024](https://confluentinc.atlassian.net/browse/DGS-24024), [DGS-20135](https://confluentinc.atlassian.net/browse/DGS-20135), [DGS-21829](https://confluentinc.atlassian.net/browse/DGS-21829)

## Test plan

- [x] Broken inter-file reference rejected when `validateFields=true`
- [x] Valid schema with references accepted
- [x] Well-known imports (timestamp, duration) accepted
- [x] Broken schema accepted when `validateFields=false` (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[INC-10296]: https://confluentinc.atlassian.net/browse/INC-10296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DGS-24035]: https://confluentinc.atlassian.net/browse/DGS-24035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ