### PR TITLE
DGS-24736 Key Avro serde caches by schema id to fix memory leak

### DIFF
--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroDeserializer.java
@@ -19,13 +19,12 @@ package io.confluent.kafka.serializers;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleMode;
 import java.io.InterruptedIOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import org.apache.avro.Schema;
@@ -60,44 +59,19 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
   protected Schema specificAvroReaderSchema = null;
   protected boolean avroReflectionAllowNull = false;
   protected boolean avroUseLogicalTypeConverters = false;
-  private final Cache<Schema, Schema> readerSchemaCache;
-  private final LoadingCache<IdentityPair<Schema, Schema>, DatumReader<?>> datumReaderCache;
+  private final Cache<Integer, Schema> readerSchemaCache;
+  private final Cache<DatumReaderKey, DatumReader<?>> datumReaderCache;
 
   public AbstractKafkaAvroDeserializer() {
-    CacheLoader<IdentityPair<Schema, Schema>, DatumReader<?>> cacheLoader =
-        new CacheLoader<IdentityPair<Schema, Schema>, DatumReader<?>>() {
-          @Override
-          public DatumReader<?> load(IdentityPair<Schema, Schema> key) {
-            Schema writerSchema = key.getKey();
-            Schema readerSchema = key.getValue();
-            Schema finalReaderSchema = getReaderSchema(writerSchema, readerSchema);
-            boolean writerSchemaIsPrimitive =
-                AvroSchemaUtils.getPrimitiveSchemas().containsValue(writerSchema);
-            if (writerSchemaIsPrimitive) {
-              return new GenericDatumReader<>(writerSchema, finalReaderSchema,
-                  AvroSchemaUtils.getGenericData(avroUseLogicalTypeConverters));
-            } else if (useSchemaReflection) {
-              return new ReflectDatumReader<>(writerSchema, finalReaderSchema,
-                  AvroSchemaUtils.getReflectData(
-                      avroUseLogicalTypeConverters, avroReflectionAllowNull));
-            } else if (useSpecificAvroReader) {
-              return new SpecificDatumReader<>(writerSchema, finalReaderSchema,
-                  AvroSchemaUtils.getSpecificDataForSchema(
-                      finalReaderSchema, avroUseLogicalTypeConverters));
-            } else {
-              return new GenericDatumReader<>(writerSchema, finalReaderSchema,
-                  AvroSchemaUtils.getGenericData(avroUseLogicalTypeConverters));
-            }
-          }
-        };
+    // Key by writer schema id (reader dimension by content), not the Schema object: schemas
+    // re-parsed from an 8.x server's responses arrive as fresh instances, so identity keying
+    // leaks a reader per call.
     readerSchemaCache = CacheBuilder.newBuilder()
         .maximumSize(DEFAULT_CACHE_CAPACITY)
-        // use identity (==) comparison for keys
-        .weakKeys()
         .build();
     datumReaderCache = CacheBuilder.newBuilder()
         .maximumSize(DEFAULT_CACHE_CAPACITY)
-        .build(cacheLoader);
+        .build();
   }
 
   protected void configure(KafkaAvroDeserializerConfig config) {
@@ -274,9 +248,35 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
     }
   }
 
-  protected DatumReader<?> getDatumReader(Schema writerSchema, Schema readerSchema)
+  protected DatumReader<?> getDatumReader(
+      Integer writerSchemaId, Schema writerSchema, Schema readerSchema)
       throws ExecutionException {
-    return datumReaderCache.get(new IdentityPair<>(writerSchema, readerSchema));
+    return datumReaderCache.get(new DatumReaderKey(writerSchemaId, readerSchema),
+        () -> createDatumReader(writerSchemaId, writerSchema, readerSchema));
+  }
+
+  private DatumReader<?> createDatumReader(
+      Integer writerSchemaId, Schema writerSchema, Schema readerSchema) {
+    Schema finalReaderSchema = getReaderSchema(writerSchemaId, writerSchema, readerSchema);
+    // Null writer schema (JSON migration path): read as identity against the reader schema.
+    Schema finalWriterSchema = writerSchema != null ? writerSchema : finalReaderSchema;
+    boolean writerSchemaIsPrimitive =
+        AvroSchemaUtils.getPrimitiveSchemas().containsValue(finalWriterSchema);
+    if (writerSchemaIsPrimitive) {
+      return new GenericDatumReader<>(finalWriterSchema, finalReaderSchema,
+          AvroSchemaUtils.getGenericData(avroUseLogicalTypeConverters));
+    } else if (useSchemaReflection) {
+      return new ReflectDatumReader<>(finalWriterSchema, finalReaderSchema,
+          AvroSchemaUtils.getReflectData(
+              avroUseLogicalTypeConverters, avroReflectionAllowNull));
+    } else if (useSpecificAvroReader) {
+      return new SpecificDatumReader<>(finalWriterSchema, finalReaderSchema,
+          AvroSchemaUtils.getSpecificDataForSchema(
+              finalReaderSchema, avroUseLogicalTypeConverters));
+    } else {
+      return new GenericDatumReader<>(finalWriterSchema, finalReaderSchema,
+          AvroSchemaUtils.getGenericData(avroUseLogicalTypeConverters));
+    }
   }
 
   /**
@@ -290,11 +290,12 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
    * <ul>otherwise use the writer schema</ul>
    * </li>
    */
-  private Schema getReaderSchema(Schema writerSchema, Schema readerSchema) {
+  private Schema getReaderSchema(
+      Integer writerSchemaId, Schema writerSchema, Schema readerSchema) {
     if (readerSchema != null) {
       return readerSchema;
     }
-    readerSchema = readerSchemaCache.getIfPresent(writerSchema);
+    readerSchema = readerSchemaCache.getIfPresent(writerSchemaId);
     if (readerSchema != null) {
       return readerSchema;
     }
@@ -304,10 +305,10 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
       readerSchema = writerSchema;
     } else if (useSchemaReflection) {
       readerSchema = getReflectionReaderSchema(writerSchema);
-      readerSchemaCache.put(writerSchema, readerSchema);
+      readerSchemaCache.put(writerSchemaId, readerSchema);
     } else if (useSpecificAvroReader) {
       readerSchema = getSpecificReaderSchema(writerSchema);
-      readerSchemaCache.put(writerSchema, readerSchema);
+      readerSchemaCache.put(writerSchemaId, readerSchema);
     } else {
       readerSchema = writerSchema;
     }
@@ -501,7 +502,7 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
           reader = new GenericDatumReader<>(writerSchema, writerSchema,
               AvroSchemaUtils.getGenericData(avroUseLogicalTypeConverters));
         } else {
-          reader = getDatumReader(writerSchema, readerSchema);
+          reader = getDatumReader(schemaId, writerSchema, readerSchema);
         }
         int length = buffer.limit() - 1 - idSize;
         Object result;
@@ -533,7 +534,7 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
             }
 
             if (result instanceof JsonNode) {
-              reader = getDatumReader(readerAvroSchema.rawSchema(), readerAvroSchema.rawSchema());
+              reader = getDatumReader(null, null, readerAvroSchema.rawSchema());
               result = AvroSchemaUtils.toObject(
                   (JsonNode) result, readerAvroSchema, (DatumReader<Object>) reader);
             }
@@ -561,21 +562,13 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
     }
   }
 
-  static class IdentityPair<K, V> {
-    private final K key;
-    private final V value;
+  static class DatumReaderKey {
+    private final Integer writerSchemaId;
+    private final Schema readerSchema;
 
-    public IdentityPair(K key, V value) {
-      this.key = key;
-      this.value = value;
-    }
-
-    public K getKey() {
-      return key;
-    }
-
-    public V getValue() {
-      return value;
+    DatumReaderKey(Integer writerSchemaId, Schema readerSchema) {
+      this.writerSchemaId = writerSchemaId;
+      this.readerSchema = readerSchema;
     }
 
     @Override
@@ -586,21 +579,22 @@ public abstract class AbstractKafkaAvroDeserializer extends AbstractKafkaSchemaS
       if (o == null || getClass() != o.getClass()) {
         return false;
       }
-      IdentityPair<?, ?> pair = (IdentityPair<?, ?>) o;
-      // Only perform identity check
-      return key == pair.key && value == pair.value;
+      DatumReaderKey that = (DatumReaderKey) o;
+      // Writer dimension compared by schema id, reader dimension by schema content.
+      return Objects.equals(writerSchemaId, that.writerSchemaId)
+          && Objects.equals(readerSchema, that.readerSchema);
     }
 
     @Override
     public int hashCode() {
-      return System.identityHashCode(key) + System.identityHashCode(value);
+      return Objects.hash(writerSchemaId, readerSchema);
     }
 
     @Override
     public String toString() {
-      return "IdentityPair{"
-          + "key=" + key
-          + ", value=" + value
+      return "DatumReaderKey{"
+          + "writerSchemaId=" + writerSchemaId
+          + ", readerSchema=" + readerSchema
           + '}';
     }
   }

--- a/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
+++ b/avro-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaAvroSerializer.java
@@ -53,15 +53,14 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
   protected boolean latestCompatStrict;
   protected boolean avroReflectionAllowNull = false;
   protected boolean avroUseLogicalTypeConverters = false;
-  private final Cache<Schema, DatumWriter<Object>> datumWriterCache;
+  private final Cache<Integer, DatumWriter<Object>> datumWriterCache;
 
   public AbstractKafkaAvroSerializer() {
-    // use identity (==) comparison for keys
+    // Key by schema id, not the Schema object: schemas re-parsed from an 8.x server's responses
+    // arrive as fresh instances, so identity keying leaks a writer per call.
     datumWriterCache = CacheBuilder.newBuilder()
         .maximumSize(DEFAULT_CACHE_CAPACITY)
-        .weakKeys()
         .build();
-
   }
 
   protected void configure(KafkaAvroSerializerConfig config) {
@@ -170,7 +169,7 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
               "Unrecognized bytes object of type: " + value.getClass().getName());
         }
       } else {
-        writeDatum(out, value, rawSchema);
+        writeDatum(out, value, rawSchema, id);
       }
       byte[] bytes = out.toByteArray();
       out.close();
@@ -191,12 +190,12 @@ public abstract class AbstractKafkaAvroSerializer extends AbstractKafkaSchemaSer
   }
 
   @SuppressWarnings("unchecked")
-  private void writeDatum(ByteArrayOutputStream out, Object value, Schema rawSchema)
+  private void writeDatum(ByteArrayOutputStream out, Object value, Schema rawSchema, int id)
           throws ExecutionException, IOException {
     BinaryEncoder encoder = encoderFactory.directBinaryEncoder(out, null);
 
     DatumWriter<Object> writer;
-    writer = datumWriterCache.get(rawSchema,
+    writer = datumWriterCache.get(id,
         () -> (DatumWriter<Object>) AvroSchemaUtils.getDatumWriter(
             value, rawSchema, avroUseLogicalTypeConverters, avroReflectionAllowNull)
     );

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
@@ -16,6 +16,7 @@
 
 package io.confluent.kafka.serializers;
 
+import com.google.common.cache.Cache;
 import com.google.common.collect.ImmutableList;
 import io.confluent.kafka.example.ExtendedWidget;
 import io.confluent.kafka.example.Widget;
@@ -46,6 +47,7 @@ import org.apache.kafka.common.errors.SerializationException;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -63,6 +65,7 @@ import kafka.utils.VerifiableProperties;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -1465,6 +1468,89 @@ public class KafkaAvroSerializerTest {
         + ",{\"type\":\"record\",\"name\":\"Account\",\"namespace\":\"example.avro\","
         + "\"fields\":[{\"name\":\"accountNumber\",\"type\":\"string\"}]}]";
     assertEquals(expectedResolved, schema.formattedString(Format.RESOLVED.symbol()));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Cache<Object, Object> getCache(
+      Object serde, Class<?> declaringClass, String fieldName) throws Exception {
+    Field field = declaringClass.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    return (Cache<Object, Object>) field.get(serde);
+  }
+
+  @Test
+  public void testDatumWriterCacheKeyedBySchemaId() throws Exception {
+    // auto.register=false keeps the caller-provided schema instance, so fresh-but-equal
+    // instances reach the cache; identity keys produced one entry per instance.
+    HashMap<String, Object> props = new HashMap<>();
+    props.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "bogus");
+    props.put(KafkaAvroSerializerConfig.AUTO_REGISTER_SCHEMAS, "false");
+    KafkaAvroSerializer serializer = new KafkaAvroSerializer(schemaRegistry, props);
+    schemaRegistry.register(topic + "-value", new AvroSchema(createUserSchema()));
+
+    byte[] bytes = null;
+    for (int i = 0; i < 5; i++) {
+      Schema schema = createUserSchema();
+      GenericRecord record = new GenericData.Record(schema);
+      record.put("name", "testUser");
+      bytes = serializer.serialize(topic, record);
+    }
+
+    Cache<Object, Object> datumWriterCache =
+        getCache(serializer, AbstractKafkaAvroSerializer.class, "datumWriterCache");
+    assertEquals(1L, datumWriterCache.size());
+    assertEquals("testUser",
+        ((GenericRecord) avroDeserializer.deserialize(topic, bytes)).get("name").toString());
+  }
+
+  @Test
+  public void testDatumWriterCacheAutoRegisterKeyedBySchemaId() throws Exception {
+    // The INC-11758 path: auto.register=true with a fresh, content-identical schema instance
+    // per call. Identity keys produced one entry per call; id keys collapse to 1.
+    byte[] bytes = null;
+    for (int i = 0; i < 5; i++) {
+      Schema schema = createUserSchema();
+      GenericRecord record = new GenericData.Record(schema);
+      record.put("name", "testUser");
+      bytes = avroSerializer.serialize(topic, record);
+    }
+
+    Cache<Object, Object> datumWriterCache =
+        getCache(avroSerializer, AbstractKafkaAvroSerializer.class, "datumWriterCache");
+    assertEquals(1L, datumWriterCache.size());
+    assertEquals("testUser",
+        ((GenericRecord) avroDeserializer.deserialize(topic, bytes)).get("name").toString());
+  }
+
+  @Test
+  public void testDatumReaderKeyUsesContentEqualityForReaderSchema() {
+    Schema readerA = createUserSchema();
+    Schema readerB = createUserSchema();
+    assertTrue(readerA != readerB);
+
+    AbstractKafkaAvroDeserializer.DatumReaderKey key1 =
+        new AbstractKafkaAvroDeserializer.DatumReaderKey(1, readerA);
+    AbstractKafkaAvroDeserializer.DatumReaderKey key2 =
+        new AbstractKafkaAvroDeserializer.DatumReaderKey(1, readerB);
+    // Same writer id + content-equal reader schema => equal key (unequal under identity keys).
+    assertEquals(key1, key2);
+    assertEquals(key1.hashCode(), key2.hashCode());
+
+    assertEquals(
+        new AbstractKafkaAvroDeserializer.DatumReaderKey(7, null),
+        new AbstractKafkaAvroDeserializer.DatumReaderKey(7, null));
+
+    assertNotEquals(key1, new AbstractKafkaAvroDeserializer.DatumReaderKey(2, readerA));
+    assertNotEquals(key1,
+        new AbstractKafkaAvroDeserializer.DatumReaderKey(1, createExtendUserSchema()));
+
+    // A null writer id (JSON migration path) must not collide with a real id for the same reader.
+    assertNotEquals(
+        new AbstractKafkaAvroDeserializer.DatumReaderKey(null, readerA),
+        new AbstractKafkaAvroDeserializer.DatumReaderKey(1, readerA));
+    assertEquals(
+        new AbstractKafkaAvroDeserializer.DatumReaderKey(null, readerA),
+        new AbstractKafkaAvroDeserializer.DatumReaderKey(null, readerB));
   }
 
   static class RecordWithUUID {

--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
@@ -1523,6 +1523,18 @@ public class KafkaAvroSerializerTest {
   }
 
   @Test
+  public void testDatumReaderCacheKeyedBySchemaId() throws Exception {
+    byte[] bytes = avroSerializer.serialize(topic, createUserRecord());
+    for (int i = 0; i < 5; i++) {
+      assertEquals("testUser",
+          ((GenericRecord) avroDeserializer.deserialize(topic, bytes)).get("name").toString());
+    }
+    Cache<Object, Object> datumReaderCache =
+        getCache(avroDeserializer, AbstractKafkaAvroDeserializer.class, "datumReaderCache");
+    assertEquals(1L, datumReaderCache.size());
+  }
+
+  @Test
   public void testDatumReaderKeyUsesContentEqualityForReaderSchema() {
     Schema readerA = createUserSchema();
     Schema readerB = createUserSchema();


### PR DESCRIPTION
What
----
Backport of #4390 to 7.x: key the Avro serde caches by schema id / content instead of `Schema` object identity.

`datumWriterCache` (`.weakKeys()`) and the deserializer `datumReaderCache` / `readerSchemaCache` (`IdentityPair`) keyed on `Schema` object identity. Against an 8.x server, schemas re-parsed from register/lookup responses arrive as fresh instances, so identity keys never hit and accumulate up to `DEFAULT_CACHE_CAPACITY` (1000) duplicate entries per serde — each pinning a full Avro schema tree, causing OOM (reported by an enterprise customer; confirmed via client heap dump).

Key design choices:
- **Key by the integer schema `id`, not `SchemaId`.** 7.x has no schema guid, so the int id fully identifies the writer schema. `DatumReaderKey` keys the writer dimension by id and the reader dimension by content (Avro `Schema.equals` is content-based).
- **Follows #4390's approach** (`SchemaId` → `Integer`), with one deliberate difference: the serializer keeps its inline `AvroSchemaUtils.getDatumWriter(...)` call rather than #4390's extracted `getDatumWriter(...)` seam (behaviorally identical).

Checklist
------------------
- **[Y]** Contains customer facing changes? Including API/behavior changes
    - `getDatumReader` is `protected` and its signature changed (added the id param) — source-incompatible for any downstream subclass that overrides it. This is the same change #4390 made in 8.x.
- **[N]** Is this change gated behind config(s)?
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
- **[N]** Does this change require modifying existing system tests or adding new system tests?
- **[N]** Must this be released together with other change(s), either in this repo or another one?

References
----------
JIRA: DGS-24736

Backport of #4390 (the 8.x fix).

Test & Review
------------
New regression tests in `KafkaAvroSerializerTest`: writer-cache collapse on both the `auto.register=true` and `auto.register=false` branches (fresh-but-equal instances → 1 entry), plus `DatumReaderKey` content-equality / sentinel semantics. Full `avro-serializer` suite: 103 tests, 0 failures.

Open questions / Follow-ups
--------------------------
Forward-merge `7.5.x → … → 7.9.x`; resolve at the `8.0.x` merge in favor of the existing `SchemaId`-based #4390.
