### PR TITLE
Fix RuleContext constructor arity mismatch in EncryptionExecutorTest

### DIFF
--- a/client-encryption/src/test/java/io/confluent/kafka/schemaregistry/encryption/EncryptionExecutorTest.java
+++ b/client-encryption/src/test/java/io/confluent/kafka/schemaregistry/encryption/EncryptionExecutorTest.java
@@ -479,7 +479,7 @@ public abstract class EncryptionExecutorTest {
       // and threaded through to the dek registry client, not dropped.
       RuleContext ctxWithContext = new RuleContext(Collections.emptyMap(), null, null, target,
           ":.myctx:widget-value", null, null, null, null, false,
-          RuleMode.WRITE, rule, 0, Collections.singletonList(rule));
+          RuleMode.WRITE, rule, 0, Collections.singletonList(rule), false);
       executor.newTransform(ctxWithContext);
       verify(mockDekClient).getKek("kek1", false, ".myctx");
 
@@ -487,7 +487,7 @@ public abstract class EncryptionExecutorTest {
       // null rather than being sent to the registry as the literal "." context.
       RuleContext ctxDefaultContext = new RuleContext(Collections.emptyMap(), null, null, target,
           "widget-value", null, null, null, null, false,
-          RuleMode.WRITE, rule, 0, Collections.singletonList(rule));
+          RuleMode.WRITE, rule, 0, Collections.singletonList(rule), false);
       executor.newTransform(ctxDefaultContext);
       verify(mockDekClient).getKek("kek1", false, null);
     } finally {


### PR DESCRIPTION
## Summary
- `testGetOrCreateKekUsesContextFromSubject` (added in #4422 / DGS-24778) calls `RuleContext`'s constructor with 14 args, but this branch's `RuleContext` has a 15th `includeRuleResults` param (from DGS-24368). #4422 was based on 8.0.x, which never got the DGS-24368 change, so it compiled there but broke test-compile once merged into 8.1.x (and from there into 8.2.x/8.3.x/master).
- Adds the missing `includeRuleResults` (`false`) argument to both `RuleContext` calls, matching the convention used elsewhere (e.g. `FieldRedactionExecutorTest`).
- Fixes the `Build schema-registry jar` Semaphore job failure: https://semaphore.ci.confluent.io/jobs/6f28c32e-93f2-46fa-83dd-63c907c23bf7/

## Test plan
- [ ] `mvn -pl client-encryption -am test-compile` passes
- [ ] `EncryptionExecutorTest#testGetOrCreateKekUsesContextFromSubject` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)