### PR TITLE
DGS-24368 Enhance ParsedSchemaAndValue w/ writer schema and rule data

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -323,7 +323,7 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
         context.getSubject(),
         schemaId.getId(),
         version,
-        schemaId.getGuid() != null ? schemaId.getGuid().toString() : null);
+        schemaId.getGuid());
     List<RuleResult> ruleResults = context.getRuleResults() == null
         || context.getRuleResults().isEmpty()
         ? Collections.emptyList()

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -22,6 +22,8 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.ParsedSchemaAndValue;
+import io.confluent.kafka.schemaregistry.rules.RuleResult;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleMode;
 import io.confluent.kafka.schemaregistry.rules.RulePhase;
@@ -279,6 +281,15 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
       String topic, boolean isKey, Headers headers, byte[] payload,
       Function<ParsedSchema, ParsedSchema> writerToReaderSchemaFunc)
       throws SerializationException, InvalidConfigurationException {
+    return deserializeWithSchemaAndVersion(
+        topic, isKey, headers, payload, writerToReaderSchemaFunc, false);
+  }
+
+  protected GenericContainerWithVersion deserializeWithSchemaAndVersion(
+      String topic, boolean isKey, Headers headers, byte[] payload,
+      Function<ParsedSchema, ParsedSchema> writerToReaderSchemaFunc,
+      boolean includeRuleResults)
+      throws SerializationException, InvalidConfigurationException {
     // Even if the caller requests schema & version, if the payload is null we cannot include it.
     // The caller must handle this case.
     if (payload == null) {
@@ -294,7 +305,8 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
     // Converter to let a version provided by a Kafka Connect source take priority over the
     // schema registry's ordering (which is implicit by auto-registration time rather than
     // explicit from the Connector).
-    DeserializationContext context = new DeserializationContext(topic, isKey, headers, payload);
+    DeserializationContext context =
+        new DeserializationContext(topic, isKey, headers, payload, includeRuleResults);
     AvroSchema schema = context.schemaForDeserialize();
     AvroSchema readerAvroSchema = writerToReaderSchemaFunc != null
         ? (AvroSchema) writerToReaderSchemaFunc.apply(schema)
@@ -302,14 +314,28 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
             ? new AvroSchema(specificAvroReaderSchema)
             : null;
     Object result = context.read(schema, readerAvroSchema);
+    readerAvroSchema = context.getReaderSchema();
 
     Integer version = schemaVersion(topic, isKey, context.getSchemaId(),
         context.getSubject(), schema, result);
-    if (schema.rawSchema().getType().equals(Schema.Type.RECORD)) {
-      return new GenericContainerWithVersion(schema, (GenericContainer) result, version);
+    SchemaId schemaId = context.getSchemaId();
+    ParsedSchemaAndValue.SchemaInfo writerInfo = new ParsedSchemaAndValue.SchemaInfo(
+        context.getSubject(),
+        schemaId.getId(),
+        version,
+        schemaId.getGuid() != null ? schemaId.getGuid().toString() : null);
+    List<RuleResult> ruleResults = context.getRuleResults() == null
+        || context.getRuleResults().isEmpty()
+        ? Collections.emptyList()
+        : Collections.unmodifiableList(new ArrayList<>(context.getRuleResults()));
+    if (readerAvroSchema.rawSchema().getType().equals(Schema.Type.RECORD)) {
+      return new GenericContainerWithVersion(
+          readerAvroSchema, (GenericContainer) result, version,
+          writerInfo, schema, ruleResults);
     } else {
       return new GenericContainerWithVersion(
-          schema, new NonRecordContainer(schema.rawSchema(), result), version);
+          readerAvroSchema, new NonRecordContainer(readerAvroSchema.rawSchema(), result), version,
+          writerInfo, schema, ruleResults);
     }
   }
 
@@ -423,14 +449,23 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
     private final byte[] payload;
     private final ByteBuffer buffer;
     private final SchemaId schemaId;
+    private AvroSchema readerSchema;
+    private final List<RuleResult> ruleResults;
     private String subject;
 
     DeserializationContext(
         final String topic, final Boolean key, Headers headers, final byte[] payload) {
+      this(topic, key, headers, payload, false);
+    }
+
+    DeserializationContext(
+        final String topic, final Boolean key, Headers headers, final byte[] payload,
+        boolean includeRuleResults) {
       this.topic = topic;
       this.isKey = key != null ? key : AbstractKafkaAvroDeserializer.this.isKey;
       this.headers = headers;
       this.payload = payload;
+      this.ruleResults = includeRuleResults ? new ArrayList<>() : null;
       SchemaId schemaId = new SchemaId(AvroSchema.TYPE);
       try (SchemaIdDeserializer schemaIdDeserializer = schemaIdDeserializer(isKey)) {
         ByteBuffer buffer = schemaIdDeserializer.deserialize(
@@ -440,7 +475,7 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
         String subjectName = getSubject();
         Object buf = executeRules(
             subjectName, topic, headers, payload, RulePhase.ENCODING, RuleMode.READ, null,
-            schema, buffer
+            schema, buffer, ruleResults
         );
         this.buffer = buf instanceof byte[] ? ByteBuffer.wrap((byte[]) buf) : (ByteBuffer) buf;
       } catch (IOException e) {
@@ -531,6 +566,14 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
       return schemaId;
     }
 
+    AvroSchema getReaderSchema() {
+      return readerSchema;
+    }
+
+    List<RuleResult> getRuleResults() {
+      return ruleResults;
+    }
+
     Object read(AvroSchema writerAvroSchema) {
       return read(writerAvroSchema,
           specificAvroReaderSchema != null ? new AvroSchema(specificAvroReaderSchema) : null);
@@ -589,6 +632,7 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
         if (readerAvroSchema == null) {
           readerAvroSchema = writerAvroSchema;
         }
+        this.readerSchema = readerAvroSchema;
 
         if (!migrations.isEmpty() || (readerAvroSchema.ruleSet() != null
             && !readerAvroSchema.ruleSet().getDomainRules().isEmpty())) {
@@ -608,7 +652,8 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
 
             // Next apply domain rules
             result = executeRules(
-                getSubject(), topic, headers, payload, RuleMode.READ, null, readerAvroSchema, result
+                getSubject(), topic, headers, payload, RulePhase.DOMAIN, RuleMode.READ, null,
+                readerAvroSchema, result, ruleResults
             );
           } finally {
             AvroSchemaUtils.clearThreadLocalData();

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/GenericContainerWithVersion.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/GenericContainerWithVersion.java
@@ -18,10 +18,12 @@ package io.confluent.kafka.serializers;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.ParsedSchemaAndValue;
+import io.confluent.kafka.schemaregistry.rules.RuleResult;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
-import org.apache.avro.generic.GenericContainer;
-
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
+import org.apache.avro.generic.GenericContainer;
 
 /**
  * Wrapper for GenericContainer along with a version number, which may be null.
@@ -36,18 +38,33 @@ public class GenericContainerWithVersion implements ParsedSchemaAndValue {
   private final AvroSchema schema;
   private final GenericContainer container;
   private final Integer version;
+  private final SchemaInfo writerSchemaInfo;
+  private final AvroSchema writerSchema;
+  private final List<RuleResult> ruleResults;
 
   public GenericContainerWithVersion(GenericContainer container, Integer version) {
-    this.schema = new AvroSchema(container.getSchema());
-    this.container = container;
-    this.version = version;
+    this(new AvroSchema(container.getSchema()), container, version, null, null,
+        Collections.emptyList());
   }
 
   public GenericContainerWithVersion(
       AvroSchema schema, GenericContainer container, Integer version) {
+    this(schema, container, version, null, null, Collections.emptyList());
+  }
+
+  public GenericContainerWithVersion(
+      AvroSchema schema,
+      GenericContainer container,
+      Integer version,
+      SchemaInfo writerSchemaInfo,
+      AvroSchema writerSchema,
+      List<RuleResult> ruleResults) {
     this.schema = schema;
     this.container = container;
     this.version = version;
+    this.writerSchemaInfo = writerSchemaInfo;
+    this.writerSchema = writerSchema;
+    this.ruleResults = ruleResults != null ? ruleResults : Collections.emptyList();
   }
 
   @Override
@@ -58,6 +75,21 @@ public class GenericContainerWithVersion implements ParsedSchemaAndValue {
   @Override
   public Object getValue() {
     return container;
+  }
+
+  @Override
+  public SchemaInfo getWriterSchemaInfo() {
+    return writerSchemaInfo;
+  }
+
+  @Override
+  public ParsedSchema getWriterSchema() {
+    return writerSchema;
+  }
+
+  @Override
+  public List<RuleResult> getRuleResults() {
+    return ruleResults;
   }
 
   public GenericContainer container() {

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java
@@ -138,6 +138,15 @@ public class KafkaAvroDeserializer extends AbstractKafkaAvroDeserializer
   }
 
   @Override
+  public GenericContainerWithVersion deserializeWithSchema(
+      String topic, Headers headers, byte[] bytes,
+      Function<ParsedSchema, ParsedSchema> writerToReaderSchemaFunc,
+      boolean includeRuleResults) {
+    return deserializeWithSchemaAndVersion(
+        topic, isKey, headers, bytes, writerToReaderSchemaFunc, includeRuleResults);
+  }
+
+  @Override
   public void close() {
     try {
       super.close();

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
@@ -1346,12 +1346,14 @@ public class KafkaAvroSerializerTest {
 
     ParsedSchemaAndValue schemaAndValue = avroDeserializer.deserializeWithSchema(
         topic, headers, bytes, User.getClassSchema());
-    assertEquals(new AvroSchema(ExtendedUser.SCHEMA$), schemaAndValue.getSchema());
+    assertEquals(new AvroSchema(User.getClassSchema()), schemaAndValue.getSchema());
+    assertEquals(new AvroSchema(ExtendedUser.SCHEMA$), schemaAndValue.getWriterSchema());
     assertEquals(obj, schemaAndValue.getValue());
 
     schemaAndValue = avroDeserializer.deserializeWithSchema(
         topic, headers, bytes, x -> new AvroSchema(User.getClassSchema()));
-    assertEquals(new AvroSchema(ExtendedUser.SCHEMA$), schemaAndValue.getSchema());
+    assertEquals(new AvroSchema(User.getClassSchema()), schemaAndValue.getSchema());
+    assertEquals(new AvroSchema(ExtendedUser.SCHEMA$), schemaAndValue.getWriterSchema());
     assertEquals(obj, schemaAndValue.getValue());
   }
 

--- a/client-encryption/src/main/java/io/confluent/kafka/schemaregistry/encryption/EncryptionExecutor.java
+++ b/client-encryption/src/main/java/io/confluent/kafka/schemaregistry/encryption/EncryptionExecutor.java
@@ -68,6 +68,34 @@ public class EncryptionExecutor implements RuleExecutor {
 
   public static final String TYPE = "ENCRYPT_PAYLOAD";
 
+  /**
+   * Per-field metadata key set by this executor in
+   * {@code RuleResult.fieldMetadata().get(fieldPath)}. The value is the
+   * name of a {@link Status} enum constant (e.g. {@code "DECRYPTED"}).
+   */
+  public static final String META_STATUS = "status";
+  /** Per-field metadata key for the KEK name resolved for the field. */
+  public static final String META_KEK_NAME = "kekName";
+  /** Per-field metadata key for the DEK version that decrypted the field. */
+  public static final String META_DEK_VERSION = "dekVersion";
+  /** Per-field metadata key for the failure message when status is FAILED. */
+  public static final String META_ERROR_MESSAGE = "errorMessage";
+
+  /**
+   * Field-level decryption outcome recorded under {@link #META_STATUS}
+   * during deserialization.
+   */
+  public enum Status {
+    /** Field ciphertext was decrypted to plaintext. */
+    DECRYPTED,
+    /** Field was left as ciphertext because the executor was configured
+     *  for passthrough (non-shared KEK). */
+    PASSTHROUGH,
+    /** Decryption was attempted but threw. The exception message is under
+     *  {@link #META_ERROR_MESSAGE}. */
+    FAILED
+  }
+
   public static final String ENCRYPT_KEK_NAME = "encrypt.kek.name";
   public static final String ENCRYPT_KMS_KEY_ID = "encrypt.kms.key.id";
   public static final String ENCRYPT_KMS_TYPE = "encrypt.kms.type";
@@ -533,6 +561,7 @@ public class EncryptionExecutor implements RuleExecutor {
           return null;
         }
         if (passthroughOnRead) {
+          recordResult(ctx, Status.PASSTHROUGH, null, null);
           return value;
         }
         Dek dek;
@@ -573,11 +602,20 @@ public class EncryptionExecutor implements RuleExecutor {
             }
             dek = getOrCreateDek(ctx, version);
             plaintext = cryptor.decrypt(dek.getKeyMaterialBytes(), ciphertext, EMPTY_AAD);
-            return toObject(type, plaintext);
+            // Record DECRYPTED only after toObject succeeds. If toObject throws
+            // we fall through to the catch and record FAILED with no leftover
+            // DEK metadata from a partial-success state.
+            Object decoded = toObject(type, plaintext);
+            recordResult(ctx, Status.DECRYPTED, dek.getVersion(), null);
+            return decoded;
           default:
             throw new IllegalArgumentException("Unsupported rule mode " + ctx.ruleMode());
         }
       } catch (Exception e) {
+        if (ctx.ruleMode() == RuleMode.READ) {
+          String msg = e.getMessage() != null ? e.getMessage() : e.toString();
+          recordResult(ctx, Status.FAILED, null, msg);
+        }
         if (e instanceof RuleException) {
           RuleException re = (RuleException) e;
           if (re.getRule() == null) {
@@ -588,6 +626,25 @@ public class EncryptionExecutor implements RuleExecutor {
           throw new RuleException(ctx.rule(), e);
         }
       }
+    }
+
+    private void recordResult(
+        RuleContext ctx,
+        Status status,
+        Integer dekVersion,
+        String errorMessage) {
+      RuleContext.FieldContext field = ctx.currentField();
+      if (field == null) {
+        // Payload-level transforms (no field) are out of scope.
+        return;
+      }
+      String path = field.getFullName();
+      ctx.putFieldMetadata(path, META_STATUS, status.name());
+      ctx.putFieldMetadata(path, META_KEK_NAME, kekName);
+      if (dekVersion != null) {
+        ctx.putFieldMetadata(path, META_DEK_VERSION, String.valueOf(dekVersion));
+      }
+      ctx.putFieldMetadata(path, META_ERROR_MESSAGE, errorMessage);
     }
 
     private byte[] prefixVersion(int version, byte[] ciphertext) {

--- a/client-encryption/src/main/java/io/confluent/kafka/schemaregistry/encryption/tools/RegisterDeks.java
+++ b/client-encryption/src/main/java/io/confluent/kafka/schemaregistry/encryption/tools/RegisterDeks.java
@@ -148,7 +148,7 @@ public class RegisterDeks implements Callable<Integer> {
       Map<String, Object> ruleConfigs = configsWithoutPrefix(rule, configs);
       executor.configure(ruleConfigs);
       RuleContext ctx = new RuleContext(configs, null, null, parsedSchema,
-          subject, null, null, null, null, false, RuleMode.WRITE, rule, i, rules);
+          subject, null, null, null, null, false, RuleMode.WRITE, rule, i, rules, false);
       EncryptionExecutorTransform transform = executor.newTransform(ctx);
       transform.getOrCreateDek(ctx, transform.isDekRotated() ? -1 : null);
     }

--- a/client-encryption/src/test/java/io/confluent/kafka/schemaregistry/encryption/FieldEncryptionExecutorTest.java
+++ b/client-encryption/src/test/java/io/confluent/kafka/schemaregistry/encryption/FieldEncryptionExecutorTest.java
@@ -22,6 +22,7 @@ import static io.confluent.kafka.schemaregistry.rules.RuleBase.DEFAULT_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -53,6 +54,8 @@ import io.confluent.kafka.schemaregistry.encryption.tink.Cryptor;
 import io.confluent.kafka.schemaregistry.encryption.tink.DekFormat;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
+import io.confluent.kafka.schemaregistry.ParsedSchemaAndValue;
+import io.confluent.kafka.schemaregistry.rules.RuleResult;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientFactory;
 import io.confluent.kafka.schemaregistry.client.rest.entities.ExecutionEnvironment;
@@ -72,6 +75,7 @@ import io.confluent.kafka.schemaregistry.testutil.FakeClock;
 import io.confluent.kafka.schemaregistry.testutil.MockSchemaRegistry;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDe;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import io.confluent.kafka.serializers.GenericContainerWithVersion;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer;
@@ -2249,6 +2253,196 @@ public abstract class FieldEncryptionExecutorTest {
     assertNull(cryptor);
     GenericRecord record = (GenericRecord) badDeserializer.deserialize(topic, headers, bytes);
     assertNotEquals("testUser", record.get("name").toString()); // still encrypted
+  }
+
+  // ---- Tests for ParsedSchemaAndValue rule results + writer info ----
+
+  /** Find the RuleResult for the first ENCRYPT rule in the wrapper. */
+  private static RuleResult findEncryptRuleResult(
+      ParsedSchemaAndValue wrapper) {
+    for (RuleResult rr : wrapper.getRuleResults()) {
+      if (rr.rule() != null && FieldEncryptionExecutor.TYPE.equals(rr.rule().getType())) {
+        return rr;
+      }
+    }
+    return null;
+  }
+
+  /** First (only) per-field metadata entry for this rule. */
+  private static Map.Entry<String, Map<String, String>> firstFieldEntry(
+      RuleResult rr) {
+    return rr.fieldMetadata().entrySet().iterator().next();
+  }
+
+  @Test
+  public void testRuleResultsDecryptedAndWriterInfo() throws Exception {
+    IndexedRecord avroRecord = createUserRecord();
+    AvroSchema avroSchema = new AvroSchema(createUserSchema());
+    Rule rule = new Rule("rule1", null, null, null,
+        FieldEncryptionExecutor.TYPE, ImmutableSortedSet.of("PII"),
+        null, null, null, null, false);
+    RuleSet ruleSet = new RuleSet(Collections.emptyList(), ImmutableList.of(rule));
+    Metadata metadata = getMetadata("kek1");
+    avroSchema = avroSchema.copy(metadata, ruleSet);
+    int registeredId = schemaRegistry.register(topic + "-value", avroSchema);
+
+    RecordHeaders headers = new RecordHeaders();
+    byte[] bytes = avroSerializer.serialize(topic, headers, avroRecord);
+
+    GenericContainerWithVersion wrapper =
+        avroDeserializer.deserializeWithSchema(topic, headers, bytes, null, true);
+    assertNotNull(wrapper);
+
+    // Writer info
+    ParsedSchemaAndValue.SchemaInfo info = wrapper.getWriterSchemaInfo();
+    assertNotNull(info);
+    assertEquals(topic + "-value", info.subject());
+    assertEquals(Integer.valueOf(registeredId), info.id());
+    assertNotNull("expected non-null writer version", info.version());
+    assertNotNull(wrapper.getWriterSchema());
+
+    // RuleResult for the ENCRYPT rule, SUCCESS, with one DECRYPTED field entry.
+    RuleResult rr = findEncryptRuleResult(wrapper);
+    assertNotNull("expected an ENCRYPT RuleResult", rr);
+    assertEquals("rule1", rr.rule().getName());
+    assertEquals(RuleResult.Result.SUCCESS, rr.result());
+    assertNull(rr.errorMessage());
+    assertTrue("expected empty messageMetadata", rr.messageMetadata().isEmpty());
+
+    assertEquals(1, rr.fieldMetadata().size());
+    Map.Entry<String, Map<String, String>> entry = firstFieldEntry(rr);
+    assertNotNull("expected non-null fieldPath", entry.getKey());
+    Map<String, String> meta = entry.getValue();
+    assertEquals(EncryptionExecutor.Status.DECRYPTED.name(),
+        meta.get(EncryptionExecutor.META_STATUS));
+    assertEquals("kek1", meta.get(EncryptionExecutor.META_KEK_NAME));
+    assertFalse("errorMessage should be absent for DECRYPTED",
+        meta.containsKey(EncryptionExecutor.META_ERROR_MESSAGE));
+  }
+
+  @Test
+  public void testRuleResultsPassthrough() throws Exception {
+    IndexedRecord avroRecord = createUserRecord();
+    AvroSchema avroSchema = new AvroSchema(createUserSchema());
+    Rule rule = new Rule("rule1", null, null, null,
+        FieldEncryptionExecutor.TYPE, ImmutableSortedSet.of("PII"),
+        null, null, null, null, false);
+    RuleSet ruleSet = new RuleSet(Collections.emptyList(), ImmutableList.of(rule));
+    Metadata metadata = getMetadata("kek1");
+    avroSchema = avroSchema.copy(metadata, ruleSet);
+    schemaRegistry.register(topic + "-value", avroSchema);
+    dekRegistry.createKek("kek1", fieldEncryptionProps.getKmsType(),
+        fieldEncryptionProps.getKmsKeyId(), null, null, false);
+
+    RecordHeaders headers = new RecordHeaders();
+    byte[] bytes = avroSerializer.serialize(topic, headers, avroRecord);
+
+    Map<String, Object> passthroughProps = fieldEncryptionProps.getClientProperties("mock://");
+    passthroughProps.put(EncryptionExecutor.ENCRYPT_NONSHARED_KEK_PASSTHROUGH, "true");
+    KafkaAvroDeserializer passthroughDeserializer =
+        new KafkaAvroDeserializer(schemaRegistry, passthroughProps);
+
+    GenericContainerWithVersion wrapper =
+        passthroughDeserializer.deserializeWithSchema(topic, headers, bytes, null, true);
+    assertNotNull(wrapper);
+
+    RuleResult rr = findEncryptRuleResult(wrapper);
+    assertNotNull(rr);
+    assertEquals(1, rr.fieldMetadata().size());
+    Map<String, String> meta = firstFieldEntry(rr).getValue();
+    assertEquals(EncryptionExecutor.Status.PASSTHROUGH.name(),
+        meta.get(EncryptionExecutor.META_STATUS));
+    assertEquals("kek1", meta.get(EncryptionExecutor.META_KEK_NAME));
+  }
+
+  @Test
+  public void testRuleResultsFailedWithNoneAction() throws Exception {
+    IndexedRecord avroRecord = createUserRecord();
+    AvroSchema avroSchema = new AvroSchema(createUserSchema());
+    // NONE,NONE so the decrypt failure is swallowed and the wrapper is still built.
+    Rule rule = new Rule("rule1", null, null, null,
+        FieldEncryptionExecutor.TYPE, ImmutableSortedSet.of("PII"),
+        null, null, null, "NONE,NONE", false);
+    RuleSet ruleSet = new RuleSet(Collections.emptyList(), ImmutableList.of(rule));
+    Metadata metadata = getMetadata("kek1");
+    avroSchema = avroSchema.copy(metadata, ruleSet);
+    schemaRegistry.register(topic + "-value", avroSchema);
+
+    // Serialize with a good cryptor to produce valid ciphertext.
+    RecordHeaders headers = new RecordHeaders();
+    addSpyToCryptor(avroSerializer);
+    byte[] bytes = avroSerializer.serialize(topic, headers, avroRecord);
+
+    // Swap in a bad cryptor on the deserializer to force a decrypt failure.
+    addBadSpyToCryptor(avroDeserializer);
+    GenericContainerWithVersion wrapper =
+        avroDeserializer.deserializeWithSchema(topic, headers, bytes, null, true);
+    assertNotNull(wrapper);
+
+    RuleResult rr = findEncryptRuleResult(wrapper);
+    assertNotNull("expected an ENCRYPT RuleResult under NONE-action failure", rr);
+    assertEquals(1, rr.fieldMetadata().size());
+    Map<String, String> meta = firstFieldEntry(rr).getValue();
+    assertEquals(EncryptionExecutor.Status.FAILED.name(),
+        meta.get(EncryptionExecutor.META_STATUS));
+    assertNotNull(meta.get(EncryptionExecutor.META_ERROR_MESSAGE));
+  }
+
+  @Test
+  public void testRuleResultsEmptyWhenNoRules() throws Exception {
+    IndexedRecord avroRecord = createUserRecord();
+    AvroSchema avroSchema = new AvroSchema(createUserSchema());
+    // No rule set, no metadata.
+    schemaRegistry.register(topic + "-value", avroSchema);
+
+    RecordHeaders headers = new RecordHeaders();
+    byte[] bytes = avroSerializer.serialize(topic, headers, avroRecord);
+    GenericContainerWithVersion wrapper =
+        avroDeserializer.deserializeWithSchema(topic, headers, bytes, null, true);
+    assertNotNull(wrapper);
+    assertTrue("rule results should be empty when no rules ran",
+        wrapper.getRuleResults().isEmpty());
+    // Writer info still populated.
+    assertNotNull(wrapper.getWriterSchemaInfo());
+    assertEquals(topic + "-value", wrapper.getWriterSchemaInfo().subject());
+  }
+
+  @Test
+  public void testRuleResultsMultipleRules() throws Exception {
+    // Two ENCRYPT rules tagging disjoint field sets. Both should appear in
+    // the wrapper's RuleResult list with their own per-field metadata.
+    IndexedRecord avroRecord = createUserRecord();
+    AvroSchema avroSchema = new AvroSchema(createUserSchema());
+    Rule rule1 = new Rule("rule1", null, null, null,
+        FieldEncryptionExecutor.TYPE, ImmutableSortedSet.of("PII"),
+        null, null, null, null, false);
+    Rule rule2 = new Rule("rule2", null, null, null,
+        FieldEncryptionExecutor.TYPE, ImmutableSortedSet.of("PII2"),
+        null, null, null, null, false);
+    RuleSet ruleSet = new RuleSet(Collections.emptyList(), ImmutableList.of(rule1, rule2));
+    Metadata metadata = getMetadata("kek1");
+    avroSchema = avroSchema.copy(metadata, ruleSet);
+    schemaRegistry.register(topic + "-value", avroSchema);
+
+    RecordHeaders headers = new RecordHeaders();
+    byte[] bytes = avroSerializer.serialize(topic, headers, avroRecord);
+
+    GenericContainerWithVersion wrapper =
+        avroDeserializer.deserializeWithSchema(topic, headers, bytes, null, true);
+    assertNotNull(wrapper);
+
+    // Two RuleResults, one per rule, each with its own fieldMetadata entry.
+    int encryptRules = 0;
+    for (RuleResult rr : wrapper.getRuleResults()) {
+      if (rr.rule() != null && FieldEncryptionExecutor.TYPE.equals(rr.rule().getType())) {
+        encryptRules++;
+        assertEquals("each rule encrypts one field", 1, rr.fieldMetadata().size());
+        Map<String, String> meta = firstFieldEntry(rr).getValue();
+        assertEquals(EncryptionExecutor.Status.DECRYPTED.name(),
+            meta.get(EncryptionExecutor.META_STATUS));
+      }
+    }
+    assertEquals("expected two ENCRYPT RuleResults", 2, encryptRules);
   }
 
   protected Metadata getMetadata(String kekName) {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchemaAndValue.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchemaAndValue.java
@@ -16,12 +16,121 @@
 
 package io.confluent.kafka.schemaregistry;
 
+import io.confluent.kafka.schemaregistry.rules.RuleResult;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
 /**
- * A parsed schema with a value.
+ * A parsed schema with a value, produced by deserialization.
  */
 public interface ParsedSchemaAndValue {
 
+  /**
+   * The reader schema used to interpret the value. When the consumer has
+   * registered a reader schema that differs from the writer schema on the
+   * wire, this returns the reader schema and {@link #getWriterSchema()}
+   * returns the writer schema; otherwise the two may be equal.
+   */
   ParsedSchema getSchema();
 
+  /**
+   * The deserialized value, projected into the reader schema. Validating this
+   * against {@link #getWriterSchema()} may fail when the reader and writer
+   * schemas differ structurally.
+   */
   Object getValue();
+
+  /**
+   * The writer's parsed schema, as it appeared on the wire payload. May
+   * differ from {@link #getSchema()} when schema projection / migration is
+   * in play. Returns {@code null} when the deserializer did not resolve a
+   * writer schema (unusual).
+   */
+  default ParsedSchema getWriterSchema() {
+    return null;
+  }
+
+  /**
+   * Identifying info (subject / id / version / guid) for the writer schema,
+   * resolved from the wire payload. Returns {@code null} when nothing was
+   * resolved. Individual fields on a populated {@code SchemaInfo} may still
+   * be null (some deserializer paths know the id but not the guid, for
+   * example).
+   */
+  default SchemaInfo getWriterSchemaInfo() {
+    return null;
+  }
+
+  /**
+   * Results of the rules visited during deserialization, one entry per rule
+   * (including rules that were skipped because they were disabled, in the
+   * wrong execution environment, or whose mode did not match the current
+   * phase). Order matches rule execution order.
+   *
+   * <p>Returns an empty, unmodifiable list when no rules ran.
+   */
+  default List<RuleResult> getRuleResults() {
+    return Collections.emptyList();
+  }
+
+  final class SchemaInfo {
+
+    private final String subject;
+    private final Integer id;
+    private final Integer version;
+    private final String guid;
+
+    public SchemaInfo(String subject, Integer id, Integer version, String guid) {
+      this.subject = subject;
+      this.id = id;
+      this.version = version;
+      this.guid = guid;
+    }
+
+    public String subject() {
+      return subject;
+    }
+
+    public Integer id() {
+      return id;
+    }
+
+    public Integer version() {
+      return version;
+    }
+
+    public String guid() {
+      return guid;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof SchemaInfo)) {
+        return false;
+      }
+      SchemaInfo that = (SchemaInfo) o;
+      return Objects.equals(subject, that.subject)
+          && Objects.equals(id, that.id)
+          && Objects.equals(version, that.version)
+          && Objects.equals(guid, that.guid);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(subject, id, version, guid);
+    }
+
+    @Override
+    public String toString() {
+      return "SchemaInfo{subject=" + subject
+          + ", id=" + id
+          + ", version=" + version
+          + ", guid=" + guid
+          + '}';
+    }
+  }
 }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchemaAndValue.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/ParsedSchemaAndValue.java
@@ -20,6 +20,7 @@ import io.confluent.kafka.schemaregistry.rules.RuleResult;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 /**
  * A parsed schema with a value, produced by deserialization.
@@ -79,9 +80,9 @@ public interface ParsedSchemaAndValue {
     private final String subject;
     private final Integer id;
     private final Integer version;
-    private final String guid;
+    private final UUID guid;
 
-    public SchemaInfo(String subject, Integer id, Integer version, String guid) {
+    public SchemaInfo(String subject, Integer id, Integer version, UUID guid) {
       this.subject = subject;
       this.id = id;
       this.version = version;
@@ -100,7 +101,7 @@ public interface ParsedSchemaAndValue {
       return version;
     }
 
-    public String guid() {
+    public UUID guid() {
       return guid;
     }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/rules/DlqAction.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/rules/DlqAction.java
@@ -209,7 +209,7 @@ public class DlqAction implements RuleAction {
           ctx.source(), ctx.target(),
           ctx.subject(), ctx.topic(), ctx.headers(),
           ctx.originalKey(), ctx.originalValue(), ctx.isKey(),
-          ctx.ruleMode(), newRule, 0, Collections.singletonList(newRule));
+          ctx.ruleMode(), newRule, 0, Collections.singletonList(newRule), false);
       return executor.transform(newCtx, message);
     } catch (RuleException e) {
       log.error("Could not redact fields", e);

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/rules/RuleContext.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/rules/RuleContext.java
@@ -26,6 +26,7 @@ import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -54,7 +55,10 @@ public class RuleContext {
   private final int index;
   private final List<Rule> rules;
   private final Map<Object, Object> customData = new ConcurrentHashMap<>();
+  private final Map<String, String> messageMetadata = new LinkedHashMap<>();
+  private final Map<String, Map<String, String>> fieldMetadata = new LinkedHashMap<>();
   private final Deque<FieldContext> fieldContexts;
+  private final boolean includeRuleResults;
 
   public RuleContext(
       Map<String, ?> configs,
@@ -70,7 +74,8 @@ public class RuleContext {
       RuleMode ruleMode,
       Rule rule,
       int index,
-      List<Rule> rules) {
+      List<Rule> rules,
+      boolean includeRuleResults) {
     this.configs = configs;
     this.enabledEnv = enabledEnv;
     this.source = source;
@@ -86,6 +91,7 @@ public class RuleContext {
     this.index = index;
     this.rules = rules;
     this.fieldContexts = new ArrayDeque<>();
+    this.includeRuleResults = includeRuleResults;
   }
 
   public Map<String, ?> configs() {
@@ -146,6 +152,42 @@ public class RuleContext {
 
   public Map<Object, Object> customData() {
     return customData;
+  }
+
+  /**
+   * Record a message-level metadata key/value for this rule's execution.
+   * When the enclosing deserialize call did not opt into rule-result
+   * collection, or when {@code value} is null, the key is not stored.
+   * Consumers can rely on key presence to mean "value known".
+   */
+  public void putMessageMetadata(String key, String value) {
+    if (!includeRuleResults || value == null) {
+      return;
+    }
+    messageMetadata.put(key, value);
+  }
+
+  /**
+   * Record a per-field metadata key/value for this rule's execution.
+   * When the enclosing deserialize call did not opt into rule-result
+   * collection, or when {@code value} is null, the key is not stored.
+   */
+  public void putFieldMetadata(String fieldPath, String key, String value) {
+    if (!includeRuleResults || value == null) {
+      return;
+    }
+    fieldMetadata.computeIfAbsent(fieldPath, k -> new LinkedHashMap<>())
+        .put(key, value);
+  }
+
+  /** Live view of message-level metadata collected so far. */
+  public Map<String, String> messageMetadata() {
+    return messageMetadata;
+  }
+
+  /** Live view of per-field metadata collected so far, keyed by field path. */
+  public Map<String, Map<String, String>> fieldMetadata() {
+    return fieldMetadata;
   }
 
   public Set<String> getTags(String fullName) {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/rules/RuleResult.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/rules/RuleResult.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rules;
+
+import io.confluent.kafka.schemaregistry.ParsedSchemaAndValue;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Rule;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Outcome of a single rule's execution during deserialization, along with any
+ * metadata the rule executor produced. One {@code RuleResult} is appended per
+ * rule visited (including skipped rules) and surfaced via
+ * {@link ParsedSchemaAndValue#getRuleResults()}.
+ *
+ * <p>Executor metadata is published in two parallel maps:
+ * <ul>
+ *   <li>{@link #messageMetadata()} — message-level key/value attributes
+ *       (one map for the whole rule execution).</li>
+ *   <li>{@link #fieldMetadata()} — per-field attributes, keyed by field
+ *       path; each value is a key/value map specific to that field.</li>
+ * </ul>
+ *
+ * <p>All values are {@code String}. Absent keys mean "not recorded" — null
+ * values are never stored. Specific key conventions are documented by the
+ * executor that produces them (for example, see
+ * {@code EncryptionExecutor}).
+ */
+public final class RuleResult {
+
+  /**
+   * Outcome of a rule's execution.
+   */
+  public enum Result {
+    /** The rule's transform ran, did not throw, and (for TRANSFORM rules)
+     *  returned a non-null value. */
+    SUCCESS,
+    /** The rule failed. Any of:
+     *  <ul>
+     *    <li>the transform threw,</li>
+     *    <li>a CONDITION rule returned false,</li>
+     *    <li>a TRANSFORM rule returned null, or</li>
+     *    <li>no executor was registered for the rule's type.</li>
+     *  </ul>
+     *  In all cases the rule's {@code onFailure} action runs; if
+     *  {@link #errorMessage()} is set it reflects the underlying cause. */
+    FAILURE,
+    /** The rule was skipped — disabled, environment mismatch, or its mode
+     *  did not match the current phase. The transform did not run. */
+    SKIPPED
+  }
+
+  private final Rule rule;
+  private final Result result;
+  private final String errorMessage;
+  private final Map<String, String> messageMetadata;
+  private final Map<String, Map<String, String>> fieldMetadata;
+
+  public RuleResult(
+      Rule rule,
+      Result result,
+      String errorMessage,
+      Map<String, String> messageMetadata,
+      Map<String, Map<String, String>> fieldMetadata) {
+    this.rule = rule;
+    this.result = result;
+    this.errorMessage = errorMessage;
+    this.messageMetadata = messageMetadata != null ? messageMetadata : Collections.emptyMap();
+    this.fieldMetadata = fieldMetadata != null ? fieldMetadata : Collections.emptyMap();
+  }
+
+  public Rule rule() {
+    return rule;
+  }
+
+  public Result result() {
+    return result;
+  }
+
+  /**
+   * The exception message when {@link #result()} is {@link Result#FAILURE};
+   * {@code null} otherwise.
+   */
+  public String errorMessage() {
+    return errorMessage;
+  }
+
+  /**
+   * Message-level metadata produced by the executor. Always non-null;
+   * empty when the executor produced nothing at the message level.
+   */
+  public Map<String, String> messageMetadata() {
+    return messageMetadata;
+  }
+
+  /**
+   * Per-field metadata produced by the executor, keyed by field path.
+   * Always non-null; empty when the executor produced no field-level
+   * metadata.
+   */
+  public Map<String, Map<String, String>> fieldMetadata() {
+    return fieldMetadata;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof RuleResult)) {
+      return false;
+    }
+    RuleResult that = (RuleResult) o;
+    return Objects.equals(rule, that.rule)
+        && result == that.result
+        && Objects.equals(errorMessage, that.errorMessage)
+        && Objects.equals(messageMetadata, that.messageMetadata)
+        && Objects.equals(fieldMetadata, that.fieldMetadata);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(rule, result, errorMessage, messageMetadata, fieldMetadata);
+  }
+
+  @Override
+  public String toString() {
+    return "RuleResult{rule=" + (rule != null ? rule.getName() : null)
+        + ", result=" + result
+        + (errorMessage != null ? ", errorMessage=" + errorMessage : "")
+        + (messageMetadata.isEmpty() ? "" : ", messageMetadata=" + messageMetadata)
+        + (fieldMetadata.isEmpty() ? "" : ", fieldMetadata=" + fieldMetadata)
+        + '}';
+  }
+}

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/rules/FieldRedactionExecutorTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/rules/FieldRedactionExecutorTest.java
@@ -70,7 +70,7 @@ public class FieldRedactionExecutorTest {
     RuleContext ctx = new RuleContext(Collections.emptyMap(), null, null, schema,
         "test-value", "test", null,
         null, null, false,
-        RuleMode.WRITE, rule, 0, Collections.singletonList(rule));
+        RuleMode.WRITE, rule, 0, Collections.singletonList(rule), false);
     List<String> redactRuleTypes = Collections.singletonList("ENCRYPT");
     Object message = createUserRecord();
     message = DlqAction.redactFields(ctx, message, redactRuleTypes);
@@ -91,7 +91,7 @@ public class FieldRedactionExecutorTest {
     RuleContext ctx = new RuleContext(Collections.emptyMap(), null, null, schema,
         "test-value", "test", null,
         null, null, false,
-        RuleMode.WRITE, rule, 0, Collections.singletonList(rule));
+        RuleMode.WRITE, rule, 0, Collections.singletonList(rule), false);
     List<String> redactRuleTypes = Collections.singletonList("ENCRYPT");
     Object message = createUserRecord();
     message = DlqAction.redactFields(ctx, message, redactRuleTypes);
@@ -107,7 +107,7 @@ public class FieldRedactionExecutorTest {
     RuleContext ctx = new RuleContext(Collections.emptyMap(), null, null, schema,
         "test-value", "test", null,
         null, null, false,
-        RuleMode.WRITE, rule, 0, Collections.singletonList(rule));
+        RuleMode.WRITE, rule, 0, Collections.singletonList(rule), false);
     List<String> redactRuleTypes = Collections.singletonList("ENCRYPT");
     Object message = createUserRecord();
     message = DlqAction.redactFields(ctx, message, redactRuleTypes);

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
@@ -268,7 +268,7 @@ public abstract class AbstractKafkaJsonSchemaDeserializer<T> extends AbstractKaf
             subject,
             schemaId.getId(),
             writerVersion,
-            schemaId.getGuid() != null ? schemaId.getGuid().toString() : null);
+            schemaId.getGuid());
         List<RuleResult> ruleResultsCopy = ruleResults == null || ruleResults.isEmpty()
             ? Collections.emptyList()
             : Collections.unmodifiableList(new ArrayList<>(ruleResults));

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/AbstractKafkaJsonSchemaDeserializer.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.ParsedSchemaAndValue;
+import io.confluent.kafka.schemaregistry.rules.RuleResult;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleMode;
 import io.confluent.kafka.schemaregistry.rules.RulePhase;
@@ -28,6 +30,7 @@ import io.confluent.kafka.serializers.schema.id.SchemaIdDeserializer;
 import io.confluent.kafka.serializers.schema.id.SchemaId;
 import java.io.InterruptedIOException;
 import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.function.Function;
@@ -124,11 +127,20 @@ public abstract class AbstractKafkaJsonSchemaDeserializer<T> extends AbstractKaf
     return deserialize(includeSchemaAndVersion, topic, isKey, headers, payload, null);
   }
 
+  protected Object deserialize(
+      boolean includeSchemaAndVersion, String topic, Boolean key, Headers headers, byte[] payload,
+      Function<ParsedSchema, ParsedSchema> writerToReaderSchemaFunc
+  ) throws SerializationException, InvalidConfigurationException {
+    return deserialize(
+        includeSchemaAndVersion, topic, key, headers, payload, writerToReaderSchemaFunc, false);
+  }
+
   // The Object return type is a bit messy, but this is the simplest way to have
   // flexible decoding and not duplicate deserialization code multiple times for different variants.
   protected Object deserialize(
       boolean includeSchemaAndVersion, String topic, Boolean key, Headers headers, byte[] payload,
-      Function<ParsedSchema, ParsedSchema> writerToReaderSchemaFunc
+      Function<ParsedSchema, ParsedSchema> writerToReaderSchemaFunc,
+      boolean includeRuleResults
   ) throws SerializationException, InvalidConfigurationException {
     if (schemaRegistry == null) {
       throw new InvalidConfigurationException(
@@ -143,6 +155,7 @@ public abstract class AbstractKafkaJsonSchemaDeserializer<T> extends AbstractKaf
 
     boolean isKey = key != null ? key : this.isKey;
     SchemaId schemaId = new SchemaId(JsonSchema.TYPE);
+    List<RuleResult> ruleResults = includeRuleResults ? new ArrayList<>() : null;
     try (SchemaIdDeserializer schemaIdDeserializer = schemaIdDeserializer(isKey)) {
       ByteBuffer buffer =
           schemaIdDeserializer.deserialize(topic, isKey, headers, payload, schemaId);
@@ -155,7 +168,7 @@ public abstract class AbstractKafkaJsonSchemaDeserializer<T> extends AbstractKaf
       }
       Object buf = executeRules(
           subject, topic, headers, payload, RulePhase.ENCODING, RuleMode.READ, null,
-          schema, buffer
+          schema, buffer, ruleResults
       );
       buffer = buf instanceof byte[] ? ByteBuffer.wrap((byte[]) buf) : (ByteBuffer) buf;
 
@@ -187,6 +200,7 @@ public abstract class AbstractKafkaJsonSchemaDeserializer<T> extends AbstractKaf
         jsonNode = (JsonNode) executeMigrations(migrations, subject, topic, headers, jsonNode);
       }
 
+      JsonSchema writerSchema = schema;
       if (readerSchema != null) {
         schema = (JsonSchema) readerSchema;
       }
@@ -198,7 +212,8 @@ public abstract class AbstractKafkaJsonSchemaDeserializer<T> extends AbstractKaf
           jsonNode = objectMapper.readValue(buffer.array(), start, length, JsonNode.class);
         }
         jsonNode = (JsonNode) executeRules(
-            subject, topic, headers, payload, RuleMode.READ, null, schema, jsonNode
+            subject, topic, headers, payload, RulePhase.DOMAIN, RuleMode.READ, null,
+            schema, jsonNode, ruleResults
         );
       }
 
@@ -248,7 +263,16 @@ public abstract class AbstractKafkaJsonSchemaDeserializer<T> extends AbstractKaf
         // schema registry's ordering (which is implicit by auto-registration time rather than
         // explicit from the Connector).
 
-        return new JsonSchemaAndValue(schema, value);
+        Integer writerVersion = schemaVersion(topic, isKey, schemaId, subject, writerSchema, null);
+        ParsedSchemaAndValue.SchemaInfo writerInfo = new ParsedSchemaAndValue.SchemaInfo(
+            subject,
+            schemaId.getId(),
+            writerVersion,
+            schemaId.getGuid() != null ? schemaId.getGuid().toString() : null);
+        List<RuleResult> ruleResultsCopy = ruleResults == null || ruleResults.isEmpty()
+            ? Collections.emptyList()
+            : Collections.unmodifiableList(new ArrayList<>(ruleResults));
+        return new JsonSchemaAndValue(schema, value, writerInfo, writerSchema, ruleResultsCopy);
       }
 
       return value;
@@ -378,8 +402,17 @@ public abstract class AbstractKafkaJsonSchemaDeserializer<T> extends AbstractKaf
       String topic, boolean isKey, Headers headers, byte[] payload,
       Function<ParsedSchema, ParsedSchema> writerToReaderSchemaFunc
   ) throws SerializationException {
+    return deserializeWithSchemaAndVersion(
+        topic, isKey, headers, payload, writerToReaderSchemaFunc, false);
+  }
+
+  protected JsonSchemaAndValue deserializeWithSchemaAndVersion(
+      String topic, boolean isKey, Headers headers, byte[] payload,
+      Function<ParsedSchema, ParsedSchema> writerToReaderSchemaFunc,
+      boolean includeRuleResults
+  ) throws SerializationException {
     return (JsonSchemaAndValue) deserialize(
-        true, topic, isKey, headers, payload, writerToReaderSchemaFunc);
+        true, topic, isKey, headers, payload, writerToReaderSchemaFunc, includeRuleResults);
   }
 
   protected JsonNode validateJson(JsonNode jsonNode, ByteBuffer buffer, int start, int length,

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/JsonSchemaAndValue.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/JsonSchemaAndValue.java
@@ -17,18 +17,35 @@
 package io.confluent.kafka.serializers.json;
 
 import io.confluent.kafka.schemaregistry.ParsedSchemaAndValue;
-import java.util.Objects;
-
+import io.confluent.kafka.schemaregistry.rules.RuleResult;
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 
 public class JsonSchemaAndValue implements ParsedSchemaAndValue {
 
   private final JsonSchema schema;
   private final Object value;
+  private final SchemaInfo writerSchemaInfo;
+  private final JsonSchema writerSchema;
+  private final List<RuleResult> ruleResults;
 
   public JsonSchemaAndValue(JsonSchema schema, Object value) {
+    this(schema, value, null, null, Collections.emptyList());
+  }
+
+  public JsonSchemaAndValue(
+      JsonSchema schema,
+      Object value,
+      SchemaInfo writerSchemaInfo,
+      JsonSchema writerSchema,
+      List<RuleResult> ruleResults) {
     this.schema = schema;
     this.value = value;
+    this.writerSchemaInfo = writerSchemaInfo;
+    this.writerSchema = writerSchema;
+    this.ruleResults = ruleResults != null ? ruleResults : Collections.emptyList();
   }
 
   @Override
@@ -39,6 +56,21 @@ public class JsonSchemaAndValue implements ParsedSchemaAndValue {
   @Override
   public Object getValue() {
     return value;
+  }
+
+  @Override
+  public SchemaInfo getWriterSchemaInfo() {
+    return writerSchemaInfo;
+  }
+
+  @Override
+  public JsonSchema getWriterSchema() {
+    return writerSchema;
+  }
+
+  @Override
+  public List<RuleResult> getRuleResults() {
+    return ruleResults;
   }
 
   @Override

--- a/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaDeserializer.java
+++ b/json-schema-serializer/src/main/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaDeserializer.java
@@ -104,6 +104,15 @@ public class KafkaJsonSchemaDeserializer<T> extends AbstractKafkaJsonSchemaDeser
   }
 
   @Override
+  public JsonSchemaAndValue deserializeWithSchema(
+      String topic, Headers headers, byte[] bytes,
+      Function<ParsedSchema, ParsedSchema> writerToReaderSchemaFunc,
+      boolean includeRuleResults) {
+    return deserializeWithSchemaAndVersion(
+        topic, isKey, headers, bytes, writerToReaderSchemaFunc, includeRuleResults);
+  }
+
+  @Override
   public void close() {
     try {
       super.close();

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufDeserializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufDeserializer.java
@@ -275,7 +275,7 @@ public abstract class AbstractKafkaProtobufDeserializer<T extends Message>
             subject,
             schemaId.getId(),
             writerVersion,
-            schemaId.getGuid() != null ? schemaId.getGuid().toString() : null);
+            schemaId.getGuid());
         List<RuleResult> ruleResultsCopy = ruleResults == null || ruleResults.isEmpty()
             ? Collections.emptyList()
             : Collections.unmodifiableList(new ArrayList<>(ruleResults));

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufDeserializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufDeserializer.java
@@ -25,6 +25,8 @@ import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.ExtensionRegistryLite;
 import com.google.protobuf.Message;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.ParsedSchemaAndValue;
+import io.confluent.kafka.schemaregistry.rules.RuleResult;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleMode;
 import io.confluent.kafka.schemaregistry.rules.RulePhase;
@@ -32,6 +34,7 @@ import io.confluent.kafka.serializers.schema.id.SchemaIdDeserializer;
 import io.confluent.kafka.serializers.schema.id.SchemaId;
 import java.io.InterruptedIOException;
 import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
@@ -128,11 +131,20 @@ public abstract class AbstractKafkaProtobufDeserializer<T extends Message>
     return deserialize(includeSchemaAndVersion, topic, isKey, headers, payload, null);
   }
 
+  protected Object deserialize(
+      boolean includeSchemaAndVersion, String topic, Boolean key, Headers headers, byte[] payload,
+      Function<ParsedSchema, ParsedSchema> writerToReaderSchemaFunc
+  ) throws SerializationException, InvalidConfigurationException {
+    return deserialize(
+        includeSchemaAndVersion, topic, key, headers, payload, writerToReaderSchemaFunc, false);
+  }
+
   // The Object return type is a bit messy, but this is the simplest way to have
   // flexible decoding and not duplicate deserialization code multiple times for different variants.
   protected Object deserialize(
       boolean includeSchemaAndVersion, String topic, Boolean key, Headers headers, byte[] payload,
-      Function<ParsedSchema, ParsedSchema> writerToReaderSchemaFunc
+      Function<ParsedSchema, ParsedSchema> writerToReaderSchemaFunc,
+      boolean includeRuleResults
   ) throws SerializationException, InvalidConfigurationException {
     if (schemaRegistry == null) {
       throw new InvalidConfigurationException(
@@ -147,6 +159,7 @@ public abstract class AbstractKafkaProtobufDeserializer<T extends Message>
 
     boolean isKey = key != null ? key : this.isKey;
     SchemaId schemaId = new SchemaId(ProtobufSchema.TYPE);
+    List<RuleResult> ruleResults = includeRuleResults ? new ArrayList<>() : null;
     try (SchemaIdDeserializer schemaIdDeserializer = schemaIdDeserializer(isKey)) {
       ByteBuffer buffer =
           schemaIdDeserializer.deserialize(topic, isKey, headers, payload, schemaId);
@@ -162,7 +175,7 @@ public abstract class AbstractKafkaProtobufDeserializer<T extends Message>
       }
       Object buf = executeRules(
           subject, topic, headers, payload, RulePhase.ENCODING, RuleMode.READ, null,
-          schema, buffer
+          schema, buffer, ruleResults
       );
       buffer = buf instanceof byte[] ? ByteBuffer.wrap((byte[]) buf) : (ByteBuffer) buf;
 
@@ -203,6 +216,7 @@ public abstract class AbstractKafkaProtobufDeserializer<T extends Message>
         message = readerSchema.fromJson((JsonNode) message);
       }
 
+      ProtobufSchema writerSchema = schema;
       if (readerSchema != null) {
         schema = readerSchema;
       }
@@ -213,7 +227,8 @@ public abstract class AbstractKafkaProtobufDeserializer<T extends Message>
               ProtobufSchema.EXTENSION_REGISTRY);
         }
         message = executeRules(
-            subject, topic, headers, payload, RuleMode.READ, null, schema, message
+            subject, topic, headers, payload, RulePhase.DOMAIN, RuleMode.READ, null,
+            schema, message, ruleResults
         );
       }
 
@@ -255,7 +270,16 @@ public abstract class AbstractKafkaProtobufDeserializer<T extends Message>
         // schema registry's ordering (which is implicit by auto-registration time rather than
         // explicit from the Connector).
 
-        return new ProtobufSchemaAndValue(schema, value);
+        Integer writerVersion = schemaVersion(topic, isKey, schemaId, subject, writerSchema, null);
+        ParsedSchemaAndValue.SchemaInfo writerInfo = new ParsedSchemaAndValue.SchemaInfo(
+            subject,
+            schemaId.getId(),
+            writerVersion,
+            schemaId.getGuid() != null ? schemaId.getGuid().toString() : null);
+        List<RuleResult> ruleResultsCopy = ruleResults == null || ruleResults.isEmpty()
+            ? Collections.emptyList()
+            : Collections.unmodifiableList(new ArrayList<>(ruleResults));
+        return new ProtobufSchemaAndValue(schema, value, writerInfo, writerSchema, ruleResultsCopy);
       }
 
       return value;
@@ -338,8 +362,17 @@ public abstract class AbstractKafkaProtobufDeserializer<T extends Message>
       String topic, boolean isKey, Headers headers, byte[] payload,
       Function<ParsedSchema, ParsedSchema> writerToReaderSchemaFunc
   ) throws SerializationException {
+    return deserializeWithSchemaAndVersion(
+        topic, isKey, headers, payload, writerToReaderSchemaFunc, false);
+  }
+
+  protected ProtobufSchemaAndValue deserializeWithSchemaAndVersion(
+      String topic, boolean isKey, Headers headers, byte[] payload,
+      Function<ParsedSchema, ParsedSchema> writerToReaderSchemaFunc,
+      boolean includeRuleResults
+  ) throws SerializationException {
     return (ProtobufSchemaAndValue) deserialize(
-        true, topic, isKey, headers, payload, writerToReaderSchemaFunc);
+        true, topic, isKey, headers, payload, writerToReaderSchemaFunc, includeRuleResults);
   }
 
   static class Pair<K, V> {

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufDeserializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufDeserializer.java
@@ -99,6 +99,14 @@ public class KafkaProtobufDeserializer<T extends Message>
   }
 
   @Override
+  public ProtobufSchemaAndValue deserializeWithSchema(String topic, Headers headers, byte[] bytes,
+      Function<ParsedSchema, ParsedSchema> writerToReaderSchemaFunc,
+      boolean includeRuleResults) {
+    return deserializeWithSchemaAndVersion(
+        topic, isKey, headers, bytes, writerToReaderSchemaFunc, includeRuleResults);
+  }
+
+  @Override
   public void close() {
     try {
       super.close();

--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/ProtobufSchemaAndValue.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/ProtobufSchemaAndValue.java
@@ -17,18 +17,35 @@
 package io.confluent.kafka.serializers.protobuf;
 
 import io.confluent.kafka.schemaregistry.ParsedSchemaAndValue;
-import java.util.Objects;
-
+import io.confluent.kafka.schemaregistry.rules.RuleResult;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 
 public class ProtobufSchemaAndValue implements ParsedSchemaAndValue {
 
   private final ProtobufSchema schema;
   private final Object value;
+  private final SchemaInfo writerSchemaInfo;
+  private final ProtobufSchema writerSchema;
+  private final List<RuleResult> ruleResults;
 
   public ProtobufSchemaAndValue(ProtobufSchema schema, Object value) {
+    this(schema, value, null, null, Collections.emptyList());
+  }
+
+  public ProtobufSchemaAndValue(
+      ProtobufSchema schema,
+      Object value,
+      SchemaInfo writerSchemaInfo,
+      ProtobufSchema writerSchema,
+      List<RuleResult> ruleResults) {
     this.schema = schema;
     this.value = value;
+    this.writerSchemaInfo = writerSchemaInfo;
+    this.writerSchema = writerSchema;
+    this.ruleResults = ruleResults != null ? ruleResults : Collections.emptyList();
   }
 
   @Override
@@ -39,6 +56,21 @@ public class ProtobufSchemaAndValue implements ParsedSchemaAndValue {
   @Override
   public Object getValue() {
     return value;
+  }
+
+  @Override
+  public SchemaInfo getWriterSchemaInfo() {
+    return writerSchemaInfo;
+  }
+
+  @Override
+  public ProtobufSchema getWriterSchema() {
+    return writerSchema;
+  }
+
+  @Override
+  public List<RuleResult> getRuleResults() {
+    return ruleResults;
   }
 
   @Override

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelUtils.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelUtils.java
@@ -57,6 +57,7 @@ import io.confluent.kafka.schemaregistry.rules.cel.builtin.BuiltinLibrary;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -311,7 +312,7 @@ public final class CelUtils {
   }
 
   private static List<CelVarDecl> downgradeStructsToMap(List<CelVarDecl> varDecls) {
-    List<CelVarDecl> out = new java.util.ArrayList<>(varDecls.size());
+    List<CelVarDecl> out = new ArrayList<>(varDecls.size());
     for (CelVarDecl decl : varDecls) {
       if (decl.type() instanceof StructTypeReference) {
         out.add(CelVarDecl.newVarDeclaration(
@@ -601,7 +602,7 @@ public final class CelUtils {
     }
     if (value instanceof List) {
       List<?> in = (List<?>) value;
-      java.util.List<Object> out = new java.util.ArrayList<>(in.size());
+      java.util.List<Object> out = new ArrayList<>(in.size());
       for (Object e : in) {
         out.add(toCelValue(e));
       }

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/avro/AvroResultWriter.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/avro/AvroResultWriter.java
@@ -19,6 +19,7 @@ package io.confluent.kafka.schemaregistry.rules.cel.avro;
 import dev.cel.common.values.CelByteString;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.avro.AvroTypeException;
@@ -202,7 +203,7 @@ public final class AvroResultWriter {
       throw typeMismatch(celValue, schema);
     }
     Map<?, ?> in = (Map<?, ?>) celValue;
-    java.util.Map<String, Object> out = new java.util.LinkedHashMap<>(in.size());
+    Map<String, Object> out = new LinkedHashMap<>(in.size());
     for (Map.Entry<?, ?> e : in.entrySet()) {
       out.put(String.valueOf(e.getKey()), convert(e.getValue(), schema.getValueType()));
     }

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -31,6 +31,7 @@ import com.google.common.base.Ticker;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
+import io.confluent.kafka.schemaregistry.rules.RuleResult;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientFactory;
@@ -788,6 +789,15 @@ public abstract class AbstractKafkaSchemaSerDe
       String subject, String topic, Headers headers, Object original,
       RulePhase rulePhase, RuleMode ruleMode,
       ParsedSchema source, ParsedSchema target, Object message) {
+    return executeRules(subject, topic, headers, original, rulePhase, ruleMode,
+        source, target, message, null);
+  }
+
+  protected Object executeRules(
+      String subject, String topic, Headers headers, Object original,
+      RulePhase rulePhase, RuleMode ruleMode,
+      ParsedSchema source, ParsedSchema target, Object message,
+      List<RuleResult> ruleResults) {
     if (message == null || target == null) {
       return message;
     }
@@ -825,11 +835,13 @@ public abstract class AbstractKafkaSchemaSerDe
           subject, topic, headers,
           isKey ? original : key(),
           isKey ? null : original,
-          isKey, ruleMode, rule, i, rules);
+          isKey, ruleMode, rule, i, rules,
+          ruleResults != null);
       if (skipRule(ctx, rule, headers)) {
         if (rm != null) {
           rm.recordSkipped(rule, ruleMode, subject);
         }
+        appendRuleResult(ruleResults, rule, RuleResult.Result.SKIPPED, null, ctx);
         continue;
       }
       if (rule.getMode() == RuleMode.WRITEREAD) {
@@ -837,6 +849,7 @@ public abstract class AbstractKafkaSchemaSerDe
           if (rm != null) {
             rm.recordSkipped(rule, ruleMode, subject);
           }
+          appendRuleResult(ruleResults, rule, RuleResult.Result.SKIPPED, null, ctx);
           continue;
         }
       } else if (rule.getMode() == RuleMode.UPDOWN) {
@@ -844,46 +857,84 @@ public abstract class AbstractKafkaSchemaSerDe
           if (rm != null) {
             rm.recordSkipped(rule, ruleMode, subject);
           }
+          appendRuleResult(ruleResults, rule, RuleResult.Result.SKIPPED, null, ctx);
           continue;
         }
       } else if (ruleMode != rule.getMode()) {
         if (rm != null) {
           rm.recordSkipped(rule, ruleMode, subject);
         }
+        appendRuleResult(ruleResults, rule, RuleResult.Result.SKIPPED, null, ctx);
         continue;
       }
+      RuleResult.Result result = RuleResult.Result.SUCCESS;
+      String errorMessage = null;
       RuleExecutor ruleExecutor = getRuleExecutor(ctx);
       if (ruleExecutor != null) {
         try {
-          Object result = ruleExecutor.transform(ctx, message);
+          Object output = ruleExecutor.transform(ctx, message);
           switch (rule.getKind()) {
             case CONDITION:
-              if (Boolean.FALSE.equals(result)) {
+              if (Boolean.FALSE.equals(output)) {
                 throw new RuleConditionException(rule);
               }
               break;
             case TRANSFORM:
-              message = result;
+              message = output;
               break;
             default:
               throw new IllegalArgumentException("Unsupported rule kind " + rule.getKind());
           }
           boolean ruleSucceeded = message != null;
+          if (!ruleSucceeded) {
+            result = RuleResult.Result.FAILURE;
+          }
           runAction(ctx, ruleMode, rule,
               ruleSucceeded ? getOnSuccess(rule) : getOnFailure(rule),
               message, null, ruleSucceeded ? null : ErrorAction.TYPE,
               ruleSucceeded);
         } catch (RuleException e) {
+          result = RuleResult.Result.FAILURE;
+          errorMessage = e.getMessage() != null ? e.getMessage() : e.toString();
           runAction(ctx, ruleMode, rule, getOnFailure(rule), message, e,
               ErrorAction.TYPE, false);
         }
       } else {
+        result = RuleResult.Result.FAILURE;
+        errorMessage = "Could not find rule executor of type " + rule.getType();
         runAction(ctx, ruleMode, rule, getOnFailure(rule), message,
-            new RuleException(rule, "Could not find rule executor of type " + rule.getType()),
+            new RuleException(rule, errorMessage),
             ErrorAction.TYPE, false);
       }
+      appendRuleResult(ruleResults, rule, result, errorMessage, ctx);
     }
     return message;
+  }
+
+  private static void appendRuleResult(
+      List<RuleResult> ruleResults,
+      Rule rule,
+      RuleResult.Result result,
+      String errorMessage,
+      RuleContext ctx) {
+    if (ruleResults == null) {
+      return;
+    }
+    Map<String, String> messageMetadata = ctx.messageMetadata().isEmpty()
+        ? Collections.emptyMap()
+        : Collections.unmodifiableMap(new LinkedHashMap<>(ctx.messageMetadata()));
+    Map<String, Map<String, String>> fieldMetadata;
+    if (ctx.fieldMetadata().isEmpty()) {
+      fieldMetadata = Collections.emptyMap();
+    } else {
+      Map<String, Map<String, String>> copy = new LinkedHashMap<>();
+      for (Map.Entry<String, Map<String, String>> e : ctx.fieldMetadata().entrySet()) {
+        copy.put(e.getKey(), Collections.unmodifiableMap(new LinkedHashMap<>(e.getValue())));
+      }
+      fieldMetadata = Collections.unmodifiableMap(copy);
+    }
+    ruleResults.add(new RuleResult(
+        rule, result, errorMessage, messageMetadata, fieldMetadata));
   }
 
   protected Object executeValidationRules(

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -867,8 +867,6 @@ public abstract class AbstractKafkaSchemaSerDe
         appendRuleResult(ruleResults, rule, RuleResult.Result.SKIPPED, null, ctx);
         continue;
       }
-      RuleResult.Result result = RuleResult.Result.SUCCESS;
-      String errorMessage = null;
       RuleExecutor ruleExecutor = getRuleExecutor(ctx);
       if (ruleExecutor != null) {
         try {
@@ -886,27 +884,20 @@ public abstract class AbstractKafkaSchemaSerDe
               throw new IllegalArgumentException("Unsupported rule kind " + rule.getKind());
           }
           boolean ruleSucceeded = message != null;
-          if (!ruleSucceeded) {
-            result = RuleResult.Result.FAILURE;
-          }
           runAction(ctx, ruleMode, rule,
               ruleSucceeded ? getOnSuccess(rule) : getOnFailure(rule),
               message, null, ruleSucceeded ? null : ErrorAction.TYPE,
-              ruleSucceeded);
+              ruleSucceeded, ruleResults);
         } catch (RuleException e) {
-          result = RuleResult.Result.FAILURE;
-          errorMessage = e.getMessage() != null ? e.getMessage() : e.toString();
           runAction(ctx, ruleMode, rule, getOnFailure(rule), message, e,
-              ErrorAction.TYPE, false);
+              ErrorAction.TYPE, false, ruleResults);
         }
       } else {
-        result = RuleResult.Result.FAILURE;
-        errorMessage = "Could not find rule executor of type " + rule.getType();
         runAction(ctx, ruleMode, rule, getOnFailure(rule), message,
-            new RuleException(rule, errorMessage),
-            ErrorAction.TYPE, false);
+            new RuleException(rule,
+                "Could not find rule executor of type " + rule.getType()),
+            ErrorAction.TYPE, false, ruleResults);
       }
-      appendRuleResult(ruleResults, rule, result, errorMessage, ctx);
     }
     return message;
   }
@@ -1110,7 +1101,8 @@ public abstract class AbstractKafkaSchemaSerDe
   }
 
   private void runAction(RuleContext ctx, RuleMode ruleMode, Rule rule, String action,
-      Object message, RuleException ex, String defaultAction, boolean ruleSucceeded) {
+      Object message, RuleException ex, String defaultAction, boolean ruleSucceeded,
+      List<RuleResult> ruleResults) {
     RuleMetrics rm = ruleMetrics;
     if (rm != null) {
       rm.recordExecution(rule, ruleMode, ctx.subject());
@@ -1120,6 +1112,14 @@ public abstract class AbstractKafkaSchemaSerDe
         rm.recordFailure(rule, ruleMode, ctx.subject());
       }
     }
+    RuleResult.Result result = ruleSucceeded
+        ? RuleResult.Result.SUCCESS
+        : RuleResult.Result.FAILURE;
+    String errorMessage = null;
+    if (!ruleSucceeded && ex != null) {
+      errorMessage = ex.getMessage() != null ? ex.getMessage() : ex.toString();
+    }
+    appendRuleResult(ruleResults, rule, result, errorMessage, ctx);
     String actionName = getRuleActionName(rule, ruleMode, action);
     if (actionName == null) {
       actionName = defaultAction;

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/DeserializerWithSchema.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/DeserializerWithSchema.java
@@ -28,4 +28,8 @@ public interface DeserializerWithSchema<T> extends Deserializer<T> {
 
   ParsedSchemaAndValue deserializeWithSchema(String topic, Headers headers, byte[] data,
       Function<ParsedSchema, ParsedSchema> writerToReaderSchemaFunc);
+
+  ParsedSchemaAndValue deserializeWithSchema(String topic, Headers headers, byte[] data,
+      Function<ParsedSchema, ParsedSchema> writerToReaderSchemaFunc,
+      boolean includeRuleResults);
 }


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
 Adds first-class access to rule-execution audit data and writer-schema metadata on the`ParsedSchemaAndValue` returned from `deserializeWithSchema`. The original driver was a request to see which fields were decrypted vs. passed through as ciphertext after an ENCRYPT rule ran; the feature generalizes to any rule executor that wants to surface per-message or per-field outcome data.

To use:
```
  import io.confluent.kafka.schemaregistry.rules.RuleResult;
  import io.confluent.kafka.schemaregistry.encryption.EncryptionExecutor;
  import io.confluent.kafka.schemaregistry.encryption.FieldEncryptionExecutor;

  GenericContainerWithVersion wrapper = avroDeserializer.deserializeWithSchema(
      topic, headers, bytes,
      /* writerToReaderSchemaFunc */ null,
      /* includeRuleResults */     true);

  for (RuleResult r : wrapper.getRuleResults()) {
    if (r.rule() == null
        || !FieldEncryptionExecutor.TYPE.equals(r.rule().getType())) {
      continue;
    }
    for (Map.Entry<String, Map<String, String>> e : r.fieldMetadata().entrySet()) {
      String fieldPath = e.getKey();
      Map<String, String> meta = e.getValue();
      String status = meta.get(EncryptionExecutor.META_STATUS);
      // status is one of: "DECRYPTED" | "PASSTHROUGH" | "FAILED"
      switch (EncryptionExecutor.Status.valueOf(status)) {
        case DECRYPTED:
          log.debug("field {} decrypted with {} v{}", fieldPath,
              meta.get(EncryptionExecutor.META_KEK_NAME),
              meta.get(EncryptionExecutor.META_DEK_VERSION));
          break;
        case PASSTHROUGH:
          log.warn("field {} returned as ciphertext (passthrough KEK {})",
              fieldPath, meta.get(EncryptionExecutor.META_KEK_NAME));
          break;
        case FAILED:
          log.error("field {} decrypt failed: {}", fieldPath,
              meta.get(EncryptionExecutor.META_ERROR_MESSAGE));
          break;
        default:
          break;
      }
    }
  }
```
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[Y]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
