### PR TITLE
DGS-24886 Fix divide-by-zero error during JSON Schema compat check

### DIFF
--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -401,6 +401,12 @@ public class JsonSchema implements ParsedSchema {
       // Use double-checked locking to avoid unnecessary synchronization
       synchronized (this) {
         if (schemaObj == null) {
+          if (!jsonNode.isObject() && !jsonNode.isBoolean()) {
+            // A JSON Schema document must be an object or a boolean.
+            throw new IllegalArgumentException(
+                "Invalid JSON schema: expected an object or boolean at the root, found "
+                    + jsonNode.getNodeType());
+          }
           try {
             if (jsonNode.isBoolean()) {
               schemaObj = jsonNode.booleanValue()

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/NumberSchemaDiff.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/NumberSchemaDiff.java
@@ -104,7 +104,12 @@ class NumberSchemaDiff {
     BigDecimal originalMultipleOf = original.getMultipleOf() != null
         ? new BigDecimal(original.getMultipleOf().toString())
         : null;
-    if (!Objects.equals(originalMultipleOf, updateMultipleOf)) {
+    // BigDecimal#equals() is scale-sensitive (0.5 != 0.50), which would otherwise misclassify
+    // numerically-equal multipleOf values (differing only in trailing zeros) as a change.
+    boolean multipleOfEqual = originalMultipleOf == null
+        ? updateMultipleOf == null
+        : updateMultipleOf != null && originalMultipleOf.compareTo(updateMultipleOf) == 0;
+    if (!multipleOfEqual) {
       if (originalMultipleOf == null) {
         ctx.addDifference("multipleOf", MULTIPLE_OF_ADDED);
       } else if (updateMultipleOf == null) {

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/NumberSchemaDiff.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/NumberSchemaDiff.java
@@ -109,9 +109,11 @@ class NumberSchemaDiff {
         ctx.addDifference("multipleOf", MULTIPLE_OF_ADDED);
       } else if (updateMultipleOf == null) {
         ctx.addDifference("multipleOf", MULTIPLE_OF_REMOVED);
-      } else if (update.getMultipleOf().intValue() % original.getMultipleOf().intValue() == 0) {
+      } else if (originalMultipleOf.compareTo(BigDecimal.ZERO) != 0
+          && updateMultipleOf.remainder(originalMultipleOf).compareTo(BigDecimal.ZERO) == 0) {
         ctx.addDifference("multipleOf", MULTIPLE_OF_EXPANDED);
-      } else if (original.getMultipleOf().intValue() % update.getMultipleOf().intValue() == 0) {
+      } else if (updateMultipleOf.compareTo(BigDecimal.ZERO) != 0
+          && originalMultipleOf.remainder(updateMultipleOf).compareTo(BigDecimal.ZERO) == 0) {
         ctx.addDifference("multipleOf", MULTIPLE_OF_REDUCED);
       } else {
         ctx.addDifference("multipleOf", MULTIPLE_OF_CHANGED);

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiffTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiffTest.java
@@ -61,6 +61,18 @@ public class SchemaDiffTest {
     checkJsonSchemaCompatibility(testCases);
   }
 
+  @Test
+  public void testMultipleOfWithFractionalValueDoesNotThrow() {
+    final JsonSchema original = new JsonSchema("{\"type\":\"number\",\"multipleOf\":0.5}");
+    final JsonSchema update = new JsonSchema("{\"type\":\"number\",\"multipleOf\":10}");
+
+    final List<Difference> differences =
+        SchemaDiff.compare(original.rawSchema(), update.rawSchema());
+
+    assertEquals(1, differences.size());
+    assertEquals(Difference.Type.MULTIPLE_OF_EXPANDED, differences.get(0).getType());
+  }
+
   private void checkJsonSchemaCompatibility(JSONArray testCases) {
     for (final Object testCaseObject : testCases) {
       final JSONObject testCase = (JSONObject) testCaseObject;

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiffTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/diff/SchemaDiffTest.java
@@ -73,6 +73,17 @@ public class SchemaDiffTest {
     assertEquals(Difference.Type.MULTIPLE_OF_EXPANDED, differences.get(0).getType());
   }
 
+  @Test
+  public void testMultipleOfWithEqualValueDifferentScaleIsNotAChange() {
+    final JsonSchema original = new JsonSchema("{\"type\":\"number\",\"multipleOf\":0.5}");
+    final JsonSchema update = new JsonSchema("{\"type\":\"number\",\"multipleOf\":0.50}");
+
+    final List<Difference> differences =
+        SchemaDiff.compare(original.rawSchema(), update.rawSchema());
+
+    assertEquals(0, differences.size());
+  }
+
   private void checkJsonSchemaCompatibility(JSONArray testCases) {
     for (final Object testCaseObject : testCases) {
       final JSONObject testCase = (JSONObject) testCaseObject;


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
- Fix `NumberSchemaDiff.compare()` throwing `ArithmeticException: / by zero` when comparing a                                                                                     
    `multipleOf` value that truncates to `0` via `Number#intValue()` (e.g. `multipleOf: 0.5`).                                                                                      
    Replaces the `intValue() % intValue()` check with `BigDecimal#remainder()` on the                                                                                               
    already-computed `originalMultipleOf`/`updateMultipleOf`, guarded against a zero divisor.   
                                                                                    
- Fix a related correctness issue surfaced by the above: the outer `multipleOf` change-detection                                                                                  
    used `BigDecimal#equals()`, which is scale-sensitive (`0.5` != `0.50`). Once the divide-by-zero                                                                                 
    crash is fixed, that scale-sensitivity was reachable and would misclassify numerically-equal                                                                                    
    `multipleOf` values (differing only in trailing zeros) as `MULTIPLE_OF_EXPANDED` instead of no                                                                                  
    change. Switched to a `compareTo`-based equality check, which is scale-insensitive.  

- Guard `JsonSchema.rawSchema()` against a schema whose root JSON is a bare scalar/array/null                                                                                     
    (syntactically valid JSON, but not a valid schema shape — a schema must be an object or                                                                                         
    boolean)


<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
