### PR TITLE
Stop inheriting gson.version from common-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,11 +142,6 @@
                 <version>${avro.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.code.gson</groupId>
-                <artifactId>gson</artifactId>
-                <version>${gson.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>commons-validator</groupId>
                 <artifactId>commons-validator</artifactId>
                 <version>${commons.validator.version}</version>


### PR DESCRIPTION
## Summary
- Removes the explicit `com.google.code.gson:gson` dependencyManagement entry that pinned to `${gson.version}` inherited from `common-parent`.
- `common`'s `gson.version` property (`2.9.0`) only exists for backward-compat with downstream repos and has drifted from what `confluent-common-bom` actually manages (`2.11.0`) — see [DP-18877](https://confluentinc.atlassian.net/browse/DP-18877).
- After this change, `gson` is managed transitively by `confluent-common-bom` like the other BOM-owned artifacts, so schema no longer depends on the stale local property.
- Targeting `8.0.x` (not `master`): this repo forward-merges via `sem-pint` (8.0.x -> 8.1.x -> 8.2.x -> 8.3.x -> master), so landing the fix at the earliest branch lets it propagate up automatically. (Supersedes #4423, which targeted master directly.)

## Test plan
- [ ] CI build/compile passes across all modules
- [ ] Confirm resolved `gson` version is `2.11.0` (`mvn dependency:tree -Dincludes=com.google.code.gson:gson`)
- [ ] Existing unit/integration tests pass with gson `2.11.0` (behavioral diff risk, not just compile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DP-18877]: https://confluentinc.atlassian.net/browse/DP-18877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ