### PR TITLE
DGS-24400 Ensure message indexes are not empty for Protobuf serialize

### DIFF
--- a/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufSerializer.java
+++ b/protobuf-serializer/src/main/java/io/confluent/kafka/serializers/protobuf/AbstractKafkaProtobufSerializer.java
@@ -195,7 +195,10 @@ public abstract class AbstractKafkaProtobufSerializer<T extends Message>
 
       MessageIndexes indexes = schema.toMessageIndexes(
           object.getDescriptorForType().getFullName(), normalizeSchema);
-      schemaId.setMessageIndexes(indexes.indexes());
+      List<Integer> indexList = indexes.indexes().isEmpty()
+          ? MessageIndexes.DEFAULT_INDEX
+          : indexes.indexes();
+      schemaId.setMessageIndexes(indexList);
       try (SchemaIdSerializer schemaIdSerializer = schemaIdSerializer(isKey)) {
         byte[] payload = object.toByteArray();
         payload = (byte[]) executeRules(

--- a/protobuf-serializer/src/test/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufSerializerTest.java
+++ b/protobuf-serializer/src/test/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufSerializerTest.java
@@ -1028,6 +1028,40 @@ public class KafkaProtobufSerializerTest {
   }
 
   @Test
+  public void testKafkaProtobufSerializerUseLatestWithMismatchedDescriptorName()
+      throws IOException, RestClientException {
+    // If the runtime descriptor's full name doesn't match any message in the
+    // registered schema, ProtobufSchema.toMessageIndexes returns an empty list.
+    // The serializer must still emit the default message-index varint (0x00).
+    String subject = topic + "-value";
+    String renamedSchema = "syntax = \"proto3\";\n"
+        + "package com.test.renamed;\n"
+        + "message Renamed {\n"
+        + "  string test_string = 1;\n"
+        + "  int32 test_int32 = 8;\n"
+        + "}\n";
+    schemaRegistry.register(subject, new ProtobufSchema(renamedSchema));
+
+    Map configs = ImmutableMap.of(
+        KafkaProtobufSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "bogus",
+        KafkaProtobufSerializerConfig.AUTO_REGISTER_SCHEMAS, false,
+        KafkaProtobufSerializerConfig.USE_LATEST_VERSION, true,
+        KafkaProtobufSerializerConfig.LATEST_COMPATIBILITY_STRICT, false
+    );
+    protobufSerializer.configure(configs, false);
+    protobufDeserializer.configure(configs, false);
+
+    RecordHeaders headers = new RecordHeaders();
+    byte[] bytes = protobufSerializer.serialize(topic, headers, HELLO_WORLD_MESSAGE);
+    DynamicMessage result =
+        (DynamicMessage) protobufDeserializer.deserialize(topic, headers, bytes);
+    assertEquals(TEST_MSG_STRING, getField(result, "test_string"));
+
+    protobufSerializer.configure(new HashMap(serializerConfig), false);
+    protobufDeserializer.configure(new HashMap(deserializerConfig), false);
+  }
+
+  @Test
   public void testDependencyPreregisterRefWithNegativeOne() throws Exception {
     String refSubject = "TestProto.proto";
     String refSchemaString = "syntax = \"proto3\";\n"


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Ensure message indexes are not empty for Protobuf serialize
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
