### PR TITLE
DGS-24660 Fix oneof handling of wrapper types in protobuf converter

### DIFF
--- a/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufData.java
+++ b/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufData.java
@@ -97,6 +97,11 @@ public class ProtobufData {
   public static final String PROTOBUF_TYPE_UNION_PREFIX = PROTOBUF_TYPE_UNION + ".";
   public static final String PROTOBUF_TYPE_TAG = NAMESPACE + ".Tag";
   public static final String PROTOBUF_TYPE_PROP = NAMESPACE + ".Type";
+  // Marks an optional scalar that originated from a protobuf wrapper type
+  // (e.g. google.protobuf.StringValue). Used to distinguish a genuine wrapper-typed oneof
+  // member from a plain scalar oneof member: oneof members are always optional, so optionality
+  // alone cannot signal wrapper-ness for them the way it does for ordinary fields.
+  public static final String PROTOBUF_TYPE_WRAPPER = NAMESPACE + ".Wrapper";
 
   public static final String PROTOBUF_PRECISION_PROP = "precision";
   public static final String PROTOBUF_SCALE_PROP = "scale";
@@ -391,10 +396,12 @@ public class ProtobufData {
       }
     }
 
-    // Oneof (union) members express nullability via the oneof itself, not via wrapper types,
-    // so they must never be wrapped even when useWrapperForNullables is set.
+    // A plain scalar oneof member expresses nullability via the oneof itself, so it must not be
+    // wrapped even when useWrapperForNullables is set. A genuine wrapper-typed oneof member
+    // (carrying the wrapper marker) must still be wrapped so it round-trips faithfully.
     boolean isWrapper = isWrapper(protobufSchema)
-        || (useWrapperForNullables && !oneofMember && schema.isOptional());
+        || (useWrapperForNullables && schema.isOptional()
+            && (!oneofMember || hasWrapperMarker(schema)));
     final Schema.Type schemaType = schema.type();
     try {
       switch (schemaType) {
@@ -589,6 +596,13 @@ public class ProtobufData {
       default:
         return false;
     }
+  }
+
+  // True if the schema is an (optional scalar) oneof member that originated from a protobuf
+  // wrapper type and must therefore be re-wrapped on the write side.
+  private boolean hasWrapperMarker(Schema schema) {
+    return schema.parameters() != null
+        && Boolean.parseBoolean(schema.parameters().get(PROTOBUF_TYPE_WRAPPER));
   }
 
   private Object getFieldType(Object ctx, String name) {
@@ -1079,11 +1093,13 @@ public class ProtobufData {
     switch (schema.type()) {
       case INT8:
         params.put(CONNECT_TYPE_PROP, CONNECT_TYPE_INT8);
-        return useWrapperForNullables && schema.isOptional() && !oneofMember
+        return useWrapperForNullables && schema.isOptional()
+            && (!oneofMember || hasWrapperMarker(schema))
             ? PROTOBUF_INT32_WRAPPER_TYPE : FieldDescriptor.Type.INT32.toString().toLowerCase();
       case INT16:
         params.put(CONNECT_TYPE_PROP, CONNECT_TYPE_INT16);
-        return useWrapperForNullables && schema.isOptional() && !oneofMember
+        return useWrapperForNullables && schema.isOptional()
+            && (!oneofMember || hasWrapperMarker(schema))
             ? PROTOBUF_INT32_WRAPPER_TYPE : FieldDescriptor.Type.INT32.toString().toLowerCase();
       case INT32:
         if (schema.parameters() != null && schema.parameters().containsKey(PROTOBUF_TYPE_ENUM)) {
@@ -1093,7 +1109,8 @@ public class ProtobufData {
         if (schema.parameters() != null && schema.parameters().containsKey(PROTOBUF_TYPE_PROP)) {
           defaultType = schema.parameters().get(PROTOBUF_TYPE_PROP);
         }
-        return useWrapperForNullables && schema.isOptional() && !oneofMember
+        return useWrapperForNullables && schema.isOptional()
+            && (!oneofMember || hasWrapperMarker(schema))
             ? PROTOBUF_INT32_WRAPPER_TYPE : defaultType;
       case INT64:
         defaultType = FieldDescriptor.Type.INT64.toString().toLowerCase();
@@ -1113,16 +1130,20 @@ public class ProtobufData {
           default:
             wrapperType = PROTOBUF_INT64_WRAPPER_TYPE;
         }
-        return useWrapperForNullables && schema.isOptional() && !oneofMember
+        return useWrapperForNullables && schema.isOptional()
+            && (!oneofMember || hasWrapperMarker(schema))
             ? wrapperType : defaultType;
       case FLOAT32:
-        return useWrapperForNullables && schema.isOptional() && !oneofMember
+        return useWrapperForNullables && schema.isOptional()
+            && (!oneofMember || hasWrapperMarker(schema))
             ? PROTOBUF_FLOAT_WRAPPER_TYPE : FieldDescriptor.Type.FLOAT.toString().toLowerCase();
       case FLOAT64:
-        return useWrapperForNullables && schema.isOptional() && !oneofMember
+        return useWrapperForNullables && schema.isOptional()
+            && (!oneofMember || hasWrapperMarker(schema))
             ? PROTOBUF_DOUBLE_WRAPPER_TYPE : FieldDescriptor.Type.DOUBLE.toString().toLowerCase();
       case BOOLEAN:
-        return useWrapperForNullables && schema.isOptional() && !oneofMember
+        return useWrapperForNullables && schema.isOptional()
+            && (!oneofMember || hasWrapperMarker(schema))
             ? PROTOBUF_BOOL_WRAPPER_TYPE : FieldDescriptor.Type.BOOL.toString().toLowerCase();
       case STRING:
         if (schema.parameters() != null) {
@@ -1132,10 +1153,12 @@ public class ProtobufData {
             return schema.parameters().get(PROTOBUF_TYPE_ENUM);
           }
         }
-        return useWrapperForNullables && schema.isOptional() && !oneofMember
+        return useWrapperForNullables && schema.isOptional()
+            && (!oneofMember || hasWrapperMarker(schema))
             ? PROTOBUF_STRING_WRAPPER_TYPE : FieldDescriptor.Type.STRING.toString().toLowerCase();
       case BYTES:
-        return useWrapperForNullables && schema.isOptional() && !oneofMember
+        return useWrapperForNullables && schema.isOptional()
+            && (!oneofMember || hasWrapperMarker(schema))
             ? PROTOBUF_BYTES_WRAPPER_TYPE : FieldDescriptor.Type.BYTES.toString().toLowerCase();
       case ARRAY:
         // Array should not occur here
@@ -1492,7 +1515,7 @@ public class ProtobufData {
   }
 
   private Schema toConnectSchema(
-      ToConnectContext ctx, FieldDescriptor descriptor, boolean forceOptional) {
+      ToConnectContext ctx, FieldDescriptor descriptor, boolean oneofMember) {
     SchemaBuilder builder;
 
     switch (descriptor.getType()) {
@@ -1631,10 +1654,18 @@ public class ProtobufData {
       builder.optional();
     }
 
-    if (forceOptional) {
+    if (oneofMember) {
       // Union (oneof) members are inherently nullable, since at most one is ever set,
       // so they must be optional regardless of the nullable handling configs.
       builder.optional();
+      if (useWrapperForNullables
+          && descriptor.getType() == FieldDescriptor.Type.MESSAGE
+          && isWrapperType(descriptor.getMessageType())) {
+        // The member was a genuine wrapper type that got unwrapped to an optional scalar.
+        // Since oneof members are always optional, record this so the write side can re-wrap
+        // it (a plain scalar member, which must stay unwrapped, looks identical otherwise).
+        builder.parameter(PROTOBUF_TYPE_WRAPPER, Boolean.TRUE.toString());
+      }
     } else if (useOptionalForNullables) {
       if (descriptor.hasOptionalKeyword()) {
         builder.optional();
@@ -1644,6 +1675,10 @@ public class ProtobufData {
     }
     builder.parameter(PROTOBUF_TYPE_TAG, String.valueOf(descriptor.getNumber()));
     return builder.build();
+  }
+
+  private boolean isWrapperType(Descriptor descriptor) {
+    return toUnwrappedSchema(descriptor) != null;
   }
 
   private SchemaBuilder toUnwrappedOrStructSchema(

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufDataTest.java
@@ -96,6 +96,7 @@ import static io.confluent.connect.protobuf.ProtobufData.PROTOBUF_TYPE_ENUM;
 import static io.confluent.connect.protobuf.ProtobufData.PROTOBUF_TYPE_PROP;
 import static io.confluent.connect.protobuf.ProtobufData.PROTOBUF_TYPE_TAG;
 import static io.confluent.connect.protobuf.ProtobufData.PROTOBUF_TYPE_UNION_PREFIX;
+import static io.confluent.connect.protobuf.ProtobufData.PROTOBUF_TYPE_WRAPPER;
 import static io.confluent.kafka.serializers.protobuf.test.TimestampValueOuterClass.TimestampValue.newBuilder;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -2390,6 +2391,10 @@ public class ProtobufDataTest {
     Struct members = flatten ? value : (Struct) value.get("payload");
     assertEquals(payloadValue, members.get(payloadField));
 
+    // Write-side fidelity is only asserted for the (non-flattened) union representation. With
+    // flattenUnions the oneof grouping is lost on read (members become plain top-level fields),
+    // so the converter cannot reconstruct the oneof on write and a byte-faithful round-trip is
+    // not achievable by design; these flattened cases therefore verify the read side only.
     if (!flatten) {
       // Write the Connect data back to protobuf. The regenerated schema must keep the oneof
       // member as its original scalar type (not a google.protobuf wrapper message), and the
@@ -2401,6 +2406,133 @@ public class ProtobufDataTest {
       assertEquals(descriptor.findFieldByName(payloadField).getType(), regeneratedField.getType());
       assertArrayEquals(originalBytes, ((Message) back.getValue()).toByteArray());
     }
+  }
+
+  private static final String WRAPPER_ONEOF_SCHEMA = "syntax = \"proto3\";\n"
+      + "package io.confluent.test;\n"
+      + "import \"google/protobuf/wrappers.proto\";\n"
+      + "message WrapperOneofMessage {\n"
+      + "  google.protobuf.StringValue display_name = 2;\n"   // wrapper, NOT in oneof
+      + "  google.protobuf.BoolValue verified = 3;\n"         // wrapper, NOT in oneof
+      + "  oneof payment_method {\n"
+      + "    google.protobuf.StringValue credit_card = 7;\n"  // wrapper IN oneof
+      + "    google.protobuf.StringValue bank_account = 8;\n" // wrapper IN oneof
+      + "  }\n"
+      + "  oneof contact_info {\n"
+      + "    string email = 5;\n"                             // plain string IN oneof
+      + "    string phone = 6;\n"                             // plain string IN oneof
+      + "  }\n"
+      + "  oneof mixed_choice {\n"
+      + "    google.protobuf.Int32Value count = 9;\n"         // wrapper IN oneof
+      + "    string note = 10;\n"                             // plain string IN oneof
+      + "  }\n"
+      + "}\n";
+
+  @Test
+  public void testWrapperTypedOneofMembersRoundTrip() throws Exception {
+    ProtobufDataConfig config = new ProtobufDataConfig.Builder()
+        .with(ProtobufDataConfig.WRAPPER_FOR_NULLABLES_CONFIG, true)
+        .with(ProtobufDataConfig.GENERATE_INDEX_FOR_UNIONS_CONFIG, false)
+        .build();
+    ProtobufData protobufData = new ProtobufData(config);
+    ProtobufSchema protobufSchema = new ProtobufSchema(WRAPPER_ONEOF_SCHEMA);
+    Descriptor descriptor = protobufSchema.toDescriptor();
+
+    // Read side: wrapper types are unwrapped to optional scalars whether or not they are in a
+    // oneof. A wrapper-typed oneof member additionally carries the wrapper marker, which is how
+    // the write side tells it apart from a plain scalar member (both are optional scalars).
+    Schema connectSchema = protobufData.toConnectSchema(protobufSchema);
+    Schema displayName = connectSchema.field("display_name").schema();
+    assertEquals(Schema.Type.STRING, displayName.type());
+    assertTrue(displayName.isOptional());
+    assertNull(displayName.parameters().get(PROTOBUF_TYPE_WRAPPER));   // not a oneof member
+
+    Schema creditCard = connectSchema.field("payment_method").schema().field("credit_card").schema();
+    assertEquals(Schema.Type.STRING, creditCard.type());
+    assertEquals("true", creditCard.parameters().get(PROTOBUF_TYPE_WRAPPER));   // wrapper in oneof
+
+    Schema email = connectSchema.field("contact_info").schema().field("email").schema();
+    assertEquals(Schema.Type.STRING, email.type());
+    assertNull(email.parameters().get(PROTOBUF_TYPE_WRAPPER));   // plain scalar in oneof
+
+    // A single oneof mixing a wrapper-typed member and a plain member: the marker is per-member,
+    // so only the wrapper member carries it.
+    Schema mixed = connectSchema.field("mixed_choice").schema();
+    assertEquals(Schema.Type.INT32, mixed.field("count").schema().type());
+    assertEquals("true", mixed.field("count").schema().parameters().get(PROTOBUF_TYPE_WRAPPER));
+    assertEquals(Schema.Type.STRING, mixed.field("note").schema().type());
+    assertNull(mixed.field("note").schema().parameters().get(PROTOBUF_TYPE_WRAPPER));
+
+    // Each oneof branch must round-trip byte-for-byte: a wrapper member stays a wrapper message
+    // and a plain member stays a plain scalar.
+    assertWrapperOneofRoundTrips(protobufData, protobufSchema, descriptor, "credit_card", "email");
+    assertWrapperOneofRoundTrips(protobufData, protobufSchema, descriptor, "bank_account", "phone");
+
+    // Same, but for the two members of the single mixed oneof.
+    FieldDescriptor countField = descriptor.findFieldByName("count");
+    Descriptor int32ValueDesc = countField.getMessageType();
+    DynamicMessage countValue = DynamicMessage.newBuilder(int32ValueDesc)
+        .setField(int32ValueDesc.findFieldByName("value"), 5)
+        .build();
+    assertOneofMemberRoundTrips(protobufData, protobufSchema, descriptor,
+        "count", countValue, FieldDescriptor.Type.MESSAGE);
+    assertOneofMemberRoundTrips(protobufData, protobufSchema, descriptor,
+        "note", "hello", FieldDescriptor.Type.STRING);
+  }
+
+  private void assertOneofMemberRoundTrips(
+      ProtobufData protobufData,
+      ProtobufSchema protobufSchema,
+      Descriptor descriptor,
+      String field,
+      Object value,
+      FieldDescriptor.Type expectedType) {
+    DynamicMessage message = DynamicMessage.newBuilder(descriptor)
+        .setField(descriptor.findFieldByName(field), value)
+        .build();
+    byte[] originalBytes = message.toByteArray();
+
+    SchemaAndValue schemaAndValue = protobufData.toConnectData(protobufSchema, message);
+    ConnectSchema.validateValue(schemaAndValue.schema(), schemaAndValue.value());
+
+    ProtobufSchemaAndValue back =
+        protobufData.fromConnectData(schemaAndValue.schema(), schemaAndValue.value());
+    Descriptor regenerated = back.getSchema().toDescriptor();
+    assertEquals(expectedType, regenerated.findFieldByName(field).getType());
+    assertArrayEquals(originalBytes, ((Message) back.getValue()).toByteArray());
+  }
+
+  private void assertWrapperOneofRoundTrips(
+      ProtobufData protobufData,
+      ProtobufSchema protobufSchema,
+      Descriptor descriptor,
+      String paymentField,
+      String contactField) {
+    FieldDescriptor displayNameField = descriptor.findFieldByName("display_name");
+    Descriptor stringValueDesc = displayNameField.getMessageType();
+    DynamicMessage stringValue = DynamicMessage.newBuilder(stringValueDesc)
+        .setField(stringValueDesc.findFieldByName("value"), "shopper")
+        .build();
+    DynamicMessage paymentValue = DynamicMessage.newBuilder(stringValueDesc)
+        .setField(stringValueDesc.findFieldByName("value"), "secret")
+        .build();
+    DynamicMessage message = DynamicMessage.newBuilder(descriptor)
+        .setField(displayNameField, stringValue)                      // non-oneof wrapper
+        .setField(descriptor.findFieldByName(paymentField), paymentValue)  // wrapper in oneof
+        .setField(descriptor.findFieldByName(contactField), "a@b.com")     // plain string in oneof
+        .build();
+    byte[] originalBytes = message.toByteArray();
+
+    SchemaAndValue schemaAndValue = protobufData.toConnectData(protobufSchema, message);
+    ConnectSchema.validateValue(schemaAndValue.schema(), schemaAndValue.value());
+
+    ProtobufSchemaAndValue back =
+        protobufData.fromConnectData(schemaAndValue.schema(), schemaAndValue.value());
+    Descriptor regenerated = back.getSchema().toDescriptor();
+    // Wrapper members stay wrapper messages; plain members stay plain scalars.
+    assertEquals(FieldDescriptor.Type.MESSAGE, regenerated.findFieldByName(paymentField).getType());
+    assertEquals(FieldDescriptor.Type.STRING, regenerated.findFieldByName(contactField).getType());
+    assertArrayEquals(originalBytes, ((Message) back.getValue()).toByteArray());
   }
 
   @Test


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Fix oneof handling of wrapper types in protobuf converter.  Another follow-up to https://github.com/confluentinc/schema-registry/pull/4392
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[Y]** Must this be released together with other change(s), either in this repo or another one?
    - https://github.com/confluentinc/schema-registry/pull/4392

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
