### PR TITLE
DGS-24485 Remove extraneous TimeConversion in AvroSchemaUtils

### DIFF
--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
@@ -73,6 +73,7 @@ import kafka.utils.VerifiableProperties;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -1518,6 +1519,34 @@ public class KafkaAvroSerializerTest {
   }
 
   @Test
+  public void testKafkaAvroSerializerReflectionInstantLogicalType() {
+    byte[] bytes;
+    Object obj;
+
+    Map configs = ImmutableMap.of(
+        KafkaAvroDeserializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "bogus",
+        AbstractKafkaSchemaSerDeConfig.SCHEMA_REFLECTION_CONFIG, true,
+        KafkaAvroSerializerConfig.AVRO_USE_LOGICAL_TYPE_CONVERTERS_CONFIG, true
+    );
+    KafkaAvroSerializer serializer = new KafkaAvroSerializer(schemaRegistry, configs);
+    KafkaAvroDeserializer deserializer = new KafkaAvroDeserializer(schemaRegistry, configs);
+
+    EventWithInstant event = new EventWithInstant(Instant.ofEpochMilli(1_460_000_000_000L));
+    Schema schema = AvroSchemaUtils.getReflectData(true, false).getSchema(EventWithInstant.class);
+    assertEquals("timestamp-millis", schema.getField("ts").schema().getLogicalType().getName());
+
+    RecordHeaders headers = new RecordHeaders();
+    bytes = serializer.serialize(topic, headers, event);
+
+    obj = deserializer.deserialize(topic, headers, bytes, schema);
+    assertTrue(
+        "Returned object should be an EventWithInstant",
+        EventWithInstant.class.isInstance(obj)
+    );
+    assertEquals(event, obj);
+  }
+
+  @Test
   public void testKafkaAvroSerializerReflectionRecordWithNullField() {
     byte[] bytes;
     Object obj;
@@ -1825,6 +1854,33 @@ public class KafkaAvroSerializerTest {
         + ",{\"type\":\"record\",\"name\":\"Account\",\"namespace\":\"example.avro\","
         + "\"fields\":[{\"name\":\"accountNumber\",\"type\":\"string\"}]}]";
     assertEquals(expectedResolved, schema.formattedString(Format.RESOLVED.symbol()));
+  }
+
+  static class EventWithInstant {
+    Instant ts;
+
+    EventWithInstant() {
+    }
+
+    EventWithInstant(Instant ts) {
+      this.ts = ts;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(ts);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (!(obj instanceof EventWithInstant)) {
+        return false;
+      }
+      return Objects.equals(this.ts, ((EventWithInstant) obj).ts);
+    }
   }
 
   static class RecordWithUUID {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaUtils.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaUtils.java
@@ -247,7 +247,6 @@ public class AvroSchemaUtils {
 
     avroData.addLogicalTypeConversion(new TimeConversions.TimeMillisConversion());
     avroData.addLogicalTypeConversion(new TimeConversions.TimeMicrosConversion());
-    avroData.addLogicalTypeConversion(new TimeConversions.TimestampNanosConversion());
 
     avroData.addLogicalTypeConversion(new TimeConversions.TimestampMillisConversion());
     avroData.addLogicalTypeConversion(new TimeConversions.TimestampMicrosConversion());


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Remove extraneous TimeConversion in AvroSchemaUtils. 

Since the first conversion wins, the extraneous conversion caused a regression where an Instant resulted in a logical type of `timestamp-nanos` instead of `timestamp-millis` being derived
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
