### PR TITLE
fix: skip schema normalization in IMPORT mode

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -1449,9 +1449,9 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     try {
       if (getModeInScope(schema.getSubject()) != Mode.IMPORT) {
         parsedSchema.validate(isSchemaFieldValidationEnabled(config));
-      }
-      if (normalize) {
-        parsedSchema = parsedSchema.normalize();
+        if (normalize) {
+          parsedSchema = parsedSchema.normalize();
+        }
       }
     } catch (Exception e) {
       String errMsg = "Invalid schema " + schema + ", details: " + e.getMessage();

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -21,6 +21,7 @@ import static io.confluent.kafka.schemaregistry.CompatibilityLevel.NONE;
 import static io.confluent.kafka.schemaregistry.utils.QualifiedSubject.DEFAULT_CONTEXT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -382,6 +383,90 @@ public class RestApiTest extends ClusterTestHarness {
       assertEquals("Overwrite schema for the same ID is not permitted.",
           Errors.OPERATION_NOT_PERMITTED_ERROR_CODE, e.getErrorCode());
     }
+  }
+
+  @Test
+  public void testNormalizeConfigFallbackNotAppliedInImportMode() throws Exception {
+    String subject = "testSubject";
+    // Normalize sorts non-standard field properties alphabetically ("aprop" before "zprop"),
+    // so this schema's raw and normalized canonical forms differ.
+    String schemaString = "{\"type\":\"record\","
+        + "\"name\":\"myrecord\","
+        + "\"fields\":"
+        + "[{\"type\":\"string\",\"name\":\"field1\",\"zprop\":\"z\",\"aprop\":\"a\"}]}";
+    AvroSchema avroSchema = AvroUtils.parseSchema(schemaString);
+    String rawSchema = avroSchema.canonicalString();
+    String normalizedSchema = avroSchema.normalize().canonicalString();
+    assertNotEquals("Test schema should have distinct raw and normalized canonical forms",
+        rawSchema, normalizedSchema);
+
+    ConfigUpdateRequest configUpdateRequest = new ConfigUpdateRequest();
+    configUpdateRequest.setNormalize(true);
+    restApp.restClient.updateConfig(configUpdateRequest, subject);
+    restApp.restClient.setMode("IMPORT", subject);
+
+    // Simulates the exporter's write path: normalize=false request, explicit id/version as
+    // required by IMPORT mode.
+    restApp.restClient.registerSchema(rawSchema, subject, 1, 1);
+
+    assertEquals(
+        "Schema should be stored unnormalized: IMPORT mode should skip the normalize "
+            + "config fallback",
+        rawSchema,
+        restApp.restClient.getVersion(subject, 1).getSchema());
+  }
+
+  @Test
+  public void testNormalizeConfigFallbackAppliedOutsideImportMode() throws Exception {
+    String subject = "testSubject";
+    // Normalize sorts non-standard field properties alphabetically ("aprop" before "zprop"),
+    // so this schema's raw and normalized canonical forms differ.
+    String schemaString = "{\"type\":\"record\","
+        + "\"name\":\"myrecord\","
+        + "\"fields\":"
+        + "[{\"type\":\"string\",\"name\":\"field1\",\"zprop\":\"z\",\"aprop\":\"a\"}]}";
+    AvroSchema avroSchema = AvroUtils.parseSchema(schemaString);
+    String rawSchema = avroSchema.canonicalString();
+    String normalizedSchema = avroSchema.normalize().canonicalString();
+
+    ConfigUpdateRequest configUpdateRequest = new ConfigUpdateRequest();
+    configUpdateRequest.setNormalize(true);
+    restApp.restClient.updateConfig(configUpdateRequest, subject);
+
+    // Mode stays READWRITE (default): the normalize config fallback still applies.
+    restApp.restClient.registerSchema(rawSchema, subject);
+
+    assertEquals(
+        "Schema should be normalized via the config fallback outside IMPORT mode",
+        normalizedSchema,
+        restApp.restClient.getVersion(subject, 1).getSchema());
+  }
+
+  @Test
+  public void testExplicitNormalizeIgnoredInImportMode() throws Exception {
+    String subject = "testSubject";
+    // Normalize sorts non-standard field properties alphabetically ("aprop" before "zprop"),
+    // so this schema's raw and normalized canonical forms differ.
+    String schemaString = "{\"type\":\"record\","
+        + "\"name\":\"myrecord\","
+        + "\"fields\":"
+        + "[{\"type\":\"string\",\"name\":\"field1\",\"zprop\":\"z\",\"aprop\":\"a\"}]}";
+    AvroSchema avroSchema = AvroUtils.parseSchema(schemaString);
+    String rawSchema = avroSchema.canonicalString();
+    String normalizedSchema = avroSchema.normalize().canonicalString();
+    assertNotEquals("Test schema should have distinct raw and normalized canonical forms",
+        rawSchema, normalizedSchema);
+
+    restApp.restClient.setMode("IMPORT", subject);
+
+    // IMPORT stores the schema verbatim, so even an explicit normalize=true is skipped.
+    restApp.restClient.registerSchema(rawSchema, subject, 1, 1, true);
+
+    assertEquals(
+        "Schema should be stored unnormalized: IMPORT mode should skip normalization even "
+            + "when normalize=true is requested",
+        rawSchema,
+        restApp.restClient.getVersion(subject, 1).getSchema());
   }
 
   @Test


### PR DESCRIPTION
What
----
The Schema Exporter replicates a source Schema Registry's stored canonical schema string byte for byte onto a destination Schema Registry. It does this by registering with an explicit id and version and `normalize=false`, into a destination subject/context that is pinned to IMPORT mode for the duration of the export.

On the destination, schema canonicalization runs through `maybeValidateAndNormalizeSchema`. Validation there was already skipped in IMPORT mode, but normalization was not: if the destination subject or context had `normalize=true` configured (via the register handler's config fallback), or if a request explicitly asked for `normalize=true`, the schema was re-normalized and stored with a canonical form (and guid) that diverged from the source. This is a pre-existing bug in the current Kafka-backed exporter, not specific to any future backend; it reproduces on any destination whose config has `normalize=true`.

Every other config-driven behavior in the register path (compatibility checks, validate, metadata/ruleset merge, and so on) is already skipped in IMPORT mode. Normalization was the one outlier.

The fix nests the normalize call inside the existing IMPORT guard in `maybeValidateAndNormalizeSchema`, so IMPORT mode never normalizes:

```java
if (getModeInScope(schema.getSubject()) != Mode.IMPORT) {
  parsedSchema.validate(isSchemaFieldValidationEnabled(config));
  if (normalize) {
    parsedSchema = parsedSchema.normalize();
  }
}
```

Because the gate lives in the shared canonicalization function rather than in a single REST handler, IMPORT-mode normalization is now skipped consistently across the register/persist path and the lookup/compatibility canonicalization paths. In IMPORT mode, normalization is skipped entirely, both the subject/context config fallback and an explicit `normalize=true` request. This matches IMPORT's semantics of storing the submitted schema verbatim.

All non-IMPORT behavior is unchanged: outside IMPORT mode, both validation and normalization (config fallback and explicit `normalize=true`) apply exactly as before.

This fix is shared by both the current Kafka-backed exporter and the RP-backed exporter that reuses the same destination write path (register with explicit id/version, normalize=false, into an IMPORT-mode destination context). Since the fix is entirely on the destination side and neither exporter has any exporter-specific normalize handling, both are covered identically with no exporter-side change and no possibility of divergence between them.

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes
    - Yes: in IMPORT mode, schemas are now stored exactly as submitted and are never re-normalized, regardless of subject/context `normalize` config or an explicit `normalize=true` request. Destinations must run a build that includes this fix for the fix to take effect.
- [ ] Is this change gated behind feature flag(s)?
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
    - Added three REST-layer tests in `RestApiTest` covering IMPORT with the config fallback, IMPORT with an explicit `normalize=true`, and the unchanged non-IMPORT path.
- [ ] Does this change require modifying existing system tests or adding new system tests?

References
----------
Targets `7.5.x` so the fix reaches Schema Linking users on older releases; it should be forward-ported to the newer release branches (8.0.x and up). cc @rayokota.

JIRA: https://confluentinc.atlassian.net/browse/DGS-24795

Design deep dive: https://confluentinc.atlassian.net/wiki/spaces/~7120207178b220e9014ec7bac32982c1e06b54/pages/5451743419/Schema+Exporter+in+RP+Config+deep+dive

Test & Review
------------
Added three tests in `RestApiTest`:
- `testNormalizeConfigFallbackNotAppliedInImportMode`: subject config `normalize=true`, subject mode IMPORT, register with a `normalize=false` request and explicit id/version; asserts the stored schema is the raw, unnormalized form.
- `testExplicitNormalizeIgnoredInImportMode`: subject mode IMPORT, register with an explicit `normalize=true` request and explicit id/version; asserts the stored schema is still the raw form.
- `testNormalizeConfigFallbackAppliedOutsideImportMode`: same config `normalize=true` but default READWRITE mode; asserts the schema is normalized, confirming the non-IMPORT path is unchanged.

The change is in the shared canonicalization path, so the `RestApiTest` integration suite was run as a regression guard. A stash-based check confirmed the two IMPORT tests fail without the fix (schema stored normalized) and pass with it.

This fix should be forward-ported to the newer release branches.

Open questions / Follow-ups
--------------------------
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
