### PR TITLE
Cherry-pick DGS-24058 to 8.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,12 @@
                 <groupId>com.hubspot.jackson</groupId>
                 <artifactId>jackson-datatype-protobuf</artifactId>
                 <version>0.9.18</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.findbugs</groupId>
+                        <artifactId>annotations</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.github.erosb</groupId>


### PR DESCRIPTION
Cherry-pick of #4342 (merged to the corresponding `.x` branch) onto the `8.3.0` versioned release branch.

## What
Excludes the LGPL-licensed `com.google.code.findbugs:annotations:3.0.1`, which `com.hubspot.jackson:jackson-datatype-protobuf` pulls in transitively at compile scope, from shipping in our assemblies. See [DGS-24058](https://confluentinc.atlassian.net/browse/DGS-24058).

## Why a blocker
RCs for the Q2 patch and CP8.3 branches were already cut, so this license fix must be cherry-picked into the versioned release branches.

Cherry-picked from `7.5.x` commit 85a8578d014 (`git cherry-pick -x`). Result on this branch: `jackson-datatype-protobuf 0.9.18` + the exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DGS-24058]: https://confluentinc.atlassian.net/browse/DGS-24058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ