### PR TITLE
INIT-5113 Add backup/restore converter support with BackupWrapper API

### DIFF
--- a/avro-converter/pom.xml
+++ b/avro-converter/pom.xml
@@ -60,6 +60,16 @@
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-schema-backup-api</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-schema-backup-core</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry-client</artifactId>
             <version>${io.confluent.schema-registry.version}</version>
         </dependency>

--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
@@ -16,6 +16,11 @@
 
 package io.confluent.connect.avro;
 
+import io.confluent.connect.schema.backup.api.BackupWrapper;
+import io.confluent.connect.schema.backup.api.SchemaBackupConfig;
+import io.confluent.connect.schema.backup.core.BackupConverterHelper;
+import io.confluent.connect.schema.backup.core.BackupReferenceResolver;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
@@ -41,17 +46,28 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.storage.Converter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Implementation of Converter that uses Avro schemas and objects.
  */
 public class AvroConverter implements Converter {
+
+  private static final Logger log = LoggerFactory.getLogger(AvroConverter.class);
+
+  private static final BackupReferenceResolver.ParsedSchemaFactory AVRO_SCHEMA_FACTORY =
+      (raw, refs, resolvedSchemas) -> !refs.isEmpty()
+          ? new AvroSchema(raw, refs, resolvedSchemas, null)
+          : new AvroSchema(raw);
 
   private SchemaRegistryClient schemaRegistry;
   private Serializer serializer;
@@ -59,6 +75,11 @@ public class AvroConverter implements Converter {
 
   private boolean isKey;
   private AvroData avroData;
+  private AvroData restoreAvroData;
+  private boolean backupEnvelopeMode;
+  private BackupConverterHelper backupHelper;
+  private final Map<Schema, Schema> wrapperSchemaCache =
+      new ConcurrentHashMap<>();
 
   public AvroConverter() {
   }
@@ -71,6 +92,8 @@ public class AvroConverter implements Converter {
   @Override
   public void configure(Map<String, ?> configs, boolean isKey) {
     this.isKey = isKey;
+    this.backupEnvelopeMode = BackupConverterHelper.isBackupEnabled(configs);
+    log.info("AvroConverter schema.backup.enabled={}, isKey={}", backupEnvelopeMode, isKey);
     AvroConverterConfig avroConverterConfig = new AvroConverterConfig(configs);
 
     if (schemaRegistry == null) {
@@ -86,6 +109,9 @@ public class AvroConverter implements Converter {
     serializer = new Serializer(configs, schemaRegistry);
     deserializer = new Deserializer(configs, schemaRegistry);
     avroData = new AvroData(new AvroDataConfig(configs));
+
+    backupHelper = new BackupConverterHelper(schemaRegistry, wrapperSchemaCache);
+    restoreAvroData = avroData;
   }
 
   @Override
@@ -95,6 +121,10 @@ public class AvroConverter implements Converter {
 
   @Override
   public byte[] fromConnectData(String topic, Headers headers, Schema schema, Object value) {
+    if (backupEnvelopeMode
+        && BackupWrapper.isWrapper(schema) && value instanceof Struct) {
+      return restoreFromWrapper(topic, headers, schema, (Struct) value);
+    }
     try {
       org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(schema);
       return serializer.serialize(
@@ -111,7 +141,8 @@ public class AvroConverter implements Converter {
     } catch (SerializationException e) {
       if (ExceptionUtils.isNetworkConnectionException(e.getCause())) {
         throw new NetworkException(
-            String.format("Network connection error while serializing Avro data for topic %s: %s",
+            String.format(
+                "Network connection error while serializing Avro data for topic %s: %s",
                 topic, e.getCause().getMessage()),
             e
         );
@@ -128,6 +159,52 @@ public class AvroConverter implements Converter {
     }
   }
 
+  private byte[] restoreFromWrapper(
+      String topic, Headers headers, Schema wrapperSchema, Struct wrapper) {
+    try {
+      if (wrapperSchema.field(BackupWrapper.FIELD_DATA) == null) {
+        throw new DataException("Malformed backup wrapper: missing '"
+            + BackupWrapper.FIELD_DATA + "' field");
+      }
+      String schemaType = wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE);
+      if (!SchemaBackupConfig.TYPE_AVRO.equals(schemaType)) {
+        throw new DataException(
+            "AvroConverter received wrapper with schemaType='" + schemaType
+            + "', expected '" + SchemaBackupConfig.TYPE_AVRO + "'");
+      }
+      Object actualData = wrapper.get(BackupWrapper.FIELD_DATA);
+      Schema actualConnectSchema = wrapperSchema.field(BackupWrapper.FIELD_DATA).schema();
+      String rawSchema = wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA);
+
+      BackupReferenceResolver.ResolutionResult resolved =
+          backupHelper.getReferenceResolver().resolveFromWrapper(
+              wrapperSchema, wrapper, AVRO_SCHEMA_FACTORY);
+
+      org.apache.avro.Schema avroSchema =
+          restoreAvroData.fromConnectSchema(actualConnectSchema);
+      Object avroValue = restoreAvroData.fromConnectData(
+          actualConnectSchema, avroSchema, actualData);
+
+      AvroSchema serializeSchema;
+      if (rawSchema != null) {
+        serializeSchema = resolved.hasReferences()
+            ? new AvroSchema(rawSchema, resolved.getTargetRefs(),
+                resolved.getResolvedSchemas(), null)
+            : new AvroSchema(rawSchema);
+      } else {
+        serializeSchema = new AvroSchema(avroSchema);
+      }
+
+      BackupWrapper.removeSchemaIdHeaders(headers, isKey);
+      return serializer.serialize(topic, isKey, headers, avroValue, serializeSchema);
+    } catch (DataException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new DataException(
+          String.format("Failed to restore Avro data for topic %s", topic), e);
+    }
+  }
+
   @Override
   public SchemaAndValue toConnectData(String topic, byte[] value) {
     return toConnectData(topic, null, value);
@@ -136,6 +213,9 @@ public class AvroConverter implements Converter {
   @Override
   public SchemaAndValue toConnectData(String topic, Headers headers, byte[] value) {
     try {
+      BackupConverterHelper.SchemaIdResult schemaIdResult = backupEnvelopeMode
+          ? backupHelper.resolveSchemaId(value, headers, isKey) : null;
+
       GenericContainerWithVersion containerWithVersion =
           deserializer.deserialize(topic, isKey, headers, value);
       if (containerWithVersion == null) {
@@ -143,15 +223,22 @@ public class AvroConverter implements Converter {
       }
       GenericContainer deserialized = containerWithVersion.container();
       Integer version = containerWithVersion.version();
+      SchemaAndValue result;
       if (deserialized instanceof IndexedRecord) {
-        return avroData.toConnectData(deserialized.getSchema(), deserialized, version);
+        result = avroData.toConnectData(deserialized.getSchema(), deserialized, version);
       } else if (deserialized instanceof NonRecordContainer) {
-        return avroData.toConnectData(
+        result = avroData.toConnectData(
             deserialized.getSchema(), ((NonRecordContainer) deserialized).getValue(), version);
+      } else {
+        throw new DataException(
+            String.format("Unsupported type returned during deserialization of topic %s ", topic)
+        );
       }
-      throw new DataException(
-          String.format("Unsupported type returned during deserialization of topic %s ", topic)
-      );
+
+      if (backupEnvelopeMode && schemaIdResult != null && result.schema() != null) {
+        return wrapWithBackupMetadata(result, topic, schemaIdResult);
+      }
+      return result;
     } catch (TimeoutException e) {
       throw new RetriableException(
           String.format("Failed to deserialize data for topic %s to Avro: ", topic),
@@ -160,7 +247,8 @@ public class AvroConverter implements Converter {
     } catch (SerializationException e) {
       if (ExceptionUtils.isNetworkConnectionException(e.getCause())) {
         throw new NetworkException(
-            String.format("Network connection error while deserializing data for topic %s: %s",
+            String.format(
+                "Network connection error while deserializing data for topic %s: %s",
                 topic, e.getCause().getMessage()),
             e
         );
@@ -177,6 +265,19 @@ public class AvroConverter implements Converter {
     }
   }
 
+  private SchemaAndValue wrapWithBackupMetadata(
+      SchemaAndValue original, String topic,
+      BackupConverterHelper.SchemaIdResult schemaIdResult) {
+    try {
+      return backupHelper.wrapWithBackupMetadata(
+          original, topic, schemaIdResult,
+          SchemaBackupConfig.TYPE_AVRO, isKey,
+          AVRO_SCHEMA_FACTORY, serializer::computeSubjectName);
+    } catch (Exception e) {
+      throw new DataException(
+          String.format("Failed to wrap backup metadata for topic %s", topic), e);
+    }
+  }
 
   static class Serializer extends AbstractKafkaAvroSerializer {
 
@@ -205,6 +306,10 @@ public class AvroConverter implements Converter {
           schema);
     }
 
+    public String computeSubjectName(String topic, boolean isKey, ParsedSchema schema) {
+      return getSubjectName(topic, isKey, null, schema);
+    }
+
     @Override
     protected DatumWriter<?> getDatumWriter(
         Object value, org.apache.avro.Schema schema, boolean useLogicalTypes, boolean allowNull) {
@@ -231,5 +336,6 @@ public class AvroConverter implements Converter {
         String topic, boolean isKey, Headers headers, byte[] payload) {
       return deserializeWithSchemaAndVersion(topic, isKey, headers, payload);
     }
+
   }
 }

--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
@@ -21,6 +21,7 @@ import io.confluent.connect.schema.backup.api.SchemaBackupConfig;
 import io.confluent.connect.schema.backup.core.BackupConverterHelper;
 import io.confluent.connect.schema.backup.core.BackupReferenceResolver;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.ParsedSchemaAndValue;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
@@ -213,9 +214,6 @@ public class AvroConverter implements Converter {
   @Override
   public SchemaAndValue toConnectData(String topic, Headers headers, byte[] value) {
     try {
-      BackupConverterHelper.SchemaIdResult schemaIdResult = backupEnvelopeMode
-          ? backupHelper.resolveSchemaId(value, headers, isKey) : null;
-
       GenericContainerWithVersion containerWithVersion =
           deserializer.deserialize(topic, isKey, headers, value);
       if (containerWithVersion == null) {
@@ -235,8 +233,10 @@ public class AvroConverter implements Converter {
         );
       }
 
-      if (backupEnvelopeMode && schemaIdResult != null && result.schema() != null) {
-        return wrapWithBackupMetadata(result, topic, schemaIdResult);
+      if (backupEnvelopeMode && containerWithVersion.getWriterSchemaInfo() != null
+          && result.schema() != null) {
+        return wrapWithBackupMetadata(
+            result, topic, containerWithVersion.getWriterSchemaInfo());
       }
       return result;
     } catch (TimeoutException e) {
@@ -267,10 +267,10 @@ public class AvroConverter implements Converter {
 
   private SchemaAndValue wrapWithBackupMetadata(
       SchemaAndValue original, String topic,
-      BackupConverterHelper.SchemaIdResult schemaIdResult) {
+      ParsedSchemaAndValue.SchemaInfo schemaInfo) {
     try {
       return backupHelper.wrapWithBackupMetadata(
-          original, topic, schemaIdResult,
+          original, topic, schemaInfo,
           SchemaBackupConfig.TYPE_AVRO, isKey,
           AVRO_SCHEMA_FACTORY, serializer::computeSubjectName);
     } catch (Exception e) {

--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
@@ -196,7 +196,6 @@ public class AvroConverter implements Converter {
         serializeSchema = new AvroSchema(avroSchema);
       }
 
-      BackupWrapper.removeSchemaIdHeaders(headers, isKey);
       return serializer.serialize(topic, isKey, headers, avroValue, serializeSchema);
     } catch (DataException e) {
       throw e;

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroConverterBackupTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroConverterBackupTest.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.avro;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import io.confluent.connect.schema.backup.api.BackupWrapper;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AvroConverterBackupTest {
+
+  private static final String TOPIC = "test-topic";
+  private static final String FIELD_NAME = "name";
+  private static final String FIELD_COUNT = "count";
+  private static final String SCHEMA_TYPE = "AVRO";
+
+  private final SchemaRegistryClient schemaRegistry;
+  private final AvroConverter converter;
+  private final AvroConverter plainConverter;
+
+  public AvroConverterBackupTest() {
+    schemaRegistry = new MockSchemaRegistryClient();
+    converter = new AvroConverter(schemaRegistry);
+    plainConverter = new AvroConverter(schemaRegistry);
+  }
+
+  @Before
+  public void setUp() {
+    Map<String, Object> backupConfig = new HashMap<>();
+    backupConfig.put("schema.registry.url", "http://fake-url");
+    backupConfig.put("schema.backup.enabled", "true");
+    converter.configure(backupConfig, false);
+
+    plainConverter.configure(
+        Collections.singletonMap("schema.registry.url", "http://fake-url"),
+        false);
+  }
+
+  @Test
+  public void testBackupToConnectDataWrapsMetadata() {
+    Schema schema = SchemaBuilder.struct()
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
+        .field("age", Schema.INT32_SCHEMA)
+        .build();
+    Struct value = new Struct(schema)
+        .put(FIELD_NAME, "Alice")
+        .put("age", 30);
+
+    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
+
+    assertNotNull(result);
+    assertNotNull(result.schema());
+    assertEquals(BackupWrapper.NAME, result.schema().name());
+
+    Struct wrapper = (Struct) result.value();
+    assertNotNull(wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_ID));
+    assertEquals(SCHEMA_TYPE, wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
+    assertNotNull(wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA));
+    assertNotNull(wrapper.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT));
+    assertNotNull(wrapper.get(BackupWrapper.FIELD_DATA));
+  }
+
+  @Test
+  public void testBackupFromConnectDataRestores() {
+    Schema schema = SchemaBuilder.struct()
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_NAME, "Bob");
+
+    // Serialize to get valid wire-format bytes
+    byte[] original = plainConverter.fromConnectData(TOPIC, schema, value);
+    assertNotNull(original);
+    assertTrue(original.length >= 5);
+
+    // Wrap via backup toConnectData
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, original);
+    assertEquals(BackupWrapper.NAME, wrapped.schema().name());
+
+    // Restore via backup fromConnectData
+    byte[] restored = converter.fromConnectData(
+        TOPIC, wrapped.schema(), wrapped.value());
+
+    assertNotNull(restored);
+    // Wire format: magic byte 0x00 followed by 4-byte schema ID
+    assertEquals(0x00, restored[0]);
+  }
+
+  @Test
+  public void testBackupRoundTrip() {
+    Schema schema = SchemaBuilder.struct()
+        .field("id", Schema.STRING_SCHEMA)
+        .field(FIELD_COUNT, Schema.INT32_SCHEMA)
+        .build();
+    Struct original = new Struct(schema)
+        .put("id", "order-1")
+        .put(FIELD_COUNT, 42);
+
+    // Serialize with plain converter
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, original);
+
+    // Backup path: toConnectData wraps, fromConnectData restores
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(
+        TOPIC, wrapped.schema(), wrapped.value());
+
+    // Deserialize restored bytes and compare values
+    SchemaAndValue restoredData = plainConverter.toConnectData(TOPIC, restoredBytes);
+    Struct restored = (Struct) restoredData.value();
+    assertEquals("order-1", restored.getString("id"));
+    assertEquals(Integer.valueOf(42), restored.getInt32(FIELD_COUNT));
+  }
+
+  @Test
+  public void testBackupDisabledNoWrapping() {
+    Schema schema = Schema.STRING_SCHEMA;
+    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, "hello");
+
+    // Use plainConverter (backup disabled)
+    SchemaAndValue result = plainConverter.toConnectData(TOPIC, serialized);
+
+    assertNotNull(result.schema());
+    assertNotEquals(BackupWrapper.NAME, result.schema().name());
+  }
+
+  @Test
+  public void testBackupNullValue() {
+    SchemaAndValue result = converter.toConnectData(TOPIC, null);
+    assertNull(result.schema());
+    assertNull(result.value());
+  }
+
+  @Test
+  public void testBackupPrimitiveType() {
+    byte[] serialized = plainConverter.fromConnectData(
+        TOPIC, Schema.STRING_SCHEMA, "test-value");
+
+    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
+
+    assertEquals(BackupWrapper.NAME, result.schema().name());
+    Struct wrapper = (Struct) result.value();
+    assertEquals(SCHEMA_TYPE, wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
+  }
+
+  @Test
+  public void testBackupWrapperFields() {
+    Schema schema = SchemaBuilder.struct()
+        .field("x", Schema.INT32_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put("x", 1);
+
+    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
+
+    Struct wrapper = (Struct) result.value();
+    assertEquals(SCHEMA_TYPE, wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
+    // Subject should follow TopicNameStrategy: topic-value
+    assertTrue(wrapper.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT)
+        .contains(TOPIC));
+  }
+
+  @Test
+  public void testBackupSchemaIdExtracted() {
+    byte[] serialized = plainConverter.fromConnectData(
+        TOPIC, Schema.INT32_SCHEMA, 42);
+
+    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
+    Struct wrapper = (Struct) result.value();
+
+    int wrappedId = wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_ID);
+    // Schema ID extracted from wire format should match what SR assigned
+    assertTrue(wrappedId > 0);
+  }
+
+  @Test
+  public void testBackupNonWrapperSchemaNormalSerialization() {
+    Schema schema = SchemaBuilder.struct()
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_NAME, "direct");
+
+    // Even in backup mode, non-wrapper schemas serialize normally
+    byte[] result = converter.fromConnectData(TOPIC, schema, value);
+    assertNotNull(result);
+    assertTrue(result.length > 5);
+    assertEquals(0x00, result[0]);
+  }
+
+  @Test
+  public void testBackupRestoreMissingDataField() {
+    // Build a struct with wrapper name but missing FIELD_DATA
+    Schema badSchema = SchemaBuilder.struct()
+        .name(BackupWrapper.NAME)
+        .field(BackupWrapper.FIELD_SCHEMA_ID, Schema.INT32_SCHEMA)
+        .build();
+    Struct badWrapper = new Struct(badSchema).put(BackupWrapper.FIELD_SCHEMA_ID, 1);
+
+    try {
+      converter.fromConnectData(TOPIC, badSchema, badWrapper);
+      fail("Expected DataException");
+    } catch (DataException e) {
+      assertTrue(e.getMessage().contains("data")
+          || e.getMessage().contains("restore")
+          || e.getMessage().contains("Failed"));
+    }
+  }
+
+  @Test
+  public void testBackupRoundTripBytesExact() {
+    Schema schema = SchemaBuilder.struct()
+        .field("id", Schema.STRING_SCHEMA)
+        .field(FIELD_COUNT, Schema.INT32_SCHEMA)
+        .build();
+    Struct original = new Struct(schema)
+        .put("id", "exact-match")
+        .put(FIELD_COUNT, 100);
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, original);
+
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(
+        TOPIC, wrapped.schema(), wrapped.value());
+
+    // Restored bytes should produce identical data
+    assertArrayEquals(originalBytes, restoredBytes);
+  }
+
+  @Test
+  public void testBackupSchemaVersionPresent() {
+    Schema schema = SchemaBuilder.struct()
+        .field("x", Schema.INT32_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put("x", 42);
+
+    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
+
+    Struct wrapper = (Struct) result.value();
+    // Schema version should be populated for registered schemas
+    assertNotNull(wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION));
+  }
+
+  @Test
+  public void testBackupRestoreNullRawSchemaFallback() {
+    Schema schema = SchemaBuilder.struct()
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_NAME, "fallback");
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+
+    // Rebuild wrapper with null rawSchema to exercise fallback branch
+    Struct original = (Struct) wrapped.value();
+    Schema wrapperSchema = wrapped.schema();
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_ID),
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION),
+        original.getString(BackupWrapper.FIELD_SCHEMA_TYPE),
+        original.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT),
+        null, null, null);
+    Struct modifiedWrapper = BackupWrapper.buildWrapper(
+        wrapperSchema, original.get(BackupWrapper.FIELD_DATA), fields);
+
+    byte[] restored = converter.fromConnectData(TOPIC, wrapperSchema, modifiedWrapper);
+    assertNotNull(restored);
+    assertEquals(0x00, restored[0]);
+  }
+}

--- a/jacoco-aggregate-schema-registry/pom.xml
+++ b/jacoco-aggregate-schema-registry/pom.xml
@@ -68,6 +68,16 @@
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-schema-backup-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-schema-backup-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-avro-data</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/json-schema-converter/pom.xml
+++ b/json-schema-converter/pom.xml
@@ -38,6 +38,16 @@
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-schema-backup-api</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-schema-backup-core</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-converter</artifactId>
             <version>${io.confluent.schema-registry.version}</version>
         </dependency>

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverter.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverter.java
@@ -17,8 +17,22 @@ package io.confluent.connect.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
+import io.confluent.connect.schema.backup.api.BackupWrapper;
+import io.confluent.connect.schema.backup.api.SchemaBackupConfig;
+import io.confluent.connect.schema.backup.core.BackupConverterHelper;
+import io.confluent.connect.schema.backup.core.BackupReferenceResolver;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientFactory;
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
 import io.confluent.kafka.schemaregistry.utils.ExceptionUtils;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDe;
+import io.confluent.kafka.serializers.json.AbstractKafkaJsonSchemaDeserializer;
+import io.confluent.kafka.serializers.json.AbstractKafkaJsonSchemaSerializer;
+import io.confluent.kafka.serializers.json.JsonSchemaAndValue;
+import io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializerConfig;
+import io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializerConfig;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.errors.NetworkException;
@@ -27,27 +41,28 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.storage.Converter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.Map;
-
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.json.JsonSchema;
-import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
-import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDe;
-import io.confluent.kafka.serializers.json.AbstractKafkaJsonSchemaDeserializer;
-import io.confluent.kafka.serializers.json.AbstractKafkaJsonSchemaSerializer;
-import io.confluent.kafka.serializers.json.JsonSchemaAndValue;
-import io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializerConfig;
-import io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializerConfig;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Implementation of Converter that supports JSON with JSON Schema.
  */
 public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Converter {
+
+  private static final Logger log = LoggerFactory.getLogger(JsonSchemaConverter.class);
+
+  private static final BackupReferenceResolver.ParsedSchemaFactory JSON_SCHEMA_FACTORY =
+      (raw, refs, resolvedSchemas) -> !refs.isEmpty()
+          ? new JsonSchema(raw, refs, resolvedSchemas, null)
+          : new JsonSchema(raw);
 
   private SchemaRegistryClient schemaRegistry;
   private Serializer serializer;
@@ -55,6 +70,10 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
 
   private boolean isKey;
   private JsonSchemaData jsonSchemaData;
+  private boolean backupEnvelopeMode;
+  private BackupConverterHelper backupHelper;
+  private final Map<Schema, Schema> wrapperSchemaCache =
+      new ConcurrentHashMap<>();
 
   public JsonSchemaConverter() {
   }
@@ -67,6 +86,8 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
   @Override
   public void configure(Map<String, ?> configs, boolean isKey) {
     this.isKey = isKey;
+    this.backupEnvelopeMode = BackupConverterHelper.isBackupEnabled(configs);
+    log.info("JsonSchemaConverter schema.backup.enabled={}, isKey={}", backupEnvelopeMode, isKey);
     JsonSchemaConverterConfig jsonSchemaConverterConfig = new JsonSchemaConverterConfig(configs);
 
     if (schemaRegistry == null) {
@@ -82,6 +103,8 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
     serializer = new Serializer(configs, schemaRegistry);
     deserializer = new Deserializer(configs, schemaRegistry);
     jsonSchemaData = new JsonSchemaData(new JsonSchemaDataConfig(configs));
+
+    backupHelper = new BackupConverterHelper(schemaRegistry, wrapperSchemaCache);
   }
 
   @Override
@@ -91,6 +114,10 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
 
   @Override
   public byte[] fromConnectData(String topic, Headers headers, Schema schema, Object value) {
+    if (backupEnvelopeMode
+        && BackupWrapper.isWrapper(schema) && value instanceof Struct) {
+      return restoreFromWrapper(topic, headers, schema, (Struct) value);
+    }
     if (schema == null && value == null) {
       return null;
     }
@@ -99,15 +126,17 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
     try {
       return serializer.serialize(topic, headers, isKey, jsonValue, jsonSchema);
     } catch (TimeoutException e) {
-      throw new RetriableException(String.format("Converting Kafka Connect data to byte[] failed "
-          + "due to serialization error of topic %s: ",
+      throw new RetriableException(String.format(
+          "Converting Kafka Connect data to byte[] failed "
+              + "due to serialization error of topic %s: ",
           topic),
           e
       );
     } catch (SerializationException e) {
       if (ExceptionUtils.isNetworkConnectionException(e.getCause())) {
         throw new NetworkException(
-            String.format("Network connection error while serializing Json data for topic %s: %s",
+            String.format(
+                "Network connection error while serializing Json data for topic %s: %s",
                 topic, e.getCause().getMessage()),
             e
         );
@@ -127,6 +156,47 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
     }
   }
 
+  private byte[] restoreFromWrapper(
+      String topic, Headers headers, Schema wrapperSchema, Struct wrapper) {
+    try {
+      if (wrapperSchema.field(BackupWrapper.FIELD_DATA) == null) {
+        throw new DataException("Malformed backup wrapper: missing '"
+            + BackupWrapper.FIELD_DATA + "' field");
+      }
+      String schemaType = wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE);
+      if (!SchemaBackupConfig.TYPE_JSON_SCHEMA.equals(schemaType)) {
+        throw new DataException(
+            "JsonSchemaConverter received wrapper with schemaType='" + schemaType
+            + "', expected '" + SchemaBackupConfig.TYPE_JSON_SCHEMA + "'");
+      }
+      Object actualData = wrapper.get(BackupWrapper.FIELD_DATA);
+      Schema actualConnectSchema = wrapperSchema.field(BackupWrapper.FIELD_DATA).schema();
+      String rawSchema = wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA);
+
+      BackupReferenceResolver.ResolutionResult resolved =
+          backupHelper.getReferenceResolver().resolveFromWrapper(
+              wrapperSchema, wrapper, JSON_SCHEMA_FACTORY);
+
+      JsonSchema jsonSchema;
+      if (rawSchema != null) {
+        jsonSchema = resolved.hasReferences()
+            ? new JsonSchema(rawSchema, resolved.getTargetRefs(),
+                resolved.getResolvedSchemas(), null)
+            : new JsonSchema(rawSchema);
+      } else {
+        jsonSchema = jsonSchemaData.fromConnectSchema(actualConnectSchema);
+      }
+      JsonNode jsonValue = jsonSchemaData.fromConnectData(actualConnectSchema, actualData);
+      BackupWrapper.removeSchemaIdHeaders(headers, isKey);
+      return serializer.serialize(topic, headers, isKey, jsonValue, jsonSchema);
+    } catch (DataException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new DataException(
+          String.format("Failed to restore JSON Schema data for topic %s", topic), e);
+    }
+  }
+
   @Override
   public SchemaAndValue toConnectData(String topic, byte[] value) {
     return toConnectData(topic, null, value);
@@ -135,7 +205,11 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
   @Override
   public SchemaAndValue toConnectData(String topic, Headers headers, byte[] value) {
     try {
-      JsonSchemaAndValue deserialized = deserializer.deserialize(topic, isKey, headers, value);
+      BackupConverterHelper.SchemaIdResult schemaIdResult = backupEnvelopeMode
+          ? backupHelper.resolveSchemaId(value, headers, isKey) : null;
+
+      JsonSchemaAndValue deserialized =
+          deserializer.deserialize(topic, isKey, headers, value);
 
       if (deserialized == null || deserialized.getValue() == null) {
         return SchemaAndValue.NULL;
@@ -143,11 +217,17 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
 
       JsonSchema jsonSchema = deserialized.getSchema();
       Schema schema = jsonSchemaData.toConnectSchema(jsonSchema);
-      return new SchemaAndValue(schema, jsonSchemaData.toConnectData(schema,
+      SchemaAndValue result = new SchemaAndValue(schema, jsonSchemaData.toConnectData(schema,
           (JsonNode) deserialized.getValue()));
+
+      if (backupEnvelopeMode && schemaIdResult != null && result.schema() != null) {
+        return wrapWithBackupMetadata(result, topic, schemaIdResult);
+      }
+      return result;
     } catch (TimeoutException e) {
-      throw new RetriableException(String.format("Converting byte[] to Kafka Connect data failed "
-          + "due to serialization error of topic %s: ",
+      throw new RetriableException(String.format(
+          "Converting byte[] to Kafka Connect data failed "
+              + "due to serialization error of topic %s: ",
           topic),
           e
       );
@@ -174,6 +254,20 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
     }
   }
 
+  private SchemaAndValue wrapWithBackupMetadata(
+      SchemaAndValue original, String topic,
+      BackupConverterHelper.SchemaIdResult schemaIdResult) {
+    try {
+      return backupHelper.wrapWithBackupMetadata(
+          original, topic, schemaIdResult,
+          SchemaBackupConfig.TYPE_JSON_SCHEMA, isKey,
+          JSON_SCHEMA_FACTORY, serializer::computeSubjectName);
+    } catch (Exception e) {
+      throw new DataException(
+          String.format("Failed to wrap backup metadata for topic %s", topic), e);
+    }
+  }
+
   static class Serializer extends AbstractKafkaJsonSchemaSerializer {
 
     public Serializer(SchemaRegistryClient client, boolean autoRegisterSchema) {
@@ -194,6 +288,10 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
       }
       return serializeImpl(
           getSubjectName(topic, isKey, value, schema), topic, isKey, headers, value, schema);
+    }
+
+    public String computeSubjectName(String topic, boolean isKey, ParsedSchema schema) {
+      return getSubjectName(topic, isKey, null, schema);
     }
   }
 

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverter.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverter.java
@@ -188,7 +188,6 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
         jsonSchema = jsonSchemaData.fromConnectSchema(actualConnectSchema);
       }
       JsonNode jsonValue = jsonSchemaData.fromConnectData(actualConnectSchema, actualData);
-      BackupWrapper.removeSchemaIdHeaders(headers, isKey);
       return serializer.serialize(topic, headers, isKey, jsonValue, jsonSchema);
     } catch (DataException e) {
       throw e;

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverter.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverter.java
@@ -22,6 +22,7 @@ import io.confluent.connect.schema.backup.api.SchemaBackupConfig;
 import io.confluent.connect.schema.backup.core.BackupConverterHelper;
 import io.confluent.connect.schema.backup.core.BackupReferenceResolver;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.ParsedSchemaAndValue;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientFactory;
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
@@ -205,9 +206,6 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
   @Override
   public SchemaAndValue toConnectData(String topic, Headers headers, byte[] value) {
     try {
-      BackupConverterHelper.SchemaIdResult schemaIdResult = backupEnvelopeMode
-          ? backupHelper.resolveSchemaId(value, headers, isKey) : null;
-
       JsonSchemaAndValue deserialized =
           deserializer.deserialize(topic, isKey, headers, value);
 
@@ -220,8 +218,10 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
       SchemaAndValue result = new SchemaAndValue(schema, jsonSchemaData.toConnectData(schema,
           (JsonNode) deserialized.getValue()));
 
-      if (backupEnvelopeMode && schemaIdResult != null && result.schema() != null) {
-        return wrapWithBackupMetadata(result, topic, schemaIdResult);
+      if (backupEnvelopeMode && deserialized.getWriterSchemaInfo() != null
+          && result.schema() != null) {
+        return wrapWithBackupMetadata(
+            result, topic, deserialized.getWriterSchemaInfo());
       }
       return result;
     } catch (TimeoutException e) {
@@ -256,10 +256,10 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
 
   private SchemaAndValue wrapWithBackupMetadata(
       SchemaAndValue original, String topic,
-      BackupConverterHelper.SchemaIdResult schemaIdResult) {
+      ParsedSchemaAndValue.SchemaInfo schemaInfo) {
     try {
       return backupHelper.wrapWithBackupMetadata(
-          original, topic, schemaIdResult,
+          original, topic, schemaInfo,
           SchemaBackupConfig.TYPE_JSON_SCHEMA, isKey,
           JSON_SCHEMA_FACTORY, serializer::computeSubjectName);
     } catch (Exception e) {

--- a/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaConverterBackupTest.java
+++ b/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaConverterBackupTest.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.json;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.connect.schema.backup.api.BackupWrapper;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.junit.Before;
+import org.junit.Test;
+
+public class JsonSchemaConverterBackupTest {
+
+  private static final String TOPIC = "test-topic";
+  private static final String SCHEMA_TYPE = "JSON_SCHEMA";
+  private static final String FIELD_COUNT = "count";
+
+  private final SchemaRegistryClient schemaRegistry;
+  private final JsonSchemaConverter converter;
+  private final JsonSchemaConverter plainConverter;
+
+  public JsonSchemaConverterBackupTest() {
+    schemaRegistry = new MockSchemaRegistryClient(
+        ImmutableList.of(new JsonSchemaProvider()));
+    converter = new JsonSchemaConverter(schemaRegistry);
+    plainConverter = new JsonSchemaConverter(schemaRegistry);
+  }
+
+  @Before
+  public void setUp() {
+    Map<String, Object> backupConfig = new HashMap<>();
+    backupConfig.put("schema.registry.url", "http://fake-url");
+    backupConfig.put("schema.backup.enabled", "true");
+    converter.configure(backupConfig, false);
+
+    Map<String, String> plainConfig = new HashMap<>();
+    plainConfig.put("schema.registry.url", "http://fake-url");
+    plainConverter.configure(plainConfig, false);
+  }
+
+  @Test
+  public void testBackupToConnectDataWrapsMetadata() {
+    Schema schema = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA)
+        .field("age", Schema.INT32_SCHEMA)
+        .build();
+    Struct value = new Struct(schema)
+        .put("name", "Alice")
+        .put("age", 30);
+
+    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
+
+    assertNotNull(result);
+    assertNotNull(result.schema());
+    assertEquals(BackupWrapper.NAME, result.schema().name());
+
+    Struct wrapper = (Struct) result.value();
+    assertNotNull(wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_ID));
+    assertEquals(SCHEMA_TYPE,
+        wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
+    assertNotNull(wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA));
+    assertNotNull(wrapper.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT));
+    assertNotNull(wrapper.get(BackupWrapper.FIELD_DATA));
+  }
+
+  @Test
+  public void testBackupFromConnectDataRestores() {
+    Schema schema = SchemaBuilder.struct()
+        .field("text", Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put("text", "hello");
+
+    byte[] original = plainConverter.fromConnectData(TOPIC, schema, value);
+    assertNotNull(original);
+
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, original);
+    assertEquals(BackupWrapper.NAME, wrapped.schema().name());
+
+    byte[] restored = converter.fromConnectData(
+        TOPIC, wrapped.schema(), wrapped.value());
+
+    assertNotNull(restored);
+    assertEquals(0x00, restored[0]);
+  }
+
+  @Test
+  public void testBackupRoundTrip() {
+    Schema schema = SchemaBuilder.struct()
+        .field("id", Schema.STRING_SCHEMA)
+        .field(FIELD_COUNT, Schema.INT32_SCHEMA)
+        .build();
+    Struct original = new Struct(schema)
+        .put("id", "item-1")
+        .put(FIELD_COUNT, 5);
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, original);
+
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(
+        TOPIC, wrapped.schema(), wrapped.value());
+
+    SchemaAndValue restoredData = plainConverter.toConnectData(
+        TOPIC, restoredBytes);
+    Struct restored = (Struct) restoredData.value();
+    assertEquals("item-1", restored.getString("id"));
+    assertEquals(Integer.valueOf(5), restored.getInt32(FIELD_COUNT));
+  }
+
+  @Test
+  public void testBackupDisabledNoWrapping() {
+    Schema schema = SchemaBuilder.struct()
+        .field("x", Schema.INT32_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put("x", 1);
+
+    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue result = plainConverter.toConnectData(TOPIC, serialized);
+
+    assertNotNull(result.schema());
+    assertNotEquals(BackupWrapper.NAME, result.schema().name());
+  }
+
+  @Test
+  public void testBackupNullValue() {
+    SchemaAndValue result = converter.toConnectData(TOPIC, null);
+    assertNull(result.schema());
+    assertNull(result.value());
+  }
+
+  @Test
+  public void testBackupPrimitiveType() {
+    Schema schema = SchemaBuilder.struct()
+        .field("val", Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put("val", "test");
+
+    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
+
+    assertEquals(BackupWrapper.NAME, result.schema().name());
+    Struct wrapper = (Struct) result.value();
+    assertEquals(SCHEMA_TYPE,
+        wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
+  }
+
+  @Test
+  public void testBackupWrapperFields() {
+    Schema schema = SchemaBuilder.struct()
+        .field("data", Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put("data", "check");
+
+    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
+
+    Struct wrapper = (Struct) result.value();
+    assertEquals(SCHEMA_TYPE,
+        wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
+    assertTrue(wrapper.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT)
+        .contains(TOPIC));
+  }
+
+  @Test
+  public void testBackupSchemaIdExtracted() {
+    Schema schema = SchemaBuilder.struct()
+        .field("n", Schema.INT32_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put("n", 7);
+
+    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
+
+    Struct wrapper = (Struct) result.value();
+    int wrappedId = wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_ID);
+    assertTrue(wrappedId > 0);
+  }
+
+  @Test
+  public void testBackupNonWrapperSchemaNormalSerialization() {
+    Schema schema = SchemaBuilder.struct()
+        .field("text", Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put("text", "direct");
+
+    byte[] result = converter.fromConnectData(TOPIC, schema, value);
+    assertNotNull(result);
+    assertTrue(result.length > 5);
+    assertEquals(0x00, result[0]);
+  }
+
+  @Test
+  public void testBackupRestoreMissingDataField() {
+    Schema badSchema = SchemaBuilder.struct()
+        .name(BackupWrapper.NAME)
+        .field(BackupWrapper.FIELD_SCHEMA_ID, Schema.INT32_SCHEMA)
+        .build();
+    Struct badWrapper = new Struct(badSchema)
+        .put(BackupWrapper.FIELD_SCHEMA_ID, 1);
+
+    try {
+      converter.fromConnectData(TOPIC, badSchema, badWrapper);
+      fail("Expected DataException");
+    } catch (DataException e) {
+      assertTrue(e.getMessage().contains("data")
+          || e.getMessage().contains("restore")
+          || e.getMessage().contains("Failed"));
+    }
+  }
+
+  @Test
+  public void testBackupRoundTripBytesExact() {
+    Schema schema = SchemaBuilder.struct()
+        .field("id", Schema.STRING_SCHEMA)
+        .field(FIELD_COUNT, Schema.INT32_SCHEMA)
+        .build();
+    Struct original = new Struct(schema)
+        .put("id", "exact")
+        .put(FIELD_COUNT, 77);
+
+    byte[] originalBytes = plainConverter.fromConnectData(
+        TOPIC, schema, original);
+
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(
+        TOPIC, wrapped.schema(), wrapped.value());
+
+    assertArrayEquals(originalBytes, restoredBytes);
+  }
+
+  @Test
+  public void testBackupSchemaVersionPresent() {
+    Schema schema = SchemaBuilder.struct()
+        .field("x", Schema.INT32_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put("x", 42);
+
+    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
+
+    Struct wrapper = (Struct) result.value();
+    assertNotNull(wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION));
+  }
+
+  @Test
+  public void testBackupRestoreNullRawSchemaFallback() {
+    Schema schema = SchemaBuilder.struct()
+        .field("fallback", Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put("fallback", "test");
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+
+    Struct original = (Struct) wrapped.value();
+    Schema wrapperSchema = wrapped.schema();
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_ID),
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION),
+        original.getString(BackupWrapper.FIELD_SCHEMA_TYPE),
+        original.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT),
+        null, null, null);
+    Struct modifiedWrapper = BackupWrapper.buildWrapper(
+        wrapperSchema, original.get(BackupWrapper.FIELD_DATA), fields);
+
+    byte[] restored = converter.fromConnectData(TOPIC, wrapperSchema, modifiedWrapper);
+    assertNotNull(restored);
+    assertEquals(0x00, restored[0]);
+  }
+}

--- a/kafka-connect-schema-backup-api/pom.xml
+++ b/kafka-connect-schema-backup-api/pom.xml
@@ -1,0 +1,60 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.confluent</groupId>
+        <artifactId>kafka-schema-registry-parent</artifactId>
+        <version>8.4.0-0</version>
+    </parent>
+
+    <licenses>
+        <license>
+            <name>Apache License 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <artifactId>kafka-connect-schema-backup-api</artifactId>
+    <packaging>jar</packaging>
+    <name>kafka-connect-schema-backup-api</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.confluent.networking</groupId>
+                    <artifactId>cc-custom-dns-resolver-java18</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.maven.plugin.version}</version>
+                <configuration>
+                    <java>
+                        <licenseHeader>
+                            <file>${maven.multiModuleProjectDirectory}/config/license-headers/apache-header.txt</file>
+                        </licenseHeader>
+                    </java>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/kafka-connect-schema-backup-api/pom.xml
+++ b/kafka-connect-schema-backup-api/pom.xml
@@ -35,6 +35,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-serializer</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
@@ -43,6 +48,13 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>8</release>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>

--- a/kafka-connect-schema-backup-api/pom.xml
+++ b/kafka-connect-schema-backup-api/pom.xml
@@ -35,11 +35,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-schema-serializer</artifactId>
-            <version>${io.confluent.schema-registry.version}</version>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/kafka-connect-schema-backup-api/src/main/java/io/confluent/connect/schema/backup/api/BackupWrapper.java
+++ b/kafka-connect-schema-backup-api/src/main/java/io/confluent/connect/schema/backup/api/BackupWrapper.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.schema.backup.api;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+/**
+ * Backup Wrapper struct for carrying schema metadata between converters and the envelope layer.
+ */
+public final class BackupWrapper {
+
+  public static final String NAME = "io.confluent.connect.backup.Wrapper";
+
+  public static final String FIELD_DATA = "data";
+  public static final String FIELD_SCHEMA_ID = "schemaId";
+  public static final String FIELD_SCHEMA_VERSION = "schemaVersion";
+  public static final String FIELD_SCHEMA_TYPE = "schemaType";
+  public static final String FIELD_SCHEMA_SUBJECT = "schemaSubject";
+  public static final String FIELD_RAW_SCHEMA = "rawSchema";
+  public static final String FIELD_REFERENCE_TREE = "referenceTree";
+  public static final String FIELD_DIRECT_REFS = "directRefs";
+  public static final String FIELD_SCHEMA_GUID = "schemaGuid";
+
+  private static final byte MAGIC_BYTE = 0x0;
+  private static final byte MAGIC_BYTE_GUID = 0x1;
+  private static final String KEY_SCHEMA_ID_HEADER = "__key_schema_id";
+  private static final String VALUE_SCHEMA_ID_HEADER = "__value_schema_id";
+
+  private BackupWrapper() {
+  }
+
+  /**
+   * Groups metadata fields for {@link #buildWrapper} to reduce parameter count.
+   */
+  public static class WrapperFields {
+    private final Integer schemaId;
+    private final Integer schemaVersion;
+    private final String schemaType;
+    private final String subject;
+    private final String rawSchema;
+    private final String referenceTreeJson;
+    private final String directRefsJson;
+    private final String schemaGuid;
+
+    public WrapperFields(Integer schemaId, Integer schemaVersion,
+        String schemaType, String subject, String rawSchema,
+        String referenceTreeJson, String directRefsJson) {
+      this(schemaId, schemaVersion, schemaType, subject, rawSchema,
+          referenceTreeJson, directRefsJson, null);
+    }
+
+    public WrapperFields(Integer schemaId, Integer schemaVersion,
+        String schemaType, String subject, String rawSchema,
+        String referenceTreeJson, String directRefsJson,
+        String schemaGuid) {
+      this.schemaId = schemaId;
+      this.schemaVersion = schemaVersion;
+      this.schemaType = schemaType;
+      this.subject = subject;
+      this.rawSchema = rawSchema;
+      this.referenceTreeJson = referenceTreeJson;
+      this.directRefsJson = directRefsJson;
+      this.schemaGuid = schemaGuid;
+    }
+
+    public Integer getSchemaId() {
+      return schemaId;
+    }
+
+    public Integer getSchemaVersion() {
+      return schemaVersion;
+    }
+
+    public String getSchemaType() {
+      return schemaType;
+    }
+
+    public String getSubject() {
+      return subject;
+    }
+
+    public String getRawSchema() {
+      return rawSchema;
+    }
+
+    public String getReferenceTreeJson() {
+      return referenceTreeJson;
+    }
+
+    public String getDirectRefsJson() {
+      return directRefsJson;
+    }
+
+    public String getSchemaGuid() {
+      return schemaGuid;
+    }
+  }
+
+  public static Schema buildSchema(Schema dataSchema) {
+    Schema safeDataSchema = dataSchema != null
+        ? dataSchema : Schema.OPTIONAL_BYTES_SCHEMA;
+    return SchemaBuilder.struct()
+        .name(NAME)
+        .field(FIELD_DATA, safeDataSchema)
+        .field(FIELD_SCHEMA_ID, Schema.OPTIONAL_INT32_SCHEMA)
+        .field(FIELD_SCHEMA_VERSION, Schema.OPTIONAL_INT32_SCHEMA)
+        .field(FIELD_SCHEMA_GUID, Schema.OPTIONAL_STRING_SCHEMA)
+        .field(FIELD_SCHEMA_TYPE, Schema.STRING_SCHEMA)
+        .field(FIELD_SCHEMA_SUBJECT, Schema.STRING_SCHEMA)
+        .field(FIELD_RAW_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA)
+        .field(FIELD_REFERENCE_TREE, Schema.OPTIONAL_STRING_SCHEMA)
+        .field(FIELD_DIRECT_REFS, Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+  }
+
+  public static Struct buildWrapper(
+      Schema wrapperSchema, Object data, WrapperFields fields) {
+    Struct wrapper = new Struct(wrapperSchema);
+    wrapper.put(FIELD_DATA, data);
+    wrapper.put(FIELD_SCHEMA_ID, fields.getSchemaId());
+    wrapper.put(FIELD_SCHEMA_VERSION, fields.getSchemaVersion());
+    wrapper.put(FIELD_SCHEMA_TYPE, fields.getSchemaType());
+    wrapper.put(FIELD_SCHEMA_SUBJECT, fields.getSubject());
+    wrapper.put(FIELD_RAW_SCHEMA, fields.getRawSchema());
+    wrapper.put(FIELD_REFERENCE_TREE, fields.getReferenceTreeJson());
+    wrapper.put(FIELD_DIRECT_REFS, fields.getDirectRefsJson());
+    wrapper.put(FIELD_SCHEMA_GUID, fields.getSchemaGuid());
+    return wrapper;
+  }
+
+  public static boolean isWrapper(Schema schema) {
+    return schema != null && NAME.equals(schema.name());
+  }
+
+  public static Integer extractSchemaId(byte[] value) {
+    if (value == null || value.length < 5 || value[0] != MAGIC_BYTE) {
+      return null;
+    }
+    return ByteBuffer.wrap(value, 1, 4).getInt();
+  }
+
+  public static Integer extractSchemaIdFromHeader(Headers headers, boolean isKey) {
+    if (headers == null) {
+      return null;
+    }
+    String headerKey = isKey ? KEY_SCHEMA_ID_HEADER : VALUE_SCHEMA_ID_HEADER;
+    Header header = headers.lastHeader(headerKey);
+    if (header == null || header.value() == null || header.value().length < 5) {
+      return null;
+    }
+    byte[] hval = header.value();
+    if (hval[0] == MAGIC_BYTE) {
+      return ByteBuffer.wrap(hval, 1, 4).getInt();
+    }
+    return null;
+  }
+
+  public static String extractSchemaGuidFromHeader(Headers headers, boolean isKey) {
+    if (headers == null) {
+      return null;
+    }
+    String headerKey = isKey ? KEY_SCHEMA_ID_HEADER : VALUE_SCHEMA_ID_HEADER;
+    Header header = headers.lastHeader(headerKey);
+    if (header == null || header.value() == null || header.value().length < 17) {
+      return null;
+    }
+    byte[] hval = header.value();
+    if (hval[0] != MAGIC_BYTE_GUID) {
+      return null;
+    }
+    ByteBuffer buf = ByteBuffer.wrap(hval, 1, 16);
+    UUID guid = new UUID(buf.getLong(), buf.getLong());
+    return guid.toString();
+  }
+
+  public static byte[] extractSchemaIdHeaderBytes(Headers headers, boolean isKey) {
+    if (headers == null) {
+      return null;
+    }
+    String headerKey = isKey ? KEY_SCHEMA_ID_HEADER : VALUE_SCHEMA_ID_HEADER;
+    Header header = headers.lastHeader(headerKey);
+    if (header == null || header.value() == null) {
+      return null;
+    }
+    return header.value();
+  }
+
+  public static void removeSchemaIdHeaders(Headers headers, boolean isKey) {
+    if (headers != null) {
+      headers.remove(isKey ? KEY_SCHEMA_ID_HEADER : VALUE_SCHEMA_ID_HEADER);
+    }
+  }
+}

--- a/kafka-connect-schema-backup-api/src/main/java/io/confluent/connect/schema/backup/api/BackupWrapper.java
+++ b/kafka-connect-schema-backup-api/src/main/java/io/confluent/connect/schema/backup/api/BackupWrapper.java
@@ -16,8 +16,6 @@
 
 package io.confluent.connect.schema.backup.api;
 
-import io.confluent.kafka.serializers.schema.id.SchemaId;
-import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -145,10 +143,4 @@ public final class BackupWrapper {
     return schema != null && NAME.equals(schema.name());
   }
 
-  public static void removeSchemaIdHeaders(Headers headers, boolean isKey) {
-    if (headers != null) {
-      headers.remove(isKey
-          ? SchemaId.KEY_SCHEMA_ID_HEADER : SchemaId.VALUE_SCHEMA_ID_HEADER);
-    }
-  }
 }

--- a/kafka-connect-schema-backup-api/src/main/java/io/confluent/connect/schema/backup/api/BackupWrapper.java
+++ b/kafka-connect-schema-backup-api/src/main/java/io/confluent/connect/schema/backup/api/BackupWrapper.java
@@ -16,10 +16,7 @@
 
 package io.confluent.connect.schema.backup.api;
 
-import java.nio.ByteBuffer;
-import java.util.UUID;
-
-import org.apache.kafka.common.header.Header;
+import io.confluent.kafka.serializers.schema.id.SchemaId;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -41,11 +38,6 @@ public final class BackupWrapper {
   public static final String FIELD_REFERENCE_TREE = "referenceTree";
   public static final String FIELD_DIRECT_REFS = "directRefs";
   public static final String FIELD_SCHEMA_GUID = "schemaGuid";
-
-  private static final byte MAGIC_BYTE = 0x0;
-  private static final byte MAGIC_BYTE_GUID = 0x1;
-  private static final String KEY_SCHEMA_ID_HEADER = "__key_schema_id";
-  private static final String VALUE_SCHEMA_ID_HEADER = "__value_schema_id";
 
   private BackupWrapper() {
   }
@@ -153,62 +145,10 @@ public final class BackupWrapper {
     return schema != null && NAME.equals(schema.name());
   }
 
-  public static Integer extractSchemaId(byte[] value) {
-    if (value == null || value.length < 5 || value[0] != MAGIC_BYTE) {
-      return null;
-    }
-    return ByteBuffer.wrap(value, 1, 4).getInt();
-  }
-
-  public static Integer extractSchemaIdFromHeader(Headers headers, boolean isKey) {
-    if (headers == null) {
-      return null;
-    }
-    String headerKey = isKey ? KEY_SCHEMA_ID_HEADER : VALUE_SCHEMA_ID_HEADER;
-    Header header = headers.lastHeader(headerKey);
-    if (header == null || header.value() == null || header.value().length < 5) {
-      return null;
-    }
-    byte[] hval = header.value();
-    if (hval[0] == MAGIC_BYTE) {
-      return ByteBuffer.wrap(hval, 1, 4).getInt();
-    }
-    return null;
-  }
-
-  public static String extractSchemaGuidFromHeader(Headers headers, boolean isKey) {
-    if (headers == null) {
-      return null;
-    }
-    String headerKey = isKey ? KEY_SCHEMA_ID_HEADER : VALUE_SCHEMA_ID_HEADER;
-    Header header = headers.lastHeader(headerKey);
-    if (header == null || header.value() == null || header.value().length < 17) {
-      return null;
-    }
-    byte[] hval = header.value();
-    if (hval[0] != MAGIC_BYTE_GUID) {
-      return null;
-    }
-    ByteBuffer buf = ByteBuffer.wrap(hval, 1, 16);
-    UUID guid = new UUID(buf.getLong(), buf.getLong());
-    return guid.toString();
-  }
-
-  public static byte[] extractSchemaIdHeaderBytes(Headers headers, boolean isKey) {
-    if (headers == null) {
-      return null;
-    }
-    String headerKey = isKey ? KEY_SCHEMA_ID_HEADER : VALUE_SCHEMA_ID_HEADER;
-    Header header = headers.lastHeader(headerKey);
-    if (header == null || header.value() == null) {
-      return null;
-    }
-    return header.value();
-  }
-
   public static void removeSchemaIdHeaders(Headers headers, boolean isKey) {
     if (headers != null) {
-      headers.remove(isKey ? KEY_SCHEMA_ID_HEADER : VALUE_SCHEMA_ID_HEADER);
+      headers.remove(isKey
+          ? SchemaId.KEY_SCHEMA_ID_HEADER : SchemaId.VALUE_SCHEMA_ID_HEADER);
     }
   }
 }

--- a/kafka-connect-schema-backup-api/src/main/java/io/confluent/connect/schema/backup/api/SchemaBackupConfig.java
+++ b/kafka-connect-schema-backup-api/src/main/java/io/confluent/connect/schema/backup/api/SchemaBackupConfig.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.schema.backup.api;
+
+/**
+ * Constants and schema type definitions for backup/restore in object storage connectors.
+ */
+public final class SchemaBackupConfig {
+
+  public static final String TYPE_AVRO = "AVRO";
+  public static final String TYPE_PROTOBUF = "PROTOBUF";
+  public static final String TYPE_JSON_SCHEMA = "JSON_SCHEMA";
+  public static final String TYPE_JSON = "JSON";
+  public static final String TYPE_JSON_SCHEMALESS = "JSON_SCHEMALESS";
+  public static final String TYPE_JSON_EMBEDDED_SCHEMA = "JSON_EMBEDDED_SCHEMA";
+  public static final String TYPE_STRING = "STRING";
+  public static final String TYPE_INT16 = "INT16";
+  public static final String TYPE_INT32 = "INT32";
+  public static final String TYPE_INT64 = "INT64";
+  public static final String TYPE_FLOAT32 = "FLOAT32";
+  public static final String TYPE_FLOAT64 = "FLOAT64";
+  public static final String TYPE_BYTES = "BYTES";
+  public static final String TYPE_NONE = "NONE";
+  public static final String TYPE_UNKNOWN = "UNKNOWN";
+
+  public static final String SCHEMA_BACKUP_ENABLED_CONFIG = "schema.backup.enabled";
+
+  public static final String REF_FIELD_SUBJECT = "subject";
+  public static final String REF_FIELD_VERSION = "version";
+  public static final String REF_FIELD_GLOBAL_ID = "globalId";
+  public static final String REF_FIELD_SCHEMA_TYPE = "schemaType";
+  public static final String REF_FIELD_SCHEMA = "schema";
+  public static final String REF_FIELD_REFERENCES = "references";
+  public static final String REF_FIELD_NAME = "name";
+
+  public static final int MAX_REFERENCE_DEPTH = 50;
+
+  private SchemaBackupConfig() {
+  }
+
+  public static boolean isSrBackedType(String schemaType) {
+    return TYPE_AVRO.equals(schemaType)
+        || TYPE_PROTOBUF.equals(schemaType)
+        || TYPE_JSON_SCHEMA.equals(schemaType)
+        || TYPE_JSON.equals(schemaType);
+  }
+}

--- a/kafka-connect-schema-backup-api/src/test/java/io/confluent/connect/schema/backup/api/BackupWrapperTest.java
+++ b/kafka-connect-schema-backup-api/src/test/java/io/confluent/connect/schema/backup/api/BackupWrapperTest.java
@@ -16,16 +16,13 @@
 
 package io.confluent.connect.schema.backup.api;
 
+import io.confluent.kafka.serializers.schema.id.SchemaId;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.Test;
 
-import java.nio.ByteBuffer;
-import java.util.UUID;
-
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -34,11 +31,8 @@ import static org.junit.Assert.assertTrue;
 
 public class BackupWrapperTest {
 
-  private static final String VALUE_HEADER = "__value_schema_id";
-  private static final String KEY_HEADER = "__key_schema_id";
   private static final String SCHEMA_TYPE_AVRO = "AVRO";
   private static final String TEST_SUBJECT = "test-value";
-  private static final String TEST_GUID = "550e8400-e29b-41d4-a716-446655440000";
 
   @Test
   public void testBuildSchemaWithDataSchema() {
@@ -54,6 +48,7 @@ public class BackupWrapperTest {
     assertNotNull(wrapperSchema.field(BackupWrapper.FIELD_RAW_SCHEMA));
     assertNotNull(wrapperSchema.field(BackupWrapper.FIELD_REFERENCE_TREE));
     assertNotNull(wrapperSchema.field(BackupWrapper.FIELD_DIRECT_REFS));
+    assertNotNull(wrapperSchema.field(BackupWrapper.FIELD_SCHEMA_GUID));
   }
 
   @Test
@@ -77,7 +72,7 @@ public class BackupWrapperTest {
     assertEquals(100, (int) wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_ID));
     assertEquals(1, (int) wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION));
     assertEquals(SCHEMA_TYPE_AVRO, wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
-    assertEquals("test-value", wrapper.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT));
+    assertEquals(TEST_SUBJECT, wrapper.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT));
     assertEquals("{}", wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA));
     assertEquals("{\"tree\":{}}", wrapper.getString(BackupWrapper.FIELD_REFERENCE_TREE));
     assertEquals("[{\"name\":\"ref\"}]", wrapper.getString(BackupWrapper.FIELD_DIRECT_REFS));
@@ -94,6 +89,7 @@ public class BackupWrapperTest {
     assertNull(wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA));
     assertNull(wrapper.getString(BackupWrapper.FIELD_REFERENCE_TREE));
     assertNull(wrapper.getString(BackupWrapper.FIELD_DIRECT_REFS));
+    assertNull(wrapper.getString(BackupWrapper.FIELD_SCHEMA_GUID));
   }
 
   @Test
@@ -123,141 +119,23 @@ public class BackupWrapperTest {
   }
 
   @Test
-  public void testExtractSchemaIdValid() {
-    byte[] wire = new byte[10];
-    wire[0] = 0x00;
-    ByteBuffer.wrap(wire, 1, 4).putInt(42);
-    assertEquals(Integer.valueOf(42), BackupWrapper.extractSchemaId(wire));
-  }
-
-  @Test
-  public void testExtractSchemaIdNull() {
-    assertNull(BackupWrapper.extractSchemaId(null));
-  }
-
-  @Test
-  public void testExtractSchemaIdTooShort() {
-    assertNull(BackupWrapper.extractSchemaId(new byte[]{0x00, 0x01}));
-  }
-
-  @Test
-  public void testExtractSchemaIdWrongMagicByte() {
-    byte[] wire = new byte[]{0x01, 0x00, 0x00, 0x00, 0x2A};
-    assertNull(BackupWrapper.extractSchemaId(wire));
-  }
-
-  @Test
-  public void testExtractSchemaIdEmptyArray() {
-    assertNull(BackupWrapper.extractSchemaId(new byte[0]));
-  }
-
-  @Test
-  public void testExtractSchemaIdFromHeaderValid() {
-    RecordHeaders headers =
-        new RecordHeaders();
-    byte[] headerValue = new byte[]{0x00, 0x00, 0x00, 0x00, 0x2A};
-    headers.add(VALUE_HEADER, headerValue);
-    assertEquals(Integer.valueOf(42),
-        BackupWrapper.extractSchemaIdFromHeader(headers, false));
-  }
-
-  @Test
-  public void testExtractSchemaIdFromHeaderKey() {
-    RecordHeaders headers =
-        new RecordHeaders();
-    byte[] headerValue = new byte[]{0x00, 0x00, 0x00, 0x00, 0x07};
-    headers.add(KEY_HEADER, headerValue);
-    assertEquals(Integer.valueOf(7),
-        BackupWrapper.extractSchemaIdFromHeader(headers, true));
-  }
-
-  @Test
-  public void testExtractSchemaIdFromHeaderNull() {
-    assertNull(BackupWrapper.extractSchemaIdFromHeader(null, false));
-  }
-
-  @Test
-  public void testExtractSchemaIdFromHeaderMissing() {
-    RecordHeaders headers =
-        new RecordHeaders();
-    assertNull(BackupWrapper.extractSchemaIdFromHeader(headers, false));
-  }
-
-  @Test
-  public void testExtractSchemaIdFromHeaderGuidReturnsNull() {
-    RecordHeaders headers =
-        new RecordHeaders();
-    byte[] guidHeader = new byte[17];
-    guidHeader[0] = 0x01;
-    headers.add(VALUE_HEADER, guidHeader);
-    assertNull(BackupWrapper.extractSchemaIdFromHeader(headers, false));
-  }
-
-  @Test
   public void testRemoveSchemaIdHeaders() {
-    RecordHeaders headers =
-        new RecordHeaders();
-    headers.add(KEY_HEADER, new byte[]{0x00, 0x00, 0x00, 0x00, 0x01});
-    headers.add(VALUE_HEADER, new byte[]{0x00, 0x00, 0x00, 0x00, 0x02});
+    RecordHeaders headers = new RecordHeaders();
+    headers.add(SchemaId.KEY_SCHEMA_ID_HEADER, new byte[]{0x00, 0x00, 0x00, 0x00, 0x01});
+    headers.add(SchemaId.VALUE_SCHEMA_ID_HEADER, new byte[]{0x00, 0x00, 0x00, 0x00, 0x02});
     headers.add("other-header", "keep".getBytes());
     BackupWrapper.removeSchemaIdHeaders(headers, true);
-    assertNull(headers.lastHeader(KEY_HEADER));
-    assertNotNull(headers.lastHeader(VALUE_HEADER));
+    assertNull(headers.lastHeader(SchemaId.KEY_SCHEMA_ID_HEADER));
+    assertNotNull(headers.lastHeader(SchemaId.VALUE_SCHEMA_ID_HEADER));
     BackupWrapper.removeSchemaIdHeaders(headers, false);
-    assertNull(headers.lastHeader(VALUE_HEADER));
+    assertNull(headers.lastHeader(SchemaId.VALUE_SCHEMA_ID_HEADER));
     assertNotNull(headers.lastHeader("other-header"));
   }
 
   @Test
-  public void testExtractSchemaGuidFromHeaderValid() {
-    RecordHeaders headers = new RecordHeaders();
-    UUID testGuid = UUID.fromString(TEST_GUID);
-    byte[] guidHeader = new byte[17];
-    guidHeader[0] = 0x01;
-    ByteBuffer buf = ByteBuffer.wrap(guidHeader, 1, 16);
-    buf.putLong(testGuid.getMostSignificantBits());
-    buf.putLong(testGuid.getLeastSignificantBits());
-    headers.add(VALUE_HEADER, guidHeader);
-    assertEquals(TEST_GUID,
-        BackupWrapper.extractSchemaGuidFromHeader(headers, false));
-  }
-
-  @Test
-  public void testExtractSchemaGuidFromHeaderKeyValid() {
-    RecordHeaders headers = new RecordHeaders();
-    UUID testGuid = UUID.fromString(TEST_GUID);
-    byte[] guidHeader = new byte[17];
-    guidHeader[0] = 0x01;
-    ByteBuffer buf = ByteBuffer.wrap(guidHeader, 1, 16);
-    buf.putLong(testGuid.getMostSignificantBits());
-    buf.putLong(testGuid.getLeastSignificantBits());
-    headers.add(KEY_HEADER, guidHeader);
-    assertEquals(TEST_GUID,
-        BackupWrapper.extractSchemaGuidFromHeader(headers, true));
-  }
-
-  @Test
-  public void testExtractSchemaGuidFromHeaderIntIdReturnsNull() {
-    RecordHeaders headers = new RecordHeaders();
-    byte[] intHeader = new byte[5];
-    intHeader[0] = 0x00;
-    ByteBuffer.wrap(intHeader, 1, 4).putInt(42);
-    headers.add(VALUE_HEADER, intHeader);
-    assertNull(BackupWrapper.extractSchemaGuidFromHeader(headers, false));
-  }
-
-  @Test
-  public void testExtractSchemaGuidFromHeaderNull() {
-    assertNull(BackupWrapper.extractSchemaGuidFromHeader(null, false));
-  }
-
-  @Test
-  public void testExtractSchemaIdHeaderBytes() {
-    RecordHeaders headers = new RecordHeaders();
-    byte[] headerValue = new byte[]{0x00, 0x00, 0x00, 0x00, 0x2A};
-    headers.add(VALUE_HEADER, headerValue);
-    assertArrayEquals(headerValue,
-        BackupWrapper.extractSchemaIdHeaderBytes(headers, false));
+  public void testRemoveSchemaIdHeadersNull() {
+    BackupWrapper.removeSchemaIdHeaders(null, true);
+    BackupWrapper.removeSchemaIdHeaders(null, false);
   }
 
   @Test
@@ -302,67 +180,5 @@ public class BackupWrapperTest {
     assertEquals("referenceTree", BackupWrapper.FIELD_REFERENCE_TREE);
     assertEquals("directRefs", BackupWrapper.FIELD_DIRECT_REFS);
     assertEquals("schemaGuid", BackupWrapper.FIELD_SCHEMA_GUID);
-  }
-
-  @Test
-  public void testExtractSchemaIdFromHeaderTooShort() {
-    RecordHeaders headers = new RecordHeaders();
-    headers.add(VALUE_HEADER, new byte[]{0x00, 0x01, 0x02});
-    assertNull(BackupWrapper.extractSchemaIdFromHeader(headers, false));
-  }
-
-  @Test
-  public void testExtractSchemaIdFromHeaderNullValue() {
-    RecordHeaders headers = new RecordHeaders();
-    headers.add(VALUE_HEADER, null);
-    assertNull(BackupWrapper.extractSchemaIdFromHeader(headers, false));
-  }
-
-  @Test
-  public void testExtractSchemaGuidFromHeaderMissing() {
-    RecordHeaders headers = new RecordHeaders();
-    assertNull(BackupWrapper.extractSchemaGuidFromHeader(headers, false));
-  }
-
-  @Test
-  public void testExtractSchemaGuidFromHeaderTooShort() {
-    RecordHeaders headers = new RecordHeaders();
-    byte[] shortGuid = new byte[10];
-    shortGuid[0] = 0x01;
-    headers.add(VALUE_HEADER, shortGuid);
-    assertNull(BackupWrapper.extractSchemaGuidFromHeader(headers, false));
-  }
-
-  @Test
-  public void testExtractSchemaGuidFromHeaderNullValue() {
-    RecordHeaders headers = new RecordHeaders();
-    headers.add(VALUE_HEADER, null);
-    assertNull(BackupWrapper.extractSchemaGuidFromHeader(headers, false));
-  }
-
-  @Test
-  public void testExtractSchemaIdHeaderBytesNull() {
-    assertNull(BackupWrapper.extractSchemaIdHeaderBytes(null, false));
-  }
-
-  @Test
-  public void testExtractSchemaIdHeaderBytesMissing() {
-    RecordHeaders headers = new RecordHeaders();
-    assertNull(BackupWrapper.extractSchemaIdHeaderBytes(headers, false));
-  }
-
-  @Test
-  public void testExtractSchemaIdHeaderBytesKey() {
-    RecordHeaders headers = new RecordHeaders();
-    byte[] val = new byte[]{0x00, 0x00, 0x00, 0x00, 0x07};
-    headers.add(KEY_HEADER, val);
-    assertArrayEquals(val,
-        BackupWrapper.extractSchemaIdHeaderBytes(headers, true));
-  }
-
-  @Test
-  public void testRemoveSchemaIdHeadersNull() {
-    BackupWrapper.removeSchemaIdHeaders(null, true);
-    BackupWrapper.removeSchemaIdHeaders(null, false);
   }
 }

--- a/kafka-connect-schema-backup-api/src/test/java/io/confluent/connect/schema/backup/api/BackupWrapperTest.java
+++ b/kafka-connect-schema-backup-api/src/test/java/io/confluent/connect/schema/backup/api/BackupWrapperTest.java
@@ -16,8 +16,6 @@
 
 package io.confluent.connect.schema.backup.api;
 
-import io.confluent.kafka.serializers.schema.id.SchemaId;
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
@@ -116,26 +114,6 @@ public class BackupWrapperTest {
     Schema noName = SchemaBuilder.struct()
         .field("data", Schema.STRING_SCHEMA).build();
     assertFalse(BackupWrapper.isWrapper(noName));
-  }
-
-  @Test
-  public void testRemoveSchemaIdHeaders() {
-    RecordHeaders headers = new RecordHeaders();
-    headers.add(SchemaId.KEY_SCHEMA_ID_HEADER, new byte[]{0x00, 0x00, 0x00, 0x00, 0x01});
-    headers.add(SchemaId.VALUE_SCHEMA_ID_HEADER, new byte[]{0x00, 0x00, 0x00, 0x00, 0x02});
-    headers.add("other-header", "keep".getBytes());
-    BackupWrapper.removeSchemaIdHeaders(headers, true);
-    assertNull(headers.lastHeader(SchemaId.KEY_SCHEMA_ID_HEADER));
-    assertNotNull(headers.lastHeader(SchemaId.VALUE_SCHEMA_ID_HEADER));
-    BackupWrapper.removeSchemaIdHeaders(headers, false);
-    assertNull(headers.lastHeader(SchemaId.VALUE_SCHEMA_ID_HEADER));
-    assertNotNull(headers.lastHeader("other-header"));
-  }
-
-  @Test
-  public void testRemoveSchemaIdHeadersNull() {
-    BackupWrapper.removeSchemaIdHeaders(null, true);
-    BackupWrapper.removeSchemaIdHeaders(null, false);
   }
 
   @Test

--- a/kafka-connect-schema-backup-api/src/test/java/io/confluent/connect/schema/backup/api/BackupWrapperTest.java
+++ b/kafka-connect-schema-backup-api/src/test/java/io/confluent/connect/schema/backup/api/BackupWrapperTest.java
@@ -1,0 +1,368 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.schema.backup.api;
+
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class BackupWrapperTest {
+
+  private static final String VALUE_HEADER = "__value_schema_id";
+  private static final String KEY_HEADER = "__key_schema_id";
+  private static final String SCHEMA_TYPE_AVRO = "AVRO";
+  private static final String TEST_SUBJECT = "test-value";
+  private static final String TEST_GUID = "550e8400-e29b-41d4-a716-446655440000";
+
+  @Test
+  public void testBuildSchemaWithDataSchema() {
+    Schema dataSchema = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA).build();
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+    assertEquals(BackupWrapper.NAME, wrapperSchema.name());
+    assertNotNull(wrapperSchema.field(BackupWrapper.FIELD_DATA));
+    assertNotNull(wrapperSchema.field(BackupWrapper.FIELD_SCHEMA_ID));
+    assertNotNull(wrapperSchema.field(BackupWrapper.FIELD_SCHEMA_VERSION));
+    assertNotNull(wrapperSchema.field(BackupWrapper.FIELD_SCHEMA_TYPE));
+    assertNotNull(wrapperSchema.field(BackupWrapper.FIELD_SCHEMA_SUBJECT));
+    assertNotNull(wrapperSchema.field(BackupWrapper.FIELD_RAW_SCHEMA));
+    assertNotNull(wrapperSchema.field(BackupWrapper.FIELD_REFERENCE_TREE));
+    assertNotNull(wrapperSchema.field(BackupWrapper.FIELD_DIRECT_REFS));
+  }
+
+  @Test
+  public void testBuildSchemaWithNullDataSchema() {
+    Schema wrapperSchema = BackupWrapper.buildSchema(null);
+    assertNotNull(wrapperSchema);
+    assertEquals(BackupWrapper.NAME, wrapperSchema.name());
+    assertNotNull(wrapperSchema.field(BackupWrapper.FIELD_DATA));
+  }
+
+  @Test
+  public void testBuildWrapperAllFields() {
+    Schema dataSchema = SchemaBuilder.struct()
+        .field("id", Schema.INT32_SCHEMA).build();
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+    Struct data = new Struct(dataSchema).put("id", 42);
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        100, 1, SCHEMA_TYPE_AVRO, TEST_SUBJECT, "{}", "{\"tree\":{}}", "[{\"name\":\"ref\"}]");
+    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, data, fields);
+    assertEquals(data, wrapper.get(BackupWrapper.FIELD_DATA));
+    assertEquals(100, (int) wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_ID));
+    assertEquals(1, (int) wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION));
+    assertEquals(SCHEMA_TYPE_AVRO, wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
+    assertEquals("test-value", wrapper.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT));
+    assertEquals("{}", wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA));
+    assertEquals("{\"tree\":{}}", wrapper.getString(BackupWrapper.FIELD_REFERENCE_TREE));
+    assertEquals("[{\"name\":\"ref\"}]", wrapper.getString(BackupWrapper.FIELD_DIRECT_REFS));
+  }
+
+  @Test
+  public void testBuildWrapperNullOptionalFields() {
+    Schema dataSchema = Schema.STRING_SCHEMA;
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        1, null, "STRING", "test-key", null, null, null);
+    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, "hello", fields);
+    assertNull(wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION));
+    assertNull(wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA));
+    assertNull(wrapper.getString(BackupWrapper.FIELD_REFERENCE_TREE));
+    assertNull(wrapper.getString(BackupWrapper.FIELD_DIRECT_REFS));
+  }
+
+  @Test
+  public void testIsWrapperTrue() {
+    Schema wrapperSchema = BackupWrapper.buildSchema(Schema.STRING_SCHEMA);
+    assertTrue(BackupWrapper.isWrapper(wrapperSchema));
+  }
+
+  @Test
+  public void testIsWrapperFalseNullSchema() {
+    assertFalse(BackupWrapper.isWrapper(null));
+  }
+
+  @Test
+  public void testIsWrapperFalseWrongName() {
+    Schema notWrapper = SchemaBuilder.struct()
+        .name("com.example.SomeStruct")
+        .field("data", Schema.STRING_SCHEMA).build();
+    assertFalse(BackupWrapper.isWrapper(notWrapper));
+  }
+
+  @Test
+  public void testIsWrapperFalseNoName() {
+    Schema noName = SchemaBuilder.struct()
+        .field("data", Schema.STRING_SCHEMA).build();
+    assertFalse(BackupWrapper.isWrapper(noName));
+  }
+
+  @Test
+  public void testExtractSchemaIdValid() {
+    byte[] wire = new byte[10];
+    wire[0] = 0x00;
+    ByteBuffer.wrap(wire, 1, 4).putInt(42);
+    assertEquals(Integer.valueOf(42), BackupWrapper.extractSchemaId(wire));
+  }
+
+  @Test
+  public void testExtractSchemaIdNull() {
+    assertNull(BackupWrapper.extractSchemaId(null));
+  }
+
+  @Test
+  public void testExtractSchemaIdTooShort() {
+    assertNull(BackupWrapper.extractSchemaId(new byte[]{0x00, 0x01}));
+  }
+
+  @Test
+  public void testExtractSchemaIdWrongMagicByte() {
+    byte[] wire = new byte[]{0x01, 0x00, 0x00, 0x00, 0x2A};
+    assertNull(BackupWrapper.extractSchemaId(wire));
+  }
+
+  @Test
+  public void testExtractSchemaIdEmptyArray() {
+    assertNull(BackupWrapper.extractSchemaId(new byte[0]));
+  }
+
+  @Test
+  public void testExtractSchemaIdFromHeaderValid() {
+    RecordHeaders headers =
+        new RecordHeaders();
+    byte[] headerValue = new byte[]{0x00, 0x00, 0x00, 0x00, 0x2A};
+    headers.add(VALUE_HEADER, headerValue);
+    assertEquals(Integer.valueOf(42),
+        BackupWrapper.extractSchemaIdFromHeader(headers, false));
+  }
+
+  @Test
+  public void testExtractSchemaIdFromHeaderKey() {
+    RecordHeaders headers =
+        new RecordHeaders();
+    byte[] headerValue = new byte[]{0x00, 0x00, 0x00, 0x00, 0x07};
+    headers.add(KEY_HEADER, headerValue);
+    assertEquals(Integer.valueOf(7),
+        BackupWrapper.extractSchemaIdFromHeader(headers, true));
+  }
+
+  @Test
+  public void testExtractSchemaIdFromHeaderNull() {
+    assertNull(BackupWrapper.extractSchemaIdFromHeader(null, false));
+  }
+
+  @Test
+  public void testExtractSchemaIdFromHeaderMissing() {
+    RecordHeaders headers =
+        new RecordHeaders();
+    assertNull(BackupWrapper.extractSchemaIdFromHeader(headers, false));
+  }
+
+  @Test
+  public void testExtractSchemaIdFromHeaderGuidReturnsNull() {
+    RecordHeaders headers =
+        new RecordHeaders();
+    byte[] guidHeader = new byte[17];
+    guidHeader[0] = 0x01;
+    headers.add(VALUE_HEADER, guidHeader);
+    assertNull(BackupWrapper.extractSchemaIdFromHeader(headers, false));
+  }
+
+  @Test
+  public void testRemoveSchemaIdHeaders() {
+    RecordHeaders headers =
+        new RecordHeaders();
+    headers.add(KEY_HEADER, new byte[]{0x00, 0x00, 0x00, 0x00, 0x01});
+    headers.add(VALUE_HEADER, new byte[]{0x00, 0x00, 0x00, 0x00, 0x02});
+    headers.add("other-header", "keep".getBytes());
+    BackupWrapper.removeSchemaIdHeaders(headers, true);
+    assertNull(headers.lastHeader(KEY_HEADER));
+    assertNotNull(headers.lastHeader(VALUE_HEADER));
+    BackupWrapper.removeSchemaIdHeaders(headers, false);
+    assertNull(headers.lastHeader(VALUE_HEADER));
+    assertNotNull(headers.lastHeader("other-header"));
+  }
+
+  @Test
+  public void testExtractSchemaGuidFromHeaderValid() {
+    RecordHeaders headers = new RecordHeaders();
+    UUID testGuid = UUID.fromString(TEST_GUID);
+    byte[] guidHeader = new byte[17];
+    guidHeader[0] = 0x01;
+    ByteBuffer buf = ByteBuffer.wrap(guidHeader, 1, 16);
+    buf.putLong(testGuid.getMostSignificantBits());
+    buf.putLong(testGuid.getLeastSignificantBits());
+    headers.add(VALUE_HEADER, guidHeader);
+    assertEquals(TEST_GUID,
+        BackupWrapper.extractSchemaGuidFromHeader(headers, false));
+  }
+
+  @Test
+  public void testExtractSchemaGuidFromHeaderKeyValid() {
+    RecordHeaders headers = new RecordHeaders();
+    UUID testGuid = UUID.fromString(TEST_GUID);
+    byte[] guidHeader = new byte[17];
+    guidHeader[0] = 0x01;
+    ByteBuffer buf = ByteBuffer.wrap(guidHeader, 1, 16);
+    buf.putLong(testGuid.getMostSignificantBits());
+    buf.putLong(testGuid.getLeastSignificantBits());
+    headers.add(KEY_HEADER, guidHeader);
+    assertEquals(TEST_GUID,
+        BackupWrapper.extractSchemaGuidFromHeader(headers, true));
+  }
+
+  @Test
+  public void testExtractSchemaGuidFromHeaderIntIdReturnsNull() {
+    RecordHeaders headers = new RecordHeaders();
+    byte[] intHeader = new byte[5];
+    intHeader[0] = 0x00;
+    ByteBuffer.wrap(intHeader, 1, 4).putInt(42);
+    headers.add(VALUE_HEADER, intHeader);
+    assertNull(BackupWrapper.extractSchemaGuidFromHeader(headers, false));
+  }
+
+  @Test
+  public void testExtractSchemaGuidFromHeaderNull() {
+    assertNull(BackupWrapper.extractSchemaGuidFromHeader(null, false));
+  }
+
+  @Test
+  public void testExtractSchemaIdHeaderBytes() {
+    RecordHeaders headers = new RecordHeaders();
+    byte[] headerValue = new byte[]{0x00, 0x00, 0x00, 0x00, 0x2A};
+    headers.add(VALUE_HEADER, headerValue);
+    assertArrayEquals(headerValue,
+        BackupWrapper.extractSchemaIdHeaderBytes(headers, false));
+  }
+
+  @Test
+  public void testBuildSchemaWithGuidField() {
+    Schema wrapperSchema = BackupWrapper.buildSchema(Schema.STRING_SCHEMA);
+    assertNotNull(wrapperSchema.field(BackupWrapper.FIELD_SCHEMA_GUID));
+    assertEquals(Schema.OPTIONAL_STRING_SCHEMA,
+        wrapperSchema.field(BackupWrapper.FIELD_SCHEMA_GUID).schema());
+  }
+
+  @Test
+  public void testBuildWrapperWithGuid() {
+    Schema dataSchema = Schema.STRING_SCHEMA;
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        null, null, SCHEMA_TYPE_AVRO, TEST_SUBJECT, null, null, null, "test-guid");
+    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, "hello", fields);
+    assertEquals("test-guid", wrapper.getString(BackupWrapper.FIELD_SCHEMA_GUID));
+    assertNull(wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_ID));
+  }
+
+  @Test
+  public void testBuildWrapperWithIntIdAndNoGuid() {
+    Schema dataSchema = Schema.STRING_SCHEMA;
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        7, null, SCHEMA_TYPE_AVRO, TEST_SUBJECT, null, null, null);
+    Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, "hello", fields);
+    assertEquals(Integer.valueOf(7), wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_ID));
+    assertNull(wrapper.getString(BackupWrapper.FIELD_SCHEMA_GUID));
+  }
+
+  @Test
+  public void testConstants() {
+    assertEquals("io.confluent.connect.backup.Wrapper", BackupWrapper.NAME);
+    assertEquals("data", BackupWrapper.FIELD_DATA);
+    assertEquals("schemaId", BackupWrapper.FIELD_SCHEMA_ID);
+    assertEquals("schemaVersion", BackupWrapper.FIELD_SCHEMA_VERSION);
+    assertEquals("schemaType", BackupWrapper.FIELD_SCHEMA_TYPE);
+    assertEquals("schemaSubject", BackupWrapper.FIELD_SCHEMA_SUBJECT);
+    assertEquals("rawSchema", BackupWrapper.FIELD_RAW_SCHEMA);
+    assertEquals("referenceTree", BackupWrapper.FIELD_REFERENCE_TREE);
+    assertEquals("directRefs", BackupWrapper.FIELD_DIRECT_REFS);
+    assertEquals("schemaGuid", BackupWrapper.FIELD_SCHEMA_GUID);
+  }
+
+  @Test
+  public void testExtractSchemaIdFromHeaderTooShort() {
+    RecordHeaders headers = new RecordHeaders();
+    headers.add(VALUE_HEADER, new byte[]{0x00, 0x01, 0x02});
+    assertNull(BackupWrapper.extractSchemaIdFromHeader(headers, false));
+  }
+
+  @Test
+  public void testExtractSchemaIdFromHeaderNullValue() {
+    RecordHeaders headers = new RecordHeaders();
+    headers.add(VALUE_HEADER, null);
+    assertNull(BackupWrapper.extractSchemaIdFromHeader(headers, false));
+  }
+
+  @Test
+  public void testExtractSchemaGuidFromHeaderMissing() {
+    RecordHeaders headers = new RecordHeaders();
+    assertNull(BackupWrapper.extractSchemaGuidFromHeader(headers, false));
+  }
+
+  @Test
+  public void testExtractSchemaGuidFromHeaderTooShort() {
+    RecordHeaders headers = new RecordHeaders();
+    byte[] shortGuid = new byte[10];
+    shortGuid[0] = 0x01;
+    headers.add(VALUE_HEADER, shortGuid);
+    assertNull(BackupWrapper.extractSchemaGuidFromHeader(headers, false));
+  }
+
+  @Test
+  public void testExtractSchemaGuidFromHeaderNullValue() {
+    RecordHeaders headers = new RecordHeaders();
+    headers.add(VALUE_HEADER, null);
+    assertNull(BackupWrapper.extractSchemaGuidFromHeader(headers, false));
+  }
+
+  @Test
+  public void testExtractSchemaIdHeaderBytesNull() {
+    assertNull(BackupWrapper.extractSchemaIdHeaderBytes(null, false));
+  }
+
+  @Test
+  public void testExtractSchemaIdHeaderBytesMissing() {
+    RecordHeaders headers = new RecordHeaders();
+    assertNull(BackupWrapper.extractSchemaIdHeaderBytes(headers, false));
+  }
+
+  @Test
+  public void testExtractSchemaIdHeaderBytesKey() {
+    RecordHeaders headers = new RecordHeaders();
+    byte[] val = new byte[]{0x00, 0x00, 0x00, 0x00, 0x07};
+    headers.add(KEY_HEADER, val);
+    assertArrayEquals(val,
+        BackupWrapper.extractSchemaIdHeaderBytes(headers, true));
+  }
+
+  @Test
+  public void testRemoveSchemaIdHeadersNull() {
+    BackupWrapper.removeSchemaIdHeaders(null, true);
+    BackupWrapper.removeSchemaIdHeaders(null, false);
+  }
+}

--- a/kafka-connect-schema-backup-api/src/test/java/io/confluent/connect/schema/backup/api/SchemaBackupConfigTest.java
+++ b/kafka-connect-schema-backup-api/src/test/java/io/confluent/connect/schema/backup/api/SchemaBackupConfigTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.schema.backup.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class SchemaBackupConfigTest {
+
+  @Test
+  public void testIsSrBackedTypeAvro() {
+    assertTrue(SchemaBackupConfig.isSrBackedType("AVRO"));
+  }
+
+  @Test
+  public void testIsSrBackedTypeProtobuf() {
+    assertTrue(SchemaBackupConfig.isSrBackedType("PROTOBUF"));
+  }
+
+  @Test
+  public void testIsSrBackedTypeJsonSchema() {
+    assertTrue(SchemaBackupConfig.isSrBackedType("JSON_SCHEMA"));
+  }
+
+  @Test
+  public void testIsSrBackedTypeJson() {
+    assertTrue(SchemaBackupConfig.isSrBackedType("JSON"));
+  }
+
+  @Test
+  public void testIsSrBackedTypeStringFalse() {
+    assertFalse(SchemaBackupConfig.isSrBackedType("STRING"));
+  }
+
+  @Test
+  public void testIsSrBackedTypeBytesFalse() {
+    assertFalse(SchemaBackupConfig.isSrBackedType("BYTES"));
+  }
+
+  @Test
+  public void testIsSrBackedTypeNullFalse() {
+    assertFalse(SchemaBackupConfig.isSrBackedType(null));
+  }
+
+  @Test
+  public void testIsSrBackedTypeNonSrTypes() {
+    assertFalse(SchemaBackupConfig.isSrBackedType("JSON_SCHEMALESS"));
+    assertFalse(SchemaBackupConfig.isSrBackedType("JSON_EMBEDDED_SCHEMA"));
+    assertFalse(SchemaBackupConfig.isSrBackedType("INT16"));
+    assertFalse(SchemaBackupConfig.isSrBackedType("INT32"));
+    assertFalse(SchemaBackupConfig.isSrBackedType("INT64"));
+    assertFalse(SchemaBackupConfig.isSrBackedType("FLOAT32"));
+    assertFalse(SchemaBackupConfig.isSrBackedType("FLOAT64"));
+    assertFalse(SchemaBackupConfig.isSrBackedType("NONE"));
+    assertFalse(SchemaBackupConfig.isSrBackedType("UNKNOWN"));
+    assertFalse(SchemaBackupConfig.isSrBackedType(""));
+    assertFalse(SchemaBackupConfig.isSrBackedType("avro"));
+  }
+
+  @Test
+  public void testConstants() {
+    assertEquals("AVRO", SchemaBackupConfig.TYPE_AVRO);
+    assertEquals("PROTOBUF", SchemaBackupConfig.TYPE_PROTOBUF);
+    assertEquals("JSON_SCHEMA", SchemaBackupConfig.TYPE_JSON_SCHEMA);
+    assertEquals("JSON", SchemaBackupConfig.TYPE_JSON);
+    assertEquals("JSON_SCHEMALESS", SchemaBackupConfig.TYPE_JSON_SCHEMALESS);
+    assertEquals("JSON_EMBEDDED_SCHEMA", SchemaBackupConfig.TYPE_JSON_EMBEDDED_SCHEMA);
+    assertEquals("STRING", SchemaBackupConfig.TYPE_STRING);
+    assertEquals("INT16", SchemaBackupConfig.TYPE_INT16);
+    assertEquals("INT32", SchemaBackupConfig.TYPE_INT32);
+    assertEquals("INT64", SchemaBackupConfig.TYPE_INT64);
+    assertEquals("FLOAT32", SchemaBackupConfig.TYPE_FLOAT32);
+    assertEquals("FLOAT64", SchemaBackupConfig.TYPE_FLOAT64);
+    assertEquals("BYTES", SchemaBackupConfig.TYPE_BYTES);
+    assertEquals("NONE", SchemaBackupConfig.TYPE_NONE);
+    assertEquals("UNKNOWN", SchemaBackupConfig.TYPE_UNKNOWN);
+    assertEquals("schema.backup.enabled",
+        SchemaBackupConfig.SCHEMA_BACKUP_ENABLED_CONFIG);
+    assertEquals(50, SchemaBackupConfig.MAX_REFERENCE_DEPTH);
+  }
+}

--- a/kafka-connect-schema-backup-core/pom.xml
+++ b/kafka-connect-schema-backup-core/pom.xml
@@ -1,0 +1,101 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.confluent</groupId>
+        <artifactId>kafka-schema-registry-parent</artifactId>
+        <version>8.4.0-0</version>
+    </parent>
+
+    <licenses>
+        <license>
+            <name>Apache License 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <artifactId>kafka-connect-schema-backup-core</artifactId>
+    <packaging>jar</packaging>
+    <name>kafka-connect-schema-backup-core</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-schema-backup-api</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-registry-client</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-types</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-serializer</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.confluent.networking</groupId>
+                    <artifactId>cc-custom-dns-resolver-java18</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-registry-client</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-avro-serializer</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.maven.plugin.version}</version>
+                <configuration>
+                    <java>
+                        <licenseHeader>
+                            <file>${maven.multiModuleProjectDirectory}/config/license-headers/apache-header.txt</file>
+                        </licenseHeader>
+                    </java>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/kafka-connect-schema-backup-core/src/main/java/io/confluent/connect/schema/backup/core/BackupAwareByteArrayConverter.java
+++ b/kafka-connect-schema-backup-core/src/main/java/io/confluent/connect/schema/backup/core/BackupAwareByteArrayConverter.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.schema.backup.core;
+
+import io.confluent.connect.schema.backup.api.BackupWrapper;
+import io.confluent.connect.schema.backup.api.SchemaBackupConfig;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.ParsedSchemaAndValue;
+import io.confluent.kafka.serializers.schema.id.DualSchemaIdDeserializer;
+import io.confluent.kafka.serializers.schema.id.SchemaId;
+import io.confluent.kafka.schemaregistry.SchemaProvider;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientFactory;
+import io.confluent.kafka.serializers.subject.TopicNameStrategy;
+import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.storage.Converter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Byte-passthrough converter with schema backup and ID translation.
+ *
+ * <p>On backup: passes raw bytes through (no deserialization) but extracts
+ * the schema ID from the Confluent wire format and wraps in a BackupWrapper
+ * so the envelope layer can back up the schema alongside the data.
+ *
+ * <p>On restore: detects BackupWrapper, resolves and registers schema
+ * references in the target SR, rewrites the schema ID in the wire format
+ * bytes if the target SR assigned a different ID, and returns the bytes.
+ *
+ * <p>For records without Confluent wire format (plain strings, JSON, etc.),
+ * bytes pass through untouched in both directions — no schema interaction.
+ */
+public class BackupAwareByteArrayConverter implements Converter {
+
+  private static final Logger log =
+      LoggerFactory.getLogger(BackupAwareByteArrayConverter.class);
+
+  private static final byte MAGIC_BYTE = 0x0;
+  private static final String KEY_SUBJECT_NAME_STRATEGY =
+      "key.subject.name.strategy";
+  private static final String VALUE_SUBJECT_NAME_STRATEGY =
+      "value.subject.name.strategy";
+
+  private SchemaRegistryClient schemaRegistry;
+  private boolean isKey;
+  private SubjectNameStrategy subjectNameStrategy;
+  private BackupConverterHelper backupHelper;
+  private final Map<Schema, Schema> wrapperSchemaCache =
+      new ConcurrentHashMap<>();
+  private final Map<Integer, Integer> schemaIdTranslation =
+      new ConcurrentHashMap<>();
+
+  public BackupAwareByteArrayConverter() {
+  }
+
+  public BackupAwareByteArrayConverter(SchemaRegistryClient client) {
+    this.schemaRegistry = client;
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    this.isKey = isKey;
+
+    Object srUrl = configs.get("schema.registry.url");
+    if (srUrl != null && schemaRegistry == null) {
+      List<SchemaProvider> providers = new ArrayList<>();
+      for (SchemaProvider p : ServiceLoader.load(SchemaProvider.class)) {
+        providers.add(p);
+      }
+      schemaRegistry = SchemaRegistryClientFactory.newClient(
+          Collections.singletonList(srUrl.toString()),
+          1000,
+          providers,
+          configs,
+          Collections.emptyMap()
+      );
+    }
+
+    backupHelper = schemaRegistry != null
+        ? new BackupConverterHelper(schemaRegistry, wrapperSchemaCache)
+        : null;
+
+    subjectNameStrategy = createSubjectNameStrategy(configs);
+
+    log.info("BackupAwareByteArrayConverter configured: isKey={}, srAvailable={}, "
+        + "subjectStrategy={}",
+        isKey, schemaRegistry != null,
+        subjectNameStrategy.getClass().getSimpleName());
+  }
+
+  @Override
+  public byte[] fromConnectData(String topic, Schema schema, Object value) {
+    return fromConnectData(topic, null, schema, value);
+  }
+
+  @Override
+  public byte[] fromConnectData(
+      String topic, Headers headers, Schema schema, Object value) {
+    if (BackupWrapper.isWrapper(schema) && value instanceof Struct) {
+      return restoreFromWrapper(topic, schema, (Struct) value);
+    }
+    return toBytes(value);
+  }
+
+  @Override
+  public SchemaAndValue toConnectData(String topic, byte[] value) {
+    return toConnectData(topic, null, value);
+  }
+
+  @Override
+  public SchemaAndValue toConnectData(
+      String topic, Headers headers, byte[] value) {
+    if (value == null) {
+      return SchemaAndValue.NULL;
+    }
+
+    ParsedSchemaAndValue.SchemaInfo schemaInfo = extractSchemaInfo(value, headers);
+
+    if (schemaInfo != null && backupHelper != null) {
+      try {
+        return backupHelper.wrapWithBackupMetadata(
+            new SchemaAndValue(Schema.BYTES_SCHEMA, value),
+            topic, schemaInfo,
+            detectSchemaType(schemaInfo.id()),
+            isKey,
+            (raw, refs, resolved) -> null,
+            (t, k, parsed) -> t + (k ? "-key" : "-value")
+        );
+      } catch (Exception e) {
+        log.warn("Failed to fetch schema metadata for key={}, "
+            + "falling back to raw bytes", schemaInfo.id(), e);
+      }
+    }
+
+    return new SchemaAndValue(Schema.OPTIONAL_BYTES_SCHEMA, value);
+  }
+
+  private ParsedSchemaAndValue.SchemaInfo extractSchemaInfo(
+      byte[] value, Headers headers) {
+    try {
+      SchemaId schemaId = new SchemaId(null);
+      DualSchemaIdDeserializer dual = new DualSchemaIdDeserializer();
+      dual.deserialize(null, isKey, headers, value, schemaId);
+      if (schemaId.getId() != null || schemaId.getGuid() != null) {
+        return new ParsedSchemaAndValue.SchemaInfo(
+            null, schemaId.getId(), null, schemaId.getGuid());
+      }
+    } catch (Exception e) {
+      log.debug("No schema ID found in value/headers, treating as raw bytes");
+    }
+    return null;
+  }
+
+  private byte[] restoreFromWrapper(
+      String topic, Schema wrapperSchema, Struct wrapper) {
+    try {
+      Object data = wrapper.get(BackupWrapper.FIELD_DATA);
+      byte[] rawBytes = toBytes(data);
+      if (rawBytes == null) {
+        return null;
+      }
+
+      String rawSchema = wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA);
+      String schemaType = wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE);
+      int originalId = wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_ID);
+
+      if (rawSchema != null && schemaRegistry != null) {
+        int newId = registerAndTranslateSchemaId(
+            topic, wrapperSchema, wrapper,
+            originalId, rawSchema, schemaType);
+        if (newId != originalId) {
+          rawBytes = rewriteSchemaId(rawBytes, newId);
+        }
+      }
+
+      return rawBytes;
+    } catch (Exception e) {
+      throw new DataException(
+          "Failed to restore byte data for topic " + topic, e);
+    }
+  }
+
+  private int registerAndTranslateSchemaId(
+      String topic, Schema wrapperSchema, Struct wrapper,
+      int originalId, String rawSchema, String schemaType) {
+    Integer cached = schemaIdTranslation.get(originalId);
+    if (cached != null) {
+      return cached;
+    }
+    try {
+      BackupReferenceResolver.ParsedSchemaFactory schemaFactory =
+          createSchemaFactory(schemaType);
+      if (schemaFactory != null) {
+        backupHelper.getReferenceResolver().resolveFromWrapper(
+            wrapperSchema, wrapper, schemaFactory);
+      }
+
+      Optional<ParsedSchema> parsed = schemaRegistry.parseSchema(
+          schemaType, rawSchema, Collections.emptyList());
+
+      if (parsed.isPresent()) {
+        String resolvedSubject = resolveSubject(topic, null, parsed.get());
+        int newId = schemaRegistry.register(resolvedSubject, parsed.get());
+        schemaIdTranslation.put(originalId, newId);
+        log.info("Schema registered: subject={}, originalId={}, newId={}, type={}",
+            resolvedSubject, originalId, newId, schemaType);
+        return newId;
+      }
+
+      log.warn("Could not parse schema type={} for id={}, "
+          + "using original ID", schemaType, originalId);
+      return originalId;
+    } catch (Exception e) {
+      log.warn("Failed to register schema id={}, using original",
+          originalId, e);
+      return originalId;
+    }
+  }
+
+  private String resolveSubject(
+      String restoredTopic, String backupSubject, ParsedSchema schema) {
+    return subjectNameStrategy.subjectName(restoredTopic, isKey, schema);
+  }
+
+  @SuppressWarnings("unchecked")
+  private SubjectNameStrategy createSubjectNameStrategy(Map<String, ?> configs) {
+    String strategyKey = isKey
+        ? KEY_SUBJECT_NAME_STRATEGY : VALUE_SUBJECT_NAME_STRATEGY;
+    Object strategyClass = configs.get(strategyKey);
+    if (strategyClass != null) {
+      try {
+        Class<?> cls = strategyClass instanceof Class
+            ? (Class<?>) strategyClass
+            : Class.forName(strategyClass.toString());
+        SubjectNameStrategy strategy =
+            (SubjectNameStrategy) cls.getDeclaredConstructor().newInstance();
+        if (schemaRegistry != null) {
+          strategy.setSchemaRegistryClient(schemaRegistry);
+        }
+        return strategy;
+      } catch (Exception e) {
+        log.warn("Failed to create subject name strategy {}, "
+            + "using TopicNameStrategy", strategyClass, e);
+      }
+    }
+    TopicNameStrategy defaultStrategy = new TopicNameStrategy();
+    if (schemaRegistry != null) {
+      defaultStrategy.setSchemaRegistryClient(schemaRegistry);
+    }
+    return defaultStrategy;
+  }
+
+  private BackupReferenceResolver.ParsedSchemaFactory createSchemaFactory(
+      String schemaType) {
+    if (schemaType == null) {
+      return null;
+    }
+    return (raw, refs, resolved) -> {
+      Optional<ParsedSchema> parsed = schemaRegistry.parseSchema(
+          schemaType, raw, refs);
+      return parsed.orElse(null);
+    };
+  }
+
+  private byte[] rewriteSchemaId(byte[] bytes, int newId) {
+    if (bytes.length < 5 || bytes[0] != MAGIC_BYTE) {
+      return bytes;
+    }
+    byte[] result = bytes.clone();
+    ByteBuffer.wrap(result, 1, 4).putInt(newId);
+    return result;
+  }
+
+  private byte[] toBytes(Object value) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof byte[]) {
+      return (byte[]) value;
+    }
+    if (value instanceof ByteBuffer) {
+      ByteBuffer buf = (ByteBuffer) value;
+      byte[] bytes = new byte[buf.remaining()];
+      buf.get(bytes);
+      return bytes;
+    }
+    throw new DataException("Expected byte[] or ByteBuffer but got "
+        + value.getClass().getName());
+  }
+
+  private String detectSchemaType(int schemaId) {
+    if (schemaRegistry == null) {
+      return SchemaBackupConfig.TYPE_UNKNOWN;
+    }
+    try {
+      String type = schemaRegistry.getSchemaById(schemaId).schemaType();
+      if ("AVRO".equals(type)) {
+        return SchemaBackupConfig.TYPE_AVRO;
+      }
+      if ("PROTOBUF".equals(type)) {
+        return SchemaBackupConfig.TYPE_PROTOBUF;
+      }
+      if ("JSON".equals(type)) {
+        return SchemaBackupConfig.TYPE_JSON_SCHEMA;
+      }
+      return type;
+    } catch (Exception e) {
+      log.debug("Could not determine schema type for id={}", schemaId, e);
+      return SchemaBackupConfig.TYPE_UNKNOWN;
+    }
+  }
+}

--- a/kafka-connect-schema-backup-core/src/main/java/io/confluent/connect/schema/backup/core/BackupConverterHelper.java
+++ b/kafka-connect-schema-backup-core/src/main/java/io/confluent/connect/schema/backup/core/BackupConverterHelper.java
@@ -19,9 +19,9 @@ package io.confluent.connect.schema.backup.core;
 import io.confluent.connect.schema.backup.api.BackupWrapper;
 import io.confluent.connect.schema.backup.api.SchemaBackupConfig;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.ParsedSchemaAndValue;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.Struct;
@@ -61,28 +61,25 @@ public class BackupConverterHelper {
   }
 
   public SchemaAndValue wrapWithBackupMetadata(
-      SchemaAndValue original, String topic, int schemaId,
+      SchemaAndValue original, String topic,
+      ParsedSchemaAndValue.SchemaInfo schemaInfo,
       String schemaType, boolean isKey,
       BackupReferenceResolver.ParsedSchemaFactory schemaFactory,
       SubjectNameComputer subjectComputer)
       throws IOException, RestClientException {
-    return wrapWithBackupMetadata(original, topic,
-        new SchemaIdResult(schemaId, null),
-        schemaType, isKey, schemaFactory, subjectComputer);
-  }
 
-  public SchemaAndValue wrapWithBackupMetadata(
-      SchemaAndValue original, String topic, SchemaIdResult schemaIdResult,
-      String schemaType, boolean isKey,
-      BackupReferenceResolver.ParsedSchemaFactory schemaFactory,
-      SubjectNameComputer subjectComputer)
-      throws IOException, RestClientException {
+    Integer schemaId = schemaInfo.id();
+    String schemaGuid = schemaInfo.guid() != null
+        ? schemaInfo.guid().toString() : null;
 
     BackupSchemaFetcher.BackupSchemaInfo info;
-    if (schemaIdResult.getSchemaId() != null) {
-      info = schemaFetcher.fetchSchemaInfo(schemaIdResult.getSchemaId());
+    if (schemaId != null) {
+      info = schemaFetcher.fetchSchemaInfo(schemaId);
+    } else if (schemaGuid != null) {
+      info = schemaFetcher.fetchSchemaInfoByGuid(schemaGuid);
     } else {
-      info = schemaFetcher.fetchSchemaInfoByGuid(schemaIdResult.getSchemaGuid());
+      throw new IllegalArgumentException(
+          "Schema info has neither id nor guid for topic=" + topic);
     }
     String rawSchema = info.getRawSchema();
 
@@ -108,56 +105,16 @@ public class BackupConverterHelper {
     }
 
     BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        schemaIdResult.getSchemaId(), schemaVersion, schemaType, subject,
+        schemaId, schemaVersion, schemaType, subject,
         rawSchema, info.getReferenceTreeJson(), info.getDirectRefsJson(),
-        schemaIdResult.getSchemaGuid());
+        schemaGuid);
     Struct wrapper = BackupWrapper.buildWrapper(
         wrapperSchema, original.value(), fields);
 
     log.debug("Wrapped backup metadata: topic={}, isKey={}, schemaId={}, guid={}, hasRefs={}",
-        topic, isKey, schemaIdResult.getSchemaId(),
-        schemaIdResult.getSchemaGuid(),
+        topic, isKey, schemaId, schemaGuid,
         info.getReferenceTreeJson() != null);
     return new SchemaAndValue(wrapperSchema, wrapper);
-  }
-
-  public SchemaIdResult resolveSchemaId(
-      byte[] value, Headers headers, boolean isKey) {
-    Integer intId = BackupWrapper.extractSchemaIdFromHeader(headers, isKey);
-    if (intId != null) {
-      return new SchemaIdResult(intId, null);
-    }
-    String guid = BackupWrapper.extractSchemaGuidFromHeader(headers, isKey);
-    if (guid != null) {
-      return new SchemaIdResult(null, guid);
-    }
-    intId = BackupWrapper.extractSchemaId(value);
-    if (intId != null) {
-      return new SchemaIdResult(intId, null);
-    }
-    return null;
-  }
-
-  public static class SchemaIdResult {
-    private final Integer schemaId;
-    private final String schemaGuid;
-
-    public SchemaIdResult(Integer schemaId, String schemaGuid) {
-      if (schemaId == null && schemaGuid == null) {
-        throw new IllegalArgumentException(
-            "SchemaIdResult requires at least one of schemaId or schemaGuid");
-      }
-      this.schemaId = schemaId;
-      this.schemaGuid = schemaGuid;
-    }
-
-    public Integer getSchemaId() {
-      return schemaId;
-    }
-
-    public String getSchemaGuid() {
-      return schemaGuid;
-    }
   }
 
   @FunctionalInterface

--- a/kafka-connect-schema-backup-core/src/main/java/io/confluent/connect/schema/backup/core/BackupConverterHelper.java
+++ b/kafka-connect-schema-backup-core/src/main/java/io/confluent/connect/schema/backup/core/BackupConverterHelper.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.schema.backup.core;
+
+import io.confluent.connect.schema.backup.api.BackupWrapper;
+import io.confluent.connect.schema.backup.api.SchemaBackupConfig;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Shared helper for backup metadata wrapping in SR converters.
+ */
+public class BackupConverterHelper {
+
+  private static final Logger log = LoggerFactory.getLogger(BackupConverterHelper.class);
+
+  private final BackupSchemaFetcher schemaFetcher;
+  private final BackupReferenceResolver referenceResolver;
+  private final Map<Schema, Schema> wrapperSchemaCache;
+
+  public BackupConverterHelper(
+      SchemaRegistryClient schemaRegistry,
+      Map<Schema, Schema> wrapperSchemaCache) {
+    this.schemaFetcher = new BackupSchemaFetcher(schemaRegistry);
+    this.referenceResolver = new BackupReferenceResolver(schemaRegistry);
+    this.wrapperSchemaCache = wrapperSchemaCache;
+  }
+
+  public BackupReferenceResolver getReferenceResolver() {
+    return referenceResolver;
+  }
+
+  public static boolean isBackupEnabled(Map<String, ?> configs) {
+    Object val = configs.get(SchemaBackupConfig.SCHEMA_BACKUP_ENABLED_CONFIG);
+    return "true".equalsIgnoreCase(val != null ? val.toString() : null);
+  }
+
+  public SchemaAndValue wrapWithBackupMetadata(
+      SchemaAndValue original, String topic, int schemaId,
+      String schemaType, boolean isKey,
+      BackupReferenceResolver.ParsedSchemaFactory schemaFactory,
+      SubjectNameComputer subjectComputer)
+      throws IOException, RestClientException {
+    return wrapWithBackupMetadata(original, topic,
+        new SchemaIdResult(schemaId, null),
+        schemaType, isKey, schemaFactory, subjectComputer);
+  }
+
+  public SchemaAndValue wrapWithBackupMetadata(
+      SchemaAndValue original, String topic, SchemaIdResult schemaIdResult,
+      String schemaType, boolean isKey,
+      BackupReferenceResolver.ParsedSchemaFactory schemaFactory,
+      SubjectNameComputer subjectComputer)
+      throws IOException, RestClientException {
+
+    BackupSchemaFetcher.BackupSchemaInfo info;
+    if (schemaIdResult.getSchemaId() != null) {
+      info = schemaFetcher.fetchSchemaInfo(schemaIdResult.getSchemaId());
+    } else {
+      info = schemaFetcher.fetchSchemaInfoByGuid(schemaIdResult.getSchemaGuid());
+    }
+    String rawSchema = info.getRawSchema();
+
+    Map<String, String> resolved = new LinkedHashMap<>();
+    if (!info.getDirectReferences().isEmpty()) {
+      for (Map.Entry<String, BackupSchemaFetcher.RefTreeEntry> e
+          : info.getReferenceTree().entrySet()) {
+        resolved.put(e.getKey(), e.getValue().getSchema());
+      }
+    }
+
+    ParsedSchema parsed = schemaFactory.create(
+        rawSchema, info.getDirectReferences(), resolved);
+    String subject = subjectComputer.computeSubjectName(topic, isKey, parsed);
+    Integer schemaVersion = info.getVersionForSubject(subject);
+
+    Schema wrapperSchema;
+    if (original.schema() == null) {
+      wrapperSchema = BackupWrapper.buildSchema(null);
+    } else {
+      wrapperSchema = wrapperSchemaCache.computeIfAbsent(
+          original.schema(), ds -> BackupWrapper.buildSchema(ds));
+    }
+
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        schemaIdResult.getSchemaId(), schemaVersion, schemaType, subject,
+        rawSchema, info.getReferenceTreeJson(), info.getDirectRefsJson(),
+        schemaIdResult.getSchemaGuid());
+    Struct wrapper = BackupWrapper.buildWrapper(
+        wrapperSchema, original.value(), fields);
+
+    log.debug("Wrapped backup metadata: topic={}, isKey={}, schemaId={}, guid={}, hasRefs={}",
+        topic, isKey, schemaIdResult.getSchemaId(),
+        schemaIdResult.getSchemaGuid(),
+        info.getReferenceTreeJson() != null);
+    return new SchemaAndValue(wrapperSchema, wrapper);
+  }
+
+  public SchemaIdResult resolveSchemaId(
+      byte[] value, Headers headers, boolean isKey) {
+    Integer intId = BackupWrapper.extractSchemaIdFromHeader(headers, isKey);
+    if (intId != null) {
+      return new SchemaIdResult(intId, null);
+    }
+    String guid = BackupWrapper.extractSchemaGuidFromHeader(headers, isKey);
+    if (guid != null) {
+      return new SchemaIdResult(null, guid);
+    }
+    intId = BackupWrapper.extractSchemaId(value);
+    if (intId != null) {
+      return new SchemaIdResult(intId, null);
+    }
+    return null;
+  }
+
+  public static class SchemaIdResult {
+    private final Integer schemaId;
+    private final String schemaGuid;
+
+    public SchemaIdResult(Integer schemaId, String schemaGuid) {
+      if (schemaId == null && schemaGuid == null) {
+        throw new IllegalArgumentException(
+            "SchemaIdResult requires at least one of schemaId or schemaGuid");
+      }
+      this.schemaId = schemaId;
+      this.schemaGuid = schemaGuid;
+    }
+
+    public Integer getSchemaId() {
+      return schemaId;
+    }
+
+    public String getSchemaGuid() {
+      return schemaGuid;
+    }
+  }
+
+  @FunctionalInterface
+  public interface SubjectNameComputer {
+    String computeSubjectName(String topic, boolean isKey, ParsedSchema schema);
+  }
+}

--- a/kafka-connect-schema-backup-core/src/main/java/io/confluent/connect/schema/backup/core/BackupReferenceResolver.java
+++ b/kafka-connect-schema-backup-core/src/main/java/io/confluent/connect/schema/backup/core/BackupReferenceResolver.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.schema.backup.core;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.connect.schema.backup.api.BackupWrapper;
+import io.confluent.connect.schema.backup.api.SchemaBackupConfig;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.errors.RetriableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Resolves and registers schema references in the target Schema Registry during restore.
+ */
+public class BackupReferenceResolver {
+
+  private static final Logger log = LoggerFactory.getLogger(BackupReferenceResolver.class);
+  private static final ObjectMapper JSON = new ObjectMapper();
+  private static final int MAX_DEPTH = SchemaBackupConfig.MAX_REFERENCE_DEPTH;
+
+  private final SchemaRegistryClient schemaRegistry;
+  private final Map<String, Integer> registrationCache = new ConcurrentHashMap<>();
+
+  public BackupReferenceResolver(SchemaRegistryClient schemaRegistry) {
+    this.schemaRegistry = schemaRegistry;
+  }
+
+  public static class ResolutionResult {
+    private final List<SchemaReference> targetRefs;
+    private final Map<String, String> resolvedSchemas;
+
+    private ResolutionResult(List<SchemaReference> targetRefs,
+        Map<String, String> resolvedSchemas) {
+      this.targetRefs = targetRefs;
+      this.resolvedSchemas = resolvedSchemas;
+    }
+
+    static ResolutionResult of(List<SchemaReference> targetRefs,
+        Map<String, String> resolvedSchemas) {
+      return new ResolutionResult(targetRefs, resolvedSchemas);
+    }
+
+    public List<SchemaReference> getTargetRefs() {
+      return targetRefs;
+    }
+
+    public Map<String, String> getResolvedSchemas() {
+      return resolvedSchemas;
+    }
+
+    public boolean hasReferences() {
+      return targetRefs != null && !targetRefs.isEmpty();
+    }
+
+    private static final ResolutionResult EMPTY =
+        new ResolutionResult(Collections.emptyList(), Collections.emptyMap());
+
+    public static ResolutionResult empty() {
+      return EMPTY;
+    }
+  }
+
+  public ResolutionResult resolveFromWrapper(
+      Schema wrapperSchema, Struct wrapper, ParsedSchemaFactory factory) {
+    String treeJson = wrapperSchema.field(BackupWrapper.FIELD_REFERENCE_TREE) != null
+        ? wrapper.getString(BackupWrapper.FIELD_REFERENCE_TREE) : null;
+    String directRefsJson = wrapperSchema.field(BackupWrapper.FIELD_DIRECT_REFS) != null
+        ? wrapper.getString(BackupWrapper.FIELD_DIRECT_REFS) : null;
+
+    Map<String, BackupSchemaFetcher.RefTreeEntry> refTree =
+        parseReferenceTree(treeJson);
+    List<SchemaReference> directRefs =
+        parseDirectRefs(directRefsJson);
+
+    if (refTree.isEmpty() || directRefs.isEmpty()) {
+      return ResolutionResult.empty();
+    }
+
+    List<SchemaReference> targetRefs = new ArrayList<>();
+    // LinkedHashMap: schema parsers need transitive deps before their dependents
+    Map<String, String> resolvedSchemas = new LinkedHashMap<>();
+    registerRefsRecursive(
+        directRefs, refTree, factory, targetRefs, resolvedSchemas);
+    return ResolutionResult.of(targetRefs, resolvedSchemas);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static Map<String, BackupSchemaFetcher.RefTreeEntry> parseReferenceTree(String json) {
+    if (json == null || json.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    try {
+      Map<String, Map<String, Object>> raw = JSON.readValue(json,
+          new TypeReference<Map<String, Map<String, Object>>>() {});
+      Map<String, BackupSchemaFetcher.RefTreeEntry> tree = new LinkedHashMap<>();
+      for (Map.Entry<String, Map<String, Object>> e : raw.entrySet()) {
+        tree.put(e.getKey(), parseRefTreeEntry(e.getValue()));
+      }
+      return tree;
+    } catch (IOException e) {
+      throw new DataException(
+          "Cannot parse reference tree JSON for restore. "
+          + "Backup metadata may be corrupt.", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static BackupSchemaFetcher.RefTreeEntry parseRefTreeEntry(Map<String, Object> v) {
+    String subject = (String) v.get(SchemaBackupConfig.REF_FIELD_SUBJECT);
+    int version = v.get(SchemaBackupConfig.REF_FIELD_VERSION) instanceof Number
+        ? ((Number) v.get(SchemaBackupConfig.REF_FIELD_VERSION)).intValue() : 0;
+    String schema = (String) v.get(SchemaBackupConfig.REF_FIELD_SCHEMA);
+    List<SchemaReference> refs = Collections.emptyList();
+    Object refsObj = v.get(SchemaBackupConfig.REF_FIELD_REFERENCES);
+    if (refsObj instanceof List) {
+      refs = new ArrayList<>();
+      for (Object item : (List<?>) refsObj) {
+        if (item instanceof Map) {
+          Map<String, Object> m = (Map<String, Object>) item;
+          refs.add(new SchemaReference(
+              (String) m.get(SchemaBackupConfig.REF_FIELD_NAME),
+              (String) m.get(SchemaBackupConfig.REF_FIELD_SUBJECT),
+              m.get(SchemaBackupConfig.REF_FIELD_VERSION) instanceof Number
+                  ? ((Number) m.get(SchemaBackupConfig.REF_FIELD_VERSION)).intValue() : 0));
+        }
+      }
+    }
+    int globalId = v.get(SchemaBackupConfig.REF_FIELD_GLOBAL_ID) instanceof Number
+        ? ((Number) v.get(SchemaBackupConfig.REF_FIELD_GLOBAL_ID)).intValue() : 0;
+    String schemaType = v.get(SchemaBackupConfig.REF_FIELD_SCHEMA_TYPE) instanceof String
+        ? (String) v.get(SchemaBackupConfig.REF_FIELD_SCHEMA_TYPE) : null;
+    return new BackupSchemaFetcher.RefTreeEntry(
+        subject, version, schema, refs, globalId, schemaType);
+  }
+
+  public static List<SchemaReference> parseDirectRefs(String json) {
+    if (json == null || json.isEmpty()) {
+      return Collections.emptyList();
+    }
+    try {
+      return JSON.readValue(json, new TypeReference<List<SchemaReference>>() {});
+    } catch (IOException e) {
+      throw new DataException(
+          "Cannot parse direct references JSON for restore. "
+          + "Backup metadata may be corrupt.", e);
+    }
+  }
+
+  public void registerRefsRecursive(
+      List<SchemaReference> refs,
+      Map<String, BackupSchemaFetcher.RefTreeEntry> tree,
+      ParsedSchemaFactory factory,
+      List<SchemaReference> targetRefsOut,
+      Map<String, String> resolvedSchemasOut) {
+    registerRefsRecursive(
+        refs, tree, factory, targetRefsOut, resolvedSchemasOut, 0);
+  }
+
+  private void registerRefsRecursive(
+      List<SchemaReference> refs,
+      Map<String, BackupSchemaFetcher.RefTreeEntry> tree,
+      ParsedSchemaFactory factory,
+      List<SchemaReference> targetRefsOut,
+      Map<String, String> resolvedSchemasOut,
+      int depth) {
+    if (refs == null) {
+      return;
+    }
+    if (depth >= MAX_DEPTH) {
+      throw new DataException(
+          "Reference registration depth limit (" + MAX_DEPTH
+          + ") exceeded. Possible circular reference chain.");
+    }
+    for (SchemaReference ref : refs) {
+      registerSingleRef(ref, tree, factory, targetRefsOut, resolvedSchemasOut, depth);
+    }
+  }
+
+  private void registerSingleRef(
+      SchemaReference ref,
+      Map<String, BackupSchemaFetcher.RefTreeEntry> tree,
+      ParsedSchemaFactory factory,
+      List<SchemaReference> targetRefsOut,
+      Map<String, String> resolvedSchemasOut,
+      int depth) {
+    String cacheKey = ref.getSubject() + ":" + ref.getVersion();
+    Integer targetVersion = registrationCache.get(cacheKey);
+    if (targetVersion != null) {
+      targetRefsOut.add(new SchemaReference(
+          ref.getName(), ref.getSubject(), targetVersion));
+      BackupSchemaFetcher.RefTreeEntry entry = tree.get(ref.getName());
+      if (entry != null) {
+        addTransitiveSchemas(ref.getName(), entry, tree, resolvedSchemasOut);
+      }
+      return;
+    }
+
+    BackupSchemaFetcher.RefTreeEntry entry = tree.get(ref.getName());
+    if (entry == null) {
+      throw new DataException(
+          "Cannot guarantee pristine restore: reference '"
+          + ref.getName()
+          + "' (subject=" + ref.getSubject()
+          + ") not found in reference tree. "
+          + "Backup may be incomplete.");
+    }
+
+    List<SchemaReference> childTargetRefs = new ArrayList<>();
+    Map<String, String> childResolvedSchemas = new LinkedHashMap<>();
+    if (!entry.getReferences().isEmpty()) {
+      registerRefsRecursive(
+          entry.getReferences(), tree, factory,
+          childTargetRefs, childResolvedSchemas, depth + 1);
+    }
+
+    resolvedSchemasOut.putAll(childResolvedSchemas);
+
+    try {
+      ParsedSchema refSchema = factory.create(
+          entry.getSchema(), childTargetRefs, childResolvedSchemas);
+      schemaRegistry.register(ref.getSubject(), refSchema);
+      targetVersion = schemaRegistry.getVersion(
+          ref.getSubject(), refSchema);
+      registrationCache.put(cacheKey, targetVersion);
+      log.debug("Registered reference: subject={}, "
+          + "srcVersion={}, targetVersion={}",
+          ref.getSubject(), ref.getVersion(), targetVersion);
+    } catch (IOException e) {
+      throw new RetriableException(
+          "Network error registering reference '" + ref.getSubject() + "'", e);
+    } catch (RestClientException e) {
+      throw new DataException(
+          "Failed to register reference '" + ref.getSubject() + "'", e);
+    }
+    targetRefsOut.add(new SchemaReference(
+        ref.getName(), ref.getSubject(), targetVersion));
+    resolvedSchemasOut.put(ref.getName(), entry.getSchema());
+  }
+
+  private void addTransitiveSchemas(
+      String refName,
+      BackupSchemaFetcher.RefTreeEntry entry,
+      Map<String, BackupSchemaFetcher.RefTreeEntry> tree,
+      Map<String, String> resolvedSchemasOut) {
+    addTransitiveSchemas(refName, entry, tree, resolvedSchemasOut, 0);
+  }
+
+  private void addTransitiveSchemas(
+      String refName,
+      BackupSchemaFetcher.RefTreeEntry entry,
+      Map<String, BackupSchemaFetcher.RefTreeEntry> tree,
+      Map<String, String> resolvedSchemasOut,
+      int depth) {
+    if (depth >= MAX_DEPTH) {
+      throw new DataException(
+          "Reference tree depth limit (" + MAX_DEPTH
+          + ") exceeded while collecting transitive schemas. "
+          + "Possible circular reference chain.");
+    }
+    if (entry.getReferences() != null) {
+      for (SchemaReference childRef : entry.getReferences()) {
+        BackupSchemaFetcher.RefTreeEntry childEntry = tree.get(childRef.getName());
+        if (childEntry != null && !resolvedSchemasOut.containsKey(childRef.getName())) {
+          addTransitiveSchemas(
+              childRef.getName(), childEntry, tree, resolvedSchemasOut, depth + 1);
+        }
+      }
+    }
+    resolvedSchemasOut.put(refName, entry.getSchema());
+  }
+
+  @FunctionalInterface
+  public interface ParsedSchemaFactory {
+    ParsedSchema create(String rawSchema, List<SchemaReference> refs,
+        Map<String, String> resolvedSchemas);
+  }
+}

--- a/kafka-connect-schema-backup-core/src/main/java/io/confluent/connect/schema/backup/core/BackupSchemaFetcher.java
+++ b/kafka-connect-schema-backup-core/src/main/java/io/confluent/connect/schema/backup/core/BackupSchemaFetcher.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.schema.backup.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.connect.schema.backup.api.SchemaBackupConfig;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Fetches schema metadata and builds reference trees from Schema Registry for backup.
+ */
+public class BackupSchemaFetcher {
+
+  private static final Logger log = LoggerFactory.getLogger(BackupSchemaFetcher.class);
+  private static final ObjectMapper JSON = new ObjectMapper();
+  private static final int MAX_DEPTH = SchemaBackupConfig.MAX_REFERENCE_DEPTH;
+
+  private final SchemaRegistryClient schemaRegistry;
+  private final Map<Integer, BackupSchemaInfo> cache = new ConcurrentHashMap<>();
+  private final Map<String, BackupSchemaInfo> guidCache = new ConcurrentHashMap<>();
+
+  public BackupSchemaFetcher(SchemaRegistryClient schemaRegistry) {
+    this.schemaRegistry = schemaRegistry;
+  }
+
+  public BackupSchemaInfo fetchSchemaInfo(int schemaId)
+      throws IOException, RestClientException {
+    BackupSchemaInfo cached = cache.get(schemaId);
+    if (cached != null) {
+      return cached;
+    }
+
+    ParsedSchema fullSchema = schemaRegistry.getSchemaById(schemaId);
+    String rawText = fullSchema.canonicalString();
+    List<SchemaReference> directRefs = fullSchema.references();
+    Map<String, RefTreeEntry> tree = new LinkedHashMap<>();
+    if (directRefs != null && !directRefs.isEmpty()) {
+      buildReferenceTree(directRefs, tree, 0);
+    }
+    String treeJson = !tree.isEmpty() ? JSON.writeValueAsString(tree) : null;
+    String directRefsJson = directRefs != null && !directRefs.isEmpty()
+        ? JSON.writeValueAsString(directRefs) : null;
+
+    Map<String, Integer> versionsBySubject = new HashMap<>();
+    try {
+      for (SubjectVersion sv : schemaRegistry.getAllVersionsById(schemaId)) {
+        versionsBySubject.put(sv.getSubject(), sv.getVersion());
+      }
+    } catch (IOException | RestClientException e) {
+      log.warn("Could not fetch versions for schemaId={}: {}",
+          schemaId, e.getMessage());
+    }
+
+    BackupSchemaInfo info = new BackupSchemaInfo(rawText, directRefs, tree,
+        treeJson, directRefsJson, versionsBySubject);
+    cache.put(schemaId, info);
+    return info;
+  }
+
+  public BackupSchemaInfo fetchSchemaInfoByGuid(String guid)
+      throws IOException, RestClientException {
+    if (guid == null || guid.isEmpty()) {
+      throw new IllegalArgumentException("Schema GUID must not be null or empty");
+    }
+    BackupSchemaInfo cached = guidCache.get(guid);
+    if (cached != null) {
+      return cached;
+    }
+    ParsedSchema fullSchema = schemaRegistry.getSchemaByGuid(guid, null);
+    String rawText = fullSchema.canonicalString();
+    List<SchemaReference> directRefs = fullSchema.references();
+    Map<String, RefTreeEntry> tree = new LinkedHashMap<>();
+    if (directRefs != null && !directRefs.isEmpty()) {
+      buildReferenceTree(directRefs, tree, 0);
+    }
+    String treeJson = !tree.isEmpty() ? JSON.writeValueAsString(tree) : null;
+    String directRefsJson = directRefs != null && !directRefs.isEmpty()
+        ? JSON.writeValueAsString(directRefs) : null;
+    BackupSchemaInfo info = new BackupSchemaInfo(rawText, directRefs, tree,
+        treeJson, directRefsJson, Collections.emptyMap());
+    guidCache.put(guid, info);
+    return info;
+  }
+
+  private void buildReferenceTree(
+      List<SchemaReference> refs, Map<String, RefTreeEntry> tree,
+      int depth) throws IOException, RestClientException {
+    if (refs == null) {
+      return;
+    }
+    if (depth >= MAX_DEPTH) {
+      throw new IOException(
+          "Reference tree depth limit (" + MAX_DEPTH + ") exceeded. "
+          + "Possible circular reference chain.");
+    }
+    for (SchemaReference ref : refs) {
+      if (tree.containsKey(ref.getName())) {
+        continue;
+      }
+      io.confluent.kafka.schemaregistry.client.SchemaMetadata meta =
+          schemaRegistry.getSchemaMetadata(ref.getSubject(), ref.getVersion());
+      String schemaText = meta.getSchema();
+      ParsedSchema parsed = schemaRegistry.getSchemaById(meta.getId());
+      List<SchemaReference> childRefs = parsed.references();
+      if (childRefs != null && !childRefs.isEmpty()) {
+        buildReferenceTree(childRefs, tree, depth + 1);
+      }
+      tree.put(ref.getName(), new RefTreeEntry(
+          ref.getSubject(), ref.getVersion(), schemaText, childRefs,
+          meta.getId(), meta.getSchemaType()));
+    }
+  }
+
+  public static class BackupSchemaInfo {
+    private final String rawSchema;
+    private final List<SchemaReference> directReferences;
+    private final Map<String, RefTreeEntry> referenceTree;
+    private final String referenceTreeJson;
+    private final String directRefsJson;
+    private final Map<String, Integer> versionsBySubject;
+
+    public BackupSchemaInfo(
+        String rawSchema,
+        List<SchemaReference> directReferences,
+        Map<String, RefTreeEntry> referenceTree,
+        String referenceTreeJson,
+        String directRefsJson,
+        Map<String, Integer> versionsBySubject) {
+      this.rawSchema = rawSchema;
+      this.directReferences = directReferences != null
+          ? directReferences : Collections.emptyList();
+      this.referenceTree = referenceTree != null
+          ? referenceTree : Collections.emptyMap();
+      this.referenceTreeJson = referenceTreeJson;
+      this.directRefsJson = directRefsJson;
+      this.versionsBySubject = versionsBySubject != null
+          ? versionsBySubject : Collections.emptyMap();
+    }
+
+    public String getRawSchema() {
+      return rawSchema;
+    }
+
+    public List<SchemaReference> getDirectReferences() {
+      return directReferences;
+    }
+
+    public Map<String, RefTreeEntry> getReferenceTree() {
+      return referenceTree;
+    }
+
+    public String getReferenceTreeJson() {
+      return referenceTreeJson;
+    }
+
+    public String getDirectRefsJson() {
+      return directRefsJson;
+    }
+
+    public Integer getVersionForSubject(String subject) {
+      return versionsBySubject.get(subject);
+    }
+  }
+
+  public static class RefTreeEntry {
+    private final String subject;
+    private final int version;
+    private final String schema;
+    private final List<SchemaReference> references;
+    private final int globalId;
+    private final String schemaType;
+
+    public RefTreeEntry(String subject, int version, String schema,
+        List<SchemaReference> references, int globalId, String schemaType) {
+      this.subject = subject;
+      this.version = version;
+      this.schema = schema;
+      this.references = references != null ? references : Collections.emptyList();
+      this.globalId = globalId;
+      this.schemaType = schemaType;
+    }
+
+    public String getSubject() {
+      return subject;
+    }
+
+    public int getVersion() {
+      return version;
+    }
+
+    public String getSchema() {
+      return schema;
+    }
+
+    public List<SchemaReference> getReferences() {
+      return references;
+    }
+
+    public int getGlobalId() {
+      return globalId;
+    }
+
+    public String getSchemaType() {
+      return schemaType;
+    }
+  }
+}

--- a/kafka-connect-schema-backup-core/src/test/java/io/confluent/connect/schema/backup/core/BackupConverterHelperTest.java
+++ b/kafka-connect-schema-backup-core/src/test/java/io/confluent/connect/schema/backup/core/BackupConverterHelperTest.java
@@ -25,16 +25,14 @@ import static org.junit.Assert.assertTrue;
 
 import io.confluent.connect.schema.backup.api.BackupWrapper;
 import io.confluent.connect.schema.backup.api.SchemaBackupConfig;
+import io.confluent.kafka.schemaregistry.ParsedSchemaAndValue;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
-import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -47,8 +45,6 @@ public class BackupConverterHelperTest {
   private static final String TOPIC = "test-topic";
   private static final String VALUE_SUFFIX = "-value";
   private static final String ADDRESS_SUBJECT = "com.example.Address";
-  private static final String VALUE_HEADER = "__value_schema_id";
-  private static final String TEST_GUID = "550e8400-e29b-41d4-a716-446655440000";
 
   private static final String USER_SCHEMA =
       "{\"type\":\"record\",\"name\":\"User\","
@@ -158,8 +154,7 @@ public class BackupConverterHelperTest {
   }
 
   @Test
-  public void testWrapSimpleSchema()
-      throws Exception {
+  public void testWrapSimpleSchema() throws Exception {
     AvroSchema avro = new AvroSchema(USER_SCHEMA);
     int schemaId = schemaRegistry.register(TOPIC + VALUE_SUFFIX, avro);
 
@@ -171,18 +166,20 @@ public class BackupConverterHelperTest {
         .put("name", "Alice")
         .put("age", 30);
 
+    ParsedSchemaAndValue.SchemaInfo schemaInfo =
+        new ParsedSchemaAndValue.SchemaInfo(
+            TOPIC + VALUE_SUFFIX, schemaId, null, null);
+
     SchemaAndValue original = new SchemaAndValue(connectSchema, value);
     SchemaAndValue wrapped = helper.wrapWithBackupMetadata(
-        original, TOPIC, schemaId,
+        original, TOPIC, schemaInfo,
         SchemaBackupConfig.TYPE_AVRO, false,
         AVRO_FACTORY, SUBJECT_COMPUTER);
 
-    // Verify it's a BackupWrapper
     assertNotNull(wrapped);
     assertNotNull(wrapped.schema());
     assertEquals(BackupWrapper.NAME, wrapped.schema().name());
 
-    // Verify wrapper fields
     Struct wrapper = (Struct) wrapped.value();
     assertEquals(schemaId, (int) wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_ID));
     assertEquals(SchemaBackupConfig.TYPE_AVRO,
@@ -190,19 +187,14 @@ public class BackupConverterHelperTest {
     assertNotNull(wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA));
     assertEquals(TOPIC + VALUE_SUFFIX,
         wrapper.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT));
-
-    // Verify data is preserved
     assertNotNull(wrapper.get(BackupWrapper.FIELD_DATA));
   }
 
   @Test
-  public void testWrapWithReferences()
-      throws Exception {
-    // Register the referenced schema first
+  public void testWrapWithReferences() throws Exception {
     AvroSchema addrSchema = new AvroSchema(ADDRESS_SCHEMA);
     schemaRegistry.register(ADDRESS_SUBJECT, addrSchema);
 
-    // Register the main schema with a reference
     SchemaReference ref = new SchemaReference(
         ADDRESS_SUBJECT, ADDRESS_SUBJECT, 1);
     AvroSchema orderSchema = new AvroSchema(
@@ -218,8 +210,12 @@ public class BackupConverterHelperTest {
     SchemaAndValue original = new SchemaAndValue(
         connectSchema, new Struct(connectSchema).put("id", "o1"));
 
+    ParsedSchemaAndValue.SchemaInfo schemaInfo =
+        new ParsedSchemaAndValue.SchemaInfo(
+            TOPIC + VALUE_SUFFIX, orderId, null, null);
+
     SchemaAndValue wrapped = helper.wrapWithBackupMetadata(
-        original, TOPIC, orderId,
+        original, TOPIC, schemaInfo,
         SchemaBackupConfig.TYPE_AVRO, false,
         AVRO_FACTORY, SUBJECT_COMPUTER);
 
@@ -229,16 +225,19 @@ public class BackupConverterHelperTest {
   }
 
   @Test
-  public void testWrapNoReferences()
-      throws Exception {
+  public void testWrapNoReferences() throws Exception {
     AvroSchema avro = new AvroSchema(USER_SCHEMA);
     int schemaId = schemaRegistry.register(TOPIC + VALUE_SUFFIX, avro);
 
     SchemaAndValue original = new SchemaAndValue(
         Schema.STRING_SCHEMA, "test");
 
+    ParsedSchemaAndValue.SchemaInfo schemaInfo =
+        new ParsedSchemaAndValue.SchemaInfo(
+            TOPIC + VALUE_SUFFIX, schemaId, null, null);
+
     SchemaAndValue wrapped = helper.wrapWithBackupMetadata(
-        original, TOPIC, schemaId,
+        original, TOPIC, schemaInfo,
         SchemaBackupConfig.TYPE_AVRO, false,
         AVRO_FACTORY, SUBJECT_COMPUTER);
 
@@ -248,160 +247,59 @@ public class BackupConverterHelperTest {
   }
 
   @Test
-  public void testWrapNullSchema()
-      throws Exception {
+  public void testWrapNullSchema() throws Exception {
     AvroSchema avro = new AvroSchema(USER_SCHEMA);
     int schemaId = schemaRegistry.register(TOPIC + VALUE_SUFFIX, avro);
 
     SchemaAndValue original = new SchemaAndValue(null, null);
 
+    ParsedSchemaAndValue.SchemaInfo schemaInfo =
+        new ParsedSchemaAndValue.SchemaInfo(
+            TOPIC + VALUE_SUFFIX, schemaId, null, null);
+
     SchemaAndValue wrapped = helper.wrapWithBackupMetadata(
-        original, TOPIC, schemaId,
+        original, TOPIC, schemaInfo,
         SchemaBackupConfig.TYPE_AVRO, false,
         AVRO_FACTORY, SUBJECT_COMPUTER);
 
     assertNotNull(wrapped.schema());
     assertEquals(BackupWrapper.NAME, wrapped.schema().name());
-    // Data field schema defaults to OPTIONAL_BYTES_SCHEMA for null original schema
     assertNotNull(wrapped.schema().field(BackupWrapper.FIELD_DATA));
   }
 
   @Test
-  public void testWrapCachedSchema()
-      throws Exception {
+  public void testWrapCachedSchema() throws Exception {
     AvroSchema avro = new AvroSchema(USER_SCHEMA);
     int schemaId = schemaRegistry.register(TOPIC + VALUE_SUFFIX, avro);
 
     Schema connectSchema = Schema.STRING_SCHEMA;
     SchemaAndValue original = new SchemaAndValue(connectSchema, "test");
 
-    // Wrap twice with the same original schema
+    ParsedSchemaAndValue.SchemaInfo schemaInfo =
+        new ParsedSchemaAndValue.SchemaInfo(
+            TOPIC + VALUE_SUFFIX, schemaId, null, null);
+
     helper.wrapWithBackupMetadata(
-        original, TOPIC, schemaId,
+        original, TOPIC, schemaInfo,
         SchemaBackupConfig.TYPE_AVRO, false,
         AVRO_FACTORY, SUBJECT_COMPUTER);
     helper.wrapWithBackupMetadata(
-        original, TOPIC, schemaId,
+        original, TOPIC, schemaInfo,
         SchemaBackupConfig.TYPE_AVRO, false,
         AVRO_FACTORY, SUBJECT_COMPUTER);
 
-    // Cache should have exactly one entry for STRING_SCHEMA
     assertEquals(1, wrapperSchemaCache.size());
     assertTrue(wrapperSchemaCache.containsKey(connectSchema));
   }
 
-  @Test
-  public void testResolveSchemaIdFromPrefix() {
-    byte[] wire = new byte[10];
-    wire[0] = 0x00;
-    ByteBuffer.wrap(wire, 1, 4).putInt(7);
-    BackupConverterHelper.SchemaIdResult result =
-        helper.resolveSchemaId(wire, null, false);
-    assertNotNull(result);
-    assertEquals(Integer.valueOf(7), result.getSchemaId());
-    assertNull(result.getSchemaGuid());
-  }
-
-  @Test
-  public void testResolveSchemaIdFromHeaderIntId() {
-    RecordHeaders headers = new RecordHeaders();
-    byte[] headerValue = new byte[5];
-    headerValue[0] = 0x00;
-    ByteBuffer.wrap(headerValue, 1, 4).putInt(42);
-    headers.add(VALUE_HEADER, headerValue);
-    byte[] plainBytes = new byte[]{0x01, 0x02, 0x03};
-    BackupConverterHelper.SchemaIdResult result =
-        helper.resolveSchemaId(plainBytes, headers, false);
-    assertNotNull(result);
-    assertEquals(Integer.valueOf(42), result.getSchemaId());
-    assertNull(result.getSchemaGuid());
-  }
-
-  @Test
-  public void testResolveSchemaIdFromHeaderGuid() {
-    RecordHeaders headers = new RecordHeaders();
-    UUID testGuid = UUID.fromString(TEST_GUID);
-    byte[] guidHeader = new byte[17];
-    guidHeader[0] = 0x01;
-    ByteBuffer buf = ByteBuffer.wrap(guidHeader, 1, 16);
-    buf.putLong(testGuid.getMostSignificantBits());
-    buf.putLong(testGuid.getLeastSignificantBits());
-    headers.add(VALUE_HEADER, guidHeader);
-    byte[] plainBytes = new byte[]{0x01, 0x02, 0x03};
-    BackupConverterHelper.SchemaIdResult result =
-        helper.resolveSchemaId(plainBytes, headers, false);
-    assertNotNull(result);
-    assertNull(result.getSchemaId());
-    assertEquals(TEST_GUID, result.getSchemaGuid());
-  }
-
-  @Test
-  public void testResolveSchemaIdNullWhenNoSchemaId() {
-    byte[] plainBytes = new byte[]{0x01, 0x02, 0x03};
-    BackupConverterHelper.SchemaIdResult result =
-        helper.resolveSchemaId(plainBytes, null, false);
-    assertNull(result);
-  }
-
-  @Test
-  public void testResolveSchemaIdHeaderPrecedesPrefix() {
-    byte[] wire = new byte[10];
-    wire[0] = 0x00;
-    ByteBuffer.wrap(wire, 1, 4).putInt(7);
-    RecordHeaders headers = new RecordHeaders();
-    byte[] headerValue = new byte[5];
-    headerValue[0] = 0x00;
-    ByteBuffer.wrap(headerValue, 1, 4).putInt(42);
-    headers.add(VALUE_HEADER, headerValue);
-    BackupConverterHelper.SchemaIdResult result =
-        helper.resolveSchemaId(wire, headers, false);
-    assertNotNull(result);
-    assertEquals(Integer.valueOf(42), result.getSchemaId());
-  }
-
   @Test(expected = IllegalArgumentException.class)
-  public void testSchemaIdResultBothNull() {
-    new BackupConverterHelper.SchemaIdResult(null, null);
-  }
-
-  @Test
-  public void testSchemaIdResultBothPresent() {
-    BackupConverterHelper.SchemaIdResult result =
-        new BackupConverterHelper.SchemaIdResult(42, "some-guid");
-    assertEquals(Integer.valueOf(42), result.getSchemaId());
-    assertEquals("some-guid", result.getSchemaGuid());
-  }
-
-  @Test
-  public void testResolveSchemaIdGuidPrecedesPrefix() {
-    byte[] wire = new byte[10];
-    wire[0] = 0x00;
-    ByteBuffer.wrap(wire, 1, 4).putInt(7);
-    RecordHeaders headers = new RecordHeaders();
-    UUID testGuid = UUID.fromString(TEST_GUID);
-    byte[] guidHeader = new byte[17];
-    guidHeader[0] = 0x01;
-    ByteBuffer guidBuf = ByteBuffer.wrap(guidHeader, 1, 16);
-    guidBuf.putLong(testGuid.getMostSignificantBits());
-    guidBuf.putLong(testGuid.getLeastSignificantBits());
-    headers.add(VALUE_HEADER, guidHeader);
-    BackupConverterHelper.SchemaIdResult result =
-        helper.resolveSchemaId(wire, headers, false);
-    assertNotNull(result);
-    assertNull(result.getSchemaId());
-    assertEquals(TEST_GUID, result.getSchemaGuid());
-  }
-
-  @Test
-  public void testResolveSchemaIdKeyHeader() {
-    RecordHeaders headers = new RecordHeaders();
-    byte[] headerValue = new byte[5];
-    headerValue[0] = 0x00;
-    ByteBuffer.wrap(headerValue, 1, 4).putInt(99);
-    headers.add("__key_schema_id", headerValue);
-    BackupConverterHelper.SchemaIdResult result =
-        helper.resolveSchemaId(null, headers, true);
-    assertNotNull(result);
-    assertEquals(Integer.valueOf(99), result.getSchemaId());
+  public void testWrapWithNeitherIdNorGuid() throws Exception {
+    SchemaAndValue original = new SchemaAndValue(Schema.STRING_SCHEMA, "test");
+    ParsedSchemaAndValue.SchemaInfo schemaInfo =
+        new ParsedSchemaAndValue.SchemaInfo(null, null, null, null);
+    helper.wrapWithBackupMetadata(
+        original, TOPIC, schemaInfo,
+        SchemaBackupConfig.TYPE_AVRO, false,
+        AVRO_FACTORY, SUBJECT_COMPUTER);
   }
 }

--- a/kafka-connect-schema-backup-core/src/test/java/io/confluent/connect/schema/backup/core/BackupConverterHelperTest.java
+++ b/kafka-connect-schema-backup-core/src/test/java/io/confluent/connect/schema/backup/core/BackupConverterHelperTest.java
@@ -1,0 +1,407 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.schema.backup.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import io.confluent.connect.schema.backup.api.BackupWrapper;
+import io.confluent.connect.schema.backup.api.SchemaBackupConfig;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BackupConverterHelperTest {
+
+  private static final String TOPIC = "test-topic";
+  private static final String VALUE_SUFFIX = "-value";
+  private static final String ADDRESS_SUBJECT = "com.example.Address";
+  private static final String VALUE_HEADER = "__value_schema_id";
+  private static final String TEST_GUID = "550e8400-e29b-41d4-a716-446655440000";
+
+  private static final String USER_SCHEMA =
+      "{\"type\":\"record\",\"name\":\"User\","
+      + "\"namespace\":\"com.example\","
+      + "\"fields\":["
+      + "{\"name\":\"name\",\"type\":\"string\"},"
+      + "{\"name\":\"age\",\"type\":\"int\"}"
+      + "]}";
+
+  private static final String ADDRESS_SCHEMA =
+      "{\"type\":\"record\",\"name\":\"Address\","
+      + "\"namespace\":\"com.example\","
+      + "\"fields\":["
+      + "{\"name\":\"street\",\"type\":\"string\"},"
+      + "{\"name\":\"city\",\"type\":\"string\"}"
+      + "]}";
+
+  private static final String ORDER_SCHEMA =
+      "{\"type\":\"record\",\"name\":\"Order\","
+      + "\"namespace\":\"com.example\","
+      + "\"fields\":["
+      + "{\"name\":\"id\",\"type\":\"string\"},"
+      + "{\"name\":\"addr\",\"type\":\"Address\"}"
+      + "]}";
+
+  private static final BackupReferenceResolver.ParsedSchemaFactory AVRO_FACTORY =
+      (raw, refs, resolved) -> !refs.isEmpty()
+          ? new AvroSchema(raw, refs, resolved, null)
+          : new AvroSchema(raw);
+
+  private static final BackupConverterHelper.SubjectNameComputer SUBJECT_COMPUTER =
+      (topic, isKey, schema) -> topic + (isKey ? "-key" : VALUE_SUFFIX);
+
+  private SchemaRegistryClient schemaRegistry;
+  private Map<Schema, Schema> wrapperSchemaCache;
+  private BackupConverterHelper helper;
+
+  @Before
+  public void setUp() {
+    schemaRegistry = new MockSchemaRegistryClient();
+    wrapperSchemaCache = new HashMap<>();
+    helper = new BackupConverterHelper(schemaRegistry, wrapperSchemaCache);
+  }
+
+  @Test
+  public void testIsBackupEnabledTrue() {
+    Map<String, String> config = new HashMap<>();
+    config.put(SchemaBackupConfig.SCHEMA_BACKUP_ENABLED_CONFIG, "true");
+    assertTrue(BackupConverterHelper.isBackupEnabled(config));
+  }
+
+  @Test
+  public void testIsBackupEnabledFalse() {
+    Map<String, String> config = new HashMap<>();
+    config.put(SchemaBackupConfig.SCHEMA_BACKUP_ENABLED_CONFIG, "false");
+    assertFalse(BackupConverterHelper.isBackupEnabled(config));
+  }
+
+  @Test
+  public void testIsBackupEnabledUppercaseTrue() {
+    Map<String, String> config = new HashMap<>();
+    config.put(SchemaBackupConfig.SCHEMA_BACKUP_ENABLED_CONFIG, "TRUE");
+    assertTrue(BackupConverterHelper.isBackupEnabled(config));
+  }
+
+  @Test
+  public void testIsBackupEnabledMixedCase() {
+    Map<String, String> config = new HashMap<>();
+    config.put(SchemaBackupConfig.SCHEMA_BACKUP_ENABLED_CONFIG, "True");
+    assertTrue(BackupConverterHelper.isBackupEnabled(config));
+  }
+
+  @Test
+  public void testIsBackupEnabledMissingKey() {
+    assertFalse(BackupConverterHelper.isBackupEnabled(Collections.emptyMap()));
+  }
+
+  @Test
+  public void testIsBackupEnabledNullValue() {
+    Map<String, String> config = new HashMap<>();
+    config.put(SchemaBackupConfig.SCHEMA_BACKUP_ENABLED_CONFIG, null);
+    assertFalse(BackupConverterHelper.isBackupEnabled(config));
+  }
+
+  @Test
+  public void testIsBackupEnabledEmptyString() {
+    Map<String, String> config = new HashMap<>();
+    config.put(SchemaBackupConfig.SCHEMA_BACKUP_ENABLED_CONFIG, "");
+    assertFalse(BackupConverterHelper.isBackupEnabled(config));
+  }
+
+  @Test
+  public void testIsBackupEnabledNonBoolean() {
+    Map<String, String> config = new HashMap<>();
+    config.put(SchemaBackupConfig.SCHEMA_BACKUP_ENABLED_CONFIG, "yes");
+    assertFalse(BackupConverterHelper.isBackupEnabled(config));
+  }
+
+  @Test
+  public void testGetReferenceResolver() {
+    assertNotNull(helper.getReferenceResolver());
+  }
+
+  @Test
+  public void testGetReferenceResolverSameInstance() {
+    assertSame(helper.getReferenceResolver(), helper.getReferenceResolver());
+  }
+
+  @Test
+  public void testWrapSimpleSchema()
+      throws Exception {
+    AvroSchema avro = new AvroSchema(USER_SCHEMA);
+    int schemaId = schemaRegistry.register(TOPIC + VALUE_SUFFIX, avro);
+
+    Schema connectSchema = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA)
+        .field("age", Schema.INT32_SCHEMA)
+        .build();
+    Struct value = new Struct(connectSchema)
+        .put("name", "Alice")
+        .put("age", 30);
+
+    SchemaAndValue original = new SchemaAndValue(connectSchema, value);
+    SchemaAndValue wrapped = helper.wrapWithBackupMetadata(
+        original, TOPIC, schemaId,
+        SchemaBackupConfig.TYPE_AVRO, false,
+        AVRO_FACTORY, SUBJECT_COMPUTER);
+
+    // Verify it's a BackupWrapper
+    assertNotNull(wrapped);
+    assertNotNull(wrapped.schema());
+    assertEquals(BackupWrapper.NAME, wrapped.schema().name());
+
+    // Verify wrapper fields
+    Struct wrapper = (Struct) wrapped.value();
+    assertEquals(schemaId, (int) wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_ID));
+    assertEquals(SchemaBackupConfig.TYPE_AVRO,
+        wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
+    assertNotNull(wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA));
+    assertEquals(TOPIC + VALUE_SUFFIX,
+        wrapper.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT));
+
+    // Verify data is preserved
+    assertNotNull(wrapper.get(BackupWrapper.FIELD_DATA));
+  }
+
+  @Test
+  public void testWrapWithReferences()
+      throws Exception {
+    // Register the referenced schema first
+    AvroSchema addrSchema = new AvroSchema(ADDRESS_SCHEMA);
+    schemaRegistry.register(ADDRESS_SUBJECT, addrSchema);
+
+    // Register the main schema with a reference
+    SchemaReference ref = new SchemaReference(
+        ADDRESS_SUBJECT, ADDRESS_SUBJECT, 1);
+    AvroSchema orderSchema = new AvroSchema(
+        ORDER_SCHEMA,
+        Collections.singletonList(ref),
+        Collections.singletonMap(ADDRESS_SUBJECT, ADDRESS_SCHEMA),
+        null);
+    int orderId = schemaRegistry.register(TOPIC + VALUE_SUFFIX, orderSchema);
+
+    Schema connectSchema = SchemaBuilder.struct()
+        .field("id", Schema.STRING_SCHEMA)
+        .build();
+    SchemaAndValue original = new SchemaAndValue(
+        connectSchema, new Struct(connectSchema).put("id", "o1"));
+
+    SchemaAndValue wrapped = helper.wrapWithBackupMetadata(
+        original, TOPIC, orderId,
+        SchemaBackupConfig.TYPE_AVRO, false,
+        AVRO_FACTORY, SUBJECT_COMPUTER);
+
+    Struct wrapper = (Struct) wrapped.value();
+    assertNotNull(wrapper.getString(BackupWrapper.FIELD_REFERENCE_TREE));
+    assertNotNull(wrapper.getString(BackupWrapper.FIELD_DIRECT_REFS));
+  }
+
+  @Test
+  public void testWrapNoReferences()
+      throws Exception {
+    AvroSchema avro = new AvroSchema(USER_SCHEMA);
+    int schemaId = schemaRegistry.register(TOPIC + VALUE_SUFFIX, avro);
+
+    SchemaAndValue original = new SchemaAndValue(
+        Schema.STRING_SCHEMA, "test");
+
+    SchemaAndValue wrapped = helper.wrapWithBackupMetadata(
+        original, TOPIC, schemaId,
+        SchemaBackupConfig.TYPE_AVRO, false,
+        AVRO_FACTORY, SUBJECT_COMPUTER);
+
+    Struct wrapper = (Struct) wrapped.value();
+    assertNull(wrapper.getString(BackupWrapper.FIELD_REFERENCE_TREE));
+    assertNull(wrapper.getString(BackupWrapper.FIELD_DIRECT_REFS));
+  }
+
+  @Test
+  public void testWrapNullSchema()
+      throws Exception {
+    AvroSchema avro = new AvroSchema(USER_SCHEMA);
+    int schemaId = schemaRegistry.register(TOPIC + VALUE_SUFFIX, avro);
+
+    SchemaAndValue original = new SchemaAndValue(null, null);
+
+    SchemaAndValue wrapped = helper.wrapWithBackupMetadata(
+        original, TOPIC, schemaId,
+        SchemaBackupConfig.TYPE_AVRO, false,
+        AVRO_FACTORY, SUBJECT_COMPUTER);
+
+    assertNotNull(wrapped.schema());
+    assertEquals(BackupWrapper.NAME, wrapped.schema().name());
+    // Data field schema defaults to OPTIONAL_BYTES_SCHEMA for null original schema
+    assertNotNull(wrapped.schema().field(BackupWrapper.FIELD_DATA));
+  }
+
+  @Test
+  public void testWrapCachedSchema()
+      throws Exception {
+    AvroSchema avro = new AvroSchema(USER_SCHEMA);
+    int schemaId = schemaRegistry.register(TOPIC + VALUE_SUFFIX, avro);
+
+    Schema connectSchema = Schema.STRING_SCHEMA;
+    SchemaAndValue original = new SchemaAndValue(connectSchema, "test");
+
+    // Wrap twice with the same original schema
+    helper.wrapWithBackupMetadata(
+        original, TOPIC, schemaId,
+        SchemaBackupConfig.TYPE_AVRO, false,
+        AVRO_FACTORY, SUBJECT_COMPUTER);
+    helper.wrapWithBackupMetadata(
+        original, TOPIC, schemaId,
+        SchemaBackupConfig.TYPE_AVRO, false,
+        AVRO_FACTORY, SUBJECT_COMPUTER);
+
+    // Cache should have exactly one entry for STRING_SCHEMA
+    assertEquals(1, wrapperSchemaCache.size());
+    assertTrue(wrapperSchemaCache.containsKey(connectSchema));
+  }
+
+  @Test
+  public void testResolveSchemaIdFromPrefix() {
+    byte[] wire = new byte[10];
+    wire[0] = 0x00;
+    ByteBuffer.wrap(wire, 1, 4).putInt(7);
+    BackupConverterHelper.SchemaIdResult result =
+        helper.resolveSchemaId(wire, null, false);
+    assertNotNull(result);
+    assertEquals(Integer.valueOf(7), result.getSchemaId());
+    assertNull(result.getSchemaGuid());
+  }
+
+  @Test
+  public void testResolveSchemaIdFromHeaderIntId() {
+    RecordHeaders headers = new RecordHeaders();
+    byte[] headerValue = new byte[5];
+    headerValue[0] = 0x00;
+    ByteBuffer.wrap(headerValue, 1, 4).putInt(42);
+    headers.add(VALUE_HEADER, headerValue);
+    byte[] plainBytes = new byte[]{0x01, 0x02, 0x03};
+    BackupConverterHelper.SchemaIdResult result =
+        helper.resolveSchemaId(plainBytes, headers, false);
+    assertNotNull(result);
+    assertEquals(Integer.valueOf(42), result.getSchemaId());
+    assertNull(result.getSchemaGuid());
+  }
+
+  @Test
+  public void testResolveSchemaIdFromHeaderGuid() {
+    RecordHeaders headers = new RecordHeaders();
+    UUID testGuid = UUID.fromString(TEST_GUID);
+    byte[] guidHeader = new byte[17];
+    guidHeader[0] = 0x01;
+    ByteBuffer buf = ByteBuffer.wrap(guidHeader, 1, 16);
+    buf.putLong(testGuid.getMostSignificantBits());
+    buf.putLong(testGuid.getLeastSignificantBits());
+    headers.add(VALUE_HEADER, guidHeader);
+    byte[] plainBytes = new byte[]{0x01, 0x02, 0x03};
+    BackupConverterHelper.SchemaIdResult result =
+        helper.resolveSchemaId(plainBytes, headers, false);
+    assertNotNull(result);
+    assertNull(result.getSchemaId());
+    assertEquals(TEST_GUID, result.getSchemaGuid());
+  }
+
+  @Test
+  public void testResolveSchemaIdNullWhenNoSchemaId() {
+    byte[] plainBytes = new byte[]{0x01, 0x02, 0x03};
+    BackupConverterHelper.SchemaIdResult result =
+        helper.resolveSchemaId(plainBytes, null, false);
+    assertNull(result);
+  }
+
+  @Test
+  public void testResolveSchemaIdHeaderPrecedesPrefix() {
+    byte[] wire = new byte[10];
+    wire[0] = 0x00;
+    ByteBuffer.wrap(wire, 1, 4).putInt(7);
+    RecordHeaders headers = new RecordHeaders();
+    byte[] headerValue = new byte[5];
+    headerValue[0] = 0x00;
+    ByteBuffer.wrap(headerValue, 1, 4).putInt(42);
+    headers.add(VALUE_HEADER, headerValue);
+    BackupConverterHelper.SchemaIdResult result =
+        helper.resolveSchemaId(wire, headers, false);
+    assertNotNull(result);
+    assertEquals(Integer.valueOf(42), result.getSchemaId());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testSchemaIdResultBothNull() {
+    new BackupConverterHelper.SchemaIdResult(null, null);
+  }
+
+  @Test
+  public void testSchemaIdResultBothPresent() {
+    BackupConverterHelper.SchemaIdResult result =
+        new BackupConverterHelper.SchemaIdResult(42, "some-guid");
+    assertEquals(Integer.valueOf(42), result.getSchemaId());
+    assertEquals("some-guid", result.getSchemaGuid());
+  }
+
+  @Test
+  public void testResolveSchemaIdGuidPrecedesPrefix() {
+    byte[] wire = new byte[10];
+    wire[0] = 0x00;
+    ByteBuffer.wrap(wire, 1, 4).putInt(7);
+    RecordHeaders headers = new RecordHeaders();
+    UUID testGuid = UUID.fromString(TEST_GUID);
+    byte[] guidHeader = new byte[17];
+    guidHeader[0] = 0x01;
+    ByteBuffer guidBuf = ByteBuffer.wrap(guidHeader, 1, 16);
+    guidBuf.putLong(testGuid.getMostSignificantBits());
+    guidBuf.putLong(testGuid.getLeastSignificantBits());
+    headers.add(VALUE_HEADER, guidHeader);
+    BackupConverterHelper.SchemaIdResult result =
+        helper.resolveSchemaId(wire, headers, false);
+    assertNotNull(result);
+    assertNull(result.getSchemaId());
+    assertEquals(TEST_GUID, result.getSchemaGuid());
+  }
+
+  @Test
+  public void testResolveSchemaIdKeyHeader() {
+    RecordHeaders headers = new RecordHeaders();
+    byte[] headerValue = new byte[5];
+    headerValue[0] = 0x00;
+    ByteBuffer.wrap(headerValue, 1, 4).putInt(99);
+    headers.add("__key_schema_id", headerValue);
+    BackupConverterHelper.SchemaIdResult result =
+        helper.resolveSchemaId(null, headers, true);
+    assertNotNull(result);
+    assertEquals(Integer.valueOf(99), result.getSchemaId());
+  }
+}

--- a/kafka-connect-schema-backup-core/src/test/java/io/confluent/connect/schema/backup/core/BackupReferenceResolverTest.java
+++ b/kafka-connect-schema-backup-core/src/test/java/io/confluent/connect/schema/backup/core/BackupReferenceResolverTest.java
@@ -1,0 +1,584 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.schema.backup.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import io.confluent.connect.schema.backup.api.BackupWrapper;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BackupReferenceResolverTest {
+
+  private static final String ADDRESS_VALUE_SUBJECT = "address-value";
+  private static final String ADDRESS_FQCN = "com.example.Address";
+  private static final String COUNTRY_FQCN = "com.example.Country";
+  private static final String COUNTRY_VALUE_SUBJECT = "country-value";
+  private static final String EXPECTED_DATA_EXCEPTION = "Expected DataException";
+  private static final String REGION_FQCN = "com.example.Region";
+  private static final String REGION_VALUE_SUBJECT = "region-value";
+  private static final String USER_VALUE_SUBJECT = "user-value";
+  private static final String SCHEMA_TYPE_AVRO = "AVRO";
+  private static final String TEST_DATA = "test-data";
+
+  private static final String ADDRESS_SCHEMA =
+      "{\"type\":\"record\",\"name\":\"Address\","
+      + "\"namespace\":\"com.example\","
+      + "\"fields\":["
+      + "{\"name\":\"street\",\"type\":\"string\"},"
+      + "{\"name\":\"city\",\"type\":\"string\"}"
+      + "]}";
+
+  private static final String COUNTRY_SCHEMA =
+      "{\"type\":\"record\",\"name\":\"Country\","
+      + "\"namespace\":\"com.example\","
+      + "\"fields\":["
+      + "{\"name\":\"code\",\"type\":\"string\"},"
+      + "{\"name\":\"name\",\"type\":\"string\"}"
+      + "]}";
+
+  private SchemaRegistryClient targetRegistry;
+  private BackupReferenceResolver resolver;
+
+  private final BackupReferenceResolver.ParsedSchemaFactory avroFactory =
+      (raw, refs, resolved) -> !refs.isEmpty()
+          ? new AvroSchema(raw, refs, resolved, null)
+          : new AvroSchema(raw);
+
+  @Before
+  public void setUp() {
+    targetRegistry = new MockSchemaRegistryClient();
+    resolver = new BackupReferenceResolver(targetRegistry);
+  }
+
+  @Test
+  public void testRegisterSingleRef()
+      throws Exception {
+    SchemaReference directRef = new SchemaReference(
+        ADDRESS_FQCN, ADDRESS_VALUE_SUBJECT, 1);
+    Map<String, BackupSchemaFetcher.RefTreeEntry> tree = new HashMap<>();
+    tree.put(ADDRESS_FQCN, new BackupSchemaFetcher.RefTreeEntry(
+        ADDRESS_VALUE_SUBJECT, 1, ADDRESS_SCHEMA,
+        Collections.emptyList(), 42, SCHEMA_TYPE_AVRO));
+    List<SchemaReference> remapped = new ArrayList<>();
+    Map<String, String> resolved = new HashMap<>();
+    resolver.registerRefsRecursive(
+        Collections.singletonList(directRef), tree, avroFactory,
+        remapped, resolved);
+    assertEquals(1, remapped.size());
+    SchemaReference remappedRef = remapped.get(0);
+    assertEquals(ADDRESS_FQCN, remappedRef.getName());
+    assertEquals(ADDRESS_VALUE_SUBJECT, remappedRef.getSubject());
+    assertTrue(remappedRef.getVersion() > 0);
+    assertEquals(1, resolved.size());
+    assertEquals(ADDRESS_SCHEMA, resolved.get(ADDRESS_FQCN));
+    int targetVersion = targetRegistry.getVersion(
+        ADDRESS_VALUE_SUBJECT, new AvroSchema(ADDRESS_SCHEMA));
+    assertEquals((int) remappedRef.getVersion(), targetVersion);
+  }
+
+  @Test
+  public void testRegisterNestedRefs()
+      throws Exception {
+    SchemaReference countryRef = new SchemaReference(
+        COUNTRY_FQCN, COUNTRY_VALUE_SUBJECT, 1);
+    SchemaReference addressRef = new SchemaReference(
+        ADDRESS_FQCN, ADDRESS_VALUE_SUBJECT, 1);
+    Map<String, BackupSchemaFetcher.RefTreeEntry> tree = new HashMap<>();
+    tree.put(COUNTRY_FQCN,
+        new BackupSchemaFetcher.RefTreeEntry(
+            COUNTRY_VALUE_SUBJECT, 1, COUNTRY_SCHEMA,
+            Collections.emptyList(), 10, SCHEMA_TYPE_AVRO));
+    tree.put(ADDRESS_FQCN,
+        new BackupSchemaFetcher.RefTreeEntry(
+            ADDRESS_VALUE_SUBJECT, 1, ADDRESS_SCHEMA,
+            Collections.singletonList(countryRef), 20, SCHEMA_TYPE_AVRO));
+    List<SchemaReference> remapped = new ArrayList<>();
+    Map<String, String> resolved = new HashMap<>();
+    resolver.registerRefsRecursive(
+        Collections.singletonList(addressRef), tree, avroFactory,
+        remapped, resolved);
+    assertEquals(1, remapped.size());
+    assertEquals(ADDRESS_FQCN, remapped.get(0).getName());
+    int countryVersion = targetRegistry.getVersion(
+        COUNTRY_VALUE_SUBJECT, new AvroSchema(COUNTRY_SCHEMA));
+    assertTrue(countryVersion > 0);
+    int addressVersion = targetRegistry.getVersion(
+        ADDRESS_VALUE_SUBJECT,
+        new AvroSchema(ADDRESS_SCHEMA,
+            Collections.singletonList(new SchemaReference(
+                COUNTRY_FQCN, COUNTRY_VALUE_SUBJECT,
+                countryVersion)),
+            Collections.singletonMap(
+                COUNTRY_FQCN, COUNTRY_SCHEMA), null));
+    assertTrue(addressVersion > 0);
+    assertEquals(addressVersion, (int) remapped.get(0).getVersion());
+  }
+
+  @Test
+  public void testRegisterRefsCached()
+      throws Exception {
+    SchemaReference directRef = new SchemaReference(
+        ADDRESS_FQCN, ADDRESS_VALUE_SUBJECT, 1);
+    Map<String, BackupSchemaFetcher.RefTreeEntry> tree = new HashMap<>();
+    tree.put(ADDRESS_FQCN, new BackupSchemaFetcher.RefTreeEntry(
+        ADDRESS_VALUE_SUBJECT, 1, ADDRESS_SCHEMA,
+        Collections.emptyList(), 42, SCHEMA_TYPE_AVRO));
+    List<SchemaReference> remapped1 = new ArrayList<>();
+    Map<String, String> resolved1 = new HashMap<>();
+    resolver.registerRefsRecursive(
+        Collections.singletonList(directRef), tree, avroFactory,
+        remapped1, resolved1);
+    List<SchemaReference> remapped2 = new ArrayList<>();
+    Map<String, String> resolved2 = new HashMap<>();
+    resolver.registerRefsRecursive(
+        Collections.singletonList(directRef), tree, avroFactory,
+        remapped2, resolved2);
+    assertEquals(
+        (int) remapped1.get(0).getVersion(),
+        (int) remapped2.get(0).getVersion());
+    assertEquals(resolved1, resolved2);
+  }
+
+  @Test
+  public void testRegisterRefsMissingInTree() {
+    SchemaReference directRef = new SchemaReference(
+        "com.example.Missing", "missing-value", 1);
+    try {
+      resolver.registerRefsRecursive(
+          Collections.singletonList(directRef), new HashMap<>(),
+          avroFactory, new ArrayList<>(), new HashMap<>());
+      fail(EXPECTED_DATA_EXCEPTION);
+    } catch (DataException e) {
+      assertTrue(e.getMessage().contains("not found in reference tree"));
+      assertTrue(e.getMessage().contains("com.example.Missing"));
+    }
+  }
+
+  @Test
+  public void testRegisterRefsNull() {
+    List<SchemaReference> remapped = new ArrayList<>();
+    Map<String, String> resolved = new HashMap<>();
+    resolver.registerRefsRecursive(
+        null, new HashMap<>(), avroFactory, remapped, resolved);
+    assertTrue(remapped.isEmpty());
+    assertTrue(resolved.isEmpty());
+  }
+
+  @Test
+  public void testRegisterRefsEmpty() {
+    List<SchemaReference> remapped = new ArrayList<>();
+    Map<String, String> resolved = new HashMap<>();
+    resolver.registerRefsRecursive(
+        Collections.emptyList(), new HashMap<>(), avroFactory,
+        remapped, resolved);
+    assertTrue(remapped.isEmpty());
+    assertTrue(resolved.isEmpty());
+  }
+
+  @Test
+  public void testParseReferenceTree() {
+    String json = "{\"com.example.Address\":{"
+        + "\"subject\":\"address-value\","
+        + "\"version\":1,"
+        + "\"schema\":" + quote(ADDRESS_SCHEMA) + ","
+        + "\"references\":[],"
+        + "\"globalId\":42,"
+        + "\"schemaType\":\"AVRO\"}}";
+    Map<String, BackupSchemaFetcher.RefTreeEntry> tree =
+        BackupReferenceResolver.parseReferenceTree(json);
+    assertEquals(1, tree.size());
+    BackupSchemaFetcher.RefTreeEntry entry =
+        tree.get(ADDRESS_FQCN);
+    assertNotNull(entry);
+    assertEquals(ADDRESS_VALUE_SUBJECT, entry.getSubject());
+    assertEquals(1L, (long) entry.getVersion());
+    assertEquals(42L, (long) entry.getGlobalId());
+    assertEquals(SCHEMA_TYPE_AVRO, entry.getSchemaType());
+    assertNotNull(entry.getSchema());
+  }
+
+  @Test
+  public void testParseReferenceTreeNested() {
+    String json = "{"
+        + "\"com.example.Country\":{"
+        + "\"subject\":\"country-value\","
+        + "\"version\":1,"
+        + "\"schema\":" + quote(COUNTRY_SCHEMA) + ","
+        + "\"references\":[],"
+        + "\"globalId\":10,"
+        + "\"schemaType\":\"AVRO\"},"
+        + "\"com.example.Address\":{"
+        + "\"subject\":\"address-value\","
+        + "\"version\":1,"
+        + "\"schema\":" + quote(ADDRESS_SCHEMA) + ","
+        + "\"references\":["
+        + "{\"name\":\"com.example.Country\","
+        + "\"subject\":\"country-value\","
+        + "\"version\":1}],"
+        + "\"globalId\":20,"
+        + "\"schemaType\":\"AVRO\"}}";
+    Map<String, BackupSchemaFetcher.RefTreeEntry> tree =
+        BackupReferenceResolver.parseReferenceTree(json);
+    assertEquals(2, tree.size());
+    BackupSchemaFetcher.RefTreeEntry address =
+        tree.get(ADDRESS_FQCN);
+    assertEquals(1, address.getReferences().size());
+    assertEquals(COUNTRY_FQCN,
+        address.getReferences().get(0).getName());
+    assertEquals(COUNTRY_VALUE_SUBJECT,
+        address.getReferences().get(0).getSubject());
+    assertEquals(1L,
+        (long) address.getReferences().get(0).getVersion());
+  }
+
+  @Test
+  public void testParseReferenceTreeNull() {
+    assertTrue(BackupReferenceResolver
+        .parseReferenceTree(null).isEmpty());
+  }
+
+  @Test
+  public void testParseReferenceTreeEmpty() {
+    assertTrue(BackupReferenceResolver
+        .parseReferenceTree("").isEmpty());
+  }
+
+  @Test
+  public void testParseDirectRefs() {
+    String json = "[{\"name\":\"com.example.Address\","
+        + "\"subject\":\"address-value\","
+        + "\"version\":1}]";
+    List<SchemaReference> refs =
+        BackupReferenceResolver.parseDirectRefs(json);
+    assertEquals(1, refs.size());
+    assertEquals(ADDRESS_FQCN, refs.get(0).getName());
+    assertEquals(ADDRESS_VALUE_SUBJECT, refs.get(0).getSubject());
+    assertEquals(1L, (long) refs.get(0).getVersion());
+  }
+
+  @Test
+  public void testParseDirectRefsMultiple() {
+    String json = "["
+        + "{\"name\":\"com.example.Address\","
+        + "\"subject\":\"address-value\",\"version\":1},"
+        + "{\"name\":\"com.example.Country\","
+        + "\"subject\":\"country-value\",\"version\":2}"
+        + "]";
+    List<SchemaReference> refs =
+        BackupReferenceResolver.parseDirectRefs(json);
+    assertEquals(2, refs.size());
+    assertEquals(1L, (long) refs.get(0).getVersion());
+    assertEquals(2L, (long) refs.get(1).getVersion());
+  }
+
+  @Test
+  public void testParseDirectRefsNull() {
+    assertTrue(BackupReferenceResolver
+        .parseDirectRefs(null).isEmpty());
+  }
+
+  @Test
+  public void testParseDirectRefsEmptyJson() {
+    assertTrue(BackupReferenceResolver
+        .parseDirectRefs("").isEmpty());
+  }
+
+  @Test
+  public void testParseReferenceTreeInvalidJson() {
+    try {
+      BackupReferenceResolver.parseReferenceTree("{invalid json}");
+      fail(EXPECTED_DATA_EXCEPTION);
+    } catch (DataException e) {
+      assertTrue(e.getMessage().contains("Cannot parse"));
+    }
+  }
+
+  @Test
+  public void testParseDirectRefsInvalidJson() {
+    try {
+      BackupReferenceResolver.parseDirectRefs("{not a list}");
+      fail(EXPECTED_DATA_EXCEPTION);
+    } catch (DataException e) {
+      assertTrue(e.getMessage().contains("Cannot parse"));
+    }
+  }
+
+  @Test
+  public void testEndToEndVersionRemapping()
+      throws Exception {
+    SchemaRegistryClient sourceRegistry =
+        new MockSchemaRegistryClient();
+    AvroSchema addressSchema = new AvroSchema(ADDRESS_SCHEMA);
+    sourceRegistry.register(ADDRESS_VALUE_SUBJECT, addressSchema);
+    SchemaReference addressRef = new SchemaReference(
+        ADDRESS_FQCN, ADDRESS_VALUE_SUBJECT, 1);
+    String userSchemaText =
+        "{\"type\":\"record\",\"name\":\"User\","
+        + "\"namespace\":\"com.example\","
+        + "\"fields\":["
+        + "{\"name\":\"name\",\"type\":\"string\"},"
+        + "{\"name\":\"address\",\"type\":\"com.example.Address\"}"
+        + "]}";
+    AvroSchema mainSchema = new AvroSchema(userSchemaText,
+        Collections.singletonList(addressRef),
+        Collections.singletonMap(
+            ADDRESS_FQCN, ADDRESS_SCHEMA), null);
+    int srcMainId = sourceRegistry.register(
+        USER_VALUE_SUBJECT, mainSchema);
+    BackupSchemaFetcher fetcher =
+        new BackupSchemaFetcher(sourceRegistry);
+    BackupSchemaFetcher.BackupSchemaInfo info =
+        fetcher.fetchSchemaInfo(srcMainId);
+    assertEquals(Integer.valueOf(1),
+        info.getVersionForSubject(USER_VALUE_SUBJECT));
+    assertNotNull(info.getReferenceTreeJson());
+    assertNotNull(info.getDirectRefsJson());
+    Map<String, BackupSchemaFetcher.RefTreeEntry> tree =
+        BackupReferenceResolver.parseReferenceTree(
+            info.getReferenceTreeJson());
+    List<SchemaReference> directRefs =
+        BackupReferenceResolver.parseDirectRefs(
+            info.getDirectRefsJson());
+    assertEquals(1, tree.size());
+    assertTrue(tree.containsKey(ADDRESS_FQCN));
+    assertEquals(1, directRefs.size());
+    assertEquals(ADDRESS_FQCN,
+        directRefs.get(0).getName());
+    assertEquals(1L, (long) directRefs.get(0).getVersion());
+    List<SchemaReference> remapped = new ArrayList<>();
+    Map<String, String> resolved = new HashMap<>();
+    resolver.registerRefsRecursive(
+        directRefs, tree, avroFactory, remapped, resolved);
+    assertEquals(1, remapped.size());
+    SchemaReference targetRef = remapped.get(0);
+    assertEquals(ADDRESS_FQCN, targetRef.getName());
+    assertEquals(ADDRESS_VALUE_SUBJECT, targetRef.getSubject());
+    assertTrue(targetRef.getVersion() > 0);
+    int targetAddressVersion = targetRegistry.getVersion(
+        ADDRESS_VALUE_SUBJECT, new AvroSchema(ADDRESS_SCHEMA));
+    assertEquals((int) targetRef.getVersion(), targetAddressVersion);
+    AvroSchema targetMainSchema = new AvroSchema(
+        userSchemaText, remapped, resolved, null);
+    targetRegistry.register(USER_VALUE_SUBJECT, targetMainSchema);
+    int targetMainVersion = targetRegistry.getVersion(
+        USER_VALUE_SUBJECT, targetMainSchema);
+    assertTrue(targetMainVersion > 0);
+  }
+
+  @Test
+  public void testResolveFromWrapperNoRefs() {
+    Schema dataSchema = Schema.STRING_SCHEMA;
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        1, 1, SCHEMA_TYPE_AVRO,"test-value", ADDRESS_SCHEMA, null, null);
+    Struct wrapper = BackupWrapper.buildWrapper(
+        wrapperSchema, TEST_DATA, fields);
+
+    BackupReferenceResolver.ResolutionResult result =
+        resolver.resolveFromWrapper(wrapperSchema, wrapper, avroFactory);
+
+    assertFalse(result.hasReferences());
+    assertTrue(result.getTargetRefs().isEmpty());
+    assertTrue(result.getResolvedSchemas().isEmpty());
+  }
+
+  @Test
+  public void testResolveFromWrapperWithRefs()
+      throws Exception {
+    String treeJson = "{\"" + ADDRESS_FQCN + "\":{"
+        + "\"subject\":\"" + ADDRESS_VALUE_SUBJECT + "\","
+        + "\"version\":1,"
+        + "\"schema\":" + quote(ADDRESS_SCHEMA) + ","
+        + "\"references\":[],"
+        + "\"globalId\":42,"
+        + "\"schemaType\":\"AVRO\"}}";
+    String directRefsJson = "[{\"name\":\"" + ADDRESS_FQCN + "\","
+        + "\"subject\":\"" + ADDRESS_VALUE_SUBJECT + "\","
+        + "\"version\":1}]";
+
+    Schema dataSchema = Schema.STRING_SCHEMA;
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        1, 1, SCHEMA_TYPE_AVRO,USER_VALUE_SUBJECT, ADDRESS_SCHEMA,
+        treeJson, directRefsJson);
+    Struct wrapper = BackupWrapper.buildWrapper(
+        wrapperSchema, TEST_DATA, fields);
+
+    BackupReferenceResolver.ResolutionResult result =
+        resolver.resolveFromWrapper(wrapperSchema, wrapper, avroFactory);
+
+    assertTrue(result.hasReferences());
+    assertEquals(1, result.getTargetRefs().size());
+    assertEquals(ADDRESS_FQCN, result.getTargetRefs().get(0).getName());
+    assertEquals(ADDRESS_VALUE_SUBJECT,
+        result.getTargetRefs().get(0).getSubject());
+    assertTrue(result.getTargetRefs().get(0).getVersion() > 0);
+    assertFalse(result.getResolvedSchemas().isEmpty());
+    assertEquals(ADDRESS_SCHEMA,
+        result.getResolvedSchemas().get(ADDRESS_FQCN));
+  }
+
+  @Test
+  public void testResolveFromWrapperTreeWithoutDirectRefs() {
+    String treeJson = "{\"" + ADDRESS_FQCN + "\":{"
+        + "\"subject\":\"" + ADDRESS_VALUE_SUBJECT + "\","
+        + "\"version\":1,"
+        + "\"schema\":" + quote(ADDRESS_SCHEMA) + ","
+        + "\"references\":[],"
+        + "\"globalId\":42,"
+        + "\"schemaType\":\"AVRO\"}}";
+
+    Schema dataSchema = Schema.STRING_SCHEMA;
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        1, 1, SCHEMA_TYPE_AVRO,USER_VALUE_SUBJECT, ADDRESS_SCHEMA,
+        treeJson, null);
+    Struct wrapper = BackupWrapper.buildWrapper(
+        wrapperSchema, TEST_DATA, fields);
+
+    BackupReferenceResolver.ResolutionResult result =
+        resolver.resolveFromWrapper(wrapperSchema, wrapper, avroFactory);
+
+    assertFalse(result.hasReferences());
+  }
+
+  @Test
+  public void testResolutionResultEmpty() {
+    BackupReferenceResolver.ResolutionResult empty =
+        BackupReferenceResolver.ResolutionResult.empty();
+    assertFalse(empty.hasReferences());
+    assertTrue(empty.getTargetRefs().isEmpty());
+    assertTrue(empty.getResolvedSchemas().isEmpty());
+  }
+
+  @Test
+  public void testTransitiveSchemasThreeLevels()
+      throws Exception {
+    String regionSchema =
+        "{\"type\":\"record\",\"name\":\"Region\","
+        + "\"namespace\":\"com.example\","
+        + "\"fields\":["
+        + "{\"name\":\"id\",\"type\":\"string\"}"
+        + "]}";
+
+    SchemaReference regionRef = new SchemaReference(
+        REGION_FQCN, REGION_VALUE_SUBJECT, 1);
+    SchemaReference countryRef = new SchemaReference(
+        COUNTRY_FQCN, COUNTRY_VALUE_SUBJECT, 1);
+    SchemaReference addressRef = new SchemaReference(
+        ADDRESS_FQCN, ADDRESS_VALUE_SUBJECT, 1);
+
+    Map<String, BackupSchemaFetcher.RefTreeEntry> tree = new HashMap<>();
+    tree.put(REGION_FQCN,
+        new BackupSchemaFetcher.RefTreeEntry(
+            REGION_VALUE_SUBJECT, 1, regionSchema,
+            Collections.emptyList(), 5, SCHEMA_TYPE_AVRO));
+    tree.put(COUNTRY_FQCN,
+        new BackupSchemaFetcher.RefTreeEntry(
+            COUNTRY_VALUE_SUBJECT, 1, COUNTRY_SCHEMA,
+            Collections.singletonList(regionRef), 10, SCHEMA_TYPE_AVRO));
+    tree.put(ADDRESS_FQCN,
+        new BackupSchemaFetcher.RefTreeEntry(
+            ADDRESS_VALUE_SUBJECT, 1, ADDRESS_SCHEMA,
+            Collections.singletonList(countryRef), 20, SCHEMA_TYPE_AVRO));
+
+    List<SchemaReference> remapped = new ArrayList<>();
+    Map<String, String> resolved = new HashMap<>();
+    resolver.registerRefsRecursive(
+        Collections.singletonList(addressRef), tree, avroFactory,
+        remapped, resolved);
+
+    assertEquals(1, remapped.size());
+    assertEquals(ADDRESS_FQCN, remapped.get(0).getName());
+    // All three schemas should be resolved transitively
+    assertEquals(3, resolved.size());
+    assertTrue(resolved.containsKey(ADDRESS_FQCN));
+    assertTrue(resolved.containsKey(COUNTRY_FQCN));
+    assertTrue(resolved.containsKey(REGION_FQCN));
+
+    // Verify all registered in target
+    assertTrue(targetRegistry.getVersion(
+        REGION_VALUE_SUBJECT, new AvroSchema(regionSchema)) > 0);
+    assertTrue(targetRegistry.getVersion(
+        COUNTRY_VALUE_SUBJECT, new AvroSchema(COUNTRY_SCHEMA,
+            Collections.singletonList(new SchemaReference(
+                REGION_FQCN, REGION_VALUE_SUBJECT,
+                targetRegistry.getVersion(
+                    REGION_VALUE_SUBJECT,
+                    new AvroSchema(regionSchema)))),
+            Collections.singletonMap(
+                REGION_FQCN, regionSchema), null)) > 0);
+  }
+
+  @Test
+  public void testRegisterRefsCachedTransitive()
+      throws Exception {
+    // First registration populates cache
+    SchemaReference addressRef = new SchemaReference(
+        ADDRESS_FQCN, ADDRESS_VALUE_SUBJECT, 1);
+    SchemaReference countryRef = new SchemaReference(
+        COUNTRY_FQCN, COUNTRY_VALUE_SUBJECT, 1);
+    Map<String, BackupSchemaFetcher.RefTreeEntry> tree = new HashMap<>();
+    tree.put(COUNTRY_FQCN,
+        new BackupSchemaFetcher.RefTreeEntry(
+            COUNTRY_VALUE_SUBJECT, 1, COUNTRY_SCHEMA,
+            Collections.emptyList(), 10, SCHEMA_TYPE_AVRO));
+    tree.put(ADDRESS_FQCN,
+        new BackupSchemaFetcher.RefTreeEntry(
+            ADDRESS_VALUE_SUBJECT, 1, ADDRESS_SCHEMA,
+            Collections.singletonList(countryRef), 20, SCHEMA_TYPE_AVRO));
+
+    List<SchemaReference> remapped1 = new ArrayList<>();
+    Map<String, String> resolved1 = new HashMap<>();
+    resolver.registerRefsRecursive(
+        Collections.singletonList(addressRef), tree, avroFactory,
+        remapped1, resolved1);
+
+    // Second call uses cache path (addTransitiveSchemas)
+    List<SchemaReference> remapped2 = new ArrayList<>();
+    Map<String, String> resolved2 = new HashMap<>();
+    resolver.registerRefsRecursive(
+        Collections.singletonList(addressRef), tree, avroFactory,
+        remapped2, resolved2);
+
+    // Transitive schemas should still be resolved via cache path
+    assertEquals(2, resolved2.size());
+    assertTrue(resolved2.containsKey(ADDRESS_FQCN));
+    assertTrue(resolved2.containsKey(COUNTRY_FQCN));
+  }
+
+  private static String quote(String s) {
+    return "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+  }
+}

--- a/kafka-connect-schema-backup-core/src/test/java/io/confluent/connect/schema/backup/core/BackupSchemaFetcherTest.java
+++ b/kafka-connect-schema-backup-core/src/test/java/io/confluent/connect/schema/backup/core/BackupSchemaFetcherTest.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.schema.backup.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BackupSchemaFetcherTest {
+
+  private static final String USERS_VALUE_SUBJECT = "users-value";
+  private static final String USER_VALUE_SUBJECT = "user-value";
+  private static final String ADDRESS_VALUE_SUBJECT = "address-value";
+  private static final String COUNTRY_VALUE_SUBJECT = "country-value";
+  private static final String ADDRESS_FQCN = "com.example.Address";
+  private static final String COUNTRY_FQCN = "com.example.Country";
+
+  private static final String ADDRESS_SCHEMA =
+      "{\"type\":\"record\",\"name\":\"Address\","
+      + "\"namespace\":\"com.example\","
+      + "\"fields\":["
+      + "{\"name\":\"street\",\"type\":\"string\"},"
+      + "{\"name\":\"city\",\"type\":\"string\"}"
+      + "]}";
+
+  private static final String USER_SCHEMA =
+      "{\"type\":\"record\",\"name\":\"User\","
+      + "\"namespace\":\"com.example\","
+      + "\"fields\":["
+      + "{\"name\":\"name\",\"type\":\"string\"},"
+      + "{\"name\":\"age\",\"type\":\"int\"}"
+      + "]}";
+
+  private static final String COUNTRY_SCHEMA =
+      "{\"type\":\"record\",\"name\":\"Country\","
+      + "\"namespace\":\"com.example\","
+      + "\"fields\":["
+      + "{\"name\":\"code\",\"type\":\"string\"},"
+      + "{\"name\":\"name\",\"type\":\"string\"}"
+      + "]}";
+
+  private static final String USER_WITH_REF_SCHEMA =
+      "{\"type\":\"record\",\"name\":\"User\","
+      + "\"namespace\":\"com.example\","
+      + "\"fields\":["
+      + "{\"name\":\"name\",\"type\":\"string\"},"
+      + "{\"name\":\"address\",\"type\":\"com.example.Address\"}"
+      + "]}";
+
+  private static final String ADDRESS_WITH_COUNTRY_SCHEMA =
+      "{\"type\":\"record\",\"name\":\"Address\","
+      + "\"namespace\":\"com.example\","
+      + "\"fields\":["
+      + "{\"name\":\"street\",\"type\":\"string\"},"
+      + "{\"name\":\"country\",\"type\":\"com.example.Country\"}"
+      + "]}";
+
+  private SchemaRegistryClient schemaRegistry;
+  private BackupSchemaFetcher fetcher;
+
+  @Before
+  public void setUp() {
+    schemaRegistry = new MockSchemaRegistryClient();
+    fetcher = new BackupSchemaFetcher(schemaRegistry);
+  }
+
+  @Test
+  public void testFetchSchemaInfo()
+      throws Exception {
+    AvroSchema avro = new AvroSchema(USER_SCHEMA);
+    int schemaId = schemaRegistry.register("orders-value", avro);
+    BackupSchemaFetcher.BackupSchemaInfo info =
+        fetcher.fetchSchemaInfo(schemaId);
+    assertNotNull(info);
+    assertNotNull(info.getRawSchema());
+    assertEquals(Integer.valueOf(1),
+        info.getVersionForSubject("orders-value"));
+  }
+
+  @Test
+  public void testFetchSchemaInfoMultipleSubjects()
+      throws Exception {
+    AvroSchema avro = new AvroSchema(USER_SCHEMA);
+    int id1 = schemaRegistry.register("topic-a-value", avro);
+    schemaRegistry.register("topic-b-value", avro);
+    BackupSchemaFetcher.BackupSchemaInfo info =
+        fetcher.fetchSchemaInfo(id1);
+    assertEquals(Integer.valueOf(1),
+        info.getVersionForSubject("topic-a-value"));
+    assertEquals(Integer.valueOf(1),
+        info.getVersionForSubject("topic-b-value"));
+    assertNull(info.getVersionForSubject("nonexistent-subject"));
+  }
+
+  @Test
+  public void testFetchSchemaInfoMultipleVersions()
+      throws Exception {
+    schemaRegistry.register(USERS_VALUE_SUBJECT, new AvroSchema(USER_SCHEMA));
+    int id2 = schemaRegistry.register(USERS_VALUE_SUBJECT,
+        new AvroSchema(ADDRESS_SCHEMA));
+    BackupSchemaFetcher.BackupSchemaInfo info =
+        fetcher.fetchSchemaInfo(id2);
+    assertEquals(Integer.valueOf(2),
+        info.getVersionForSubject(USERS_VALUE_SUBJECT));
+  }
+
+  @Test
+  public void testFetchSchemaInfoWithReference()
+      throws Exception {
+    AvroSchema addressSchema = new AvroSchema(ADDRESS_SCHEMA);
+    int addressId = schemaRegistry.register(
+        ADDRESS_VALUE_SUBJECT, addressSchema);
+    SchemaReference addressRef = new SchemaReference(
+        ADDRESS_FQCN, ADDRESS_VALUE_SUBJECT, 1);
+    AvroSchema mainSchema = new AvroSchema(USER_WITH_REF_SCHEMA,
+        Collections.singletonList(addressRef),
+        Collections.singletonMap(
+            ADDRESS_FQCN, ADDRESS_SCHEMA), null);
+    int mainId = schemaRegistry.register(USER_VALUE_SUBJECT, mainSchema);
+    BackupSchemaFetcher.BackupSchemaInfo info =
+        fetcher.fetchSchemaInfo(mainId);
+    assertNotNull(info.getReferenceTreeJson());
+    assertNotNull(info.getDirectRefsJson());
+    assertEquals(1, info.getDirectReferences().size());
+    Map<String, BackupSchemaFetcher.RefTreeEntry> tree =
+        info.getReferenceTree();
+    assertTrue(tree.containsKey(ADDRESS_FQCN));
+    BackupSchemaFetcher.RefTreeEntry entry =
+        tree.get(ADDRESS_FQCN);
+    assertEquals(ADDRESS_VALUE_SUBJECT, entry.getSubject());
+    assertEquals(1, entry.getVersion());
+    assertEquals(addressId, entry.getGlobalId());
+    assertNotNull(entry.getSchema());
+  }
+
+  @Test
+  public void testFetchSchemaInfoNestedReferences()
+      throws Exception {
+    AvroSchema countrySchema = new AvroSchema(COUNTRY_SCHEMA);
+    int countryId = schemaRegistry.register(
+        COUNTRY_VALUE_SUBJECT, countrySchema);
+    SchemaReference countryRef = new SchemaReference(
+        COUNTRY_FQCN, COUNTRY_VALUE_SUBJECT, 1);
+    AvroSchema addressSchema = new AvroSchema(ADDRESS_WITH_COUNTRY_SCHEMA,
+        Collections.singletonList(countryRef),
+        Collections.singletonMap(
+            COUNTRY_FQCN, COUNTRY_SCHEMA), null);
+    int addressId = schemaRegistry.register(
+        ADDRESS_VALUE_SUBJECT, addressSchema);
+    SchemaReference addressRef = new SchemaReference(
+        ADDRESS_FQCN, ADDRESS_VALUE_SUBJECT, 1);
+    Map<String, String> userResolved = new HashMap<>();
+    userResolved.put(ADDRESS_FQCN, ADDRESS_WITH_COUNTRY_SCHEMA);
+    userResolved.put(COUNTRY_FQCN, COUNTRY_SCHEMA);
+    AvroSchema mainSchema = new AvroSchema(USER_WITH_REF_SCHEMA,
+        Collections.singletonList(addressRef),
+        userResolved, null);
+    int mainId = schemaRegistry.register(USER_VALUE_SUBJECT, mainSchema);
+    BackupSchemaFetcher.BackupSchemaInfo info =
+        fetcher.fetchSchemaInfo(mainId);
+    Map<String, BackupSchemaFetcher.RefTreeEntry> tree =
+        info.getReferenceTree();
+    assertEquals(2, tree.size());
+    assertTrue(tree.containsKey(ADDRESS_FQCN));
+    assertTrue(tree.containsKey(COUNTRY_FQCN));
+    assertEquals(ADDRESS_VALUE_SUBJECT,
+        tree.get(ADDRESS_FQCN).getSubject());
+    assertEquals(addressId,
+        tree.get(ADDRESS_FQCN).getGlobalId());
+    assertEquals(COUNTRY_VALUE_SUBJECT,
+        tree.get(COUNTRY_FQCN).getSubject());
+    assertEquals(countryId,
+        tree.get(COUNTRY_FQCN).getGlobalId());
+  }
+
+  @Test
+  public void testFetchSchemaInfoCache()
+      throws Exception {
+    AvroSchema avro = new AvroSchema(USER_SCHEMA);
+    int schemaId = schemaRegistry.register("test-value", avro);
+    BackupSchemaFetcher.BackupSchemaInfo first =
+        fetcher.fetchSchemaInfo(schemaId);
+    BackupSchemaFetcher.BackupSchemaInfo second =
+        fetcher.fetchSchemaInfo(schemaId);
+    assertSame(first, second);
+  }
+
+  @Test
+  public void testFetchSchemaInfoNoReferences()
+      throws Exception {
+    AvroSchema avro = new AvroSchema(USER_SCHEMA);
+    int schemaId = schemaRegistry.register("test-value", avro);
+    BackupSchemaFetcher.BackupSchemaInfo info =
+        fetcher.fetchSchemaInfo(schemaId);
+    assertTrue(info.getReferenceTree().isEmpty());
+    assertTrue(info.getDirectReferences().isEmpty());
+    assertNull(info.getReferenceTreeJson());
+    assertNull(info.getDirectRefsJson());
+  }
+
+  @Test
+  public void testFetchSchemaInfoSchemaType()
+      throws Exception {
+    AvroSchema countrySchema = new AvroSchema(COUNTRY_SCHEMA);
+    schemaRegistry.register(COUNTRY_VALUE_SUBJECT, countrySchema);
+    SchemaReference countryRef = new SchemaReference(
+        COUNTRY_FQCN, COUNTRY_VALUE_SUBJECT, 1);
+    AvroSchema addressSchema = new AvroSchema(ADDRESS_WITH_COUNTRY_SCHEMA,
+        Collections.singletonList(countryRef),
+        Collections.singletonMap(
+            COUNTRY_FQCN, COUNTRY_SCHEMA), null);
+    schemaRegistry.register(ADDRESS_VALUE_SUBJECT, addressSchema);
+    SchemaReference addressRef = new SchemaReference(
+        ADDRESS_FQCN, ADDRESS_VALUE_SUBJECT, 1);
+    Map<String, String> userResolved = new HashMap<>();
+    userResolved.put(ADDRESS_FQCN, ADDRESS_WITH_COUNTRY_SCHEMA);
+    userResolved.put(COUNTRY_FQCN, COUNTRY_SCHEMA);
+    AvroSchema mainSchema = new AvroSchema(USER_WITH_REF_SCHEMA,
+        Collections.singletonList(addressRef), userResolved, null);
+    int mainId = schemaRegistry.register(USER_VALUE_SUBJECT, mainSchema);
+
+    BackupSchemaFetcher.BackupSchemaInfo info =
+        fetcher.fetchSchemaInfo(mainId);
+
+    Map<String, BackupSchemaFetcher.RefTreeEntry> tree =
+        info.getReferenceTree();
+    assertEquals(2, tree.size());
+    // Verify schemaType is populated for entries
+    BackupSchemaFetcher.RefTreeEntry countryEntry =
+        tree.get(COUNTRY_FQCN);
+    assertNotNull(countryEntry);
+    assertNotNull(countryEntry.getSchemaType());
+    // Verify direct refs json is parseable
+    assertNotNull(info.getDirectRefsJson());
+    assertNotNull(info.getReferenceTreeJson());
+  }
+
+  @Test
+  public void testFetchSchemaInfoVersionMapping()
+      throws Exception {
+    AvroSchema schemaV1 = new AvroSchema(USER_SCHEMA);
+    AvroSchema schemaV2 = new AvroSchema(ADDRESS_SCHEMA);
+    AvroSchema schemaV3 = new AvroSchema(COUNTRY_SCHEMA);
+    String subject = "evolving-value";
+    int id1 = schemaRegistry.register(subject, schemaV1);
+    int id2 = schemaRegistry.register(subject, schemaV2);
+    int id3 = schemaRegistry.register(subject, schemaV3);
+    assertTrue("IDs must be unique", id1 != id2 && id2 != id3);
+    BackupSchemaFetcher.BackupSchemaInfo info1 =
+        fetcher.fetchSchemaInfo(id1);
+    BackupSchemaFetcher.BackupSchemaInfo info2 =
+        fetcher.fetchSchemaInfo(id2);
+    BackupSchemaFetcher.BackupSchemaInfo info3 =
+        fetcher.fetchSchemaInfo(id3);
+    assertEquals("ID " + id1 + " must be version 1",
+        Integer.valueOf(1), info1.getVersionForSubject(subject));
+    assertEquals("ID " + id2 + " must be version 2",
+        Integer.valueOf(2), info2.getVersionForSubject(subject));
+    assertEquals("ID " + id3 + " must be version 3",
+        Integer.valueOf(3), info3.getVersionForSubject(subject));
+    assertEquals(schemaV1.canonicalString(), info1.getRawSchema());
+    assertEquals(schemaV2.canonicalString(), info2.getRawSchema());
+    assertEquals(schemaV3.canonicalString(), info3.getRawSchema());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,8 @@
         <module>avro-types</module>
         <module>avro-serializer</module>
         <module>json-serializer</module>
+        <module>kafka-connect-schema-backup-api</module>
+        <module>kafka-connect-schema-backup-core</module>
         <module>schema-converter</module>
         <module>avro-data</module>
         <module>avro-converter</module>

--- a/protobuf-converter/pom.xml
+++ b/protobuf-converter/pom.xml
@@ -39,6 +39,16 @@
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-schema-backup-api</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-schema-backup-core</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
             <artifactId>kafka-protobuf-serializer</artifactId>
             <version>${io.confluent.schema-registry.version}</version>
             <type>test-jar</type>

--- a/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufConverter.java
+++ b/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufConverter.java
@@ -16,8 +16,21 @@
 package io.confluent.connect.protobuf;
 
 import com.google.protobuf.Message;
+import io.confluent.connect.schema.backup.api.BackupWrapper;
+import io.confluent.connect.schema.backup.api.SchemaBackupConfig;
+import io.confluent.connect.schema.backup.core.BackupConverterHelper;
+import io.confluent.connect.schema.backup.core.BackupReferenceResolver;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientFactory;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import io.confluent.kafka.schemaregistry.utils.ExceptionUtils;
+import io.confluent.kafka.serializers.protobuf.AbstractKafkaProtobufDeserializer;
+import io.confluent.kafka.serializers.protobuf.AbstractKafkaProtobufSerializer;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializerConfig;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializerConfig;
+import io.confluent.kafka.serializers.protobuf.ProtobufSchemaAndValue;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.errors.NetworkException;
@@ -26,27 +39,28 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.storage.Converter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.Map;
-
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
-import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
-import io.confluent.kafka.serializers.protobuf.AbstractKafkaProtobufDeserializer;
-import io.confluent.kafka.serializers.protobuf.AbstractKafkaProtobufSerializer;
-import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializerConfig;
-import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializerConfig;
-import io.confluent.kafka.serializers.protobuf.ProtobufSchemaAndValue;
-
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Implementation of Converter that uses Protobuf schemas and objects.
  */
 public class ProtobufConverter implements Converter {
+
+  private static final Logger log = LoggerFactory.getLogger(ProtobufConverter.class);
+
+  private static final BackupReferenceResolver.ParsedSchemaFactory PROTOBUF_SCHEMA_FACTORY =
+      (raw, refs, resolvedSchemas) -> !refs.isEmpty()
+          ? new ProtobufSchema(raw, refs, resolvedSchemas, null, null)
+          : new ProtobufSchema(raw);
 
   private SchemaRegistryClient schemaRegistry;
   private Serializer serializer;
@@ -54,6 +68,10 @@ public class ProtobufConverter implements Converter {
 
   private boolean isKey;
   private ProtobufData protobufData;
+  private boolean backupEnvelopeMode;
+  private BackupConverterHelper backupHelper;
+  private final Map<Schema, Schema> wrapperSchemaCache =
+      new ConcurrentHashMap<>();
 
   public ProtobufConverter() {
   }
@@ -66,6 +84,8 @@ public class ProtobufConverter implements Converter {
   @Override
   public void configure(Map<String, ?> configs, boolean isKey) {
     this.isKey = isKey;
+    this.backupEnvelopeMode = BackupConverterHelper.isBackupEnabled(configs);
+    log.info("ProtobufConverter schema.backup.enabled={}, isKey={}", backupEnvelopeMode, isKey);
     ProtobufConverterConfig protobufConverterConfig = new ProtobufConverterConfig(configs);
 
     if (schemaRegistry == null) {
@@ -81,6 +101,8 @@ public class ProtobufConverter implements Converter {
     serializer = new Serializer(configs, schemaRegistry);
     deserializer = new Deserializer(configs, schemaRegistry);
     protobufData = new ProtobufData(new ProtobufDataConfig(configs));
+
+    backupHelper = new BackupConverterHelper(schemaRegistry, wrapperSchemaCache);
   }
 
   @Override
@@ -90,6 +112,10 @@ public class ProtobufConverter implements Converter {
 
   @Override
   public byte[] fromConnectData(String topic, Headers headers, Schema schema, Object value) {
+    if (backupEnvelopeMode
+        && BackupWrapper.isWrapper(schema) && value instanceof Struct) {
+      return restoreFromWrapper(topic, headers, schema, (Struct) value);
+    }
     try {
       ProtobufSchemaAndValue schemaAndValue = protobufData.fromConnectData(schema, value);
       Object v = schemaAndValue.getValue();
@@ -126,8 +152,59 @@ public class ProtobufConverter implements Converter {
       }
     } catch (InvalidConfigurationException e) {
       throw new ConfigException(
-          String.format("Failed to access Protobuf data from topic %s : %s", topic, e.getMessage())
+          String.format(
+              "Failed to access Protobuf data from topic %s : %s", topic, e.getMessage())
       );
+    }
+  }
+
+  private byte[] restoreFromWrapper(
+      String topic, Headers headers, Schema wrapperSchema, Struct wrapper) {
+    try {
+      if (wrapperSchema.field(BackupWrapper.FIELD_DATA) == null) {
+        throw new DataException("Malformed backup wrapper: missing '"
+            + BackupWrapper.FIELD_DATA + "' field");
+      }
+      String schemaType = wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE);
+      if (!SchemaBackupConfig.TYPE_PROTOBUF.equals(schemaType)) {
+        throw new DataException(
+            "ProtobufConverter received wrapper with schemaType='" + schemaType
+            + "', expected '" + SchemaBackupConfig.TYPE_PROTOBUF + "'");
+      }
+      Object actualData = wrapper.get(BackupWrapper.FIELD_DATA);
+      Schema actualConnectSchema = wrapperSchema.field(BackupWrapper.FIELD_DATA).schema();
+      String rawSchema = wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA);
+
+      BackupReferenceResolver.ResolutionResult resolved =
+          backupHelper.getReferenceResolver().resolveFromWrapper(
+              wrapperSchema, wrapper, PROTOBUF_SCHEMA_FACTORY);
+
+      ProtobufSchemaAndValue schemaAndValue =
+          protobufData.fromConnectData(actualConnectSchema, actualData);
+      Object v = schemaAndValue.getValue();
+
+      ProtobufSchema serializeSchema;
+      if (rawSchema != null) {
+        serializeSchema = resolved.hasReferences()
+            ? new ProtobufSchema(rawSchema, resolved.getTargetRefs(),
+                resolved.getResolvedSchemas(), null, null)
+            : new ProtobufSchema(rawSchema);
+      } else {
+        serializeSchema = schemaAndValue.getSchema();
+      }
+
+      if (v instanceof Message) {
+        BackupWrapper.removeSchemaIdHeaders(headers, isKey);
+        return serializer.serialize(topic, isKey, headers,
+            (Message) v, serializeSchema);
+      }
+      throw new DataException("Unsupported type during restore: "
+          + (v != null ? v.getClass().getName() : "null"));
+    } catch (DataException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new DataException(
+          String.format("Failed to restore Protobuf data for topic %s", topic), e);
     }
   }
 
@@ -139,22 +216,31 @@ public class ProtobufConverter implements Converter {
   @Override
   public SchemaAndValue toConnectData(String topic, Headers headers, byte[] value) {
     try {
-      ProtobufSchemaAndValue deserialized = deserializer.deserialize(topic, isKey, headers, value);
+      BackupConverterHelper.SchemaIdResult schemaIdResult = backupEnvelopeMode
+          ? backupHelper.resolveSchemaId(value, headers, isKey) : null;
+
+      ProtobufSchemaAndValue deserialized =
+          deserializer.deserialize(topic, isKey, headers, value);
 
       if (deserialized == null || deserialized.getValue() == null) {
         return SchemaAndValue.NULL;
-      } else {
-        Object object = deserialized.getValue();
-        if (object instanceof Message) {
-          Message message = (Message) object;
-          return protobufData.toConnectData(deserialized.getSchema(), message);
-        }
+      }
+      Object object = deserialized.getValue();
+      if (!(object instanceof Message)) {
         throw new DataException(String.format(
             "Unsupported type %s returned during deserialization of topic %s ",
             object.getClass().getName(),
             topic
         ));
       }
+
+      Message message = (Message) object;
+      SchemaAndValue result = protobufData.toConnectData(deserialized.getSchema(), message);
+
+      if (backupEnvelopeMode && schemaIdResult != null && result.schema() != null) {
+        return wrapWithBackupMetadata(result, topic, schemaIdResult);
+      }
+      return result;
     } catch (TimeoutException e) {
       throw new RetriableException(String.format(
           "Failed to deserialize data for topic %s to Protobuf: ",
@@ -175,8 +261,23 @@ public class ProtobufConverter implements Converter {
       }
     } catch (InvalidConfigurationException e) {
       throw new ConfigException(
-          String.format("Failed to access Protobuf data from topic %s : %s", topic, e.getMessage())
+          String.format(
+              "Failed to access Protobuf data from topic %s : %s", topic, e.getMessage())
       );
+    }
+  }
+
+  private SchemaAndValue wrapWithBackupMetadata(
+      SchemaAndValue original, String topic,
+      BackupConverterHelper.SchemaIdResult schemaIdResult) {
+    try {
+      return backupHelper.wrapWithBackupMetadata(
+          original, topic, schemaIdResult,
+          SchemaBackupConfig.TYPE_PROTOBUF, isKey,
+          PROTOBUF_SCHEMA_FACTORY, serializer::computeSubjectName);
+    } catch (Exception e) {
+      throw new DataException(
+          String.format("Failed to wrap backup metadata for topic %s", topic), e);
     }
   }
 
@@ -200,6 +301,10 @@ public class ProtobufConverter implements Converter {
       return serializeImpl(getSubjectName(topic, isKey, value, schema),
           topic, isKey, headers, value, schema);
     }
+
+    public String computeSubjectName(String topic, boolean isKey, ParsedSchema schema) {
+      return getSubjectName(topic, isKey, null, schema);
+    }
   }
 
   static class Deserializer extends AbstractKafkaProtobufDeserializer {
@@ -217,5 +322,6 @@ public class ProtobufConverter implements Converter {
         String topic, boolean isKey, Headers headers, byte[] payload) {
       return deserializeWithSchemaAndVersion(topic, isKey, headers, payload);
     }
+
   }
 }

--- a/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufConverter.java
+++ b/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufConverter.java
@@ -195,7 +195,6 @@ public class ProtobufConverter implements Converter {
       }
 
       if (v instanceof Message) {
-        BackupWrapper.removeSchemaIdHeaders(headers, isKey);
         return serializer.serialize(topic, isKey, headers,
             (Message) v, serializeSchema);
       }

--- a/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufConverter.java
+++ b/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufConverter.java
@@ -21,6 +21,7 @@ import io.confluent.connect.schema.backup.api.SchemaBackupConfig;
 import io.confluent.connect.schema.backup.core.BackupConverterHelper;
 import io.confluent.connect.schema.backup.core.BackupReferenceResolver;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.ParsedSchemaAndValue;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientFactory;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
@@ -216,9 +217,6 @@ public class ProtobufConverter implements Converter {
   @Override
   public SchemaAndValue toConnectData(String topic, Headers headers, byte[] value) {
     try {
-      BackupConverterHelper.SchemaIdResult schemaIdResult = backupEnvelopeMode
-          ? backupHelper.resolveSchemaId(value, headers, isKey) : null;
-
       ProtobufSchemaAndValue deserialized =
           deserializer.deserialize(topic, isKey, headers, value);
 
@@ -237,8 +235,10 @@ public class ProtobufConverter implements Converter {
       Message message = (Message) object;
       SchemaAndValue result = protobufData.toConnectData(deserialized.getSchema(), message);
 
-      if (backupEnvelopeMode && schemaIdResult != null && result.schema() != null) {
-        return wrapWithBackupMetadata(result, topic, schemaIdResult);
+      if (backupEnvelopeMode && deserialized.getWriterSchemaInfo() != null
+          && result.schema() != null) {
+        return wrapWithBackupMetadata(
+            result, topic, deserialized.getWriterSchemaInfo());
       }
       return result;
     } catch (TimeoutException e) {
@@ -269,10 +269,10 @@ public class ProtobufConverter implements Converter {
 
   private SchemaAndValue wrapWithBackupMetadata(
       SchemaAndValue original, String topic,
-      BackupConverterHelper.SchemaIdResult schemaIdResult) {
+      ParsedSchemaAndValue.SchemaInfo schemaInfo) {
     try {
       return backupHelper.wrapWithBackupMetadata(
-          original, topic, schemaIdResult,
+          original, topic, schemaInfo,
           SchemaBackupConfig.TYPE_PROTOBUF, isKey,
           PROTOBUF_SCHEMA_FACTORY, serializer::computeSubjectName);
     } catch (Exception e) {

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufConverterBackupTest.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufConverterBackupTest.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.protobuf;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.google.common.collect.ImmutableList;
+import io.confluent.connect.schema.backup.api.BackupWrapper;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ProtobufConverterBackupTest {
+
+  private static final String TOPIC = "test-topic";
+  private static final String SCHEMA_TYPE = "PROTOBUF";
+  private static final String FIELD_NAME = "name";
+  private static final String FIELD_TEXT = "text";
+  private static final String FIELD_VALUE = "value";
+  private static final String FIELD_DATA = "data";
+
+  private final SchemaRegistryClient schemaRegistry;
+  private final ProtobufConverter converter;
+  private final ProtobufConverter plainConverter;
+
+  public ProtobufConverterBackupTest() {
+    schemaRegistry = new MockSchemaRegistryClient(
+        ImmutableList.of(new ProtobufSchemaProvider()));
+    converter = new ProtobufConverter(schemaRegistry);
+    plainConverter = new ProtobufConverter(schemaRegistry);
+  }
+
+  @Before
+  public void setUp() {
+    Map<String, Object> backupConfig = new HashMap<>();
+    backupConfig.put("schema.registry.url", "http://fake-url");
+    backupConfig.put("schema.backup.enabled", "true");
+    converter.configure(backupConfig, false);
+
+    plainConverter.configure(
+        Collections.singletonMap("schema.registry.url", "http://fake-url"),
+        false);
+  }
+
+  @Test
+  public void testBackupToConnectDataWrapsMetadata() {
+    Schema schema = SchemaBuilder.struct()
+        .name("TestRecord")
+        .field("id", Schema.STRING_SCHEMA)
+        .field("count", Schema.INT32_SCHEMA)
+        .build();
+    Struct value = new Struct(schema)
+        .put("id", "rec-1")
+        .put("count", 10);
+
+    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
+
+    assertNotNull(result);
+    assertNotNull(result.schema());
+    assertEquals(BackupWrapper.NAME, result.schema().name());
+
+    Struct wrapper = (Struct) result.value();
+    assertNotNull(wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_ID));
+    assertEquals(SCHEMA_TYPE, wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
+    assertNotNull(wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA));
+    assertNotNull(wrapper.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT));
+    assertNotNull(wrapper.get(BackupWrapper.FIELD_DATA));
+  }
+
+  @Test
+  public void testBackupFromConnectDataRestores() {
+    Schema schema = SchemaBuilder.struct()
+        .name("SimpleMsg")
+        .field(FIELD_TEXT, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_TEXT, "hello");
+
+    byte[] original = plainConverter.fromConnectData(TOPIC, schema, value);
+    assertNotNull(original);
+
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, original);
+    assertEquals(BackupWrapper.NAME, wrapped.schema().name());
+
+    byte[] restored = converter.fromConnectData(
+        TOPIC, wrapped.schema(), wrapped.value());
+
+    assertNotNull(restored);
+    assertEquals(0x00, restored[0]);
+  }
+
+  @Test
+  public void testBackupRoundTrip() {
+    Schema schema = SchemaBuilder.struct()
+        .name("RoundTripMsg")
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
+        .field(FIELD_VALUE, Schema.INT32_SCHEMA)
+        .build();
+    Struct original = new Struct(schema)
+        .put(FIELD_NAME, "test")
+        .put(FIELD_VALUE, 99);
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, original);
+
+    // Backup wraps, then restore unwraps
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(
+        TOPIC, wrapped.schema(), wrapped.value());
+
+    SchemaAndValue restoredData = plainConverter.toConnectData(TOPIC, restoredBytes);
+    Struct restored = (Struct) restoredData.value();
+    assertEquals("test", restored.getString(FIELD_NAME));
+    assertEquals(Integer.valueOf(99), restored.getInt32(FIELD_VALUE));
+  }
+
+  @Test
+  public void testBackupDisabledNoWrapping() {
+    Schema schema = SchemaBuilder.struct()
+        .name("NoBackupMsg")
+        .field("x", Schema.INT32_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put("x", 1);
+
+    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue result = plainConverter.toConnectData(TOPIC, serialized);
+
+    assertNotNull(result.schema());
+    assertNotEquals(BackupWrapper.NAME, result.schema().name());
+  }
+
+  @Test
+  public void testBackupNullValue() {
+    SchemaAndValue result = converter.toConnectData(TOPIC, null);
+    assertNull(result.schema());
+    assertNull(result.value());
+  }
+
+  @Test
+  public void testBackupPrimitiveType() {
+    Schema schema = SchemaBuilder.struct()
+        .name("PrimitiveHolder")
+        .field("val", Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put("val", "test");
+
+    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
+
+    assertEquals(BackupWrapper.NAME, result.schema().name());
+    Struct wrapper = (Struct) result.value();
+    assertEquals(SCHEMA_TYPE, wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
+  }
+
+  @Test
+  public void testBackupWrapperFields() {
+    Schema schema = SchemaBuilder.struct()
+        .name("FieldCheck")
+        .field(FIELD_DATA, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_DATA, "check");
+
+    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
+
+    Struct wrapper = (Struct) result.value();
+    assertEquals(SCHEMA_TYPE, wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
+    assertTrue(wrapper.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT)
+        .contains(TOPIC));
+  }
+
+  @Test
+  public void testBackupSchemaIdExtracted() {
+    Schema schema = SchemaBuilder.struct()
+        .name("IdCheck")
+        .field("n", Schema.INT32_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put("n", 7);
+
+    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
+
+    Struct wrapper = (Struct) result.value();
+    int wrappedId = wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_ID);
+    assertTrue(wrappedId > 0);
+  }
+
+  @Test
+  public void testBackupNonWrapperSchemaNormalSerialization() {
+    Schema schema = SchemaBuilder.struct()
+        .name("DirectMsg")
+        .field(FIELD_TEXT, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_TEXT, "direct");
+
+    byte[] result = converter.fromConnectData(TOPIC, schema, value);
+    assertNotNull(result);
+    assertTrue(result.length > 5);
+    assertEquals(0x00, result[0]);
+  }
+
+  @Test
+  public void testBackupRestoreMissingDataField() {
+    Schema badSchema = SchemaBuilder.struct()
+        .name(BackupWrapper.NAME)
+        .field(BackupWrapper.FIELD_SCHEMA_ID, Schema.INT32_SCHEMA)
+        .build();
+    Struct badWrapper = new Struct(badSchema)
+        .put(BackupWrapper.FIELD_SCHEMA_ID, 1);
+
+    try {
+      converter.fromConnectData(TOPIC, badSchema, badWrapper);
+      fail("Expected DataException");
+    } catch (DataException e) {
+      assertTrue(e.getMessage().contains("data")
+          || e.getMessage().contains("restore")
+          || e.getMessage().contains("Failed"));
+    }
+  }
+
+  @Test
+  public void testBackupRoundTripBytesExact() {
+    Schema schema = SchemaBuilder.struct()
+        .name("ExactMsg")
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
+        .field(FIELD_VALUE, Schema.INT32_SCHEMA)
+        .build();
+    Struct original = new Struct(schema)
+        .put(FIELD_NAME, "exact")
+        .put(FIELD_VALUE, 77);
+
+    byte[] originalBytes = plainConverter.fromConnectData(
+        TOPIC, schema, original);
+
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(
+        TOPIC, wrapped.schema(), wrapped.value());
+
+    assertArrayEquals(originalBytes, restoredBytes);
+  }
+
+  @Test
+  public void testBackupSchemaVersionPresent() {
+    Schema schema = SchemaBuilder.struct()
+        .name("VersionCheck")
+        .field("x", Schema.INT32_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put("x", 42);
+
+    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
+
+    Struct wrapper = (Struct) result.value();
+    assertNotNull(wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION));
+  }
+
+  @Test
+  public void testBackupRestoreNullRawSchemaFallback() {
+    Schema schema = SchemaBuilder.struct()
+        .name("FallbackMsg")
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_NAME, "fallback");
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+
+    Struct original = (Struct) wrapped.value();
+    Schema wrapperSchema = wrapped.schema();
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_ID),
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION),
+        original.getString(BackupWrapper.FIELD_SCHEMA_TYPE),
+        original.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT),
+        null, null, null);
+    Struct modifiedWrapper = BackupWrapper.buildWrapper(
+        wrapperSchema, original.get(BackupWrapper.FIELD_DATA), fields);
+
+    byte[] restored = converter.fromConnectData(TOPIC, wrapperSchema, modifiedWrapper);
+    assertNotNull(restored);
+    assertEquals(0x00, restored[0]);
+  }
+}


### PR DESCRIPTION
What
  ----
  Add backup/restore schema preservation support to Avro, Protobuf, and JSON Schema converters.

  Introduces two new modules:   
  - `kafka-connect-schema-backup-api`: BackupWrapper struct and SchemaBackupConfig constants
  - `kafka-connect-schema-backup-core`: BackupConverterHelper, BackupSchemaFetcher, BackupReferenceResolver

  When `schema.backup.enabled=true`, converters wrap deserialized data with schema metadata (ID, type, raw schema text, subject, reference tree) during backup, and detect/unwrap BackupWrapper structs to re-register schemas during restore.
  Supports all three subject name strategies and transitive schema references.

  Checklist
  ------------------  
  - **[Y]** Contains customer facing changes? Including API/behavior changes
      - New `schema.backup.enabled` converter config. New backup-api and backup-core modules. No behavior change unless config is explicitly enabled.
  - **[Y]** Is this change gated behind config(s)?
      - `value.converter.schema.backup.enabled=true` (and/or `key.converter.schema.backup.enabled=true`). Defaults to `false`.
  - **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
      - 87 unit tests across 8 test classes: BackupWrapperTest, SchemaBackupConfigTest, BackupSchemaFetcherTest, BackupReferenceResolverTest, BackupConverterHelperTest, AvroConverterBackupTest, ProtobufConverterBackupTest,
  JsonSchemaConverterBackupTest.
  - **[N]** Does this change require modifying existing system tests or adding new system tests?
      - No existing system tests affected. Feature is off by default. E2E tests for the full backup/restore pipeline are tracked separately with the storage connector changes.
  - **[Y]** Must this be released together with other change(s), either in this repo or another one?
      - This PR provides converter-side support. Full feature requires coordinated changes in:
        - `kafka-connect-storage-common` (envelope infrastructure, INIT-5113)
        - `kafka-connect-storage-cloud` (S3 sink backup mode, INIT-5113)
        - `kafka-connect-object-store-source` (S3/GCS/Azure source restore mode, INIT-5113)
        - `kafka-connect-gcs` (GCS sink backup mode, INIT-5113)
        - `kafka-connect-azure-blob-storage` (Azure sink backup mode, INIT-5113)

  References
  ----------
  JIRA: INIT-5113

  Test & Review
  ------------
  - All unit tests pass
  - E2E validated with local docker setup (S3/MinIO backup and restore round-trips for Avro, Protobuf, JSON Schema, plain JSON, and String data)

  Open questions / Follow-ups   
  --------------------------
  - Proto shared message type (same message used at 2+ fields) loses field tags through Avro/Parquet format round-trip — known limitation, works with JsonFormat

  Review stakeholders 
  ------------------
  @rayokota 
