### PR TITLE
MINOR: Fix NetworkClient constructor for kafka-clients metadataClusterCheckEnable param

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/KafkaGroupLeaderElector.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/KafkaGroupLeaderElector.java
@@ -153,7 +153,8 @@ public class KafkaGroupLeaderElector implements LeaderElector, SchemaRegistryReb
           true,
           new ApiVersions(),
           logContext,
-          MetadataRecoveryStrategy.NONE);
+          MetadataRecoveryStrategy.NONE,
+          false);
 
       this.client = new ConsumerNetworkClient(
           logContext,


### PR DESCRIPTION


The Kafka NetworkClient constructor in latest kafka-clients added a trailing boolean metadataClusterCheckEnable parameter, breaking compilation of KafkaGroupLeaderElector. Pass false to match the existing MetadataRecoveryStrategy.NONE behavior (the flag is ignored when rebootstrapping is disabled).