### PR TITLE
Support Variant in V1 mode for Flink intereop

### DIFF
--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
@@ -99,6 +99,31 @@ public class AvroToLogicalTypeConverter {
         ctx.getDefaultValues());
   }
 
+  /**
+   * Recognizes the Confluent VARIANT Avro encoding: a record {@code confluent.type.Variant} with
+   * two {@code bytes} fields ({@code metadata}, {@code value}). Detection is structural rather than
+   * relying solely on the resolved Avro logical type: schemas fetched from Schema Registry arrive
+   * parsed from a JSON string (kafka-avro-types registers no {@code variant} logical-type factory,
+   * so {@code getLogicalType()} is null) or in canonical form (the {@code logicalType} property is
+   * stripped), yet must still map to VARIANT.
+   */
+  private static boolean isVariantRecord(org.apache.avro.Schema avroSchema) {
+    org.apache.avro.LogicalType logicalType = avroSchema.getLogicalType();
+    if (logicalType != null && VariantLogicalType.NAME.equals(logicalType.getName())) {
+      return true;
+    }
+    if (!"confluent.type.Variant".equals(avroSchema.getFullName())
+        || avroSchema.getFields().size() != 2) {
+      return false;
+    }
+    org.apache.avro.Schema.Field metadata = avroSchema.getField("metadata");
+    org.apache.avro.Schema.Field value = avroSchema.getField("value");
+    return metadata != null
+        && value != null
+        && metadata.schema().getType() == org.apache.avro.Schema.Type.BYTES
+        && value.schema().getType() == org.apache.avro.Schema.Type.BYTES;
+  }
+
   private static String extractNamespace(AvroSchema avroSchema) {
     Metadata metadata = avroSchema.metadata();
     if (metadata == null || metadata.getProperties() == null) {
@@ -390,8 +415,7 @@ public class AvroToLogicalTypeConverter {
             isMultisetType2);
 
       case RECORD: {
-        if (avroSchema.getLogicalType() != null
-            && VariantLogicalType.NAME.equals(avroSchema.getLogicalType().getName())) {
+        if (isVariantRecord(avroSchema)) {
           return Schema.create(Schema.Type.VARIANT).setNullable(isNullable);
         }
         // Anything not explicitly marked anonymous is a named record. Insert a

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/LogicalTypeToAvroConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/LogicalTypeToAvroConverter.java
@@ -243,9 +243,8 @@ public class LogicalTypeToAvroConverter {
         return LogicalTypes.decimal(schema.getPrecision(), schema.getScale())
             .addToSchema(SchemaBuilder.builder().bytesType());
       case VARIANT:
-        if (ctx.isV1()) {
-          throw new ValidationException("VARIANT not supported in V1 emission mode");
-        }
+        // Emitted in both V1 and V2: Flink has a native VariantType (LogicalTypeRoot.VARIANT),
+        // so VARIANT is not an LT-only construct.
         return new VariantConversion().getRecommendedSchema();
       case NAMED_TYPE_REF: {
         String name = schema.getQualifiedName();

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/common/LogicalTypeVersion.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/common/LogicalTypeVersion.java
@@ -25,8 +25,9 @@ package io.confluent.kafka.schemaregistry.type.logical.common;
  * {@code cc-flink-schema-converters} — a strict subset of LT capabilities.
  *
  * <p>V1 throws {@code ValidationException} for LT-only constructs that have no
- * Flink equivalent (UNION, VARIANT, TIME/TIMESTAMP precision &gt; 6 in Avro,
+ * Flink equivalent (UNION, TIME/TIMESTAMP precision &gt; 6 in Avro,
  * ENUM in JSON). It auto-promotes anonymous proto ENUMs to named enums.
+ * VARIANT is emitted in both editions — Flink has a native VariantType.
  * It silently skips LT-only metadata that Flink wouldn't carry.
  *
  * <p>The selected version is also recorded in the Schema Registry metadata

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/LogicalTypeToJsonConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/LogicalTypeToJsonConverter.java
@@ -424,9 +424,8 @@ public class LogicalTypeToJsonConverter {
       case MULTISET:
         return convertMultiset(schema, rowName, ctx);
       case VARIANT:
-        if (ctx.isV1()) {
-          throw new ValidationException("VARIANT not supported in V1 emission mode");
-        }
+        // Emitted in both V1 and V2: Flink has a native VariantType (LogicalTypeRoot.VARIANT),
+        // so VARIANT is not an LT-only construct.
         return EmptySchema.builder();
       case NAMED_TYPE_REF: {
         String name = schema.getQualifiedName();

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/LogicalTypeToProtoConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/LogicalTypeToProtoConverter.java
@@ -841,9 +841,8 @@ public class LogicalTypeToProtoConverter {
       case DECIMAL:
         return createDecimalField(schema, dependencies, builder);
       case VARIANT:
-        if (ctx.isV1()) {
-          throw new ValidationException("VARIANT not supported in V1 emission mode");
-        }
+        // Emitted in both V1 and V2: Flink has a native VariantType (LogicalTypeRoot.VARIANT),
+        // so VARIANT is not an LT-only construct.
         builder.setType(Type.TYPE_MESSAGE);
         builder.setTypeName(makeItTopLevelScoped(CommonConstants.PROTOBUF_VARIANT_TYPE));
         dependencies.add(CommonConstants.PROTOBUF_VARIANT_LOCATION);

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverterTest.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -39,6 +40,40 @@ class AvroToLogicalTypeConverterTest {
           new AvroSchema(mapping.getAvroSchema()));
       assertEquals(mapping.getLogicalType(), result, "Failed for: " + mapping);
     }
+  }
+
+  @Test
+  void testVariantParsedFromStringMapsToVariant() {
+    // Production read path: a schema fetched from Schema Registry arrives as a JSON
+    // string. kafka-avro-types registers no "variant" logical-type factory, so after
+    // parsing getLogicalType() is null and detection must be structural (a record
+    // confluent.type.Variant with two bytes fields metadata/value).
+    String withLogicalTypeProp =
+        "{\"type\":\"record\",\"name\":\"Variant\",\"namespace\":\"confluent.type\","
+            + "\"fields\":[{\"name\":\"metadata\",\"type\":\"bytes\"},"
+            + "{\"name\":\"value\",\"type\":\"bytes\"}],\"logicalType\":\"variant\"}";
+    Schema withProp =
+        AvroToLogicalTypeConverter.toRootSchema(new AvroSchema(withLogicalTypeProp));
+    assertEquals(Schema.Type.VARIANT, withProp.getType());
+    assertFalse(withProp.isNullable());
+
+    // Avro parsing canonical form strips the logicalType property entirely;
+    // structural detection must still recognize the record as VARIANT.
+    String noProp =
+        "{\"type\":\"record\",\"name\":\"Variant\",\"namespace\":\"confluent.type\","
+            + "\"fields\":[{\"name\":\"metadata\",\"type\":\"bytes\"},"
+            + "{\"name\":\"value\",\"type\":\"bytes\"}]}";
+    Schema withoutProp = AvroToLogicalTypeConverter.toRootSchema(new AvroSchema(noProp));
+    assertEquals(Schema.Type.VARIANT, withoutProp.getType());
+
+    // Nullable variant: union [null, Variant] parsed from a string stays nullable VARIANT.
+    String nullableVariant =
+        "[\"null\",{\"type\":\"record\",\"name\":\"Variant\",\"namespace\":\"confluent.type\","
+            + "\"fields\":[{\"name\":\"metadata\",\"type\":\"bytes\"},"
+            + "{\"name\":\"value\",\"type\":\"bytes\"}],\"logicalType\":\"variant\"}]";
+    Schema nullable = AvroToLogicalTypeConverter.toRootSchema(new AvroSchema(nullableVariant));
+    assertEquals(Schema.Type.VARIANT, nullable.getType());
+    assertTrue(nullable.isNullable());
   }
 
   @Test

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/LogicalTypeToAvroConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/LogicalTypeToAvroConverterTest.java
@@ -2327,14 +2327,17 @@ class LogicalTypeToAvroConverterTest {
   }
 
   @Test
-  void testV1ThrowsOnVariant() {
-    Schema rootSchema = Schema.createStruct(Arrays.asList(
-        new Field("v", Schema.create(Schema.Type.VARIANT).setNullable(false), 0)))
-        .setNullable(false);
-    ValidationException ex = assertThrows(ValidationException.class, () ->
-        LogicalTypeToAvroConverter.fromLogicalType(
-            new LogicalType(rootSchema), "Holder", LogicalTypeVersion.V1));
-    assertTrue(ex.getMessage().contains("VARIANT"));
+  void testV1EmitsVariant() {
+    // Flink has a native VariantType, so V1 emits VARIANT identically to V2:
+    // a RECORD carrying the Variant logical type with metadata/value fields.
+    Schema variant = Schema.create(Schema.Type.VARIANT).setNullable(false);
+    AvroSchema avro = LogicalTypeToAvroConverter.fromLogicalType(
+        new LogicalType(variant), "row", LogicalTypeVersion.V1);
+    assertEquals(org.apache.avro.Schema.Type.RECORD, avro.rawSchema().getType());
+    assertEquals(VariantLogicalType.NAME, avro.rawSchema().getLogicalType().getName());
+    assertEquals(2, avro.rawSchema().getFields().size());
+    assertEquals("metadata", avro.rawSchema().getFields().get(0).name());
+    assertEquals("value", avro.rawSchema().getFields().get(1).name());
   }
 
   @Test

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/json/LogicalTypeToJsonConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/json/LogicalTypeToJsonConverterTest.java
@@ -2328,14 +2328,13 @@ class LogicalTypeToJsonConverterTest {
   }
 
   @Test
-  void testV1ThrowsOnVariant() {
-    Schema rootSchema = Schema.createStruct(Arrays.asList(
-        new Field("v", Schema.create(Schema.Type.VARIANT).setNullable(false), 0)))
-        .setNullable(false);
-    ValidationException ex = assertThrows(ValidationException.class, () ->
-        LogicalTypeToJsonConverter.fromLogicalType(
-            new LogicalType(rootSchema), "Holder", LogicalTypeVersion.V1));
-    assertTrue(ex.getMessage().contains("VARIANT"));
+  void testV1EmitsVariant() {
+    // Flink has a native VariantType, so V1 emits VARIANT identically to V2:
+    // the match-anything empty JSON schema.
+    Schema schema = Schema.create(Schema.Type.VARIANT).setNullable(false);
+    JsonSchema result = LogicalTypeToJsonConverter.fromLogicalType(
+        new LogicalType(schema), "row", LogicalTypeVersion.V1);
+    assertTrue(result.rawSchema() instanceof EmptySchema);
   }
 
   @Test

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/LogicalTypeToProtoConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/LogicalTypeToProtoConverterTest.java
@@ -2549,14 +2549,18 @@ class LogicalTypeToProtoConverterTest {
   }
 
   @Test
-  void testV1ThrowsOnVariant() {
-    Schema rootSchema = Schema.createStruct(Arrays.asList(
-        new Field("v", Schema.create(Schema.Type.VARIANT).setNullable(false), 0)))
+  void testV1EmitsVariant() {
+    // Flink has a native VariantType, so V1 emits VARIANT identically to V2:
+    // a confluent.type.Variant message field.
+    Schema struct = Schema.createStruct(Arrays.asList(
+        new Field("v", Schema.create(Schema.Type.VARIANT).setNullable(true), 0)))
         .setNullable(false);
-    ValidationException ex = assertThrows(ValidationException.class, () ->
-        LogicalTypeToProtoConverter.fromLogicalType(
-            new LogicalType(rootSchema), "Holder", LogicalTypeVersion.V1));
-    assertTrue(ex.getMessage().contains("VARIANT"));
+    Descriptor descriptor = LogicalTypeToProtoConverter.fromLogicalType(
+        new LogicalType(struct), "Holder", LogicalTypeVersion.V1).toDescriptor();
+    FieldDescriptor dataField = descriptor.findFieldByName("v");
+    assertNotNull(dataField);
+    assertEquals(FieldDescriptor.Type.MESSAGE, dataField.getType());
+    assertEquals("confluent.type.Variant", dataField.getMessageType().getFullName());
   }
 
   @Test

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/v1/LogicalTypeV1NegativePathTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/v1/LogicalTypeV1NegativePathTest.java
@@ -78,14 +78,6 @@ class LogicalTypeV1NegativePathTest {
         .isInstanceOf(ValidationException.class);
   }
 
-  @Test
-  void avroRejectsVariant() {
-    Schema v = Schema.create(Schema.Type.VARIANT).setNullable(false);
-    assertThatThrownBy(() -> LogicalTypeToAvroConverter
-            .fromLogicalType(new LogicalType(v), "Row", LogicalTypeVersion.V1))
-        .isInstanceOf(ValidationException.class);
-  }
-
   // ---------- Proto ----------
 
   @Test
@@ -101,17 +93,6 @@ class LogicalTypeV1NegativePathTest {
         .isInstanceOf(ValidationException.class);
   }
 
-  @Test
-  void protoRejectsVariant() {
-    Schema struct = Schema.createStruct(Collections.singletonList(
-        new Schema.Field("v",
-            Schema.create(Schema.Type.VARIANT).setNullable(false), 0)))
-        .setNullable(false);
-    assertThatThrownBy(() -> LogicalTypeToProtoConverter
-            .fromLogicalType(new LogicalType(struct), "Row", LogicalTypeVersion.V1))
-        .isInstanceOf(ValidationException.class);
-  }
-
   // ---------- JSON ----------
 
   @Test
@@ -122,14 +103,6 @@ class LogicalTypeV1NegativePathTest {
         .setNullable(false);
     assertThatThrownBy(() -> LogicalTypeToJsonConverter
             .fromLogicalType(new LogicalType(u), "Row", LogicalTypeVersion.V1))
-        .isInstanceOf(ValidationException.class);
-  }
-
-  @Test
-  void jsonRejectsVariant() {
-    Schema v = Schema.create(Schema.Type.VARIANT).setNullable(false);
-    assertThatThrownBy(() -> LogicalTypeToJsonConverter
-            .fromLogicalType(new LogicalType(v), "Row", LogicalTypeVersion.V1))
         .isInstanceOf(ValidationException.class);
   }
 


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----

Flink now supports Variant, so allow emission of Variant code in mode V1 for interoperability with Flink.                                                                                                                  
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
