### PR TITLE
fix: correct assertEquals argument order in normalize/IMPORT-mode tests

### DIFF
--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -484,8 +484,8 @@ public abstract class RestApiTest {
     AvroSchema avroSchema = AvroUtils.parseSchema(schemaString);
     String rawSchema = avroSchema.canonicalString();
     String normalizedSchema = avroSchema.normalize().canonicalString();
-    assertNotEquals("Test schema should have distinct raw and normalized canonical forms",
-        rawSchema, normalizedSchema);
+    assertNotEquals(rawSchema, normalizedSchema,
+        "Test schema should have distinct raw and normalized canonical forms");
 
     ConfigUpdateRequest configUpdateRequest = new ConfigUpdateRequest();
     configUpdateRequest.setNormalize(true);
@@ -497,10 +497,10 @@ public abstract class RestApiTest {
     restApp.restClient.registerSchema(rawSchema, subject, 1, 1);
 
     assertEquals(
-        "Schema should be stored unnormalized: IMPORT mode should skip the normalize "
-            + "config fallback",
         rawSchema,
-        restApp.restClient.getVersion(subject, 1).getSchema());
+        restApp.restClient.getVersion(subject, 1).getSchema(),
+        "Schema should be stored unnormalized: IMPORT mode should skip the normalize "
+            + "config fallback");
   }
 
   @Test
@@ -524,9 +524,9 @@ public abstract class RestApiTest {
     restApp.restClient.registerSchema(rawSchema, subject);
 
     assertEquals(
-        "Schema should be normalized via the config fallback outside IMPORT mode",
         normalizedSchema,
-        restApp.restClient.getVersion(subject, 1).getSchema());
+        restApp.restClient.getVersion(subject, 1).getSchema(),
+        "Schema should be normalized via the config fallback outside IMPORT mode");
   }
 
   @Test
@@ -541,8 +541,8 @@ public abstract class RestApiTest {
     AvroSchema avroSchema = AvroUtils.parseSchema(schemaString);
     String rawSchema = avroSchema.canonicalString();
     String normalizedSchema = avroSchema.normalize().canonicalString();
-    assertNotEquals("Test schema should have distinct raw and normalized canonical forms",
-        rawSchema, normalizedSchema);
+    assertNotEquals(rawSchema, normalizedSchema,
+        "Test schema should have distinct raw and normalized canonical forms");
 
     restApp.restClient.setMode("IMPORT", subject);
 
@@ -550,10 +550,10 @@ public abstract class RestApiTest {
     restApp.restClient.registerSchema(rawSchema, subject, 1, 1, true);
 
     assertEquals(
-        "Schema should be stored unnormalized: IMPORT mode should skip normalization even "
-            + "when normalize=true is requested",
         rawSchema,
-        restApp.restClient.getVersion(subject, 1).getSchema());
+        restApp.restClient.getVersion(subject, 1).getSchema(),
+        "Schema should be stored unnormalized: IMPORT mode should skip normalization even "
+            + "when normalize=true is requested");
   }
 
   public void testImportSameSchemaDifferentVersion() throws Exception {


### PR DESCRIPTION
What
----
The three IMPORT-mode normalize tests added by #4434 (targeting 7.5.x, which uses JUnit 4 `org.junit.Assert`) used `assertEquals(message, expected, actual)` order. 8.0.x already uses JUnit 5 (`org.junit.jupiter.api.Assertions`), whose `assertEquals` is `(expected, actual, message)`. The forward-merged tests compiled fine (same arity) but silently compared the wrong values, failing regardless of actual behavior.

Verified the underlying IMPORT-mode normalize fix is working correctly on 8.0.x; only the test assertion argument order was wrong. Same fix applied to the paired `assertNotEquals` calls in the same tests.

Checklist
------------------
- [ ] Contains customer facing changes? No, test-only fix.
- [x] Did you add sufficient unit test and/or integration test coverage for this PR? N/A, fixes existing tests.

Test & Review
------------
Ran the 3 previously-failing tests locally via failsafe against 8.0.x: `Tests run: 3, Failures: 0, Errors: 0, Skipped: 0`.