### PR TITLE
fix: AssociatedNameStrategy.usesSchema() should reflect fallback strategy

### DIFF
--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/subject/AssociatedNameStrategy.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/subject/AssociatedNameStrategy.java
@@ -146,6 +146,12 @@ public class AssociatedNameStrategy implements SubjectNameStrategy {
   }
 
   @Override
+  public boolean usesSchema() {
+    SubjectNameStrategy fallback = getFallbackSubjectNameStrategy();
+    return fallback != null && fallback.usesSchema();
+  }
+
+  @Override
   public String subjectName(String topic, boolean isKey, ParsedSchema schema) {
     if (topic == null) {
       return null;

--- a/schema-serializer/src/test/java/io/confluent/kafka/serializers/subject/AssociatedNameStrategyTest.java
+++ b/schema-serializer/src/test/java/io/confluent/kafka/serializers/subject/AssociatedNameStrategyTest.java
@@ -17,7 +17,9 @@
 package io.confluent.kafka.serializers.subject;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Ticker;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
@@ -92,6 +94,46 @@ public class AssociatedNameStrategyTest {
     strategy.setKafkaClusterId("cluster-1");
 
     assertEquals("correct-subject", strategy.subjectName("my-topic", false, SCHEMA));
+  }
+
+  @Test
+  public void testUsesSchemaWithRecordFallback() {
+    AssociatedNameStrategy strategy = new AssociatedNameStrategy();
+    strategy.setSchemaRegistryClient(new MockSchemaRegistryClient());
+    Map<String, Object> configs = new HashMap<>();
+    configs.put(AssociatedNameStrategy.FALLBACK_TYPE, "RECORD");
+    strategy.configure(configs);
+    assertTrue(strategy.usesSchema());
+  }
+
+  @Test
+  public void testUsesSchemaWithTopicRecordFallback() {
+    AssociatedNameStrategy strategy = new AssociatedNameStrategy();
+    strategy.setSchemaRegistryClient(new MockSchemaRegistryClient());
+    Map<String, Object> configs = new HashMap<>();
+    configs.put(AssociatedNameStrategy.FALLBACK_TYPE, "TOPIC_RECORD");
+    strategy.configure(configs);
+    assertTrue(strategy.usesSchema());
+  }
+
+  @Test
+  public void testUsesSchemaWithTopicFallback() {
+    AssociatedNameStrategy strategy = new AssociatedNameStrategy();
+    strategy.setSchemaRegistryClient(new MockSchemaRegistryClient());
+    Map<String, Object> configs = new HashMap<>();
+    configs.put(AssociatedNameStrategy.FALLBACK_TYPE, "TOPIC");
+    strategy.configure(configs);
+    assertFalse(strategy.usesSchema());
+  }
+
+  @Test
+  public void testUsesSchemaWithNoneFallback() {
+    AssociatedNameStrategy strategy = new AssociatedNameStrategy();
+    strategy.setSchemaRegistryClient(new MockSchemaRegistryClient());
+    Map<String, Object> configs = new HashMap<>();
+    configs.put(AssociatedNameStrategy.FALLBACK_TYPE, "NONE");
+    strategy.configure(configs);
+    assertFalse(strategy.usesSchema());
   }
 
   @Test


### PR DESCRIPTION

<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/

AssociatedNameStrategy inherited the default usesSchema()=false from SubjectNameStrategy, but when the association lookup misses and the strategy falls back to RecordNameStrategy or TopicRecordNameStrategy, those fallbacks require the schema. The deserializer gates schema fetching on usesSchema(), so the fallback received schema=null and silently returned a null subject. Delegate usesSchema() to the configured fallback so the schema is fetched when the fallback needs it.


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[ ]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[ ]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[X ]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[ ]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[ ]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

DGS-23457

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
