### PR TITLE
docs: add SECURITY.md routing reports to security@confluent.io (closes #4048)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report suspected security vulnerabilities privately to
+**[security@confluent.io](mailto:security@confluent.io)** — Confluent's
+coordinated-disclosure contact (see the company's published
+[security.txt](https://www.confluent.io/.well-known/security.txt) and
+[Trust and Security](https://www.confluent.io/trust-and-security/) pages).
+Please mention the repository name in the subject line.
+
+Please do **not** report security vulnerabilities through public GitHub
+issues, discussions, or pull requests.


### PR DESCRIPTION
Hi, and thank you for Schema Registry.

This picks up **#4048 ("Document security policy")**, open since December with no reply: the repo has no `SECURITY.md` (and no org-level default), so GitHub's Security tab gives reporters no routing.

The added `SECURITY.md` points at the channel Confluent already publishes company-wide — `security@confluent.io`, per the live [`https://www.confluent.io/.well-known/security.txt`](https://www.confluent.io/.well-known/security.txt) (`Contact: mailto:security@confluent.io`, `Expires: 2027-12-31`) and the [Trust and Security](https://www.confluent.io/trust-and-security/) page — so it documents existing process rather than inventing one. If there's a more specific internal routing you prefer, happy to adjust.

Closes #4048.

For transparency: I used AI assistance to spot and draft this; I verified the missing file, the open issue, and the live security.txt myself.
