### PR TITLE
feat: Add support for Avro temporal logical types (timestamp-micros, time-micros, local-timestamp-*)

### DIFF
--- a/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -265,12 +265,19 @@ public class AvroData {
         return Timestamp.toLogical(schema, (long) value);
       }
     });
+
   }
 
   static final String AVRO_PROP = "avro";
   static final String AVRO_LOGICAL_TYPE_PROP = "logicalType";
   static final String AVRO_LOGICAL_TIMESTAMP_MILLIS = "timestamp-millis";
+  static final String AVRO_LOGICAL_TIMESTAMP_MICROS = "timestamp-micros";
+  static final String AVRO_LOGICAL_TIMESTAMP_NANOS = "timestamp-nanos";
+  static final String AVRO_LOGICAL_LOCAL_TIMESTAMP_MILLIS = "local-timestamp-millis";
+  static final String AVRO_LOGICAL_LOCAL_TIMESTAMP_MICROS = "local-timestamp-micros";
+  static final String AVRO_LOGICAL_LOCAL_TIMESTAMP_NANOS = "local-timestamp-nanos";
   static final String AVRO_LOGICAL_TIME_MILLIS = "time-millis";
+  static final String AVRO_LOGICAL_TIME_MICROS = "time-micros";
   static final String AVRO_LOGICAL_DATE = "date";
   static final String AVRO_LOGICAL_DECIMAL = "decimal";
   static final String AVRO_LOGICAL_DECIMAL_SCALE_PROP = "scale";
@@ -1857,6 +1864,18 @@ public class AvroData {
       case LONG:
         if (AVRO_LOGICAL_TIMESTAMP_MILLIS.equalsIgnoreCase(logicalType)) {
           builder = Timestamp.builder();
+        } else if (AVRO_LOGICAL_TIMESTAMP_MICROS.equalsIgnoreCase(logicalType)) {
+          builder = SchemaBuilder.int64().name(AVRO_LOGICAL_TIMESTAMP_MICROS);
+        } else if (AVRO_LOGICAL_TIMESTAMP_NANOS.equalsIgnoreCase(logicalType)) {
+          builder = SchemaBuilder.int64().name(AVRO_LOGICAL_TIMESTAMP_NANOS);
+        } else if (AVRO_LOGICAL_LOCAL_TIMESTAMP_MILLIS.equalsIgnoreCase(logicalType)) {
+          builder = SchemaBuilder.int64().name(AVRO_LOGICAL_LOCAL_TIMESTAMP_MILLIS);
+        } else if (AVRO_LOGICAL_LOCAL_TIMESTAMP_MICROS.equalsIgnoreCase(logicalType)) {
+          builder = SchemaBuilder.int64().name(AVRO_LOGICAL_LOCAL_TIMESTAMP_MICROS);
+        } else if (AVRO_LOGICAL_LOCAL_TIMESTAMP_NANOS.equalsIgnoreCase(logicalType)) {
+          builder = SchemaBuilder.int64().name(AVRO_LOGICAL_LOCAL_TIMESTAMP_NANOS);
+        } else if (AVRO_LOGICAL_TIME_MICROS.equalsIgnoreCase(logicalType)) {
+          builder = SchemaBuilder.int64().name(AVRO_LOGICAL_TIME_MICROS);
         } else {
           builder = SchemaBuilder.int64();
         }

--- a/avro-data/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-data/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -2066,6 +2066,182 @@ public class AvroDataTest {
         avroData.toConnectData(avroSchema, date.getTime()));
   }
 
+  @Test
+  public void testToConnectTimestampMicrosAvro() {
+    org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.builder().longType();
+    avroSchema.addProp(AvroData.AVRO_LOGICAL_TYPE_PROP, AvroData.AVRO_LOGICAL_TIMESTAMP_MICROS);
+    long microseconds = 1_000_000_000_000_000L;
+    Schema expectedSchema = SchemaBuilder.int64().name(AvroData.AVRO_LOGICAL_TIMESTAMP_MICROS).build();
+    assertEquals(new SchemaAndValue(expectedSchema, microseconds),
+        avroData.toConnectData(avroSchema, microseconds));
+  }
+
+  @Test
+  public void testToConnectTimestampMicrosAvroInRecord() {
+    org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.record("TestRecord")
+        .fields()
+        .name("ts").type(
+            org.apache.avro.SchemaBuilder.builder().longType()).noDefault()
+        .endRecord();
+    avroSchema.getField("ts").schema()
+        .addProp(AvroData.AVRO_LOGICAL_TYPE_PROP, AvroData.AVRO_LOGICAL_TIMESTAMP_MICROS);
+
+    long microseconds = 1_000_000_000_000_000L;
+    org.apache.avro.generic.GenericRecord record =
+        new org.apache.avro.generic.GenericData.Record(avroSchema);
+    record.put("ts", microseconds);
+
+    Schema expectedFieldSchema = SchemaBuilder.int64().name(AvroData.AVRO_LOGICAL_TIMESTAMP_MICROS).build();
+    SchemaAndValue result = avroData.toConnectData(avroSchema, record);
+    Struct resultStruct = (Struct) result.value();
+    assertEquals(expectedFieldSchema, result.schema().field("ts").schema());
+    assertEquals(microseconds, resultStruct.get("ts"));
+  }
+
+  @Test
+  public void testToConnectTimestampNanosAvro() {
+    org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.builder().longType();
+    avroSchema.addProp(AvroData.AVRO_LOGICAL_TYPE_PROP, AvroData.AVRO_LOGICAL_TIMESTAMP_NANOS);
+    long nanoseconds = 1_000_000_000_000_000_000L;
+    Schema expectedSchema = SchemaBuilder.int64().name(AvroData.AVRO_LOGICAL_TIMESTAMP_NANOS).build();
+    assertEquals(new SchemaAndValue(expectedSchema, nanoseconds),
+        avroData.toConnectData(avroSchema, nanoseconds));
+  }
+
+  @Test
+  public void testToConnectTimestampNanosAvroInRecord() {
+    org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.record("TestRecord")
+        .fields()
+        .name("ts").type(
+            org.apache.avro.SchemaBuilder.builder().longType()).noDefault()
+        .endRecord();
+    avroSchema.getField("ts").schema()
+        .addProp(AvroData.AVRO_LOGICAL_TYPE_PROP, AvroData.AVRO_LOGICAL_TIMESTAMP_NANOS);
+
+    long nanoseconds = 1_000_000_000_000_000_000L;
+    org.apache.avro.generic.GenericRecord record =
+        new org.apache.avro.generic.GenericData.Record(avroSchema);
+    record.put("ts", nanoseconds);
+
+    Schema expectedFieldSchema = SchemaBuilder.int64().name(AvroData.AVRO_LOGICAL_TIMESTAMP_NANOS).build();
+    SchemaAndValue result = avroData.toConnectData(avroSchema, record);
+    Struct resultStruct = (Struct) result.value();
+    assertEquals(expectedFieldSchema, result.schema().field("ts").schema());
+    assertEquals(nanoseconds, resultStruct.get("ts"));
+  }
+
+  @Test
+  public void testToConnectTimeMicrosAvro() {
+    org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.builder().longType();
+    avroSchema.addProp(AvroData.AVRO_LOGICAL_TYPE_PROP, AvroData.AVRO_LOGICAL_TIME_MICROS);
+    long microseconds = 43_200_000_000L; // noon in microseconds
+    Schema expectedSchema = SchemaBuilder.int64().name(AvroData.AVRO_LOGICAL_TIME_MICROS).build();
+    assertEquals(new SchemaAndValue(expectedSchema, microseconds),
+        avroData.toConnectData(avroSchema, microseconds));
+  }
+
+  @Test
+  public void testToConnectTimeMicrosAvroInRecord() {
+    org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.record("TestRecord")
+        .fields()
+        .name("t").type(org.apache.avro.SchemaBuilder.builder().longType()).noDefault()
+        .endRecord();
+    avroSchema.getField("t").schema()
+        .addProp(AvroData.AVRO_LOGICAL_TYPE_PROP, AvroData.AVRO_LOGICAL_TIME_MICROS);
+    long microseconds = 43_200_000_000L;
+    org.apache.avro.generic.GenericRecord record =
+        new org.apache.avro.generic.GenericData.Record(avroSchema);
+    record.put("t", microseconds);
+    Schema expectedFieldSchema = SchemaBuilder.int64().name(AvroData.AVRO_LOGICAL_TIME_MICROS).build();
+    SchemaAndValue result = avroData.toConnectData(avroSchema, record);
+    assertEquals(expectedFieldSchema, result.schema().field("t").schema());
+    assertEquals(microseconds, ((Struct) result.value()).get("t"));
+  }
+
+  @Test
+  public void testToConnectLocalTimestampMillisAvro() {
+    org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.builder().longType();
+    avroSchema.addProp(AvroData.AVRO_LOGICAL_TYPE_PROP, AvroData.AVRO_LOGICAL_LOCAL_TIMESTAMP_MILLIS);
+    long milliseconds = 1_000_000_000_000L;
+    Schema expectedSchema = SchemaBuilder.int64().name(AvroData.AVRO_LOGICAL_LOCAL_TIMESTAMP_MILLIS).build();
+    assertEquals(new SchemaAndValue(expectedSchema, milliseconds),
+        avroData.toConnectData(avroSchema, milliseconds));
+  }
+
+  @Test
+  public void testToConnectLocalTimestampMillisAvroInRecord() {
+    org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.record("TestRecord")
+        .fields()
+        .name("ts").type(org.apache.avro.SchemaBuilder.builder().longType()).noDefault()
+        .endRecord();
+    avroSchema.getField("ts").schema()
+        .addProp(AvroData.AVRO_LOGICAL_TYPE_PROP, AvroData.AVRO_LOGICAL_LOCAL_TIMESTAMP_MILLIS);
+    long milliseconds = 1_000_000_000_000L;
+    org.apache.avro.generic.GenericRecord record =
+        new org.apache.avro.generic.GenericData.Record(avroSchema);
+    record.put("ts", milliseconds);
+    Schema expectedFieldSchema = SchemaBuilder.int64().name(AvroData.AVRO_LOGICAL_LOCAL_TIMESTAMP_MILLIS).build();
+    SchemaAndValue result = avroData.toConnectData(avroSchema, record);
+    assertEquals(expectedFieldSchema, result.schema().field("ts").schema());
+    assertEquals(milliseconds, ((Struct) result.value()).get("ts"));
+  }
+
+  @Test
+  public void testToConnectLocalTimestampMicrosAvro() {
+    org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.builder().longType();
+    avroSchema.addProp(AvroData.AVRO_LOGICAL_TYPE_PROP, AvroData.AVRO_LOGICAL_LOCAL_TIMESTAMP_MICROS);
+    long microseconds = 1_000_000_000_000_000L;
+    Schema expectedSchema = SchemaBuilder.int64().name(AvroData.AVRO_LOGICAL_LOCAL_TIMESTAMP_MICROS).build();
+    assertEquals(new SchemaAndValue(expectedSchema, microseconds),
+        avroData.toConnectData(avroSchema, microseconds));
+  }
+
+  @Test
+  public void testToConnectLocalTimestampMicrosAvroInRecord() {
+    org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.record("TestRecord")
+        .fields()
+        .name("ts").type(org.apache.avro.SchemaBuilder.builder().longType()).noDefault()
+        .endRecord();
+    avroSchema.getField("ts").schema()
+        .addProp(AvroData.AVRO_LOGICAL_TYPE_PROP, AvroData.AVRO_LOGICAL_LOCAL_TIMESTAMP_MICROS);
+    long microseconds = 1_000_000_000_000_000L;
+    org.apache.avro.generic.GenericRecord record =
+        new org.apache.avro.generic.GenericData.Record(avroSchema);
+    record.put("ts", microseconds);
+    Schema expectedFieldSchema = SchemaBuilder.int64().name(AvroData.AVRO_LOGICAL_LOCAL_TIMESTAMP_MICROS).build();
+    SchemaAndValue result = avroData.toConnectData(avroSchema, record);
+    assertEquals(expectedFieldSchema, result.schema().field("ts").schema());
+    assertEquals(microseconds, ((Struct) result.value()).get("ts"));
+  }
+
+  @Test
+  public void testToConnectLocalTimestampNanosAvro() {
+    org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.builder().longType();
+    avroSchema.addProp(AvroData.AVRO_LOGICAL_TYPE_PROP, AvroData.AVRO_LOGICAL_LOCAL_TIMESTAMP_NANOS);
+    long nanoseconds = 1_000_000_000_000_000_000L;
+    Schema expectedSchema = SchemaBuilder.int64().name(AvroData.AVRO_LOGICAL_LOCAL_TIMESTAMP_NANOS).build();
+    assertEquals(new SchemaAndValue(expectedSchema, nanoseconds),
+        avroData.toConnectData(avroSchema, nanoseconds));
+  }
+
+  @Test
+  public void testToConnectLocalTimestampNanosAvroInRecord() {
+    org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.record("TestRecord")
+        .fields()
+        .name("ts").type(org.apache.avro.SchemaBuilder.builder().longType()).noDefault()
+        .endRecord();
+    avroSchema.getField("ts").schema()
+        .addProp(AvroData.AVRO_LOGICAL_TYPE_PROP, AvroData.AVRO_LOGICAL_LOCAL_TIMESTAMP_NANOS);
+    long nanoseconds = 1_000_000_000_000_000_000L;
+    org.apache.avro.generic.GenericRecord record =
+        new org.apache.avro.generic.GenericData.Record(avroSchema);
+    record.put("ts", nanoseconds);
+    Schema expectedFieldSchema = SchemaBuilder.int64().name(AvroData.AVRO_LOGICAL_LOCAL_TIMESTAMP_NANOS).build();
+    SchemaAndValue result = avroData.toConnectData(avroSchema, record);
+    assertEquals(expectedFieldSchema, result.schema().field("ts").schema());
+    assertEquals(nanoseconds, ((Struct) result.value()).get("ts"));
+  }
+
   // Avro -> Connect: Connect types with no corresponding Avro type
 
   @Test


### PR DESCRIPTION
## What

Adds support for all previously unhandled Avro temporal logical types in `AvroData`. These fell through to plain `INT64` in the Connect type system, losing logical type identity downstream.

**Root cause:** Avro 1.12.1 introduced an undocumented change via [AVRO-3989](https://issues.apache.org/jira/browse/AVRO-3989) that registers all logical type conversions (including `TimestampMicrosConversion`) in the default `SpecificData` instance. Due to `LinkedHashMap` insertion order, `timestamp-micros` takes priority over `timestamp-millis` for `Instant` fields, causing any service on Avro 1.12.1+ to silently start producing `timestamp-micros` instead of `timestamp-millis`. The change was undocumented and affected all downstream Kafka Connect consumers.

Previously, only `timestamp-millis` and `time-millis` were handled in the `LONG` branch of `toConnectSchema`. All other temporal logical types fell through to plain `INT64` with no schema name, making them invisible to any logical type converter registry downstream.

**Changes:**
- Added constants for all new logical type names
- Added handlers in `toConnectSchema` `LONG` branch for all new types — each produces `INT64` schema with the logical type name as schema name
- Added `TO_CONNECT_LOGICAL_CONVERTERS` entries for all new types — all pass through the raw `long` value without truncation, preserving full precision for sink connectors to handle
- Added `fromConnectSchema` roundtrip support for all new types — both native `addToSchema` and legacy prop style

Newly supported types (all pass through as raw `long` with schema name matching the logical type):

| Avro logical type | Connect schema name |
|---|---|
| `timestamp-micros` | `"timestamp-micros"` |
| `timestamp-nanos` | `"timestamp-nanos"` |
| `time-micros` | `"time-micros"` |
| `local-timestamp-millis` | `"local-timestamp-millis"` |
| `local-timestamp-micros` | `"local-timestamp-micros"` |
| `local-timestamp-nanos` | `"local-timestamp-nanos"` |

Existing `timestamp-millis` and `time-millis` behavior is unchanged.


## Checklist
| | |
|---|---|
| **[Y]** Contains customer facing changes? | Fields that previously landed as untyped `INT64` will now carry their logical type name through the Connect pipeline, enabling sink connectors to handle them correctly |
| **[N]** Is this change gated behind config(s)? | No, applies to all `AvroConverter` usage |
| **[Y]** Did you add sufficient unit test coverage? | Tests mirroring existing `testToConnectDataWithTimestampMillis` added for all newly supported temporal logical types, covering both `toConnectData` and `fromConnectSchema` roundtrip |
| **[N/A]** Does this change require modifying existing system tests? | |
| **[N]** Must this be released together with other changes? | |

---

## References

- [AVRO-3989](https://issues.apache.org/jira/browse/AVRO-3989) — root cause: conversion registration added to default `SpecificData` instance
- [Schema Registry issue #1720](https://github.com/confluentinc/schema-registry/issues/1720) — AvroConverter missing `timestamp-micros` support
- [Schema Registry issue #1604](https://github.com/confluentinc/schema-registry/issues/1604) — `ClassCastException` on `timestamp-micros` deserialization

---