### PR TITLE
DGS-24660 Fix oneofs in protobuf converter with wrapper/optional for nullables

### DIFF
--- a/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufData.java
+++ b/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufData.java
@@ -1425,7 +1425,7 @@ public class ProtobufData {
         if (flattenUnions) {
           List<FieldDescriptor> fieldDescriptors = oneOfDescriptor.getFields();
           for (FieldDescriptor fieldDescriptor : fieldDescriptors) {
-            builder.field(fieldDescriptor.getName(), toConnectSchema(ctx, fieldDescriptor));
+            builder.field(fieldDescriptor.getName(), toConnectSchema(ctx, fieldDescriptor, true));
           }
         } else {
           String unionFieldName = unionFieldName(oneOfDescriptor);
@@ -1462,13 +1462,18 @@ public class ProtobufData {
     }
     List<FieldDescriptor> fieldDescriptors = descriptor.getFields();
     for (FieldDescriptor fieldDescriptor : fieldDescriptors) {
-      builder.field(fieldDescriptor.getName(), toConnectSchema(ctx, fieldDescriptor));
+      builder.field(fieldDescriptor.getName(), toConnectSchema(ctx, fieldDescriptor, true));
     }
     builder.optional();
     return builder.build();
   }
 
   private Schema toConnectSchema(ToConnectContext ctx, FieldDescriptor descriptor) {
+    return toConnectSchema(ctx, descriptor, false);
+  }
+
+  private Schema toConnectSchema(
+      ToConnectContext ctx, FieldDescriptor descriptor, boolean forceOptional) {
     SchemaBuilder builder;
 
     switch (descriptor.getType()) {
@@ -1607,7 +1612,11 @@ public class ProtobufData {
       builder.optional();
     }
 
-    if (useOptionalForNullables) {
+    if (forceOptional) {
+      // Union (oneof) members are inherently nullable, since at most one is ever set,
+      // so they must be optional regardless of the nullable handling configs.
+      builder.optional();
+    } else if (useOptionalForNullables) {
       if (descriptor.hasOptionalKeyword()) {
         builder.optional();
       }

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
@@ -2288,6 +2288,83 @@ public class ProtobufDataTest {
     return result;
   }
 
+  private static final String ONEOF_WRAPPER_SCHEMA = "syntax = \"proto3\";\n"
+      + "package io.confluent.test;\n"
+      + "import \"google/protobuf/wrappers.proto\";\n"
+      + "message OneofWrapFixed {\n"
+      + "  int32 id = 1;\n"
+      + "  string name = 2;\n"
+      + "  google.protobuf.StringValue nickname = 3;\n"
+      + "  google.protobuf.Int32Value priority = 4;\n"
+      + "  google.protobuf.BoolValue verified = 5;\n"
+      + "  oneof payload {\n"
+      + "    string text_payload = 6;\n"
+      + "    int64 number_payload = 7;\n"
+      + "  }\n"
+      + "}\n";
+
+  @Test
+  public void testOneofWithWrapperForNullables() throws Exception {
+    ProtobufDataConfig config = new ProtobufDataConfig.Builder()
+        .with(ProtobufDataConfig.WRAPPER_FOR_NULLABLES_CONFIG, true)
+        .with(ProtobufDataConfig.GENERATE_INDEX_FOR_UNIONS_CONFIG, false)
+        .build();
+    assertOneofMembersOptionalAndRoundTrip(config);
+  }
+
+  @Test
+  public void testOneofWithOptionalForNullables() throws Exception {
+    ProtobufDataConfig config = new ProtobufDataConfig.Builder()
+        .with(ProtobufDataConfig.OPTIONAL_FOR_NULLABLES_CONFIG, true)
+        .with(ProtobufDataConfig.GENERATE_INDEX_FOR_UNIONS_CONFIG, false)
+        .build();
+    assertOneofMembersOptionalAndRoundTrip(config);
+  }
+
+  private void assertOneofMembersOptionalAndRoundTrip(ProtobufDataConfig config) throws Exception {
+    ProtobufData protobufData = new ProtobufData(config);
+    ProtobufSchema protobufSchema = new ProtobufSchema(ONEOF_WRAPPER_SCHEMA);
+    Descriptor descriptor = protobufSchema.toDescriptor();
+
+    // Union (oneof) members must be optional, since at most one is ever set. Without this,
+    // the nullable configs leave them required and validation rejects the unset member.
+    Schema connectSchema = protobufData.toConnectSchema(protobufSchema);
+    Schema unionSchema = connectSchema.field("payload").schema();
+    assertTrue(unionSchema.field("text_payload").schema().isOptional());
+    assertTrue(unionSchema.field("number_payload").schema().isOptional());
+
+    // Setting either oneof member must deserialize and validate without crashing,
+    // even though the other member is absent (null).
+    assertOneofBranchRoundTrips(protobufData, protobufSchema, descriptor, "text_payload", "hello");
+    assertOneofBranchRoundTrips(protobufData, protobufSchema, descriptor, "number_payload", 7L);
+  }
+
+  private void assertOneofBranchRoundTrips(
+      ProtobufData protobufData,
+      ProtobufSchema protobufSchema,
+      Descriptor descriptor,
+      String payloadField,
+      Object payloadValue) {
+    DynamicMessage.Builder builder = DynamicMessage.newBuilder(descriptor);
+    builder.setField(descriptor.findFieldByName("id"), 42);
+    builder.setField(descriptor.findFieldByName("name"), "alice");
+    FieldDescriptor nicknameField = descriptor.findFieldByName("nickname");
+    Descriptor stringValueDesc = nicknameField.getMessageType();
+    builder.setField(nicknameField, DynamicMessage.newBuilder(stringValueDesc)
+        .setField(stringValueDesc.findFieldByName("value"), "ally")
+        .build());
+    builder.setField(descriptor.findFieldByName(payloadField), payloadValue);
+    DynamicMessage message = builder.build();
+
+    SchemaAndValue schemaAndValue = protobufData.toConnectData(protobufSchema, message);
+    // Mirrors the converter validation path that previously threw for the unset oneof member.
+    ConnectSchema.validateValue(schemaAndValue.schema(), schemaAndValue.value());
+
+    Struct value = (Struct) schemaAndValue.value();
+    Struct payload = (Struct) value.get("payload");
+    assertEquals(payloadValue, payload.get(payloadField));
+  }
+
   @Test
   public void testToConnectRecursiveSchema() {
     ProtobufSchema protobufSchema = new ProtobufSchema(

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
@@ -2309,7 +2309,7 @@ public class ProtobufDataTest {
         .with(ProtobufDataConfig.WRAPPER_FOR_NULLABLES_CONFIG, true)
         .with(ProtobufDataConfig.GENERATE_INDEX_FOR_UNIONS_CONFIG, false)
         .build();
-    assertOneofMembersOptionalAndRoundTrip(config);
+    assertOneofMembersOptionalAndRoundTrip(config, false);
   }
 
   @Test
@@ -2318,31 +2318,55 @@ public class ProtobufDataTest {
         .with(ProtobufDataConfig.OPTIONAL_FOR_NULLABLES_CONFIG, true)
         .with(ProtobufDataConfig.GENERATE_INDEX_FOR_UNIONS_CONFIG, false)
         .build();
-    assertOneofMembersOptionalAndRoundTrip(config);
+    assertOneofMembersOptionalAndRoundTrip(config, false);
   }
 
-  private void assertOneofMembersOptionalAndRoundTrip(ProtobufDataConfig config) throws Exception {
+  @Test
+  public void testFlattenedOneofWithWrapperForNullables() throws Exception {
+    ProtobufDataConfig config = new ProtobufDataConfig.Builder()
+        .with(ProtobufDataConfig.WRAPPER_FOR_NULLABLES_CONFIG, true)
+        .with(ProtobufDataConfig.FLATTEN_UNIONS_CONFIG, true)
+        .build();
+    assertOneofMembersOptionalAndRoundTrip(config, true);
+  }
+
+  @Test
+  public void testFlattenedOneofWithOptionalForNullables() throws Exception {
+    ProtobufDataConfig config = new ProtobufDataConfig.Builder()
+        .with(ProtobufDataConfig.OPTIONAL_FOR_NULLABLES_CONFIG, true)
+        .with(ProtobufDataConfig.FLATTEN_UNIONS_CONFIG, true)
+        .build();
+    assertOneofMembersOptionalAndRoundTrip(config, true);
+  }
+
+  private void assertOneofMembersOptionalAndRoundTrip(ProtobufDataConfig config, boolean flatten)
+      throws Exception {
     ProtobufData protobufData = new ProtobufData(config);
     ProtobufSchema protobufSchema = new ProtobufSchema(ONEOF_WRAPPER_SCHEMA);
     Descriptor descriptor = protobufSchema.toDescriptor();
 
     // Union (oneof) members must be optional, since at most one is ever set. Without this,
     // the nullable configs leave them required and validation rejects the unset member.
+    // When unions are flattened the members are top-level fields; otherwise they live in a
+    // nested "payload" struct.
     Schema connectSchema = protobufData.toConnectSchema(protobufSchema);
-    Schema unionSchema = connectSchema.field("payload").schema();
-    assertTrue(unionSchema.field("text_payload").schema().isOptional());
-    assertTrue(unionSchema.field("number_payload").schema().isOptional());
+    Schema membersSchema = flatten ? connectSchema : connectSchema.field("payload").schema();
+    assertTrue(membersSchema.field("text_payload").schema().isOptional());
+    assertTrue(membersSchema.field("number_payload").schema().isOptional());
 
     // Setting either oneof member must deserialize and validate without crashing,
     // even though the other member is absent (null).
-    assertOneofBranchRoundTrips(protobufData, protobufSchema, descriptor, "text_payload", "hello");
-    assertOneofBranchRoundTrips(protobufData, protobufSchema, descriptor, "number_payload", 7L);
+    assertOneofBranchRoundTrips(protobufData, protobufSchema, descriptor, flatten,
+        "text_payload", "hello");
+    assertOneofBranchRoundTrips(protobufData, protobufSchema, descriptor, flatten,
+        "number_payload", 7L);
   }
 
   private void assertOneofBranchRoundTrips(
       ProtobufData protobufData,
       ProtobufSchema protobufSchema,
       Descriptor descriptor,
+      boolean flatten,
       String payloadField,
       Object payloadValue) {
     DynamicMessage.Builder builder = DynamicMessage.newBuilder(descriptor);
@@ -2361,8 +2385,8 @@ public class ProtobufDataTest {
     ConnectSchema.validateValue(schemaAndValue.schema(), schemaAndValue.value());
 
     Struct value = (Struct) schemaAndValue.value();
-    Struct payload = (Struct) value.get("payload");
-    assertEquals(payloadValue, payload.get(payloadField));
+    Struct members = flatten ? value : (Struct) value.get("payload");
+    assertEquals(payloadValue, members.get(payloadField));
   }
 
   @Test


### PR DESCRIPTION


<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Fix oneofs in protobuf converter with wrapper/optional for nullables
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
