### PR TITLE
DGS-23783 Raise CircularRefSchemaDiffTest timeout from 10s to 60s

### DIFF
--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/diff/CircularRefSchemaDiffTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/diff/CircularRefSchemaDiffTest.java
@@ -115,6 +115,8 @@ public class CircularRefSchemaDiffTest {
     return sb.toString();
   }
 
+  private static final int TIMEOUT_SECONDS = 60;
+
   private void assertComparisonTerminates(
       String description, String originalSchemaStr, String updateSchemaStr) {
     JsonSchema original = new JsonSchema(originalSchemaStr);
@@ -125,11 +127,11 @@ public class CircularRefSchemaDiffTest {
       Future<List<Difference>> future = executor.submit(
           () -> SchemaDiff.compare(original.rawSchema(), update.rawSchema()));
       try {
-        List<Difference> result = future.get(10, TimeUnit.SECONDS);
+        List<Difference> result = future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
       } catch (TimeoutException e) {
         future.cancel(true);
-        fail(description + ": SchemaDiff.compare did not terminate within 10 seconds. "
-            + "Circular $ref caused combinatorial explosion.");
+        fail(description + ": SchemaDiff.compare did not terminate within "
+            + TIMEOUT_SECONDS + " seconds. Circular $ref caused combinatorial explosion.");
       } catch (ExecutionException e) {
         if (e.getCause() instanceof StackOverflowError) {
           fail(description + ": StackOverflowError from circular $ref recursion.");


### PR DESCRIPTION
## Summary
The 12-branch x 5-prop diff completes in ~5.5s locally but trips the 10s wall on CI (measured 10.01s in [job dd85044a](https://semaphore.ci.confluent.io/jobs/dd85044a-aa9a-4e01-ad89-078e4ee723c7)). CI agents are ~2x slower under Surefire load. Raise to 60s — still catches the original "hung for hours" regression.

## Test plan
- [x] `./mvnw test -pl json-schema-provider -Dtest=CircularRefSchemaDiffTest` passes locally (3 runs, ~5.5s each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)