### PR TITLE
Stop inheriting gson.version from common-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,11 +142,6 @@
                 <version>${avro.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.code.gson</groupId>
-                <artifactId>gson</artifactId>
-                <version>${gson.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>commons-validator</groupId>
                 <artifactId>commons-validator</artifactId>
                 <version>${commons.validator.version}</version>


### PR DESCRIPTION
## Summary
- Removes the explicit `com.google.code.gson:gson` dependencyManagement entry that pinned to `${gson.version}` inherited from `common-parent`.
- `common`'s `gson.version` property (`2.9.0`) only exists for backward-compat with downstream repos and has drifted from what `confluent-common-bom` actually manages (`2.11.0`) 
- After this change, `gson` is managed transitively by `confluent-common-bom` like the other BOM-owned artifacts, so schema no longer depends on the stale local property.
- confluent-common-bom https://github.com/confluentinc/confluent-common-bom/blob/master/pom.xml