### PR TITLE
DGS-24489: [fix] add max limit depth and memoization to schema diff comparator

### DIFF
--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/Context.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/Context.java
@@ -27,10 +27,6 @@ import java.util.Map;
 import java.util.Set;
 
 public class Context {
-  // Safety backstop (DGS-24489): a compatibility check can never run unbounded and starve the
-  // registry. A deterministic call budget bounds total work (and, since per-call cost is bounded
-  // by schema size, wall time too). Overridable via system property; the default is generous so
-  // only pathological schemas trip it.
   static final String MAX_CALLS_PROP = "schema.registry.json.diff.max.calls";
   static final long DEFAULT_MAX_CALLS = 50_000_000L;
 
@@ -39,14 +35,8 @@ public class Context {
   private final Deque<String> jsonPath;
   private final List<Difference> diffs;
   private final long maxCalls;
-  // Single shared counter across all subcontexts of one top-level comparison.
   private final long[] callCount;
-  // Memoization of compare(original, update) results, keyed by object identity, shared across
-  // all subcontexts of a single top-level comparison. Collapses the exponential re-computation
-  // that recursive schemas with large oneOf/anyOf unions otherwise trigger (DGS-24489).
   private final Map<Schema, Map<Schema, List<Difference>>> resultCache;
-  // Pairs currently being computed on the call stack — re-entry means a reference cycle, handled
-  // identically to the path-based schema guard below (contributes no differences).
   private final Map<Schema, Set<Schema>> inProgress;
 
   public Context(Set<Difference.Type> compatibleChanges) {

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/Context.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/Context.java
@@ -23,26 +23,107 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class Context {
+  // Safety backstop (DGS-24489): a compatibility check can never run unbounded and starve the
+  // registry. A deterministic call budget bounds total work (and, since per-call cost is bounded
+  // by schema size, wall time too). Overridable via system property; the default is generous so
+  // only pathological schemas trip it.
+  static final String MAX_CALLS_PROP = "schema.registry.json.diff.max.calls";
+  static final long DEFAULT_MAX_CALLS = 50_000_000L;
+
   private final Set<Difference.Type> compatibleChanges;
   private final Set<Schema> schemas;
   private final Deque<String> jsonPath;
   private final List<Difference> diffs;
+  private final long maxCalls;
+  // Single shared counter across all subcontexts of one top-level comparison.
+  private final long[] callCount;
+  // Memoization of compare(original, update) results, keyed by object identity, shared across
+  // all subcontexts of a single top-level comparison. Collapses the exponential re-computation
+  // that recursive schemas with large oneOf/anyOf unions otherwise trigger (DGS-24489).
+  private final Map<Schema, Map<Schema, List<Difference>>> resultCache;
+  // Pairs currently being computed on the call stack — re-entry means a reference cycle, handled
+  // identically to the path-based schema guard below (contributes no differences).
+  private final Map<Schema, Set<Schema>> inProgress;
 
   public Context(Set<Difference.Type> compatibleChanges) {
     this.compatibleChanges = compatibleChanges;
     this.schemas = Collections.newSetFromMap(new IdentityHashMap<>());
     this.jsonPath = new ArrayDeque<>();
     this.diffs = new ArrayList<>();
+    this.resultCache = new IdentityHashMap<>();
+    this.inProgress = new IdentityHashMap<>();
+    this.maxCalls = Long.getLong(MAX_CALLS_PROP, DEFAULT_MAX_CALLS);
+    this.callCount = new long[] {0L};
+  }
+
+  private Context(Context parent) {
+    this.compatibleChanges = parent.compatibleChanges;
+    this.schemas = Collections.newSetFromMap(new IdentityHashMap<>());
+    this.jsonPath = new ArrayDeque<>();
+    this.diffs = new ArrayList<>();
+    // Cache, in-progress set, and the call budget are shared by reference across the comparison.
+    this.resultCache = parent.resultCache;
+    this.inProgress = parent.inProgress;
+    this.maxCalls = parent.maxCalls;
+    this.callCount = parent.callCount;
+  }
+
+  /**
+   * Records one comparison call and enforces the call budget. Throws {@link IllegalStateException}
+   * (the same hard-stop signal used for unresolved {@code $ref}s) if the comparison has made too
+   * many calls, aborting a pathological check rather than letting it starve the registry.
+   */
+  public void checkBudget() {
+    if (++callCount[0] > maxCalls) {
+      throw new IllegalStateException(
+          "Compatibility check exceeded the limit of " + maxCalls + " schema comparisons");
+    }
   }
 
   public Context getSubcontext() {
-    Context ctx = new Context(this.compatibleChanges);
+    Context ctx = new Context(this);
     ctx.schemas.addAll(this.schemas);
     ctx.jsonPath.addAll(this.jsonPath);
     return ctx;
+  }
+
+  public List<Difference> getCachedResult(final Schema original, final Schema update) {
+    Map<Schema, List<Difference>> byUpdate = resultCache.get(original);
+    return byUpdate == null ? null : byUpdate.get(update);
+  }
+
+  public void cacheResult(
+      final Schema original, final Schema update, final List<Difference> result) {
+    resultCache.computeIfAbsent(original, k -> new IdentityHashMap<>()).put(update, result);
+  }
+
+  public boolean isInProgress(final Schema original, final Schema update) {
+    Set<Schema> updates = inProgress.get(original);
+    return updates != null && updates.contains(update);
+  }
+
+  public void enterPair(final Schema original, final Schema update) {
+    inProgress.computeIfAbsent(original, k -> Collections.newSetFromMap(new IdentityHashMap<>()))
+        .add(update);
+  }
+
+  public void exitPair(final Schema original, final Schema update) {
+    Set<Schema> updates = inProgress.get(original);
+    if (updates != null) {
+      updates.remove(update);
+    }
+  }
+
+  public int differencesSize() {
+    return diffs.size();
+  }
+
+  public List<Difference> differencesSince(final int mark) {
+    return new ArrayList<>(diffs.subList(mark, diffs.size()));
   }
 
   public SchemaScope enterSchema(final Schema schema) {

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiff.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiff.java
@@ -118,6 +118,7 @@ public class SchemaDiff {
 
   @SuppressWarnings("ConstantConditions")
   static void compare(final Context ctx, Schema original, Schema update) {
+    ctx.checkBudget();
     if (original == null && update == null) {
       return;
     } else if (original == null) {
@@ -131,6 +132,34 @@ public class SchemaDiff {
     original = normalizeSchema(original);
     update = normalizeSchema(update);
 
+    // Reuse a previously computed result for this (original, update) pair if we have one.
+    // Recursive schemas reach the same pair of subschemas along exponentially many paths;
+    // memoizing keeps the total work bounded by the number of distinct pairs (DGS-24489).
+    List<Difference> cached = ctx.getCachedResult(original, update);
+    if (cached != null) {
+      ctx.addDifferences(cached);
+      return;
+    }
+    // Re-entry of a pair already on the stack is a reference cycle; contribute nothing, matching
+    // the path-based schema guard in enterSchema(). Do not cache: this empty result is only
+    // valid within the enclosing computation of the same pair.
+    if (ctx.isInProgress(original, update)) {
+      return;
+    }
+
+    ctx.enterPair(original, update);
+    int mark = ctx.differencesSize();
+    try {
+      compareInternal(ctx, original, update);
+    } finally {
+      ctx.exitPair(original, update);
+    }
+    ctx.cacheResult(original, update, ctx.differencesSince(mark));
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  private static void compareInternal(
+      final Context ctx, final Schema original, final Schema update) {
     if (!(original instanceof CombinedSchema) && update instanceof CombinedSchema) {
       CombinedSchema combinedSchema = (CombinedSchema) update;
       // Special case of singleton unions

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiff.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiff.java
@@ -132,17 +132,12 @@ public class SchemaDiff {
     original = normalizeSchema(original);
     update = normalizeSchema(update);
 
-    // Reuse a previously computed result for this (original, update) pair if we have one.
-    // Recursive schemas reach the same pair of subschemas along exponentially many paths;
-    // memoizing keeps the total work bounded by the number of distinct pairs (DGS-24489).
+    // reuse a result if we have one
     List<Difference> cached = ctx.getCachedResult(original, update);
     if (cached != null) {
       ctx.addDifferences(cached);
       return;
     }
-    // Re-entry of a pair already on the stack is a reference cycle; contribute nothing, matching
-    // the path-based schema guard in enterSchema(). Do not cache: this empty result is only
-    // valid within the enclosing computation of the same pair.
     if (ctx.isInProgress(original, update)) {
       return;
     }

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiffTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiffTest.java
@@ -95,6 +95,56 @@ public class SchemaDiffTest {
     Assert.assertTrue(SchemaDiff.compare(original, newOne).isEmpty());
   }
 
+  @Test(timeout = 30000)
+  public void testRecursiveOneOfUnionTerminates() {
+    final Schema original = SchemaLoader.load(recursiveOneOfTradeSchema());
+    final Schema update = SchemaLoader.load(recursiveOneOfTradeSchema());
+    Assert.assertTrue(SchemaDiff.compare(original, update).isEmpty());
+  }
+
+  // Memoization must not mask real differences in the recursive structure: a type change deep in
+  // one product type is still detected as incompatible.
+  @Test(timeout = 30000)
+  public void testRecursiveOneOfUnionDetectsIncompatibleChange() {
+    final Schema original = SchemaLoader.load(recursiveOneOfTradeSchema());
+    final JSONObject changed = recursiveOneOfTradeSchema();
+    changed.getJSONObject("definitions").getJSONObject("Asset")
+        .getJSONObject("properties").getJSONObject("id").put("type", "number");
+    final Schema update = SchemaLoader.load(changed);
+    Assert.assertFalse(SchemaDiff.compare(original, update).isEmpty());
+  }
+
+  private static JSONObject recursiveOneOfTradeSchema() {
+    final String[] types = {"Asset", "Basket", "Swap", "Bond", "Option", "Future",
+        "Forward", "Loan", "Repo", "Equity", "Index", "CommodityLeg"};
+    final JSONObject definitions = new JSONObject();
+    for (String type : types) {
+      JSONObject properties = new JSONObject();
+      properties.put("id", new JSONObject().put("type", "string"));
+      properties.put("underlying", inlineUnion(types));
+      properties.put("referenceProduct", inlineUnion(types));
+      definitions.put(type, new JSONObject().put("type", "object").put("properties", properties));
+    }
+    JSONObject rootProperties = new JSONObject();
+    rootProperties.put("tradeId", new JSONObject().put("type", "string"));
+    rootProperties.put("product", inlineUnion(types));
+    return new JSONObject()
+        .put("$schema", "http://json-schema.org/draft-07/schema#")
+        .put("title", "Trade")
+        .put("type", "object")
+        .put("additionalProperties", true)
+        .put("definitions", definitions)
+        .put("properties", rootProperties);
+  }
+
+  private static JSONObject inlineUnion(final String[] types) {
+    JSONArray oneOf = new JSONArray();
+    for (String type : types) {
+      oneOf.put(new JSONObject().put("$ref", "#/definitions/" + type));
+    }
+    return new JSONObject().put("oneOf", oneOf);
+  }
+
   @Test
   public void testSchemaAddsProperties() {
     final Schema first = SchemaLoader.load(new JSONObject("{}"));


### PR DESCRIPTION
What
----
- Memoize `SchemaDiff.compare` by `(original, update)` object identity (`Context`), shared by reference across all subcontexts of one comparison. 
- Add a deterministic call budget as a backstop (`schema.registry.json.diff.max.calls`, default 50,000,000). When exceeded, `compare` throws `IllegalStateException`

Checklist
------------------
- **[Y]** Contains customer facing changes? Including API/behavior changes
- **[N]** Is this change gated behind config(s)?
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
- **[N]** Does this change require modifying existing system tests or adding new system tests?
- **[N]** Must this be released together with other change(s), either in this repo or another one?

References
----------
JIRA: https://confluentinc.atlassian.net/browse/DGS-24489

Test & Review
------------

Open questions / Follow-ups
--------------------------
- The protobuf provider has the same diff structure (`protobuf-provider/.../diff/`) and is likely vulnerable to the same blowup. could add a follow up 
