### PR TITLE
DGS-24835 Fix handling of Proto custom options during normalization

### DIFF
--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -1529,7 +1529,24 @@ public class ProtobufSchema implements ParsedSchema {
     if (existing.getKind() == Kind.MAP && replacement.getKind() == Kind.MAP) {
       Map<String, ?> existingMap = (Map<String, ?>) existing.getValue();
       Map<String, ?> replacementMap = (Map<String, ?>) replacement.getValue();
-      Map<String, Object> mergedMap = mergeMaps(existingMap, replacementMap);
+      Map<String, Object> mergedMap = new LinkedHashMap<>(existingMap);
+      for (Map.Entry<String, ?> entry : replacementMap.entrySet()) {
+        // Merging should only be needed for repeated fields
+        mergedMap.merge(entry.getKey(), entry.getValue(), (v1, v2) -> {
+          Set<Object> set = new LinkedHashSet<>();
+          if (v1 instanceof List) {
+            set.addAll((List<Object>) v1);
+          } else {
+            set.add(v1);
+          }
+          if (v2 instanceof List) {
+            set.addAll((List<Object>) v2);
+          } else {
+            set.add(v2);
+          }
+          return new ArrayList<>(set);
+        });
+      }
       return new OptionElement(
           replacement.getName(), Kind.MAP, mergedMap, replacement.isParenthesized());
     } else {
@@ -1537,37 +1554,6 @@ public class ProtobufSchema implements ParsedSchema {
       // This should only happen with custom options that are ignored
       return replacement;
     }
-  }
-
-  @SuppressWarnings("unchecked")
-  private static Map<String, Object> mergeMaps(
-      Map<String, ?> existingMap, Map<String, ?> replacementMap) {
-    Map<String, Object> mergedMap = new LinkedHashMap<>(existingMap);
-    for (Map.Entry<String, ?> entry : replacementMap.entrySet()) {
-      mergedMap.merge(entry.getKey(), entry.getValue(), (v1, v2) -> {
-        if (v1 instanceof Map && v2 instanceof Map) {
-          // Both values are nested message literals (e.g. from two separate dotted-path
-          // option assignments targeting the same singular submessage field, such as
-          // `(opt).sub.a = 1, (opt).sub.b = 2`); deep-merge them instead of collapsing
-          // into a list, which would produce invalid syntax for a singular field.
-          return mergeMaps((Map<String, ?>) v1, (Map<String, ?>) v2);
-        }
-        // Merging should only be needed for repeated fields
-        Set<Object> set = new LinkedHashSet<>();
-        if (v1 instanceof List) {
-          set.addAll((List<Object>) v1);
-        } else {
-          set.add(v1);
-        }
-        if (v2 instanceof List) {
-          set.addAll((List<Object>) v2);
-        } else {
-          set.add(v2);
-        }
-        return new ArrayList<>(set);
-      });
-    }
-    return mergedMap;
   }
 
   protected static OptionElement transform(OptionElement option) {

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -1529,24 +1529,7 @@ public class ProtobufSchema implements ParsedSchema {
     if (existing.getKind() == Kind.MAP && replacement.getKind() == Kind.MAP) {
       Map<String, ?> existingMap = (Map<String, ?>) existing.getValue();
       Map<String, ?> replacementMap = (Map<String, ?>) replacement.getValue();
-      Map<String, Object> mergedMap = new LinkedHashMap<>(existingMap);
-      for (Map.Entry<String, ?> entry : replacementMap.entrySet()) {
-        // Merging should only be needed for repeated fields
-        mergedMap.merge(entry.getKey(), entry.getValue(), (v1, v2) -> {
-          Set<Object> set = new LinkedHashSet<>();
-          if (v1 instanceof List) {
-            set.addAll((List<Object>) v1);
-          } else {
-            set.add(v1);
-          }
-          if (v2 instanceof List) {
-            set.addAll((List<Object>) v2);
-          } else {
-            set.add(v2);
-          }
-          return new ArrayList<>(set);
-        });
-      }
+      Map<String, Object> mergedMap = mergeMaps(existingMap, replacementMap);
       return new OptionElement(
           replacement.getName(), Kind.MAP, mergedMap, replacement.isParenthesized());
     } else {
@@ -1554,6 +1537,37 @@ public class ProtobufSchema implements ParsedSchema {
       // This should only happen with custom options that are ignored
       return replacement;
     }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Object> mergeMaps(
+      Map<String, ?> existingMap, Map<String, ?> replacementMap) {
+    Map<String, Object> mergedMap = new LinkedHashMap<>(existingMap);
+    for (Map.Entry<String, ?> entry : replacementMap.entrySet()) {
+      mergedMap.merge(entry.getKey(), entry.getValue(), (v1, v2) -> {
+        if (v1 instanceof Map && v2 instanceof Map) {
+          // Both values are nested message literals (e.g. from two separate dotted-path
+          // option assignments targeting the same singular submessage field, such as
+          // `(opt).sub.a = 1, (opt).sub.b = 2`); deep-merge them instead of collapsing
+          // into a list, which would produce invalid syntax for a singular field.
+          return mergeMaps((Map<String, ?>) v1, (Map<String, ?>) v2);
+        }
+        // Merging should only be needed for repeated fields
+        Set<Object> set = new LinkedHashSet<>();
+        if (v1 instanceof List) {
+          set.addAll((List<Object>) v1);
+        } else {
+          set.add(v1);
+        }
+        if (v2 instanceof List) {
+          set.addAll((List<Object>) v2);
+        } else {
+          set.add(v2);
+        }
+        return new ArrayList<>(set);
+      });
+    }
+    return mergedMap;
   }
 
   protected static OptionElement transform(OptionElement option) {

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaUtils.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaUtils.java
@@ -63,9 +63,11 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -1264,7 +1266,9 @@ public class ProtobufSchemaUtils {
               List<OptionElement> list = entry.getValue();
               ExtendFieldElementInfo fieldInfo = getExtendFieldForFullName(name, true);
               if (fieldInfo != null && !fieldInfo.isRepeated() && list.size() > 0) {
-                return Stream.of(list.stream().reduce(ProtobufSchema::merge).get());
+                FieldElement rootField = fieldInfo.field();
+                return Stream.of(
+                    list.stream().reduce((e1, e2) -> mergeOption(rootField, e1, e2)).get());
               } else {
                 return list.stream();
               }
@@ -1272,6 +1276,97 @@ public class ProtobufSchemaUtils {
             .collect(Collectors.toList());
       }
       return options;
+    }
+
+    @SuppressWarnings("unchecked")
+    private OptionElement mergeOption(
+        FieldElement field, OptionElement existing, OptionElement replacement) {
+      replacement = transform(replacement);
+      if (existing.getKind() == Kind.MAP && replacement.getKind() == Kind.MAP) {
+        Map<String, ?> existingMap = (Map<String, ?>) existing.getValue();
+        Map<String, ?> replacementMap = (Map<String, ?>) replacement.getValue();
+        Map<String, Object> mergedMap = mergeOptionMaps(field, existingMap, replacementMap);
+        return new OptionElement(
+            replacement.getName(), Kind.MAP, mergedMap, replacement.isParenthesized());
+      } else {
+        // Discard existing option
+        // This should only happen with custom options that are ignored
+        return replacement;
+      }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> mergeOptionMaps(
+        FieldElement containerField, Map<String, ?> existingMap, Map<String, ?> replacementMap) {
+      MessageElement containerType = resolveMessageType(containerField);
+      Map<String, Object> mergedMap = new LinkedHashMap<>(existingMap);
+      for (Map.Entry<String, ?> entry : replacementMap.entrySet()) {
+        String key = entry.getKey();
+        FieldElement nestedField = containerType != null
+            ? findField(containerType, key) : null;
+        mergedMap.merge(key, entry.getValue(),
+            (v1, v2) -> mergeOptionValues(nestedField, v1, v2));
+      }
+      return mergedMap;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Object mergeOptionValues(FieldElement field, Object v1, Object v2) {
+      boolean isSingular = field != null && field.getLabel() != Label.REPEATED;
+      if (isSingular && v1 instanceof Map && v2 instanceof Map
+          && resolveMessageType(field) != null) {
+        // Both values are nested message literals for the same singular submessage
+        // field (e.g. from two dotted-path assignments `(opt).sub.a = 1, (opt).sub.b = 2`);
+        // deep-merge them instead of collapsing into a list, which would be invalid
+        // syntax for a singular field.
+        return mergeOptionMaps(field, (Map<String, ?>) v1, (Map<String, ?>) v2);
+      }
+      if (isSingular) {
+        // Singular scalar field set more than once; last one wins, matching
+        // standard protobuf text-format merge semantics.
+        return v2;
+      }
+      // Repeated field (or a field we couldn't resolve, kept conservative):
+      // accumulate values as a list.
+      Set<Object> set = new LinkedHashSet<>();
+      if (v1 instanceof List) {
+        set.addAll((List<Object>) v1);
+      } else {
+        set.add(v1);
+      }
+      if (v2 instanceof List) {
+        set.addAll((List<Object>) v2);
+      } else {
+        set.add(v2);
+      }
+      return new ArrayList<>(set);
+    }
+
+    private MessageElement resolveMessageType(FieldElement field) {
+      if (field == null) {
+        return null;
+      }
+      TypeElementInfo typeInfo = getType(field.getType(), true);
+      if (typeInfo != null && typeInfo.type() instanceof MessageElement) {
+        return (MessageElement) typeInfo.type();
+      }
+      return null;
+    }
+
+    private FieldElement findField(MessageElement messageElement, String name) {
+      for (FieldElement field : messageElement.getFields()) {
+        if (field.getName().equals(name)) {
+          return field;
+        }
+      }
+      for (OneOfElement oneOf : messageElement.getOneOfs()) {
+        for (FieldElement field : oneOf.getFields()) {
+          if (field.getName().equals(name)) {
+            return field;
+          }
+        }
+      }
+      return null;
     }
   }
 }

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -2405,6 +2405,60 @@ public class ProtobufSchemaTest {
   }
 
   @Test
+  public void testNormalizationWithNestedComplexCustomOptions() {
+    // Two dotted-path option assignments (`.range.min` and `.range.max`) share the
+    // singular nested message field `range`; normalization must merge them into a
+    // single message literal rather than collapsing them into an invalid list.
+    String schemaString = "package acme.common;\n"
+        + "\n"
+        + "import \"google/protobuf/descriptor.proto\";\n"
+        + "\n"
+        + "message Container {\n"
+        + "  optional string value = 1 [\n"
+        + "    (constraints).range.min = 1.0, (constraints).range.max = 1024.0];\n"
+        + "}\n"
+        + "\n"
+        + "extend google.protobuf.FieldOptions {\n"
+        + "  optional Constraints constraints = 22302;\n"
+        + "}\n"
+        + "\n"
+        + "message Constraints {\n"
+        + "  optional Range range = 1;\n"
+        + "}\n"
+        + "\n"
+        + "message Range {\n"
+        + "  optional double min = 1;\n"
+        + "  optional double max = 2;\n"
+        + "}\n";
+    String normalized = "package acme.common;\n"
+        + "\n"
+        + "import \"google/protobuf/descriptor.proto\";\n"
+        + "\n"
+        + "message Container {\n"
+        + "  optional string value = 1 [(acme.common.constraints) = {\n"
+        + "    range: {\n"
+        + "      max: 1024,\n"
+        + "      min: 1\n"
+        + "    }\n"
+        + "  }];\n"
+        + "}\n"
+        + "message Constraints {\n"
+        + "  optional .acme.common.Range range = 1;\n"
+        + "}\n"
+        + "message Range {\n"
+        + "  optional double min = 1;\n"
+        + "  optional double max = 2;\n"
+        + "}\n"
+        + "\n"
+        + "extend .google.protobuf.FieldOptions {\n"
+        + "  optional .acme.common.Constraints constraints = 22302;\n"
+        + "}\n";
+    ProtobufSchema schema = new ProtobufSchema(schemaString);
+    ProtobufSchema normalizedSchema = schema.normalize();
+    assertEquals(normalized, normalizedSchema.canonicalString());
+  }
+
+  @Test
   public void testNormalizationWithPackagePrefix() {
     String schemaString = "syntax = \"proto3\";\n"
         + "package confluent.package;\n"

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -2459,6 +2459,63 @@ public class ProtobufSchemaTest {
   }
 
   @Test
+  public void testNormalizationWithRepeatedNestedCustomOptions() {
+    // Two dotted-path option assignments (`.tags.name = "a"` and `.tags.name = "b"`) share
+    // the intermediate path segment `tags`, but `tags` is a *repeated* submessage field, so
+    // each assignment must remain a separate list entry rather than being deep-merged into
+    // a single message (which would incorrectly turn the singular `name` field into a list).
+    String schemaString = "package acme.common;\n"
+        + "\n"
+        + "import \"google/protobuf/descriptor.proto\";\n"
+        + "\n"
+        + "message Container {\n"
+        + "  optional string value = 1 [\n"
+        + "    (wrapper).tags.name = \"a\", (wrapper).tags.name = \"b\"];\n"
+        + "}\n"
+        + "\n"
+        + "extend google.protobuf.FieldOptions {\n"
+        + "  optional Wrapper wrapper = 22303;\n"
+        + "}\n"
+        + "\n"
+        + "message Wrapper {\n"
+        + "  repeated Tag tags = 1;\n"
+        + "}\n"
+        + "\n"
+        + "message Tag {\n"
+        + "  optional string name = 1;\n"
+        + "}\n";
+    String normalized = "package acme.common;\n"
+        + "\n"
+        + "import \"google/protobuf/descriptor.proto\";\n"
+        + "\n"
+        + "message Container {\n"
+        + "  optional string value = 1 [(acme.common.wrapper) = {\n"
+        + "    tags: [\n"
+        + "      {\n"
+        + "        name: \"a\"\n"
+        + "      },\n"
+        + "      {\n"
+        + "        name: \"b\"\n"
+        + "      }\n"
+        + "    ]\n"
+        + "  }];\n"
+        + "}\n"
+        + "message Wrapper {\n"
+        + "  repeated .acme.common.Tag tags = 1;\n"
+        + "}\n"
+        + "message Tag {\n"
+        + "  optional string name = 1;\n"
+        + "}\n"
+        + "\n"
+        + "extend .google.protobuf.FieldOptions {\n"
+        + "  optional .acme.common.Wrapper wrapper = 22303;\n"
+        + "}\n";
+    ProtobufSchema schema = new ProtobufSchema(schemaString);
+    ProtobufSchema normalizedSchema = schema.normalize();
+    assertEquals(normalized, normalizedSchema.canonicalString());
+  }
+
+  @Test
   public void testNormalizationWithPackagePrefix() {
     String schemaString = "syntax = \"proto3\";\n"
         + "package confluent.package;\n"


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
The normalization merge in `ProtobufSchemaUtils.FormatContext` is now cardinality-aware: it walks the custom option's message type (via the schema's type registry, including fields declared inside oneofs) to determine the real field label at each nesting level, then:                                 
    - singular message field → deep-merges nested assignments into one message literal (fixes the reported bug)                                                                         
    - repeated field → keeps each assignment as a separate list entry (preserves correct behavior for genuinely repeated fields, e.g. `(opt).tags.name = "a"`, `(opt).tags.name = "b"` where tags is repeated)                                                                                                                                                                     
    - singular scalar field → last write wins, matching standard protobuf text-format merge semantics                                                                                   
    - unresolvable field → falls back to the prior list-collapsing behavior
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
