### PR TITLE
DGS-24376 Add opt-in strict validation for conflicting schema reference versions

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/AbstractSchemaProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/AbstractSchemaProvider.java
@@ -20,7 +20,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,16 +28,24 @@ import java.util.Map;
 import io.confluent.kafka.schemaregistry.client.SchemaVersionFetcher;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
-import java.util.Set;
 
 public abstract class AbstractSchemaProvider implements SchemaProvider {
 
+  public static final String REFERENCE_VERSIONS_STRICT_CONFIG = "reference.versions.strict";
+
   private SchemaVersionFetcher schemaVersionFetcher;
+  private boolean referenceVersionsStrict = false;
 
   @Override
   public void configure(Map<String, ?> configs) {
     schemaVersionFetcher =
         (SchemaVersionFetcher) configs.get(SchemaProvider.SCHEMA_VERSION_FETCHER_CONFIG);
+    Object strict = configs.get(REFERENCE_VERSIONS_STRICT_CONFIG);
+    if (strict instanceof Boolean) {
+      referenceVersionsStrict = (Boolean) strict;
+    } else if (strict instanceof String) {
+      referenceVersionsStrict = Boolean.parseBoolean((String) strict);
+    }
   }
 
   public SchemaVersionFetcher schemaVersionFetcher() {
@@ -54,13 +62,14 @@ public abstract class AbstractSchemaProvider implements SchemaProvider {
       return Collections.emptyMap();
     }
     Map<String, String> result = new LinkedHashMap<>();
-    Set<String> visited = new HashSet<>();
+    Map<String, Integer> visited = new HashMap<>();
     resolveReferences(schema, result, visited, validateAsNew);
     return result;
   }
 
   private void resolveReferences(
-      Schema schema, Map<String, String> schemas, Set<String> visited, boolean validateAsNew) {
+      Schema schema, Map<String, String> schemas, Map<String, Integer> visited,
+      boolean validateAsNew) {
     boolean lookupDeletedSchema = !validateAsNew;
     List<SchemaReference> references = schema.getReferences();
     for (SchemaReference reference : references) {
@@ -83,10 +92,19 @@ public abstract class AbstractSchemaProvider implements SchemaProvider {
         // Update the version with the latest
         reference.setVersion(s.getVersion());
       }
-      if (visited.contains(reference.getName())) {
+      if (visited.containsKey(reference.getName())) {
+        if (referenceVersionsStrict) {
+          Integer previousVersion = visited.get(reference.getName());
+          if (!previousVersion.equals(reference.getVersion())) {
+            throw new IllegalStateException(
+                "Conflicting reference versions for \"" + reference.getName()
+                + "\": version " + previousVersion
+                + " and version " + reference.getVersion());
+          }
+        }
         continue;
       } else {
-        visited.add(reference.getName());
+        visited.put(reference.getName(), reference.getVersion());
       }
       if (!schemas.containsKey(reference.getName())) {
         resolveReferences(s, schemas, visited, validateAsNew);

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/SchemaProvider.java
@@ -37,6 +37,8 @@ public interface SchemaProvider extends Configurable {
 
   String SCHEMA_VERSION_FETCHER_CONFIG = "schemaVersionFetcher";
 
+  String SCHEMA_PROVIDERS_PREFIX = "schema.providers";
+
   default void configure(Map<String, ?> configs) {
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/CachedSchemaRegistryClient.java
@@ -291,6 +291,15 @@ public class CachedSchemaRegistryClient implements SchemaRegistryClient {
         ? providers.stream().collect(Collectors.toMap(SchemaProvider::schemaType, p -> p))
         : Collections.singletonMap(AvroSchema.TYPE, new AvroSchemaProvider());
     Map<String, Object> schemaProviderConfigs = new HashMap<>();
+    if (configs != null) {
+      String prefix = SchemaProvider.SCHEMA_PROVIDERS_PREFIX + ".";
+      for (Map.Entry<String, ?> entry : configs.entrySet()) {
+        if (entry.getKey().startsWith(prefix)) {
+          schemaProviderConfigs.put(
+              entry.getKey().substring(prefix.length()), entry.getValue());
+        }
+      }
+    }
     schemaProviderConfigs.put(SchemaProvider.SCHEMA_VERSION_FETCHER_CONFIG, this);
     for (SchemaProvider provider : this.providers.values()) {
       provider.configure(schemaProviderConfigs);

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/AvroSchemaProviderTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/AvroSchemaProviderTest.java
@@ -28,9 +28,12 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class AvroSchemaProviderTest {
 
@@ -127,5 +130,124 @@ public class AvroSchemaProviderTest {
     assertEquals(
             mockSchemaRegistryClient.getByVersion("test2", 2, true).getReferences(),
             referencesForTest2Resolved);
+  }
+
+  @Test
+  public void testConflictingReferenceVersionsStrictRejects()
+      throws RestClientException, IOException {
+    AvroSchemaProvider avroSchemaProvider = new AvroSchemaProvider();
+    SchemaRegistryClient mockSchemaRegistryClient = new MockSchemaRegistryClient();
+    Map<String, Object> configs = new HashMap<>();
+    configs.put(SchemaProvider.SCHEMA_VERSION_FETCHER_CONFIG, mockSchemaRegistryClient);
+    configs.put(AbstractSchemaProvider.REFERENCE_VERSIONS_STRICT_CONFIG, true);
+    avroSchemaProvider.configure(configs);
+
+    String innerSchemaV1 = "{ \"type\": \"record\", \"name\": \"Inner\", "
+        + "\"fields\": [ { \"type\": \"string\", \"name\": \"f1\" }]}";
+    String innerSchemaV2 = "{ \"type\": \"record\", \"name\": \"Inner\", "
+        + "\"fields\": [ { \"type\": \"string\", \"name\": \"f1\" }, "
+        + "{ \"type\": [\"null\", \"string\"], \"name\": \"f2\" }]}";
+    String middleSchemaStr = "{ \"type\": \"record\", \"name\": \"Middle\", "
+        + "\"fields\": [ { \"type\": \"string\", \"name\": \"m1\" }]}";
+    String rootSchemaStr = "{ \"type\": \"record\", \"name\": \"Root\", "
+        + "\"fields\": [ { \"type\": \"string\", \"name\": \"r1\" }]}";
+
+    mockSchemaRegistryClient.register("inner", new AvroSchema(innerSchemaV1));
+    mockSchemaRegistryClient.register("inner", new AvroSchema(innerSchemaV2));
+
+    List<SchemaReference> middleRefs = Collections.singletonList(
+        new SchemaReference("Inner", "inner", 2));
+    Schema middleSchema = new Schema("middle", 1, 2001, AvroSchema.TYPE,
+        middleRefs, middleSchemaStr);
+    mockSchemaRegistryClient.register("middle", new AvroSchema(middleSchemaStr,
+        middleRefs, avroSchemaProvider.resolveReferences(middleSchema), null));
+
+    // Root references Inner at version 1 directly, and Middle which references Inner at version 2
+    List<SchemaReference> rootRefs = Arrays.asList(
+        new SchemaReference("Inner", "inner", 1),
+        new SchemaReference("Middle", "middle", 1));
+    Schema rootSchema = new Schema("root", 1, 3001, AvroSchema.TYPE, rootRefs, rootSchemaStr);
+
+    try {
+      avroSchemaProvider.resolveReferences(rootSchema);
+      fail("Expected IllegalStateException for conflicting reference versions");
+    } catch (IllegalStateException e) {
+      assertEquals("Conflicting reference versions for \"Inner\": version 1 and version 2",
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testConflictingReferenceVersionsAllowedByDefault()
+      throws RestClientException, IOException {
+    AvroSchemaProvider avroSchemaProvider = new AvroSchemaProvider();
+    SchemaRegistryClient mockSchemaRegistryClient = new MockSchemaRegistryClient();
+    avroSchemaProvider.configure(Collections.singletonMap(
+        SchemaProvider.SCHEMA_VERSION_FETCHER_CONFIG, mockSchemaRegistryClient));
+
+    String innerSchemaV1 = "{ \"type\": \"record\", \"name\": \"Inner\", "
+        + "\"fields\": [ { \"type\": \"string\", \"name\": \"f1\" }]}";
+    String innerSchemaV2 = "{ \"type\": \"record\", \"name\": \"Inner\", "
+        + "\"fields\": [ { \"type\": \"string\", \"name\": \"f1\" }, "
+        + "{ \"type\": [\"null\", \"string\"], \"name\": \"f2\" }]}";
+    String middleSchemaStr = "{ \"type\": \"record\", \"name\": \"Middle\", "
+        + "\"fields\": [ { \"type\": \"string\", \"name\": \"m1\" }]}";
+    String rootSchemaStr = "{ \"type\": \"record\", \"name\": \"Root\", "
+        + "\"fields\": [ { \"type\": \"string\", \"name\": \"r1\" }]}";
+
+    mockSchemaRegistryClient.register("inner", new AvroSchema(innerSchemaV1));
+    mockSchemaRegistryClient.register("inner", new AvroSchema(innerSchemaV2));
+
+    List<SchemaReference> middleRefs = Collections.singletonList(
+        new SchemaReference("Inner", "inner", 2));
+    Schema middleSchema = new Schema("middle", 1, 2001, AvroSchema.TYPE,
+        middleRefs, middleSchemaStr);
+    mockSchemaRegistryClient.register("middle", new AvroSchema(middleSchemaStr,
+        middleRefs, avroSchemaProvider.resolveReferences(middleSchema), null));
+
+    // Root references Inner at version 1 directly, and Middle which references Inner at version 2
+    List<SchemaReference> rootRefs = Arrays.asList(
+        new SchemaReference("Inner", "inner", 1),
+        new SchemaReference("Middle", "middle", 1));
+    Schema rootSchema = new Schema("root", 1, 3001, AvroSchema.TYPE, rootRefs, rootSchemaStr);
+
+    // Should not throw — default behavior allows conflicting versions
+    avroSchemaProvider.resolveReferences(rootSchema);
+  }
+
+  @Test
+  public void testSameReferenceVersionNotRejectedWhenStrict()
+      throws RestClientException, IOException {
+    AvroSchemaProvider avroSchemaProvider = new AvroSchemaProvider();
+    SchemaRegistryClient mockSchemaRegistryClient = new MockSchemaRegistryClient();
+    Map<String, Object> configs = new HashMap<>();
+    configs.put(SchemaProvider.SCHEMA_VERSION_FETCHER_CONFIG, mockSchemaRegistryClient);
+    configs.put(AbstractSchemaProvider.REFERENCE_VERSIONS_STRICT_CONFIG, true);
+    avroSchemaProvider.configure(configs);
+
+    String innerSchemaStr = "{ \"type\": \"record\", \"name\": \"Inner\", "
+        + "\"fields\": [ { \"type\": \"string\", \"name\": \"f1\" }]}";
+    String middleSchemaStr = "{ \"type\": \"record\", \"name\": \"Middle\", "
+        + "\"fields\": [ { \"type\": \"string\", \"name\": \"m1\" }]}";
+    String rootSchemaStr = "{ \"type\": \"record\", \"name\": \"Root\", "
+        + "\"fields\": [ { \"type\": \"string\", \"name\": \"r1\" }]}";
+
+    mockSchemaRegistryClient.register("inner", new AvroSchema(innerSchemaStr));
+
+    List<SchemaReference> middleRefs = Collections.singletonList(
+        new SchemaReference("Inner", "inner", 1));
+    Schema middleSchema = new Schema("middle", 1, 2001, AvroSchema.TYPE,
+        middleRefs, middleSchemaStr);
+    mockSchemaRegistryClient.register("middle", new AvroSchema(middleSchemaStr,
+        middleRefs, avroSchemaProvider.resolveReferences(middleSchema), null));
+
+    // Root references Inner at version 1, and Middle also references Inner at version 1 — no clash
+    List<SchemaReference> rootRefs = Arrays.asList(
+        new SchemaReference("Inner", "inner", 1),
+        new SchemaReference("Middle", "middle", 1));
+    Schema rootSchema = new Schema("root", 1, 3001, AvroSchema.TYPE, rootRefs, rootSchemaStr);
+
+    // Should not throw — same version is not a conflict
+    avroSchemaProvider.resolveReferences(rootSchema);
   }
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -15,7 +15,9 @@
 
 package io.confluent.kafka.schemaregistry.rest;
 
+import io.confluent.kafka.schemaregistry.AbstractSchemaProvider;
 import io.confluent.kafka.schemaregistry.CompatibilityLevel;
+import io.confluent.kafka.schemaregistry.SchemaProvider;
 import io.confluent.kafka.schemaregistry.utils.AppInfoParser;
 import io.confluent.rest.metrics.RestMetricsContext;
 import io.confluent.rest.NamedURI;
@@ -184,7 +186,7 @@ public class SchemaRegistryConfig extends RestConfig {
 
   public static final String HOST_PORT_CONFIG = "host.port";
 
-  public static final String SCHEMA_PROVIDERS_CONFIG = "schema.providers";
+  public static final String SCHEMA_PROVIDERS_CONFIG = SchemaProvider.SCHEMA_PROVIDERS_PREFIX;
 
   /**
    * <code>schema.compatibility.level</code>
@@ -201,6 +203,10 @@ public class SchemaRegistryConfig extends RestConfig {
 
   public static final String SCHEMA_REJECT_EMPTY_SUBJECT_CONFIG = "schema.reject.empty.subject";
   public static final boolean SCHEMA_REJECT_EMPTY_SUBJECT_DEFAULT = false;
+
+  public static final String REFERENCE_VERSIONS_STRICT_CONFIG =
+      SCHEMA_PROVIDERS_CONFIG + "." + AbstractSchemaProvider.REFERENCE_VERSIONS_STRICT_CONFIG;
+  public static final boolean REFERENCE_VERSIONS_STRICT_DEFAULT = false;
 
   /**
    * <code>schema.cache.size</code>
@@ -441,6 +447,10 @@ public class SchemaRegistryConfig extends RestConfig {
       "If true, reject schema registration requests whose subject name is the empty string. "
       + "Defaults to false to preserve backward compatibility with existing deployments that "
       + "may have schemas registered under an empty subject.";
+  protected static final String REFERENCE_VERSIONS_STRICT_DOC =
+      "If true, reject schema registration when the reference graph contains the same "
+      + "reference name at different versions. This prevents conflicting type definitions "
+      + "from coexisting in the resolved schema graph. Defaults to false.";
   protected static final String SCHEMA_CACHE_SIZE_DOC =
       "The maximum size of the schema cache.";
   protected static final String SCHEMA_CACHE_EXPIRY_SECS_DOC =
@@ -686,6 +696,10 @@ public class SchemaRegistryConfig extends RestConfig {
     .define(SCHEMA_REJECT_EMPTY_SUBJECT_CONFIG, ConfigDef.Type.BOOLEAN,
         SCHEMA_REJECT_EMPTY_SUBJECT_DEFAULT,
         ConfigDef.Importance.LOW, REJECT_EMPTY_SUBJECT_DOC
+    )
+    .define(REFERENCE_VERSIONS_STRICT_CONFIG, ConfigDef.Type.BOOLEAN,
+        REFERENCE_VERSIONS_STRICT_DEFAULT,
+        ConfigDef.Importance.LOW, REFERENCE_VERSIONS_STRICT_DOC
     )
     .define(SCHEMA_CACHE_SIZE_CONFIG, ConfigDef.Type.INT, SCHEMA_CACHE_SIZE_DEFAULT,
         ConfigDef.Importance.LOW, SCHEMA_CACHE_SIZE_DOC

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiReferenceVersionsStrictClusterTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiReferenceVersionsStrictClusterTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rest;
+
+import io.confluent.kafka.schemaregistry.ClusterTestHarness;
+import java.util.Properties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+
+public class RestApiReferenceVersionsStrictClusterTest
+    extends RestApiReferenceVersionsStrictTest {
+
+  protected ClusterTestHarness harness;
+
+  public RestApiReferenceVersionsStrictClusterTest() {
+    this.harness = new ClusterTestHarness(1, true);
+    this.harness.injectSchemaRegistryProperties(getSchemaRegistryProperties());
+  }
+
+  @BeforeEach
+  public void setUpTest(TestInfo testInfo) throws Exception {
+    harness.setUpTest(testInfo);
+    setRestApp(harness.getRestApp());
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    harness.tearDown();
+  }
+
+  public Properties getSchemaRegistryProperties() {
+    Properties props = new Properties();
+    props.put(SchemaRegistryConfig.REFERENCE_VERSIONS_STRICT_CONFIG, true);
+    return props;
+  }
+}

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiReferenceVersionsStrictTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiReferenceVersionsStrictTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import io.confluent.kafka.schemaregistry.RestApp;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("IntegrationTest")
+public abstract class RestApiReferenceVersionsStrictTest {
+
+  protected RestApp restApp;
+
+  public void setRestApp(RestApp restApp) {
+    this.restApp = restApp;
+  }
+
+  private static final String INNER_SCHEMA_V1 =
+      "{\"type\":\"record\",\"name\":\"Inner\","
+      + "\"fields\":[{\"name\":\"f1\",\"type\":\"string\"}]}";
+
+  private static final String INNER_SCHEMA_V2 =
+      "{\"type\":\"record\",\"name\":\"Inner\","
+      + "\"fields\":[{\"name\":\"f1\",\"type\":\"string\"},"
+      + "{\"name\":\"f2\",\"type\":[\"null\",\"string\"],\"default\":null}]}";
+
+  private static final String MIDDLE_SCHEMA =
+      "{\"type\":\"record\",\"name\":\"Middle\","
+      + "\"fields\":[{\"name\":\"m1\",\"type\":\"string\"}]}";
+
+  private static final String ROOT_SCHEMA =
+      "{\"type\":\"record\",\"name\":\"Root\","
+      + "\"fields\":[{\"name\":\"r1\",\"type\":\"string\"}]}";
+
+  @Test
+  public void testConflictingReferenceVersionsRejected() throws Exception {
+    // Register inner schema with two versions
+    restApp.restClient.registerSchema(INNER_SCHEMA_V1, "inner");
+    restApp.restClient.registerSchema(INNER_SCHEMA_V2, "inner");
+
+    // Register middle schema referencing inner v2
+    restApp.restClient.registerSchema(
+        MIDDLE_SCHEMA, "AVRO",
+        Collections.singletonList(new SchemaReference("Inner", "inner", 2)),
+        "middle");
+
+    // Register root referencing inner v1 directly AND middle (which refs inner v2)
+    try {
+      restApp.restClient.registerSchema(
+          ROOT_SCHEMA, "AVRO",
+          Arrays.asList(
+              new SchemaReference("Inner", "inner", 1),
+              new SchemaReference("Middle", "middle", 1)),
+          "root");
+      fail("Should reject schema with conflicting reference versions");
+    } catch (RestClientException rce) {
+      assertEquals(Errors.INVALID_SCHEMA_ERROR_CODE, rce.getErrorCode());
+      assertTrue(rce.getMessage().contains("Conflicting reference versions"));
+    }
+  }
+
+  @Test
+  public void testConsistentReferenceVersionsAllowed() throws Exception {
+    // Register inner schema
+    restApp.restClient.registerSchema(INNER_SCHEMA_V1, "innerOk");
+
+    // Register middle schema referencing inner v1
+    restApp.restClient.registerSchema(
+        MIDDLE_SCHEMA, "AVRO",
+        Collections.singletonList(new SchemaReference("InnerOk", "innerOk", 1)),
+        "middleOk");
+
+    // Root references inner v1 directly AND middle (which also refs inner v1) — no clash
+    restApp.restClient.registerSchema(
+        ROOT_SCHEMA, "AVRO",
+        Arrays.asList(
+            new SchemaReference("InnerOk", "innerOk", 1),
+            new SchemaReference("MiddleOk", "middleOk", 1)),
+        "rootOk");
+  }
+}


### PR DESCRIPTION
What
----
Add opt-in strict validation for conflicting schema reference versions
    
When schema.providers.reference.versions.strict is enabled, schema registration is rejected if the reference graph contains the same reference name at different versions (e.g., a direct ref to v1 and a transitive ref to v2 of the same schema). This prevents conflicting type definitions from coexisting in the resolved schema graph.

The config defaults to false to preserve backward compatibility. Also fixes CachedSchemaRegistryClient to propagate schema.providers.* configs to schema providers (matching server-side behavior), and introduces SchemaProvider.SCHEMA_PROVIDERS_PREFIX as the single source of truth for the "schema.providers" prefix.
    
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change This is gated behind a config that is disabled by default
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA: https://confluentinc.atlassian.net/browse/DGS-24376

Test & Review
------------
- Unit tests and Integrations tests

