### PR TITLE
DGS-24457 Fix use of $ref with sibling property

### DIFF
--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiff.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiff.java
@@ -235,7 +235,13 @@ public class SchemaDiff {
 
   private static Schema normalizeSchema(final Schema schema) {
     if (schema instanceof ReferenceSchema) {
-      return ((ReferenceSchema) schema).getReferredSchema();
+      ReferenceSchema referenceSchema = (ReferenceSchema) schema;
+      Schema referredSchema = referenceSchema.getReferredSchema();
+      if (referredSchema == null) {
+        throw new IllegalStateException(
+            "Unresolved $ref '" + referenceSchema.getReferenceValue() + "'");
+      }
+      return referredSchema;
     } else {
       return schema;
     }

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/schema/SchemaTranslator.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/schema/SchemaTranslator.java
@@ -110,10 +110,19 @@ public class SchemaTranslator extends SchemaVisitor<SchemaTranslator.SchemaConte
 
   private final Map<Schema, org.everit.json.schema.Schema.Builder<?>> schemaMapping;
   private final Deque<Pair<org.everit.json.schema.ReferenceSchema, Schema>> refMapping;
+  // Tracks the jsonsKema schema each everit ReferenceSchema refers to, so a ReferenceSchema
+  // that is rebuilt (e.g. via schemaToBuilder) can be re-registered for deferred resolution.
+  private final Map<org.everit.json.schema.ReferenceSchema, Schema> refReferred;
 
   public SchemaTranslator() {
     this.schemaMapping = new IdentityHashMap<>();
     this.refMapping = new ArrayDeque<>();
+    this.refReferred = new IdentityHashMap<>();
+  }
+
+  private void offerRef(org.everit.json.schema.ReferenceSchema ref, Schema referredSchema) {
+    this.refMapping.offer(new Pair<>(ref, referredSchema));
+    this.refReferred.put(ref, referredSchema);
   }
 
   @Override
@@ -193,8 +202,18 @@ public class SchemaTranslator extends SchemaVisitor<SchemaTranslator.SchemaConte
       if (combinedSchema.getSubschemas().isEmpty()) {
         ctx = new SchemaContext(ctx.source(), EmptySchema.builder());
       } else if (combinedSchema.getSubschemas().size() == 1) {
-        ctx = new SchemaContext(ctx.source(),
-            schemaToBuilder(combinedSchema.getSubschemas().iterator().next()));
+        org.everit.json.schema.Schema subschema = combinedSchema.getSubschemas().iterator().next();
+        org.everit.json.schema.Schema.Builder<?> subBuilder = schemaToBuilder(subschema);
+        if (subschema instanceof org.everit.json.schema.ReferenceSchema) {
+          // schemaToBuilder rebuilds the ReferenceSchema into a fresh instance that is not
+          // registered for deferred $ref resolution; re-register the rebuilt instance so its
+          // referredSchema gets set when refMapping is drained.
+          Schema referred = this.refReferred.get(subschema);
+          if (referred != null) {
+            offerRef((org.everit.json.schema.ReferenceSchema) subBuilder.build(), referred);
+          }
+        }
+        ctx = new SchemaContext(ctx.source(), subBuilder);
       }
     }
     if (schema.getId() != null) {
@@ -504,7 +523,7 @@ public class SchemaTranslator extends SchemaVisitor<SchemaTranslator.SchemaConte
     org.everit.json.schema.ReferenceSchema.Builder ref =
         org.everit.json.schema.ReferenceSchema.builder()
             .refValue(refValue);
-    this.refMapping.offer(new Pair<>(ref.build(), referredSchema));
+    offerRef(ref.build(), referredSchema);
     return new SchemaContext(schema, ref);
   }
 

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaTest.java
@@ -598,6 +598,36 @@ public class JsonSchemaTest {
   }
 
   @Test
+  public void testRefWithReadOnly() {
+    String schema = "{\n"
+        + "    \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n"
+        + "    \"type\": \"object\",\n"
+        + "    \"properties\": { \"incidentContext\": { \"$ref\": \"#/$defs/IncidentContext\" } },\n"
+        + "    \"$defs\": {\n"
+        + "      \"IncidentContext\": {\n"
+        + "        \"type\": \"object\",\n"
+        + "        \"properties\": { \"incidentInvolvedParties\": {\n"
+        + "          \"type\": \"array\", \"items\": { \"$ref\": \"#/$defs/RelatedPerson\" } } }\n"
+        + "      },\n"
+        + "      \"RelatedPerson\": {\n"
+        + "        \"type\": \"object\",\n"
+        + "        \"properties\": { \"sanctionsCheckResult\": { \"readOnly\": true, \"$ref\": \"#/$defs/SanctionsCheckResult\" } },\n"
+        + "        \"discriminator\": {\n"
+        + "          \"propertyName\": \"relatedPersonType\",\n"
+        + "          \"mapping\": { \"NaturalPerson\": \"#/$defs/NaturalPerson\", \"LegalPerson\": \"#/$defs/LegalPerson\" }\n"
+        + "        }\n"
+        + "      },\n"
+        + "      \"NaturalPerson\": { \"type\": \"object\", \"allOf\": [], \"properties\": {} },\n"
+        + "      \"LegalPerson\":   { \"type\": \"object\", \"allOf\": [], \"properties\": {} },\n"
+        + "      \"SanctionsCheckResult\": { \"type\": \"object\", \"properties\": {} }\n"
+        + "    }\n"
+        + "  }";
+    JsonSchema jsonSchema = new JsonSchema(schema);
+    List<Difference> diff = SchemaDiff.compare(jsonSchema.rawSchema(), jsonSchema.rawSchema());
+    assertEquals(0, diff.size());
+  }
+
+  @Test
   public void testParseSchema() {
     SchemaProvider jsonSchemaProvider = new JsonSchemaProvider();
     ParsedSchema parsedSchema = jsonSchemaProvider.parseSchemaOrElseThrow(


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----

Summary                                                                                                                                                                               
                                                                                                                                                                                        
  Translating a JSON Schema where a $ref carries a sibling keyword (such as readOnly: true) could leave the reference unresolved, causing a NullPointerException during schema comparison (SchemaDiff).                                                                                                                                                              
                                                                                                                                                                                        
  Background                                                                                                                                                                            
                                                                                                                                                                                        
  $ref resolution in SchemaTranslator is deferred: each everit ReferenceSchema is queued in refMapping while visiting, and SchemaContext.close() later drains the queue and calls setReferredSchema(...) on each instance.                                                                                                                                              
                                                                                                                                                                                        
  A $ref with a sibling keyword is modeled by jsonsKema as a composite schema. After the ignored keyword (readOnly) is dropped, this collapses to a generated allOf with a single subschema — the reference. visitCompositeSchema unwraps that single-element allOf via schemaToBuilder(...), which for a ReferenceSchema goes through SchemaUtils.toBuilder → merge(ReferenceSchema.builder(), s). That rebuilds a fresh ReferenceSchema instance, copying only refValue — not the deferred link — and the new instance is never registered in refMapping. The reference in the final tree therefore keeps a null referredSchema, and SchemaDiff.normalizeSchema returns null, surfacing as a cryptic NPE deep in the comparator.    
                                                                                                                                                                                        
  Changes                                                                                                                                                                               
                                                                                                                                                                                        
  - SchemaTranslator: track the jsonsKema schema each everit ReferenceSchema refers to (refReferred), via a small offerRef helper. When the single-subschema unwrap rebuilds a ReferenceSchema, re-register the rebuilt instance so it gets resolved when refMapping is drained.                                                                                     
  - SchemaDiff: when a reference cannot be resolved, throw IllegalStateException("Unresolved $ref '<ref>'") instead of returning null and producing an opaque NPE.                      
                         

<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
