### PR TITLE
MINOR Fix compilation error in RewrapDeksTest

### DIFF
--- a/client-encryption/src/test/java/io/confluent/kafka/schemaregistry/encryption/tools/RewrapDeksTest.java
+++ b/client-encryption/src/test/java/io/confluent/kafka/schemaregistry/encryption/tools/RewrapDeksTest.java
@@ -69,7 +69,7 @@ public class RewrapDeksTest {
 
     // Pass subject positionally so this test verifies an explicit subject is
     // actually rewrapped, not just that the command exits cleanly.
-    int exitCode = cmd.execute("mock://", kekName, subject,
+    int exitCode = cmd.execute("mock://", kekName, subject1,
         "--property", "rule.executors._default_.param.secret=mysecret");
     assertEquals(0, exitCode);
 
@@ -111,7 +111,7 @@ public class RewrapDeksTest {
 
   @Test
   public void testRewrapDekNoSubjectSpecified() throws Exception {
-    String subject = topic + "-value";
+    String subject = topic1 + "-value";
     String kekName = "kek1";
     dekRegistry.createKek(kekName, "local-kms", "mykey", Collections.emptyMap(), null, false);
     String encryptedDek = "07V2ndh02DA73p+dTybwZFm7DKQSZN1tEwQh+FoX1DZLk4Yj2LLu4omYjp/84tAg3BYlkfGSz+zZacJHIE4=";


### PR DESCRIPTION
What
----
Fix a compilation error in `RewrapDeksTest` that breaks the build on `7.7.x` and everything merged from it since (`7.8.x`, `7.9.x`, `8.0.x`-`8.3.x`, `master`).

`testRewrapDek` and `testRewrapDekNoSubjectSpecified` referenced a nonexistent `subject`/`topic` variable instead of `subject1`/`topic1`. This was introduced by `7f9852f6a23` ("Merge branch '7.6.x' into 7.7.x"), which combined 7.6.x's multi-subject refactor of this test class (`topic1`/`topic2`/`subject1`/`subject2`, from `13cd3fc769a`) with the fix-rewrap PR (#4418), whose changes were made against the older single-variable version of the file. The merge conflict resolution kept both sides inconsistently, leaving two dangling references that don't compile.

Checklist
------------------
- **[N]** Contains customer facing changes? Including API/behavior changes
- **[N]** Is this change gated behind config(s)?
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - No new coverage needed; this restores existing test methods to a compilable, correct state.
- **[N]** Does this change require modifying existing system tests or adding new system tests?
- **[N]** Must this be released together with other change(s), either in this repo or another one?

References
----------
JIRA: N/A

Test & Review
------------
Verified locally: `./mvnw -pl client-encryption -am clean test -Dtest=RewrapDeksTest -Dsurefire.failIfNoSpecifiedTests=false`

Open questions / Follow-ups
--------------------------
This same break exists on every branch merged from `7.7.x` since (`7.8.x`, `7.9.x`, `8.0.x`-`8.3.x`, `master`) and will need to be merged forward / cherry-picked per the usual release process. `7.5.x` and `7.6.x` are unaffected.