### PR TITLE
DGS-24591 Hide frozen attribute for its default in Association APIs

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Association.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Association.java
@@ -17,6 +17,7 @@
 package io.confluent.kafka.schemaregistry.client.rest.entities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -41,7 +42,7 @@ public class Association implements Comparable<Association> {
   private String resourceType;
   private String associationType;
   private LifecyclePolicy lifecycle;
-  private boolean frozen;
+  private Boolean frozen;
   private Long createTimestamp;
   private Long updateTimestamp;
 
@@ -53,7 +54,7 @@ public class Association implements Comparable<Association> {
       @JsonProperty("resourceType") String resourceType,
       @JsonProperty("associationType") String associationType,
       @JsonProperty("lifecycle") LifecyclePolicy lifecycle,
-      @JsonProperty("frozen") boolean frozen) {
+      @JsonProperty("frozen") Boolean frozen) {
     this(subject, guid, resourceName, resourceNamespace, resourceId, resourceType, associationType,
         lifecycle, frozen, null, null);
   }
@@ -67,7 +68,7 @@ public class Association implements Comparable<Association> {
       @JsonProperty("resourceType") String resourceType,
       @JsonProperty("associationType") String associationType,
       @JsonProperty("lifecycle") LifecyclePolicy lifecycle,
-      @JsonProperty("frozen") boolean frozen,
+      @JsonProperty("frozen") Boolean frozen,
       @JsonProperty("createTs") Long createTimestamp,
       @JsonProperty("updateTs") Long updateTimestamp) {
     this.subject = subject;
@@ -163,14 +164,34 @@ public class Association implements Comparable<Association> {
     this.lifecycle = lifecycle;
   }
 
-  @JsonProperty("frozen")
+  /**
+   * The effective frozen value, applying the lifecycle default when unset.
+   * Used by business logic; not serialized directly.
+   */
+  @JsonIgnore
   public boolean isFrozen() {
+    return frozen != null ? frozen : defaultFrozen();
+  }
+
+  /**
+   * The frozen value for serialization. Returns {@code null} (so the property is
+   * omitted) when it matches the lifecycle default, and the explicit value otherwise.
+   */
+  @JsonProperty("frozen")
+  public Boolean getFrozen() {
+    if (frozen == null || frozen == defaultFrozen()) {
+      return null;
+    }
     return frozen;
   }
 
   @JsonProperty("frozen")
-  public void setFrozen(boolean frozen) {
+  public void setFrozen(Boolean frozen) {
     this.frozen = frozen;
+  }
+
+  private boolean defaultFrozen() {
+    return lifecycle == LifecyclePolicy.STRONG;
   }
 
   @JsonProperty("createTs")
@@ -199,7 +220,7 @@ public class Association implements Comparable<Association> {
       return false;
     }
     Association that = (Association) o;
-    return frozen == that.frozen
+    return Objects.equals(frozen, that.frozen)
         && Objects.equals(subject, that.subject)
         && Objects.equals(guid, that.guid)
         && Objects.equals(resourceName, that.resourceName)

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Association.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/Association.java
@@ -220,7 +220,7 @@ public class Association implements Comparable<Association> {
       return false;
     }
     Association that = (Association) o;
-    return Objects.equals(frozen, that.frozen)
+    return isFrozen() == that.isFrozen()
         && Objects.equals(subject, that.subject)
         && Objects.equals(guid, that.guid)
         && Objects.equals(resourceName, that.resourceName)
@@ -237,7 +237,7 @@ public class Association implements Comparable<Association> {
   public int hashCode() {
     return Objects.hash(
         subject, guid, resourceName, resourceNamespace, resourceId,
-        resourceType, associationType, lifecycle, frozen, createTimestamp, updateTimestamp);
+        resourceType, associationType, lifecycle, isFrozen(), createTimestamp, updateTimestamp);
   }
 
   public boolean isEquivalent(AssociationCreateOrUpdateInfo info) {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/AssociationInfo.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/AssociationInfo.java
@@ -17,6 +17,7 @@
 package io.confluent.kafka.schemaregistry.client.rest.entities.requests;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -33,7 +34,7 @@ public class AssociationInfo {
   private String subject;
   private String associationType;
   private LifecyclePolicy lifecycle;
-  private boolean frozen;
+  private Boolean frozen;
   private Schema schema;
 
   @JsonCreator
@@ -41,7 +42,7 @@ public class AssociationInfo {
       @JsonProperty("subject") String subject,
       @JsonProperty("associationType") String associationType,
       @JsonProperty("lifecycle") LifecyclePolicy lifecycle,
-      @JsonProperty("frozen") boolean frozen,
+      @JsonProperty("frozen") Boolean frozen,
       @JsonProperty("schema") Schema schema) {
     this.subject = subject;
     this.associationType = associationType;
@@ -80,14 +81,34 @@ public class AssociationInfo {
     this.lifecycle = lifecycle;
   }
 
-  @JsonProperty("frozen")
+  /**
+   * The effective frozen value, applying the lifecycle default when unset.
+   * Used by business logic; not serialized directly.
+   */
+  @JsonIgnore
   public boolean isFrozen() {
+    return frozen != null ? frozen : defaultFrozen();
+  }
+
+  /**
+   * The frozen value for serialization. Returns {@code null} (so the property is
+   * omitted) when it matches the lifecycle default, and the explicit value otherwise.
+   */
+  @JsonProperty("frozen")
+  public Boolean getFrozen() {
+    if (frozen == null || frozen == defaultFrozen()) {
+      return null;
+    }
     return frozen;
   }
 
   @JsonProperty("frozen")
-  public void setFrozen(boolean frozen) {
+  public void setFrozen(Boolean frozen) {
     this.frozen = frozen;
+  }
+
+  private boolean defaultFrozen() {
+    return lifecycle == LifecyclePolicy.STRONG;
   }
 
   @JsonProperty("schema")
@@ -106,7 +127,7 @@ public class AssociationInfo {
       return false;
     }
     AssociationInfo that = (AssociationInfo) o;
-    return frozen == that.frozen
+    return Objects.equals(frozen, that.frozen)
         && Objects.equals(subject, that.subject)
         && Objects.equals(associationType, that.associationType)
         && lifecycle == that.lifecycle

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/AssociationInfo.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/AssociationInfo.java
@@ -127,7 +127,7 @@ public class AssociationInfo {
       return false;
     }
     AssociationInfo that = (AssociationInfo) o;
-    return Objects.equals(frozen, that.frozen)
+    return isFrozen() == that.isFrozen()
         && Objects.equals(subject, that.subject)
         && Objects.equals(associationType, that.associationType)
         && lifecycle == that.lifecycle
@@ -137,7 +137,7 @@ public class AssociationInfo {
   @Override
   public int hashCode() {
     return Objects.hash(
-        subject, associationType, lifecycle, frozen, schema);
+        subject, associationType, lifecycle, isFrozen(), schema);
   }
 
   public String toJson() throws IOException {

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/entities/AssociationSerializationTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/entities/AssociationSerializationTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.client.rest.entities;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationInfo;
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * Verifies that {@code frozen} is serialized only when it differs from the lifecycle default
+ * (STRONG defaults to {@code true}, WEAK defaults to {@code false}), and that round-tripping
+ * preserves the effective {@code isFrozen()} value.
+ */
+public class AssociationSerializationTest {
+
+  private static final ObjectMapper MAPPER = JacksonMapper.INSTANCE;
+
+  private static Association association(LifecyclePolicy lifecycle, Boolean frozen) {
+    return new Association(
+        "test-subject", "guid-1", "resource", "ns", "id", "topic", "value", lifecycle, frozen);
+  }
+
+  private static AssociationInfo info(LifecyclePolicy lifecycle, Boolean frozen) {
+    return new AssociationInfo("test-subject", "value", lifecycle, frozen, null);
+  }
+
+  private static boolean hasFrozen(Object o) throws IOException {
+    JsonNode node = MAPPER.readTree(MAPPER.writeValueAsString(o));
+    return node.has("frozen");
+  }
+
+  // Association
+
+  @Test
+  public void testAssociationStrongFrozenTrueOmitted() throws IOException {
+    // STRONG default is true, so frozen=true matches the default and is hidden
+    assertFalse(hasFrozen(association(LifecyclePolicy.STRONG, true)));
+  }
+
+  @Test
+  public void testAssociationStrongFrozenFalseSerialized() throws IOException {
+    // STRONG default is true, so frozen=false differs and is shown
+    JsonNode node = MAPPER.readTree(
+        MAPPER.writeValueAsString(association(LifecyclePolicy.STRONG, false)));
+    assertTrue(node.has("frozen"));
+    assertFalse(node.get("frozen").asBoolean());
+  }
+
+  @Test
+  public void testAssociationStrongFrozenNullOmitted() throws IOException {
+    // null frozen falls back to the lifecycle default, so it matches and is hidden
+    assertFalse(hasFrozen(association(LifecyclePolicy.STRONG, null)));
+  }
+
+  @Test
+  public void testAssociationWeakFrozenFalseOmitted() throws IOException {
+    // WEAK default is false, so frozen=false matches the default and is hidden
+    assertFalse(hasFrozen(association(LifecyclePolicy.WEAK, false)));
+  }
+
+  @Test
+  public void testAssociationWeakFrozenTrueSerialized() throws IOException {
+    // WEAK default is false, so frozen=true differs and is shown
+    JsonNode node = MAPPER.readTree(
+        MAPPER.writeValueAsString(association(LifecyclePolicy.WEAK, true)));
+    assertTrue(node.has("frozen"));
+    assertTrue(node.get("frozen").asBoolean());
+  }
+
+  @Test
+  public void testAssociationStrongDefaultRoundTrip() throws IOException {
+    // STRONG with frozen omitted from JSON deserializes to an effective frozen of true
+    Association deserialized = MAPPER.readValue(
+        MAPPER.writeValueAsString(association(LifecyclePolicy.STRONG, true)), Association.class);
+    assertTrue(deserialized.isFrozen());
+  }
+
+  @Test
+  public void testAssociationStrongNonDefaultRoundTrip() throws IOException {
+    Association deserialized = MAPPER.readValue(
+        MAPPER.writeValueAsString(association(LifecyclePolicy.STRONG, false)), Association.class);
+    assertFalse(deserialized.isFrozen());
+  }
+
+  @Test
+  public void testAssociationWeakDefaultRoundTrip() throws IOException {
+    Association deserialized = MAPPER.readValue(
+        MAPPER.writeValueAsString(association(LifecyclePolicy.WEAK, false)), Association.class);
+    assertFalse(deserialized.isFrozen());
+  }
+
+  // AssociationInfo
+
+  @Test
+  public void testInfoStrongFrozenTrueOmitted() throws IOException {
+    assertFalse(hasFrozen(info(LifecyclePolicy.STRONG, true)));
+  }
+
+  @Test
+  public void testInfoStrongFrozenFalseSerialized() throws IOException {
+    JsonNode node = MAPPER.readTree(MAPPER.writeValueAsString(info(LifecyclePolicy.STRONG, false)));
+    assertTrue(node.has("frozen"));
+    assertFalse(node.get("frozen").asBoolean());
+  }
+
+  @Test
+  public void testInfoWeakFrozenFalseOmitted() throws IOException {
+    assertFalse(hasFrozen(info(LifecyclePolicy.WEAK, false)));
+  }
+
+  @Test
+  public void testInfoStrongDefaultRoundTrip() throws IOException {
+    AssociationInfo deserialized = MAPPER.readValue(
+        MAPPER.writeValueAsString(info(LifecyclePolicy.STRONG, true)), AssociationInfo.class);
+    assertTrue(deserialized.isFrozen());
+  }
+
+  @Test
+  public void testInfoStrongNonDefaultRoundTrip() throws IOException {
+    AssociationInfo deserialized = MAPPER.readValue(
+        MAPPER.writeValueAsString(info(LifecyclePolicy.STRONG, false)), AssociationInfo.class);
+    assertFalse(deserialized.isFrozen());
+  }
+}

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/entities/AssociationSerializationTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/entities/AssociationSerializationTest.java
@@ -142,4 +142,33 @@ public class AssociationSerializationTest {
         MAPPER.writeValueAsString(info(LifecyclePolicy.STRONG, false)), AssociationInfo.class);
     assertFalse(deserialized.isFrozen());
   }
+
+  // equals()/hashCode() are stable across serialize -> deserialize even though the wire form
+  // omits frozen when it matches the lifecycle default (lossy for the raw field).
+
+  @Test
+  public void testAssociationEqualsStableAcrossRoundTrip() throws IOException {
+    for (LifecyclePolicy lifecycle : LifecyclePolicy.values()) {
+      for (Boolean frozen : new Boolean[] {Boolean.TRUE, Boolean.FALSE, null}) {
+        Association original = association(lifecycle, frozen);
+        Association roundTripped = MAPPER.readValue(
+            MAPPER.writeValueAsString(original), Association.class);
+        assertEquals(original, roundTripped);
+        assertEquals(original.hashCode(), roundTripped.hashCode());
+      }
+    }
+  }
+
+  @Test
+  public void testInfoEqualsStableAcrossRoundTrip() throws IOException {
+    for (LifecyclePolicy lifecycle : LifecyclePolicy.values()) {
+      for (Boolean frozen : new Boolean[] {Boolean.TRUE, Boolean.FALSE, null}) {
+        AssociationInfo original = info(lifecycle, frozen);
+        AssociationInfo roundTripped = MAPPER.readValue(
+            MAPPER.writeValueAsString(original), AssociationInfo.class);
+        assertEquals(original, roundTripped);
+        assertEquals(original.hashCode(), roundTripped.hashCode());
+      }
+    }
+  }
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.CompatibilityLevel;
@@ -44,7 +45,9 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.requests.Associati
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationResult;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationUpsertOp;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
+import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 import io.confluent.kafka.schemaregistry.utils.TestUtils;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -3169,8 +3172,10 @@ public class RestApiAssociationTest extends ClusterTestHarness {
 
     // The wire format omits frozen because it matches the STRONG default (true)
     String rawJson = rawGet("/associations/resources/" + resourceId + "?resourceType=topic");
+    JsonNode root = JacksonMapper.INSTANCE.readTree(rawJson);
+    assertEquals(1, root.size());
     assertFalse(
-        rawJson.contains("\"frozen\""),
+        root.get(0).has("frozen"),
         "frozen should be hidden for a default STRONG association: " + rawJson);
 
     // The deserialized association still reports the effective frozen value
@@ -3185,8 +3190,10 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     URL url = new URL(restApp.restConnect + path);
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
     conn.setRequestMethod("GET");
-    try {
-      return new String(conn.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    conn.setConnectTimeout(10_000);
+    conn.setReadTimeout(10_000);
+    try (InputStream in = conn.getInputStream()) {
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
     } finally {
       conn.disconnect();
     }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
@@ -45,6 +45,9 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.requests.Associati
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationUpsertOp;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
 import io.confluent.kafka.schemaregistry.utils.TestUtils;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -3138,6 +3141,55 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertThrows(Exception.class, () ->
         restApp.restClient.createAssociation(
             RestService.DEFAULT_REQUEST_PROPERTIES, null, false, request));
+  }
+
+  // Serialization: frozen is hidden when it matches the lifecycle default
+
+  @Test
+  public void testStrongAssociationWithoutFrozenHidesFrozenInResponse() throws Exception {
+    String resourceName = "topic1";
+    String resourceNamespace = "default";
+    String resourceId = "strong-hidden-frozen-123";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(1);
+
+    RegisterSchemaRequest schemaRequest = new RegisterSchemaRequest();
+    schemaRequest.setSchema(allSchemas.get(0));
+
+    // Create a STRONG association without passing frozen — defaults to frozen=true for STRONG
+    AssociationCreateOrUpdateRequest request = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            null, "value", null, null, schemaRequest, null)));
+
+    AssociationResponse createResponse = restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, request);
+    assertEquals(LifecyclePolicy.STRONG, createResponse.getAssociations().get(0).getLifecycle());
+    // The effective value is frozen even though frozen was never passed
+    assertTrue(createResponse.getAssociations().get(0).isFrozen());
+
+    // The wire format omits frozen because it matches the STRONG default (true)
+    String rawJson = rawGet("/associations/resources/" + resourceId + "?resourceType=topic");
+    assertFalse(
+        rawJson.contains("\"frozen\""),
+        "frozen should be hidden for a default STRONG association: " + rawJson);
+
+    // The deserialized association still reports the effective frozen value
+    List<Association> associations = restApp.restClient.getAssociationsByResourceId(
+        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
+        Collections.singletonList("value"), null, 0, -1);
+    assertEquals(1, associations.size());
+    assertTrue(associations.get(0).isFrozen());
+  }
+
+  private String rawGet(String path) throws Exception {
+    URL url = new URL(restApp.restConnect + path);
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    conn.setRequestMethod("GET");
+    try {
+      return new String(conn.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+    } finally {
+      conn.disconnect();
+    }
   }
 
 }

--- a/findbugs/findbugs-exclude.xml
+++ b/findbugs/findbugs-exclude.xml
@@ -98,6 +98,16 @@ For a detailed description of findbugs bug categories, see http://findbugs.sourc
     </Match>
 
     <Match>
+        <Class name="io.confluent.kafka.schemaregistry.client.rest.entities.Association"/>
+        <Bug pattern="NP_BOOLEAN_RETURN_NULL"/>
+    </Match>
+
+    <Match>
+        <Class name="io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationInfo"/>
+        <Bug pattern="NP_BOOLEAN_RETURN_NULL"/>
+    </Match>
+
+    <Match>
         <Class name="io.confluent.kafka.schemaregistry.rules.FieldRuleExecutor"/>
         <Bug pattern="NP_LOAD_OF_KNOWN_NULL_VALUE"/>
     </Match>


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
This PR updates Schema Registry association REST entities so the frozen JSON property is omitted when it matches the lifecycle default (STRONG ⇒ true, WEAK ⇒ false).
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
