### PR TITLE
DGS-23927 Ensure Flink compat for JSON union branch names

### DIFF
--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/JsonToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/JsonToLogicalTypeConverter.java
@@ -638,10 +638,14 @@ public class JsonToLogicalTypeConverter {
         String branchName;
         if (hint != null && hint.get("name") != null) {
           branchName = (String) hint.get("name");
+        } else if (!ctx.isV1() && subSchema.getTitle() != null) {
+          // V2 prefers a subschema's title as the branch name. V1 is the
+          // Flink-byte-compat edition, which always synthesizes
+          // connect_union_field_<index> (old Flink converter ignored titles);
+          // preserving titles under V1 would rename union RowType fields.
+          branchName = subSchema.getTitle();
         } else {
-          branchName = subSchema.getTitle() != null
-              ? subSchema.getTitle()
-              : GENERALIZED_TYPE_UNION_PREFIX + index;
+          branchName = GENERALIZED_TYPE_UNION_PREFIX + index;
         }
         String branchDoc = hint != null ? (String) hint.get("doc") : null;
         @SuppressWarnings("unchecked")

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/json/JsonToLogicalTypeConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/json/JsonToLogicalTypeConverterTest.java
@@ -187,6 +187,30 @@ class JsonToLogicalTypeConverterTest {
   }
 
   @Test
+  void testUnionBranchNamesUseTitleInV2ButSynthesizeInV1() {
+    // A 2-branch union whose subschemas set `title`. V2 uses the titles as the
+    // branch names; V1 (the Flink-byte-compat edition) ignores titles and
+    // synthesizes connect_union_field_<index>, matching the old Flink converter
+    // and keeping union RowType field names stable across the upgrade.
+    org.everit.json.schema.Schema jsonSchema = CombinedSchema.builder()
+        .criterion(CombinedSchema.ONE_CRITERION)
+        .subschema(StringSchema.builder().title("myString").build())
+        .subschema(BooleanSchema.builder().title("myBool").build())
+        .build();
+
+    Schema v1 = JsonToLogicalTypeConverter
+        .toLogicalType(new JsonSchema(jsonSchema), LogicalTypeVersion.V1).getRootSchema();
+    assertEquals(Schema.Type.UNION, v1.getType());
+    assertEquals("connect_union_field_0", v1.getBranches().get(0).getName());
+    assertEquals("connect_union_field_1", v1.getBranches().get(1).getName());
+
+    Schema v2 = JsonToLogicalTypeConverter.toRootSchema(new JsonSchema(jsonSchema));
+    assertEquals(Schema.Type.UNION, v2.getType());
+    assertEquals("myString", v2.getBranches().get(0).getName());
+    assertEquals("myBool", v2.getBranches().get(1).getName());
+  }
+
+  @Test
   void testSingletonOneOfCollapsesToMemberType() {
     // oneOf:[T] is semantically equivalent to T in JSON Schema (the value
     // satisfies exactly one schema, but there's only one option). Reader


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
  Gates JSON union branch naming by `LogicalTypeVersion`, following the same pattern                                                                                                    
  as #4436 (single-member oneOf collapse).                                                                                                                            
                                                                                                                                                                                        
  When converting a JSON `oneOf`/`anyOf` to a `UNION`, `JsonToLogicalTypeConverter`                                                                                                     
  picks each branch's name as follows:                                                                                                                                                  
                                                                                                                                                                                        
  | Precedence | Source | V1 (Flink-compat) | V2 (canonical) |                                                                                                                          
  |-----------|--------|-------------------|----------------|                                                                                                                           
  | 1 | explicit `confluent:union` `name` hint | used | used |                                                                                                                          
  | 2 | subschema `title` | **ignored** | used |                                                                                                                                        
  | 3 | fallback | `connect_union_field_<index>` | `connect_union_field_<index>` |                                                                                                      
                                                                                                                                                                                        
  - **V1** always synthesizes `connect_union_field_<index>` (ignoring `title`), matching                                                                                                
    the old Flink JSON converter. Preserving titles under V1 would rename the union                                                                                                     
    `RowType` fields on the Flink success path — a breaking change for consumers that                                                                                                   
    select fields by name.                                                                                                                                                              
  - **V2** prefers a subschema's `title` when present (the better canonical default),                                                                                                   
    falling back to the synthesized name.                                                                                                                                               
                                                                                                                                                                                        
  An explicit `confluent:union` `name` hint continues to win in both editions.  
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
