### PR TITLE
DGS-24058 Exclude LGPL findbugs annotations from jackson-datatype-protobuf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,12 @@
                 <groupId>com.hubspot.jackson</groupId>
                 <artifactId>jackson-datatype-protobuf</artifactId>
                 <version>0.9.16</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>annotations</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.github.erosb</groupId>


### PR DESCRIPTION
## Problem
`com.hubspot.jackson:jackson-datatype-protobuf` transitively pulls in `com.google.code.findbugs:annotations:3.0.1` at compile scope (inherited from the `com.hubspot:basepom` parent). That artifact is **LGPL-licensed** and was shipping in our assemblies — see [DGS-24058](https://confluentinc.atlassian.net/browse/DGS-24058).

## Fix
Exclude `com.google.code.findbugs:annotations` in the root `dependencyManagement` entry for `jackson-datatype-protobuf`, so every module that resolves it is covered from a single point.

The findbugs annotations have `CLASS` retention (compile-time only), are not needed at runtime, and are not referenced by any Schema Registry source — so the exclusion is compile- and runtime-safe.

## Verification
`mvn dependency:tree -Dincludes=com.google.code.findbugs:annotations` across the full reactor now reports **zero** matches (only `jsr305:3.0.2`, Apache/BSD, remains). Build succeeds.

> Note: the LGPL `annotations` jar also originates from **ce-kafka**, which is outside this repo and tracked separately with the ce-kafka team per the JIRA discussion. This PR addresses the Schema Registry side only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DGS-24058]: https://confluentinc.atlassian.net/browse/DGS-24058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ