### PR TITLE
DGS-24489 Improve memoization during JSON Schema diff

### DIFF
--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/Context.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/Context.java
@@ -39,20 +39,38 @@ public class Context {
   // progress is a recursive cycle; it is treated as compatible (no differences) and is not cached,
   // since its truncated result is only valid within the enclosing comparison.
   private final Set<SchemaPair> inProgress;
+  // Pairs known (from a previous fixpoint pass) to be incompatible, mapped to their pair-relative
+  // differences. When a recursive cycle re-enters such a pair, its real differences are propagated
+  // instead of optimistically assuming the cycle compatible. Iterating this seed to a fixpoint is
+  // what makes cross-branch memoization sound. See SchemaDiff#compare.
+  private final Map<SchemaPair, List<Difference>> incompatibleSeed;
+  // Set to true (in the shared holder) whenever a recursive cycle is optimistically assumed
+  // compatible. If a pass never does this, its result does not depend on any assumption and the
+  // fixpoint iteration can stop immediately.
+  private final boolean[] optimismUsed;
   private final Deque<String> jsonPath;
   private final List<Difference> diffs;
 
   public Context(Set<Difference.Type> compatibleChanges) {
-    this(compatibleChanges, new HashMap<>(), new HashSet<>());
+    this(compatibleChanges, Collections.emptyMap());
+  }
+
+  public Context(Set<Difference.Type> compatibleChanges,
+      Map<SchemaPair, List<Difference>> incompatibleSeed) {
+    this(compatibleChanges, new HashMap<>(), new HashSet<>(), incompatibleSeed, new boolean[1]);
   }
 
   private Context(
       Set<Difference.Type> compatibleChanges,
       Map<SchemaPair, List<Difference>> memo,
-      Set<SchemaPair> inProgress) {
+      Set<SchemaPair> inProgress,
+      Map<SchemaPair, List<Difference>> incompatibleSeed,
+      boolean[] optimismUsed) {
     this.compatibleChanges = compatibleChanges;
     this.memo = memo;
     this.inProgress = inProgress;
+    this.incompatibleSeed = incompatibleSeed;
+    this.optimismUsed = optimismUsed;
     this.jsonPath = new ArrayDeque<>();
     this.diffs = new ArrayList<>();
   }
@@ -60,7 +78,8 @@ public class Context {
   public Context getSubcontext() {
     // The memo and in-progress set are shared by reference so that caching and cycle detection
     // span the whole comparison, not just a single branch.
-    Context ctx = new Context(this.compatibleChanges, this.memo, this.inProgress);
+    Context ctx = new Context(this.compatibleChanges, this.memo, this.inProgress,
+        this.incompatibleSeed, this.optimismUsed);
     ctx.jsonPath.addAll(this.jsonPath);
     return ctx;
   }
@@ -80,11 +99,19 @@ public class Context {
       return cached;
     }
     if (!inProgress.add(key)) {
-      // Recursive cycle: assume compatible and do not cache the truncated result.
+      // Recursive cycle. If this pair is already known to be incompatible (from a prior fixpoint
+      // pass), propagate its differences rather than optimistically assuming compatibility.
+      List<Difference> seeded = incompatibleSeed.get(key);
+      if (seeded != null) {
+        return seeded;
+      }
+      // Otherwise assume compatible (greatest fixed point) and do not cache the truncated result.
+      optimismUsed[0] = true;
       return Collections.emptyList();
     }
     try {
-      Context subctx = new Context(this.compatibleChanges, this.memo, this.inProgress);
+      Context subctx = new Context(this.compatibleChanges, this.memo, this.inProgress,
+          this.incompatibleSeed, this.optimismUsed);
       comparator.compare(subctx);
       // Cache an immutable snapshot so the memoized value cannot be corrupted by a caller (or a
       // future refactor) mutating the list returned from getDifferences().
@@ -139,6 +166,28 @@ public class Context {
     return !notCompatible;
   }
 
+  /**
+   * Returns the memoized pairs whose differences make them incompatible, mapped to those
+   * (pair-relative) differences. Used by {@link SchemaDiff#compare} to grow the incompatible seed
+   * between fixpoint passes.
+   */
+  public Map<SchemaPair, List<Difference>> collectIncompatiblePairs() {
+    Map<SchemaPair, List<Difference>> incompatible = new HashMap<>();
+    for (Map.Entry<SchemaPair, List<Difference>> entry : memo.entrySet()) {
+      boolean entryIncompatible = entry.getValue().stream()
+          .anyMatch(d -> !compatibleChanges.contains(d.getType()));
+      if (entryIncompatible) {
+        incompatible.put(entry.getKey(), entry.getValue());
+      }
+    }
+    return incompatible;
+  }
+
+  /** Whether this comparison optimistically assumed any recursive cycle compatible. */
+  public boolean usedOptimisticTruncation() {
+    return optimismUsed[0];
+  }
+
   public List<Difference> getDifferences() {
     return diffs;
   }
@@ -173,7 +222,7 @@ public class Context {
   // Identity-based key over a pair of schemas. Two distinct Java objects are never equal even if
   // structurally identical, which is what allows a genuine change deep in a recursive structure to
   // be detected rather than masked by the cache.
-  private static final class SchemaPair {
+  static final class SchemaPair {
     private final Schema original;
     private final Schema update;
 

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/Context.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/Context.java
@@ -55,7 +55,9 @@ public class Context {
     this(compatibleChanges, Collections.emptyMap());
   }
 
-  public Context(Set<Difference.Type> compatibleChanges,
+  // Package-private: the incompatible seed (a fixpoint detail keyed on the package-private
+  // SchemaPair) is only supplied by SchemaDiff.
+  Context(Set<Difference.Type> compatibleChanges,
       Map<SchemaPair, List<Difference>> incompatibleSeed) {
     this(compatibleChanges, new HashMap<>(), new HashSet<>(), incompatibleSeed, new boolean[1]);
   }
@@ -171,7 +173,7 @@ public class Context {
    * (pair-relative) differences. Used by {@link SchemaDiff#compare} to grow the incompatible seed
    * between fixpoint passes.
    */
-  public Map<SchemaPair, List<Difference>> collectIncompatiblePairs() {
+  Map<SchemaPair, List<Difference>> collectIncompatiblePairs() {
     Map<SchemaPair, List<Difference>> incompatible = new HashMap<>();
     for (Map.Entry<SchemaPair, List<Difference>> entry : memo.entrySet()) {
       boolean entryIncompatible = entry.getValue().stream()
@@ -184,7 +186,7 @@ public class Context {
   }
 
   /** Whether this comparison optimistically assumed any recursive cycle compatible. */
-  public boolean usedOptimisticTruncation() {
+  boolean usedOptimisticTruncation() {
     return optimismUsed[0];
   }
 

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/Context.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/Context.java
@@ -86,7 +86,10 @@ public class Context {
     try {
       Context subctx = new Context(this.compatibleChanges, this.memo, this.inProgress);
       comparator.compare(subctx);
-      List<Difference> result = subctx.getDifferences();
+      // Cache an immutable snapshot so the memoized value cannot be corrupted by a caller (or a
+      // future refactor) mutating the list returned from getDifferences().
+      List<Difference> result =
+          Collections.unmodifiableList(new ArrayList<>(subctx.getDifferences()));
       memo.put(key, result);
       return result;
     } finally {

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/Context.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/Context.java
@@ -21,46 +21,97 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
-import java.util.IdentityHashMap;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class Context {
   private final Set<Difference.Type> compatibleChanges;
-  private final Set<Schema> schemas;
+  // Memoizes the result of comparing a given (original, update) pair so that the cross-product
+  // comparisons performed for combined schemas (oneOf/anyOf/allOf) are not recomputed for every
+  // path that reaches the same pair. Without this, recursive schemas where many definitions refer
+  // to one another produce a combinatorial explosion. Differences are stored relative to the pair
+  // being compared (i.e. with an empty path prefix) and rebased onto the current path on reuse.
+  private final Map<SchemaPair, List<Difference>> memo;
+  // Pairs currently being compared on the call stack. A pair that is re-encountered while still in
+  // progress is a recursive cycle; it is treated as compatible (no differences) and is not cached,
+  // since its truncated result is only valid within the enclosing comparison.
+  private final Set<SchemaPair> inProgress;
   private final Deque<String> jsonPath;
   private final List<Difference> diffs;
 
   public Context(Set<Difference.Type> compatibleChanges) {
+    this(compatibleChanges, new HashMap<>(), new HashSet<>());
+  }
+
+  private Context(
+      Set<Difference.Type> compatibleChanges,
+      Map<SchemaPair, List<Difference>> memo,
+      Set<SchemaPair> inProgress) {
     this.compatibleChanges = compatibleChanges;
-    this.schemas = Collections.newSetFromMap(new IdentityHashMap<>());
+    this.memo = memo;
+    this.inProgress = inProgress;
     this.jsonPath = new ArrayDeque<>();
     this.diffs = new ArrayList<>();
   }
 
   public Context getSubcontext() {
-    Context ctx = new Context(this.compatibleChanges);
-    ctx.schemas.addAll(this.schemas);
+    // The memo and in-progress set are shared by reference so that caching and cycle detection
+    // span the whole comparison, not just a single branch.
+    Context ctx = new Context(this.compatibleChanges, this.memo, this.inProgress);
     ctx.jsonPath.addAll(this.jsonPath);
     return ctx;
   }
 
-  public SchemaScope enterSchema(final Schema schema) {
-    return !schemas.contains(schema) ? new SchemaScope(schema) : null;
+  /**
+   * Compares a pair of schemas with memoization, returning the differences with paths relative to
+   * the pair (i.e. as if the pair were the root). If the pair is already cached the cached result
+   * is returned; if it is currently being compared higher in the stack it is treated as a
+   * compatible cycle and an empty list is returned without caching. Otherwise {@code comparator}
+   * is invoked on a fresh subcontext rooted at the pair, and its differences are cached.
+   */
+  public List<Difference> compareMemoized(
+      final Schema original, final Schema update, final PairComparator comparator) {
+    SchemaPair key = new SchemaPair(original, update);
+    List<Difference> cached = memo.get(key);
+    if (cached != null) {
+      return cached;
+    }
+    if (!inProgress.add(key)) {
+      // Recursive cycle: assume compatible and do not cache the truncated result.
+      return Collections.emptyList();
+    }
+    try {
+      Context subctx = new Context(this.compatibleChanges, this.memo, this.inProgress);
+      comparator.compare(subctx);
+      List<Difference> result = subctx.getDifferences();
+      memo.put(key, result);
+      return result;
+    } finally {
+      inProgress.remove(key);
+    }
   }
 
-  public class SchemaScope implements AutoCloseable {
-    private final Schema schema;
-
-    public SchemaScope(final Schema schema) {
-      this.schema = schema;
-      schemas.add(schema);
+  /**
+   * Adds differences that were computed relative to a nested pair, rebasing each one onto the
+   * current path.
+   */
+  public void addDifferencesRebased(final List<Difference> relativeDiffs) {
+    if (jsonPath.isEmpty()) {
+      diffs.addAll(relativeDiffs);
+      return;
     }
-
-    @Override
-    public void close() {
-      schemas.remove(schema);
+    String prefix = jsonPathString(jsonPath);
+    for (Difference diff : relativeDiffs) {
+      diffs.add(new Difference(diff.getType(), rebase(prefix, diff.getJsonPath())));
     }
+  }
+
+  @FunctionalInterface
+  public interface PairComparator {
+    void compare(Context subctx);
   }
 
   public PathScope enterPath(final String path) {
@@ -105,5 +156,44 @@ public class Context {
 
   private static String jsonPathString(final Deque<String> jsonPath) {
     return "#/" + String.join("/", jsonPath);
+  }
+
+  // Combines a path prefix (e.g. "#/a/b") with a path relative to it (e.g. "#/x/y" -> "#/a/b/x/y").
+  // The relative path "#/" denotes the root of the pair and resolves to the prefix itself.
+  private static String rebase(final String prefix, final String relativePath) {
+    if (relativePath.length() <= 2) {
+      return prefix;
+    }
+    return prefix + "/" + relativePath.substring(2);
+  }
+
+  // Identity-based key over a pair of schemas. Two distinct Java objects are never equal even if
+  // structurally identical, which is what allows a genuine change deep in a recursive structure to
+  // be detected rather than masked by the cache.
+  private static final class SchemaPair {
+    private final Schema original;
+    private final Schema update;
+
+    SchemaPair(final Schema original, final Schema update) {
+      this.original = original;
+      this.update = update;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof SchemaPair)) {
+        return false;
+      }
+      SchemaPair that = (SchemaPair) o;
+      return this.original == that.original && this.update == that.update;
+    }
+
+    @Override
+    public int hashCode() {
+      return 31 * System.identityHashCode(original) + System.identityHashCode(update);
+    }
   }
 }

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiff.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiff.java
@@ -19,6 +19,7 @@ import io.confluent.kafka.schemaregistry.json.diff.Difference.Type;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import org.everit.json.schema.ArraySchema;
@@ -111,9 +112,26 @@ public class SchemaDiff {
   }
 
   public static List<Difference> compare(final Schema original, final Schema update) {
-    final Context ctx = new Context(COMPATIBLE_CHANGES);
-    compare(ctx, original, update);
-    return ctx.getDifferences();
+    // Cross-branch memoization optimistically truncates recursive cycles as compatible. A pair can
+    // therefore be cached compatible under an assumption about an in-progress ancestor that later
+    // proves incompatible, and reusing that cached result in a sibling branch could mask a real
+    // incompatibility. To remain sound we iterate to a fixpoint: each pass feeds back the pairs
+    // found incompatible so that, when a cycle re-enters one of them, its real differences are
+    // propagated instead of an optimistic "compatible". The incompatible set grows monotonically
+    // and is bounded by the number of distinct schema pairs, so this converges; a pass that never
+    // truncated a cycle optimistically is already exact and ends the loop immediately (the common,
+    // non-recursive case costs a single pass).
+    Map<Context.SchemaPair, List<Difference>> incompatibleSeed = Collections.emptyMap();
+    while (true) {
+      final Context ctx = new Context(COMPATIBLE_CHANGES, incompatibleSeed);
+      compare(ctx, original, update);
+      Map<Context.SchemaPair, List<Difference>> incompatible = ctx.collectIncompatiblePairs();
+      if (!ctx.usedOptimisticTruncation()
+          || incompatible.keySet().equals(incompatibleSeed.keySet())) {
+        return ctx.getDifferences();
+      }
+      incompatibleSeed = incompatible;
+    }
   }
 
   @SuppressWarnings("ConstantConditions")

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiff.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiff.java
@@ -128,9 +128,18 @@ public class SchemaDiff {
       return;
     }
 
-    original = normalizeSchema(original);
-    update = normalizeSchema(update);
+    final Schema normalizedOriginal = normalizeSchema(original);
+    final Schema normalizedUpdate = normalizeSchema(update);
 
+    // Compare the pair through the memoization layer to bound recursion over schemas where many
+    // definitions refer to one another, then rebase the (pair-relative) result onto the current
+    // path. The memo also breaks cycles: a pair already on the stack is treated as compatible.
+    List<Difference> diffs = ctx.compareMemoized(normalizedOriginal, normalizedUpdate,
+        subctx -> compareTypes(subctx, normalizedOriginal, normalizedUpdate));
+    ctx.addDifferencesRebased(diffs);
+  }
+
+  private static void compareTypes(final Context ctx, final Schema original, final Schema update) {
     if (!(original instanceof CombinedSchema) && update instanceof CombinedSchema) {
       CombinedSchema combinedSchema = (CombinedSchema) update;
       // Special case of singleton unions
@@ -197,39 +206,35 @@ public class SchemaDiff {
       return;
     }
 
-    try (Context.SchemaScope schemaScope = ctx.enterSchema(original)) {
-      if (schemaScope != null) {
-        if (!Objects.equals(original.getId(), update.getId())) {
-          ctx.addDifference(Type.ID_CHANGED);
-        }
-        if (!Objects.equals(original.getTitle(), update.getTitle())) {
-          ctx.addDifference(Type.TITLE_CHANGED);
-        }
-        if (!Objects.equals(original.getDescription(), update.getDescription())) {
-          ctx.addDifference(Type.DESCRIPTION_CHANGED);
-        }
-        if (!Objects.equals(original.getDefaultValue(), update.getDefaultValue())) {
-          ctx.addDifference(Type.DEFAULT_CHANGED);
-        }
+    if (!Objects.equals(original.getId(), update.getId())) {
+      ctx.addDifference(Type.ID_CHANGED);
+    }
+    if (!Objects.equals(original.getTitle(), update.getTitle())) {
+      ctx.addDifference(Type.TITLE_CHANGED);
+    }
+    if (!Objects.equals(original.getDescription(), update.getDescription())) {
+      ctx.addDifference(Type.DESCRIPTION_CHANGED);
+    }
+    if (!Objects.equals(original.getDefaultValue(), update.getDefaultValue())) {
+      ctx.addDifference(Type.DEFAULT_CHANGED);
+    }
 
-        if (original instanceof StringSchema) {
-          StringSchemaDiff.compare(ctx, (StringSchema) original, (StringSchema) update);
-        } else if (original instanceof NumberSchema) {
-          NumberSchemaDiff.compare(ctx, (NumberSchema) original, (NumberSchema) update);
-        } else if (original instanceof ConstSchema) {
-          ConstSchemaDiff.compare(ctx, (ConstSchema) original, (ConstSchema) update);
-        } else if (original instanceof EnumSchema) {
-          EnumSchemaDiff.compare(ctx, (EnumSchema) original, (EnumSchema) update);
-        } else if (original instanceof CombinedSchema) {
-          CombinedSchemaDiff.compare(ctx, (CombinedSchema) original, (CombinedSchema) update);
-        } else if (original instanceof NotSchema) {
-          NotSchemaDiff.compare(ctx, (NotSchema) original, (NotSchema) update);
-        } else if (original instanceof ObjectSchema) {
-          ObjectSchemaDiff.compare(ctx, (ObjectSchema) original, (ObjectSchema) update);
-        } else if (original instanceof ArraySchema) {
-          ArraySchemaDiff.compare(ctx, (ArraySchema) original, (ArraySchema) update);
-        }
-      }
+    if (original instanceof StringSchema) {
+      StringSchemaDiff.compare(ctx, (StringSchema) original, (StringSchema) update);
+    } else if (original instanceof NumberSchema) {
+      NumberSchemaDiff.compare(ctx, (NumberSchema) original, (NumberSchema) update);
+    } else if (original instanceof ConstSchema) {
+      ConstSchemaDiff.compare(ctx, (ConstSchema) original, (ConstSchema) update);
+    } else if (original instanceof EnumSchema) {
+      EnumSchemaDiff.compare(ctx, (EnumSchema) original, (EnumSchema) update);
+    } else if (original instanceof CombinedSchema) {
+      CombinedSchemaDiff.compare(ctx, (CombinedSchema) original, (CombinedSchema) update);
+    } else if (original instanceof NotSchema) {
+      NotSchemaDiff.compare(ctx, (NotSchema) original, (NotSchema) update);
+    } else if (original instanceof ObjectSchema) {
+      ObjectSchemaDiff.compare(ctx, (ObjectSchema) original, (ObjectSchema) update);
+    } else if (original instanceof ArraySchema) {
+      ArraySchemaDiff.compare(ctx, (ArraySchema) original, (ArraySchema) update);
     }
   }
 

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiffTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiffTest.java
@@ -96,6 +96,56 @@ public class SchemaDiffTest {
   }
 
   @Test
+  public void testRecursiveOneOfUnionTerminates() {
+    final Schema original = SchemaLoader.load(recursiveOneOfTradeSchema());
+    final Schema update = SchemaLoader.load(recursiveOneOfTradeSchema());
+    Assert.assertTrue(SchemaDiff.compare(original, update).isEmpty());
+  }
+
+  // Memoization must not mask real differences in the recursive structure: a type change deep in
+  // one product type is still detected as incompatible.
+  @Test
+  public void testRecursiveOneOfUnionDetectsIncompatibleChange() {
+    final Schema original = SchemaLoader.load(recursiveOneOfTradeSchema());
+    final JSONObject changed = recursiveOneOfTradeSchema();
+    changed.getJSONObject("definitions").getJSONObject("Asset")
+        .getJSONObject("properties").getJSONObject("id").put("type", "number");
+    final Schema update = SchemaLoader.load(changed);
+    Assert.assertFalse(SchemaDiff.compare(original, update).isEmpty());
+  }
+
+  private static JSONObject recursiveOneOfTradeSchema() {
+    final String[] types = {"Asset", "Basket", "Swap", "Bond", "Option", "Future",
+        "Forward", "Loan", "Repo", "Equity", "Index", "CommodityLeg"};
+    final JSONObject definitions = new JSONObject();
+    for (String type : types) {
+      JSONObject properties = new JSONObject();
+      properties.put("id", new JSONObject().put("type", "string"));
+      properties.put("underlying", inlineUnion(types));
+      properties.put("referenceProduct", inlineUnion(types));
+      definitions.put(type, new JSONObject().put("type", "object").put("properties", properties));
+    }
+    JSONObject rootProperties = new JSONObject();
+    rootProperties.put("tradeId", new JSONObject().put("type", "string"));
+    rootProperties.put("product", inlineUnion(types));
+    return new JSONObject()
+        .put("$schema", "http://json-schema.org/draft-07/schema#")
+        .put("title", "Trade")
+        .put("type", "object")
+        .put("additionalProperties", true)
+        .put("definitions", definitions)
+        .put("properties", rootProperties);
+  }
+
+  private static JSONObject inlineUnion(final String[] types) {
+    JSONArray oneOf = new JSONArray();
+    for (String type : types) {
+      oneOf.put(new JSONObject().put("$ref", "#/definitions/" + type));
+    }
+    return new JSONObject().put("oneOf", oneOf);
+  }
+
+  @Test
   public void testSchemaAddsProperties() {
     final Schema first = SchemaLoader.load(new JSONObject("{}"));
 

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiffTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiffTest.java
@@ -95,7 +95,7 @@ public class SchemaDiffTest {
     Assert.assertTrue(SchemaDiff.compare(original, newOne).isEmpty());
   }
 
-  @Test
+  @Test(timeout = 10000)
   public void testRecursiveOneOfUnionTerminates() {
     final Schema original = SchemaLoader.load(recursiveOneOfTradeSchema());
     final Schema update = SchemaLoader.load(recursiveOneOfTradeSchema());
@@ -104,7 +104,7 @@ public class SchemaDiffTest {
 
   // Memoization must not mask real differences in the recursive structure: a type change deep in
   // one product type is still detected as incompatible.
-  @Test
+  @Test(timeout = 10000)
   public void testRecursiveOneOfUnionDetectsIncompatibleChange() {
     final Schema original = SchemaLoader.load(recursiveOneOfTradeSchema());
     final JSONObject changed = recursiveOneOfTradeSchema();

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiffTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiffTest.java
@@ -114,13 +114,12 @@ public class SchemaDiffTest {
     Assert.assertFalse(SchemaDiff.compare(original, update).isEmpty());
   }
 
-  // A deterministic reproducer (originally surfaced by SchemaDiffMemoizationDifferentialTest, fuzz
-  // seed 637) for cross-branch memoization masking a real incompatibility. The genuine type changes
-  // to T0.id and T1.id sit behind a recursive oneOf cycle (T0 -> T2 -> T0). A single memoized pass
-  // caches the (T0,T0) sub-comparison as compatible while the cycle back into it is optimistically
-  // truncated, then the root oneOf[T0,T1] matching reuses that cached edge and wrongly reports the
-  // evolution compatible. The greatest-fixed-point iteration in SchemaDiff.compare corrects this;
-  // without it this assertion fails (the comparison returns no incompatible differences).
+  // A deterministic reproducer for cross-branch memoization. The genuine type changes to T0.id and
+  // T1.id sit behind a recursive oneOf cycle (T0 -> T2 -> T0). A single memoized pass caches the
+  // (T0,T0) sub-comparison as compatible while the cycle back into it is optimistically truncated,
+  // then the root oneOf[T0,T1] matching reuses that cached edge and wrongly reports the evolution
+  // compatible. The greatest-fixed-point iteration in SchemaDiff.compare corrects this; without it
+  // this assertion fails (the comparison returns no incompatible differences).
   @Test(timeout = 10000)
   public void testRecursiveOneOfMemoizationDoesNotMaskIncompatibility() {
     final Schema original = SchemaLoader.load(memoMaskingSchema("integer", "boolean"));

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiffTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiffTest.java
@@ -114,6 +114,53 @@ public class SchemaDiffTest {
     Assert.assertFalse(SchemaDiff.compare(original, update).isEmpty());
   }
 
+  // A deterministic reproducer (originally surfaced by SchemaDiffMemoizationDifferentialTest, fuzz
+  // seed 637) for cross-branch memoization masking a real incompatibility. The genuine type changes
+  // to T0.id and T1.id sit behind a recursive oneOf cycle (T0 -> T2 -> T0). A single memoized pass
+  // caches the (T0,T0) sub-comparison as compatible while the cycle back into it is optimistically
+  // truncated, then the root oneOf[T0,T1] matching reuses that cached edge and wrongly reports the
+  // evolution compatible. The greatest-fixed-point iteration in SchemaDiff.compare corrects this;
+  // without it this assertion fails (the comparison returns no incompatible differences).
+  @Test(timeout = 10000)
+  public void testRecursiveOneOfMemoizationDoesNotMaskIncompatibility() {
+    final Schema original = SchemaLoader.load(memoMaskingSchema("integer", "boolean"));
+    final Schema update = SchemaLoader.load(memoMaskingSchema("boolean", "number"));
+    final boolean incompatible = SchemaDiff.compare(original, update).stream()
+        .anyMatch(d -> !SchemaDiff.COMPATIBLE_CHANGES.contains(d.getType()));
+    Assert.assertTrue(
+        "a recursive oneOf incompatibility must not be masked by cross-branch memoization",
+        incompatible);
+  }
+
+  // T0 and T1 carry an "id" of the given types and a "ref" that is a singleton oneOf; T0.ref -> T2,
+  // T1.ref -> T2, T2.ref -> T0 (so T0 -> T2 -> T0 is a cycle). The root is oneOf[T0, T1].
+  private static JSONObject memoMaskingSchema(final String t0Id, final String t1Id) {
+    final JSONObject definitions = new JSONObject();
+    definitions.put("T0", recursiveObject(t0Id, "T2"));
+    definitions.put("T1", recursiveObject(t1Id, "T2"));
+    definitions.put("T2", recursiveObject("integer", "T0"));
+    final JSONArray rootUnion = new JSONArray()
+        .put(new JSONObject().put("$ref", "#/definitions/T0"))
+        .put(new JSONObject().put("$ref", "#/definitions/T1"));
+    return new JSONObject()
+        .put("$schema", "http://json-schema.org/draft-07/schema#")
+        .put("type", "object")
+        .put("additionalProperties", true)
+        .put("definitions", definitions)
+        .put("properties", new JSONObject().put("root", new JSONObject().put("oneOf", rootUnion)));
+  }
+
+  private static JSONObject recursiveObject(final String idType, final String refTarget) {
+    final JSONObject properties = new JSONObject();
+    properties.put("id", new JSONObject().put("type", idType));
+    properties.put("ref", new JSONObject().put("oneOf", new JSONArray()
+        .put(new JSONObject().put("$ref", "#/definitions/" + refTarget))));
+    return new JSONObject()
+        .put("type", "object")
+        .put("additionalProperties", true)
+        .put("properties", properties);
+  }
+
   private static JSONObject recursiveOneOfTradeSchema() {
     final String[] types = {"Asset", "Basket", "Swap", "Bond", "Option", "Future",
         "Forward", "Loan", "Repo", "Equity", "Index", "CommodityLeg"};


### PR DESCRIPTION
  Improve memoization during `SchemaDiff.compare` on JSON Schemas with recursive `oneOf`/`anyOf`                                                                                           
  unions where many definitions reference one another (e.g. 12 mutually-recursive product                                                                                               
  types, each with union-valued properties over all the others).                                                                                                              
                                                                                                                                                                                        
  The existing cycle guard (`Context.enterSchema`, an `IdentityHashMap` of the `original`                                                                                               
  schemas on the current branch) only prevented revisiting the same schema along a single DFS                                                                                           
  path; it did not memoize results. (This is the same class of failure as the circular-`$ref`                                                                                        
  hang fixed in DGS-23783, which made `$ref`s to one definition resolve to a single object;                                                                                             
  that restored cycle detection but did not bound the cross-product breadth.)                                                                                                           
                                                                                                                                                                                        
  ## Fix                                                                                                                                                                                
                                                                                                                                                                                        
  **1. Identity-keyed memoization.** Replace the per-`original` branch guard with a memo keyed on                                                                                       
  the `(original, update)` schema-identity pair, shared across the whole comparison. Each distinct                                                                                      
  pair is compared once; results are stored relative to the pair and rebased onto the current path                                                                                      
  on reuse, so reported `jsonPath`s stay correct.                                                                                                                                  
                                                                                                                                                                                        
  **2. Greatest-fixed-point iteration for soundness.** Memoization optimistically truncates                                                                                             
  recursive cycles as compatible. A pair can therefore be cached compatible under an assumption                                                                                         
  about an in-progress ancestor that later proves incompatible, and reusing that cached result in a                                                                                     
  sibling `oneOf` branch could mask a real incompatibility — a false "compatible" verdict. To stay                                                                                      
  sound, `compare` iterates to a fixpoint: each pass feeds back the pairs found incompatible so                                                                                         
  that, when a cycle re-enters one of them, its real differences are propagated instead of an                                                                                           
  optimistic "compatible." The incompatible set grows monotonically and is bounded by the number of                                                                                     
  distinct schema pairs, so it converges in a few passes. A pass that never optimistically truncated                                                                                    
  a cycle is already exact and ends the loop immediately, so the common non-recursive case still                                                                                        
  costs a single pass with no added overhead.                                                                                                                                           
                                                                                                                                                                                        
  This computes the same greatest fixed point a cache-free, recompute-every-branch comparison would,                                                                                    
  i.e. the coinductive notion of recursive-schema compatibility. 