### PR TITLE
Surface Schema Registry auth failures clearly instead of a misleading schema-retrieval error

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
@@ -258,8 +258,11 @@ public class AvroConverter implements Converter {
         );
       }
     } catch (InvalidConfigurationException e) {
+      // ConfigException has no Throwable constructor, so fold the underlying cause
+      // into the message rather than dropping it (e.g. a Schema Registry auth failure).
       throw new ConfigException(
-          String.format("Failed to access Avro data from topic %s : %s", topic, e.getMessage())
+          String.format("Failed to access Avro data from topic %s : %s", topic,
+              e.getCause() != null ? e.getMessage() + "; caused by: " + e.getCause() : e.getMessage())
       );
     }
   }

--- a/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
+++ b/schema-serializer/src/main/java/io/confluent/kafka/serializers/AbstractKafkaSchemaSerDe.java
@@ -1204,9 +1204,15 @@ public abstract class AbstractKafkaSchemaSerDe
   protected static KafkaException toKafkaException(RestClientException e, String errorMessage) {
     int status = e.getStatus();
     if (status == 401) {
-      return new AuthenticationException(errorMessage, e);
+      return new AuthenticationException(errorMessage
+          + " (Schema Registry authentication failed with HTTP 401 Unauthorized; "
+          + "verify the Schema Registry credentials, e.g. the API key and secret "
+          + "or basic.auth.user.info): " + e.getMessage(), e);
     } else if (status == 403) {
-      return new AuthorizationException(errorMessage, e);
+      return new AuthorizationException(errorMessage
+          + " (Schema Registry authorization failed with HTTP 403 Forbidden; the "
+          + "configured Schema Registry principal is not permitted to perform this "
+          + "operation): " + e.getMessage(), e);
     } else if (status == 429) {        // Too Many Requests
       return new ThrottlingQuotaExceededException(e.getMessage());
     } else if (status == 408    // Request Timeout


### PR DESCRIPTION
## Problem

A customer running Replicator hit a task failure and, after checking Schema Registry themselves, found the inconsistency: the error pointed at a schema problem even though the schema existed. The real cause was a wrong Schema Registry API key/secret, but the message read like the schema was missing or unreadable:

```
ConfigException: Failed to access Avro data from topic <t> :
  Error retrieving Avro value schema for id SchemaId{schemaType='AVRO', id=101288, ...}
    at io.confluent.connect.avro.AvroConverter.toConnectData(AvroConverter.java:175)
```

## Fix

- `toKafkaException`: 401 → `AuthenticationException` and 403 → `AuthorizationException` now include the HTTP status and the credential to check. Type and cause are preserved as before.
- `AvroConverter.toConnectData`: fold the underlying cause into the `ConfigException` message when present, so it is no longer discarded.

A bad SR key now surfaces as:

```
Error retrieving Avro value schema for id 101288 (Schema Registry authentication failed
with HTTP 401 Unauthorized; verify the Schema Registry credentials, e.g. the API key and
secret or basic.auth.user.info): Unauthorized; error code: 401
```

