### PR TITLE
Add tenant enumeration and removal API to dek-registry MetricsManager

### DIFF
--- a/dek-registry/src/main/java/io/confluent/dekregistry/metrics/MetricsManager.java
+++ b/dek-registry/src/main/java/io/confluent/dekregistry/metrics/MetricsManager.java
@@ -22,6 +22,7 @@ import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
 import java.io.Closeable;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.kafka.common.MetricName;
@@ -82,6 +83,20 @@ public class MetricsManager implements Closeable {
   public void decrementSharedKeyCount(String tenant) {
     TenantMetrics tenantMetrics = getOrCreateTenantMetrics(tenant);
     tenantMetrics.getSensor(MetricDescriptor.NUM_KEKS_SHARED_MD, null, null).add(-1);
+  }
+
+  public Set<String> getTrackedTenants() {
+    return Set.copyOf(tenantMetrics.keySet());
+  }
+
+  public void removeTenant(String tenant) {
+    TenantMetrics tm = tenantMetrics.remove(tenant);
+    if (tm == null) {
+      return;
+    }
+    for (String sensorName : tm.sensors.keySet()) {
+      metrics.removeSensor(sensorName);
+    }
   }
 
   private TenantMetrics getOrCreateTenantMetrics(String tenant) {

--- a/dek-registry/src/main/java/io/confluent/dekregistry/metrics/MetricsManager.java
+++ b/dek-registry/src/main/java/io/confluent/dekregistry/metrics/MetricsManager.java
@@ -85,7 +85,7 @@ public class MetricsManager implements Closeable {
     tenantMetrics.getSensor(MetricDescriptor.NUM_KEKS_SHARED_MD, null, null).add(-1);
   }
 
-  public Set<String> getTrackedTenants() {
+  public Set<String> getTenants() {
     return Set.copyOf(tenantMetrics.keySet());
   }
 

--- a/dek-registry/src/test/java/io/confluent/dekregistry/metrics/MetricsManagerTest.java
+++ b/dek-registry/src/test/java/io/confluent/dekregistry/metrics/MetricsManagerTest.java
@@ -83,22 +83,22 @@ public class MetricsManagerTest {
   }
 
   @Test
-  public void getTrackedTenants_emptyByDefault() {
-    assertTrue(metricsManager.getTrackedTenants().isEmpty());
+  public void getTenants_emptyByDefault() {
+    assertTrue(metricsManager.getTenants().isEmpty());
   }
 
   @Test
-  public void getTrackedTenants_returnsTenantsAfterIncrements() {
+  public void getTenants_returnsTenantsAfterIncrements() {
     metricsManager.incrementKeyCount("tenant-a", KeyType.KEK);
     metricsManager.incrementSharedKeyCount("tenant-b");
 
-    assertEquals(Set.of("tenant-a", "tenant-b"), metricsManager.getTrackedTenants());
+    assertEquals(Set.of("tenant-a", "tenant-b"), metricsManager.getTenants());
   }
 
   @Test
-  public void getTrackedTenants_isSnapshot() {
+  public void getTenants_isSnapshot() {
     metricsManager.incrementKeyCount("tenant-a", KeyType.KEK);
-    Set<String> snapshot = metricsManager.getTrackedTenants();
+    Set<String> snapshot = metricsManager.getTenants();
 
     metricsManager.incrementKeyCount("tenant-b", KeyType.KEK);
 
@@ -121,7 +121,7 @@ public class MetricsManagerTest {
 
     metricsManager.removeTenant("tenant-a");
 
-    assertFalse(metricsManager.getTrackedTenants().contains("tenant-a"));
+    assertFalse(metricsManager.getTenants().contains("tenant-a"));
     assertNull(metrics.getSensor(sensorName(MetricsManager.NUM_KEKS, "tenant-a")));
     assertNull(metrics.getSensor(sensorName(MetricsManager.NUM_KEKS_SHARED, "tenant-a")));
     assertNull(metrics.getSensor(sensorName(MetricsManager.NUM_DEKS, "tenant-a")));
@@ -138,7 +138,7 @@ public class MetricsManagerTest {
 
     metricsManager.removeTenant("tenant-a");
 
-    assertEquals(Set.of("tenant-b"), metricsManager.getTrackedTenants());
+    assertEquals(Set.of("tenant-b"), metricsManager.getTenants());
     assertNotNull(metrics.getSensor(sensorName(MetricsManager.NUM_KEKS, "tenant-b")));
     assertNotNull(metrics.metric(tenantMetric(MetricsManager.NUM_KEKS, "tenant-b")));
     assertEquals(2L, metricsManager.getKeyCount("tenant-b", KeyType.KEK));
@@ -150,7 +150,7 @@ public class MetricsManagerTest {
 
     assertDoesNotThrow(() -> metricsManager.removeTenant("never-registered"));
 
-    assertEquals(Set.of("tenant-a"), metricsManager.getTrackedTenants());
+    assertEquals(Set.of("tenant-a"), metricsManager.getTenants());
   }
 
   @Test
@@ -159,7 +159,7 @@ public class MetricsManagerTest {
     metricsManager.removeTenant("tenant-a");
 
     assertDoesNotThrow(() -> metricsManager.removeTenant("tenant-a"));
-    assertTrue(metricsManager.getTrackedTenants().isEmpty());
+    assertTrue(metricsManager.getTenants().isEmpty());
   }
 
   @Test
@@ -170,7 +170,7 @@ public class MetricsManagerTest {
 
     metricsManager.incrementKeyCount("tenant-a", KeyType.KEK);
 
-    assertTrue(metricsManager.getTrackedTenants().contains("tenant-a"));
+    assertTrue(metricsManager.getTenants().contains("tenant-a"));
     assertEquals(1L, metricsManager.getKeyCount("tenant-a", KeyType.KEK));
     assertNotNull(metrics.getSensor(sensorName(MetricsManager.NUM_KEKS, "tenant-a")));
     assertNotNull(metrics.metric(tenantMetric(MetricsManager.NUM_KEKS, "tenant-a")));

--- a/dek-registry/src/test/java/io/confluent/dekregistry/metrics/MetricsManagerTest.java
+++ b/dek-registry/src/test/java/io/confluent/dekregistry/metrics/MetricsManagerTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.dekregistry.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.confluent.dekregistry.client.rest.entities.KeyType;
+import io.confluent.kafka.schemaregistry.metrics.MetricsContainer;
+import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Metrics;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class MetricsManagerTest {
+
+  private Metrics metrics;
+  private MetricsManager metricsManager;
+
+  @BeforeEach
+  public void setUp() {
+    metrics = new Metrics();
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    MetricsContainer metricsContainer = mock(MetricsContainer.class);
+    when(schemaRegistry.getMetricsContainer()).thenReturn(metricsContainer);
+    when(metricsContainer.getMetrics()).thenReturn(metrics);
+    when(schemaRegistry.properties()).thenReturn(new HashMap<>());
+    metricsManager = new MetricsManager(schemaRegistry);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    metrics.close();
+  }
+
+  private MetricName tenantMetric(String metricName, String tenant) {
+    Map<String, String> tags = new HashMap<>();
+    tags.put(MetricsManager.TENANT_TAG, tenant);
+    String description;
+    switch (metricName) {
+      case MetricsManager.NUM_KEKS:
+        description = "Number of keks";
+        break;
+      case MetricsManager.NUM_KEKS_SHARED:
+        description = "Number of keks shared";
+        break;
+      case MetricsManager.NUM_DEKS:
+        description = "Number of deks";
+        break;
+      default:
+        throw new IllegalArgumentException(metricName);
+    }
+    return new MetricName(metricName, MetricsManager.METRIC_GROUP, description, tags);
+  }
+
+  private String sensorName(String metricName, String tenant) {
+    return metricName + "." + tenant;
+  }
+
+  @Test
+  public void getTrackedTenants_emptyByDefault() {
+    assertTrue(metricsManager.getTrackedTenants().isEmpty());
+  }
+
+  @Test
+  public void getTrackedTenants_returnsTenantsAfterIncrements() {
+    metricsManager.incrementKeyCount("tenant-a", KeyType.KEK);
+    metricsManager.incrementSharedKeyCount("tenant-b");
+
+    assertEquals(Set.of("tenant-a", "tenant-b"), metricsManager.getTrackedTenants());
+  }
+
+  @Test
+  public void getTrackedTenants_isSnapshot() {
+    metricsManager.incrementKeyCount("tenant-a", KeyType.KEK);
+    Set<String> snapshot = metricsManager.getTrackedTenants();
+
+    metricsManager.incrementKeyCount("tenant-b", KeyType.KEK);
+
+    assertEquals(Set.of("tenant-a"), snapshot);
+    assertThrows(UnsupportedOperationException.class, () -> snapshot.add("tenant-c"));
+  }
+
+  @Test
+  public void removeTenant_dropsAllSensorsForTenant() {
+    metricsManager.incrementKeyCount("tenant-a", KeyType.KEK);
+    metricsManager.incrementSharedKeyCount("tenant-a");
+    metricsManager.incrementKeyCount("tenant-a", KeyType.DEK);
+
+    assertNotNull(metrics.getSensor(sensorName(MetricsManager.NUM_KEKS, "tenant-a")));
+    assertNotNull(metrics.getSensor(sensorName(MetricsManager.NUM_KEKS_SHARED, "tenant-a")));
+    assertNotNull(metrics.getSensor(sensorName(MetricsManager.NUM_DEKS, "tenant-a")));
+    assertNotNull(metrics.metric(tenantMetric(MetricsManager.NUM_KEKS, "tenant-a")));
+    assertNotNull(metrics.metric(tenantMetric(MetricsManager.NUM_KEKS_SHARED, "tenant-a")));
+    assertNotNull(metrics.metric(tenantMetric(MetricsManager.NUM_DEKS, "tenant-a")));
+
+    metricsManager.removeTenant("tenant-a");
+
+    assertFalse(metricsManager.getTrackedTenants().contains("tenant-a"));
+    assertNull(metrics.getSensor(sensorName(MetricsManager.NUM_KEKS, "tenant-a")));
+    assertNull(metrics.getSensor(sensorName(MetricsManager.NUM_KEKS_SHARED, "tenant-a")));
+    assertNull(metrics.getSensor(sensorName(MetricsManager.NUM_DEKS, "tenant-a")));
+    assertNull(metrics.metric(tenantMetric(MetricsManager.NUM_KEKS, "tenant-a")));
+    assertNull(metrics.metric(tenantMetric(MetricsManager.NUM_KEKS_SHARED, "tenant-a")));
+    assertNull(metrics.metric(tenantMetric(MetricsManager.NUM_DEKS, "tenant-a")));
+  }
+
+  @Test
+  public void removeTenant_doesNotAffectOtherTenants() {
+    metricsManager.incrementKeyCount("tenant-a", KeyType.KEK);
+    metricsManager.incrementKeyCount("tenant-b", KeyType.KEK);
+    metricsManager.incrementKeyCount("tenant-b", KeyType.KEK);
+
+    metricsManager.removeTenant("tenant-a");
+
+    assertEquals(Set.of("tenant-b"), metricsManager.getTrackedTenants());
+    assertNotNull(metrics.getSensor(sensorName(MetricsManager.NUM_KEKS, "tenant-b")));
+    assertNotNull(metrics.metric(tenantMetric(MetricsManager.NUM_KEKS, "tenant-b")));
+    assertEquals(2L, metricsManager.getKeyCount("tenant-b", KeyType.KEK));
+  }
+
+  @Test
+  public void removeTenant_unknownTenantIsNoOp() {
+    metricsManager.incrementKeyCount("tenant-a", KeyType.KEK);
+
+    assertDoesNotThrow(() -> metricsManager.removeTenant("never-registered"));
+
+    assertEquals(Set.of("tenant-a"), metricsManager.getTrackedTenants());
+  }
+
+  @Test
+  public void removeTenant_isIdempotent() {
+    metricsManager.incrementKeyCount("tenant-a", KeyType.KEK);
+    metricsManager.removeTenant("tenant-a");
+
+    assertDoesNotThrow(() -> metricsManager.removeTenant("tenant-a"));
+    assertTrue(metricsManager.getTrackedTenants().isEmpty());
+  }
+
+  @Test
+  public void removeTenant_thenIncrementReregisters() {
+    metricsManager.incrementKeyCount("tenant-a", KeyType.KEK);
+    metricsManager.incrementKeyCount("tenant-a", KeyType.KEK);
+    metricsManager.removeTenant("tenant-a");
+
+    metricsManager.incrementKeyCount("tenant-a", KeyType.KEK);
+
+    assertTrue(metricsManager.getTrackedTenants().contains("tenant-a"));
+    assertEquals(1L, metricsManager.getKeyCount("tenant-a", KeyType.KEK));
+    assertNotNull(metrics.getSensor(sensorName(MetricsManager.NUM_KEKS, "tenant-a")));
+    assertNotNull(metrics.metric(tenantMetric(MetricsManager.NUM_KEKS, "tenant-a")));
+  }
+}


### PR DESCRIPTION
## Summary
- Add `MetricsManager.getTrackedTenants()` returning an immutable snapshot of tenants for which sensors have been registered.
- Add `MetricsManager.removeTenant(String)` which drops the tenant entry and unregisters every sensor it held from the underlying `Metrics`. No-op for unknown tenants; idempotent.
- Add `MetricsManagerTest` covering the new API and verifying underlying `Metrics` state (sensor + `MetricName` lookup).

## Test plan
- [x] `mvn test -pl dek-registry -Dtest=MetricsManagerTest` — 8/8 pass
- [x] SpotBugs clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)