### PR TITLE
DGS-23927 Gate JSON single-member oneOf collapse by version

### DIFF
--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/common/ToLogicalContext.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/common/ToLogicalContext.java
@@ -77,17 +77,13 @@ public final class ToLogicalContext<T> extends CycleContext<T> {
   // walk runs) so a synthesized name never silently shadows an authored one.
   private int nextRefIndex = 1;
 
-  public ToLogicalContext(
-      ParsedSchema parsedSchema, Map<String, Object> unionMetadata) {
-    this(parsedSchema, unionMetadata, LogicalTypeVersion.V2);
-  }
-
   public ToLogicalContext(ParsedSchema parsedSchema) {
     this(parsedSchema, Map.of(), LogicalTypeVersion.V2);
   }
 
-  public ToLogicalContext(ParsedSchema parsedSchema, LogicalTypeVersion version) {
-    this(parsedSchema, Map.of(), version);
+  public ToLogicalContext(
+      ParsedSchema parsedSchema, Map<String, Object> unionMetadata) {
+    this(parsedSchema, unionMetadata, LogicalTypeVersion.V2);
   }
 
   public ToLogicalContext(

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/common/ToLogicalContext.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/common/ToLogicalContext.java
@@ -59,6 +59,7 @@ public final class ToLogicalContext<T> extends CycleContext<T> {
   public static final int MAX_TYPE_DEPTH = 256;
 
   private final ParsedSchema parsedSchema;
+  private final LogicalTypeVersion version;
   private Map<String, Object> unionMetadata;
   private final Map<String, Schema> namedTypes = new LinkedHashMap<>();
   private final Set<String> externalTypes = new LinkedHashSet<>();
@@ -78,8 +79,23 @@ public final class ToLogicalContext<T> extends CycleContext<T> {
 
   public ToLogicalContext(
       ParsedSchema parsedSchema, Map<String, Object> unionMetadata) {
+    this(parsedSchema, unionMetadata, LogicalTypeVersion.V2);
+  }
+
+  public ToLogicalContext(ParsedSchema parsedSchema) {
+    this(parsedSchema, Map.of(), LogicalTypeVersion.V2);
+  }
+
+  public ToLogicalContext(ParsedSchema parsedSchema, LogicalTypeVersion version) {
+    this(parsedSchema, Map.of(), version);
+  }
+
+  public ToLogicalContext(
+      ParsedSchema parsedSchema, Map<String, Object> unionMetadata,
+      LogicalTypeVersion version) {
     this.parsedSchema = parsedSchema;
     this.unionMetadata = unionMetadata != null ? unionMetadata : Map.of();
+    this.version = version != null ? version : LogicalTypeVersion.V2;
     // Seed externals from the SR reference list. Each entry's `name` is the
     // import string used in the schema text — for proto enum-only files
     // (which have no top-level messages and so don't get walked by the
@@ -94,12 +110,16 @@ public final class ToLogicalContext<T> extends CycleContext<T> {
     }
   }
 
-  public ToLogicalContext(ParsedSchema parsedSchema) {
-    this(parsedSchema, Map.of());
-  }
-
   public ParsedSchema getParsedSchema() {
     return parsedSchema;
+  }
+
+  public LogicalTypeVersion getVersion() {
+    return version;
+  }
+
+  public boolean isV1() {
+    return version == LogicalTypeVersion.V1;
   }
 
   public List<SchemaReference> getReferences() {

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/JsonToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/JsonToLogicalTypeConverter.java
@@ -123,7 +123,7 @@ public class JsonToLogicalTypeConverter {
 
   private static LogicalType toLogicalTypeInternal(
       final JsonSchema schema, final LogicalTypeVersion version) {
-    final ToLogicalContext<String> ctx = new ToLogicalContext<>(schema, version);
+    final ToLogicalContext<String> ctx = new ToLogicalContext<>(schema, Map.of(), version);
     // Recover named types from $defs (entries are keyed by qualified name).
     recoverNamedTypesFromDefs(schema, ctx);
     final Schema logicalType =
@@ -598,13 +598,14 @@ public class JsonToLogicalTypeConverter {
       throw new ValidationException("Unsupported criterion " + criterion);
     }
 
-    // Singleton-collapse: a oneOf with one non-null member.
-    //  - oneOf:[null, T] is always collapsed to nullable T — the null member
-    //    conveys nullability, not a branch.
-    //  - A bare oneOf:[T] (no null member) is collapsed only in V2 (canonical,
+    // Singleton-collapse: a oneOf/anyOf with one non-null member (this branch is
+    // reached for both ONE_CRITERION and ANY_CRITERION; allOf is handled above).
+    //  - [null, T] is always collapsed to nullable T — the null member conveys
+    //    nullability, not a branch.
+    //  - A bare [T] (no null member) is collapsed only in V2 (canonical,
     //    semantically equivalent to T). In V1 it is kept as a 1-branch union so
     //    the Flink projection reproduces old Flink's union-wrapper RowType (old
-    //    Flink's JSON converter wrapped a bare singleton oneOf rather than
+    //    Flink's JSON converter wrapped a bare singleton oneOf/anyOf rather than
     //    collapsing it).
     List<org.everit.json.schema.Schema> nonNullSubschemas = new ArrayList<>();
     boolean hasNullMember = false;

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/JsonToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/JsonToLogicalTypeConverter.java
@@ -24,6 +24,7 @@ import io.confluent.kafka.schemaregistry.type.logical.Schema.Field;
 import io.confluent.kafka.schemaregistry.type.logical.Schema.UnionBranch;
 import io.confluent.kafka.schemaregistry.type.logical.LogicalType;
 import io.confluent.kafka.schemaregistry.type.logical.ValidationException;
+import io.confluent.kafka.schemaregistry.type.logical.common.LogicalTypeVersion;
 import io.confluent.kafka.schemaregistry.type.logical.common.ToLogicalContext;
 import org.everit.json.schema.ArraySchema;
 import org.everit.json.schema.BooleanSchema;
@@ -108,15 +109,21 @@ public class JsonToLogicalTypeConverter {
   }
 
   public static LogicalType toLogicalType(final JsonSchema schema) {
+    return toLogicalType(schema, LogicalTypeVersion.V2);
+  }
+
+  public static LogicalType toLogicalType(
+      final JsonSchema schema, final LogicalTypeVersion version) {
     try {
-      return toLogicalTypeInternal(schema);
+      return toLogicalTypeInternal(schema, version);
     } catch (StackOverflowError e) {
       throw new ValidationException("JSON schema nests types too deeply to convert");
     }
   }
 
-  private static LogicalType toLogicalTypeInternal(final JsonSchema schema) {
-    final ToLogicalContext<String> ctx = new ToLogicalContext<>(schema);
+  private static LogicalType toLogicalTypeInternal(
+      final JsonSchema schema, final LogicalTypeVersion version) {
+    final ToLogicalContext<String> ctx = new ToLogicalContext<>(schema, version);
     // Recover named types from $defs (entries are keyed by qualified name).
     recoverNamedTypesFromDefs(schema, ctx);
     final Schema logicalType =
@@ -591,11 +598,14 @@ public class JsonToLogicalTypeConverter {
       throw new ValidationException("Unsupported criterion " + criterion);
     }
 
-    // Singleton-collapse: a oneOf with exactly one non-null member is
-    // semantically equivalent to that member type. Mirrors Avro's
-    // AvroToLogicalTypeConverter behavior — in content-variant systems
-    // (Avro/JSON), UNION<T> conveys no information beyond T. Catches both
-    // bare oneOf:[T] and the wrapper shape oneOf:[null, T].
+    // Singleton-collapse: a oneOf with one non-null member.
+    //  - oneOf:[null, T] is always collapsed to nullable T — the null member
+    //    conveys nullability, not a branch.
+    //  - A bare oneOf:[T] (no null member) is collapsed only in V2 (canonical,
+    //    semantically equivalent to T). In V1 it is kept as a 1-branch union so
+    //    the Flink projection reproduces old Flink's union-wrapper RowType (old
+    //    Flink's JSON converter wrapped a bare singleton oneOf rather than
+    //    collapsing it).
     List<org.everit.json.schema.Schema> nonNullSubschemas = new ArrayList<>();
     boolean hasNullMember = false;
     for (org.everit.json.schema.Schema subSchema : combinedSchema.getSubschemas()) {
@@ -605,7 +615,7 @@ public class JsonToLogicalTypeConverter {
         nonNullSubschemas.add(subSchema);
       }
     }
-    if (nonNullSubschemas.size() == 1) {
+    if (nonNullSubschemas.size() == 1 && (hasNullMember || !ctx.isV1())) {
       return convertWithCycleDetection(
           nonNullSubschemas.get(0), isNullable || hasNullMember, ctx, indexPath);
     }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/json/JsonToLogicalTypeConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/json/JsonToLogicalTypeConverterTest.java
@@ -17,7 +17,9 @@
 package io.confluent.kafka.schemaregistry.type.logical.json;
 
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import io.confluent.kafka.schemaregistry.type.logical.LogicalType;
 import io.confluent.kafka.schemaregistry.type.logical.Schema;
+import io.confluent.kafka.schemaregistry.type.logical.common.LogicalTypeVersion;
 import org.everit.json.schema.BooleanSchema;
 import org.everit.json.schema.CombinedSchema;
 import org.everit.json.schema.EmptySchema;
@@ -221,5 +223,90 @@ class JsonToLogicalTypeConverterTest {
     Schema result = JsonToLogicalTypeConverter.toRootSchema(new JsonSchema(jsonSchema));
     assertEquals(Schema.Type.STRUCT, result.getType());
     assertTrue(result.getFields().isEmpty());
+  }
+
+  @Test
+  void testSingletonObjectOneOfIsUnionInV1ButCollapsesInV2() {
+    // Mirrors getNullableReference: a single-member oneOf of an object stays a
+    // 1-branch union under V1 (old Flink's union-wrapper) but collapses to the
+    // member under V2 (canonical).
+    org.everit.json.schema.Schema oneOf = CombinedSchema.builder()
+        .criterion(CombinedSchema.ONE_CRITERION)
+        .subschema(ObjectSchema.builder()
+            .addPropertySchema("x", NumberSchema.builder().requiresInteger(true).build())
+            .build())
+        .build();
+
+    Schema v1 = JsonToLogicalTypeConverter
+        .toLogicalType(new JsonSchema(oneOf), LogicalTypeVersion.V1).getRootSchema();
+    assertEquals(Schema.Type.UNION, v1.getType());
+    assertEquals(1, v1.getBranches().size());
+    assertEquals(Schema.Type.STRUCT, v1.getBranches().get(0).getSchema().getType());
+
+    Schema v2 = JsonToLogicalTypeConverter.toRootSchema(new JsonSchema(oneOf));
+    assertEquals(Schema.Type.STRUCT, v2.getType());
+  }
+
+  @Test
+  void testSingletonOneOfFieldIsUnionInV1ButCollapsesInV2() {
+    // Mirrors testSchemaReference (nested references): a field whose type is a
+    // single-member oneOf stays a union field under V1, collapses under V2.
+    org.everit.json.schema.Schema root = ObjectSchema.builder()
+        .addPropertySchema("f1", CombinedSchema.builder()
+            .criterion(CombinedSchema.ONE_CRITERION)
+            .subschema(ObjectSchema.builder()
+                .addPropertySchema("x", StringSchema.builder().build()).build())
+            .build())
+        .addRequiredProperty("f1")
+        .build();
+
+    Schema f1V1 = JsonToLogicalTypeConverter
+        .toLogicalType(new JsonSchema(root), LogicalTypeVersion.V1)
+        .getRootSchema().getField("f1").getSchema();
+    assertEquals(Schema.Type.UNION, f1V1.getType());
+
+    Schema f1V2 = JsonToLogicalTypeConverter.toRootSchema(new JsonSchema(root))
+        .getField("f1").getSchema();
+    assertEquals(Schema.Type.STRUCT, f1V2.getType());
+  }
+
+  @Test
+  void testSingletonOneOfOfReferenceIsUnionInV1() {
+    // Mirrors testRoundTrip[5] / the reference cases: a single-member oneOf of a
+    // $ref stays a 1-branch union (wrapping a NAMED_TYPE_REF) under V1 and
+    // collapses to the NAMED_TYPE_REF under V2.
+    String json = "{\"type\":\"object\","
+        + "\"properties\":{\"f1\":{\"oneOf\":[{\"$ref\":\"#/definitions/T\"}]}},"
+        + "\"required\":[\"f1\"],"
+        + "\"definitions\":{\"T\":{\"type\":\"object\","
+        + "\"properties\":{\"x\":{\"type\":\"string\"}}}}}";
+
+    Schema f1V1 = JsonToLogicalTypeConverter
+        .toLogicalType(new JsonSchema(json), LogicalTypeVersion.V1)
+        .getRootSchema().getField("f1").getSchema();
+    assertEquals(Schema.Type.UNION, f1V1.getType());
+
+    Schema f1V2 = JsonToLogicalTypeConverter.toRootSchema(new JsonSchema(json))
+        .getField("f1").getSchema();
+    assertEquals(Schema.Type.NAMED_TYPE_REF, f1V2.getType());
+  }
+
+  @Test
+  void testReferenceToNullableObjectStaysNullable() {
+    // Mirrors getNonRequiredReference: a required field referencing a nullable
+    // object (type:[object,null]) must keep the referenced type nullable, so the
+    // Flink projection reads it as a nullable row rather than a union.
+    String json = "{\"$schema\":\"http://json-schema.org/draft-07/schema#\","
+        + "\"type\":\"object\","
+        + "\"properties\":{\"ref1\":{\"$ref\":\"#/definitions/opt\"}},"
+        + "\"required\":[\"ref1\"],"
+        + "\"definitions\":{\"opt\":{\"type\":[\"object\",\"null\"],"
+        + "\"properties\":{\"x\":{\"type\":\"string\"}}}}}";
+
+    LogicalType lt = JsonToLogicalTypeConverter.toLogicalType(
+        new JsonSchema(json), LogicalTypeVersion.V1);
+    Schema opt = lt.getNamedTypes().get("opt");
+    assertTrue(opt != null && opt.isNullable(),
+        "referenced nullable object must remain nullable: " + lt.getNamedTypes());
   }
 }


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
                                                                                                                                                                       
  Threads `LogicalTypeVersion` into the JSON to-logical reader so a bare                                                                                                                
  single-member `anyOf/oneOf:[T]` is handled per emission edition:                                                                                                                            
                                                                                                                                                                                        
  - **V2 (canonical, default):** collapse `anyOf/oneOf:[T]` to `T` (unchanged).                                                                                                               
  - **V1 (Flink-compat):** keep `anyOf/oneOf:[T]` as a **1-branch union**, reproducing                                                                                                        
    the union-wrapper shape old Flink's JSON converter produced.                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                 
  The reader collapses *any* single-non-null-member `anyOf/oneOf` to its member — correct                                                                                                     
  for the canonical (V2) model, but old Flink's JSON converter only collapsed the                                                                                                       
  nullable wrapper `anyOf/oneOf:[null, T]` and wrapped a bare `anyOf/oneOf:[T]` in a union.                                                                                                         
  Since the Flink integration reads schemas in V1 (byte/structure compat), the                                                                                                          
  unconditional collapse dropped a union-wrapper level the Flink runtime `RowData`                                                                                                      
  converters expect, breaking conversion of JSON schemas that use single-member                                                                                                         
  `anyOf/oneOf`s (including `$ref`-wrapped ones).                                                                                                                                             
                                                                                                                                                                                        
  The reader stays canonical/version-agnostic apart from this one V1 concession;                                                                                                        
  `[null, T]` still always collapses to nullable `T`. Avro and Proto need no change                                                                                                     
  — their readers already match old Flink (Avro collapses single-member unions;                                                                                                         
  Proto never collapses oneofs).                                                                                                                                                        
                                        


<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
