### PR TITLE
INIT-5113: Preserve field-level connect.parameters through Avro named…

### DIFF
--- a/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -60,6 +60,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
@@ -1244,6 +1245,9 @@ public class AvroData {
       defaultVal = JsonProperties.NULL_VALUE;
     }
     org.apache.avro.Schema.Field field;
+    String scrubbedName = scrubFullName(fieldSchema.name(), scrubInvalidNames);
+    boolean alreadySeen = scrubbedName != null
+        && !fromConnectContext.seenNamedTypes.add(scrubbedName);
     org.apache.avro.Schema schema = fromConnectSchema(fieldSchema, fromConnectContext, false);
     try {
       field = new org.apache.avro.Schema.Field(
@@ -1258,9 +1262,87 @@ public class AvroData {
           discardTypeDocDefault ? fieldSchema.doc() : fieldDoc);
       log.warn("Ignoring invalid default for field {}", fieldName, e);
     }
+    if (connectMetaData && alreadySeen
+        && fieldSchema.parameters() != null && !fieldSchema.parameters().isEmpty()
+        && isNamedAvroType(schema)) {
+      JsonNode fieldParams = parametersFromConnect(fieldSchema.parameters());
+      if (fieldParams.size() > 0) {
+        field.addProp(CONNECT_PARAMETERS_PROP, fieldParams);
+      }
+    }
     fields.add(field);
   }
 
+  /**
+   * Returns true if the Avro schema is a named type (RECORD, ENUM, or FIXED) that is subject
+   * to deduplication via bare-name references. For UNION schemas, checks if any branch is named.
+   */
+  private static boolean isNamedAvroType(org.apache.avro.Schema avroSchema) {
+    org.apache.avro.Schema.Type type = avroSchema.getType();
+    if (type == org.apache.avro.Schema.Type.RECORD
+        || type == org.apache.avro.Schema.Type.ENUM
+        || type == org.apache.avro.Schema.Type.FIXED) {
+      return true;
+    }
+    if (type == org.apache.avro.Schema.Type.UNION) {
+      for (org.apache.avro.Schema branch : avroSchema.getTypes()) {
+        org.apache.avro.Schema.Type bt = branch.getType();
+        if (bt == org.apache.avro.Schema.Type.RECORD
+            || bt == org.apache.avro.Schema.Type.ENUM
+            || bt == org.apache.avro.Schema.Type.FIXED) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Rebuilds a Connect schema with field-level parameter overrides. Returns the original schema
+   * unchanged if the field-level parameters match the existing type-level parameters.
+   */
+  private static Schema applyFieldLevelParams(Schema original, Map<?, ?> fieldParams) {
+    Map<String, String> originalParams =
+        original.parameters() != null ? original.parameters() : Collections.emptyMap();
+    boolean same = true;
+    for (Map.Entry<?, ?> e : fieldParams.entrySet()) {
+      if (!e.getValue().toString().equals(originalParams.get(e.getKey().toString()))) {
+        same = false;
+        break;
+      }
+    }
+    if (same) {
+      return original;
+    }
+    SchemaBuilder builder = new SchemaBuilder(original.type());
+    if (original.name() != null) {
+      builder.name(original.name());
+    }
+    if (original.version() != null) {
+      builder.version(original.version());
+    }
+    if (original.doc() != null) {
+      builder.doc(original.doc());
+    }
+    if (original.isOptional()) {
+      builder.optional();
+    }
+    if (original.defaultValue() != null) {
+      builder.defaultValue(original.defaultValue());
+    }
+    for (Map.Entry<String, String> e : originalParams.entrySet()) {
+      builder.parameter(e.getKey(), e.getValue());
+    }
+    for (Map.Entry<?, ?> e : fieldParams.entrySet()) {
+      builder.parameter(e.getKey().toString(), e.getValue().toString());
+    }
+    if (original.type() == Schema.Type.STRUCT) {
+      for (Field f : original.fields()) {
+        builder.field(f.name(), f.schema());
+      }
+    }
+    return builder.build();
+  }
 
   private static Object toAvroLogical(Schema schema, Object value) {
     if (schema != null && schema.name() != null) {
@@ -1924,6 +2006,12 @@ public class AvroData {
           }
           Schema fieldSchema = toConnectSchema(field.schema(), getForceOptionalDefault(),
                   defaultVal, field.doc(), toConnectContext);
+          if (connectMetaData) {
+            Object fieldConnectParams = field.getObjectProp(CONNECT_PARAMETERS_PROP);
+            if (fieldConnectParams instanceof Map) {
+              fieldSchema = applyFieldLevelParams(fieldSchema, (Map<?, ?>) fieldConnectParams);
+            }
+          }
           builder.field(field.name(), fieldSchema);
         }
         break;
@@ -2731,11 +2819,13 @@ public class AvroData {
     private final Map<Schema, org.apache.avro.Schema> schemaMap;
     //schema name to Schema reference to resolve cycles
     private final Map<String, org.apache.avro.Schema> cycleReferences;
+    private final Set<String> seenNamedTypes;
     private int defaultSchemaNameIndex = 0;
 
     private FromConnectContext(Map<Schema, org.apache.avro.Schema> schemaMap) {
       this.schemaMap = schemaMap;
       this.cycleReferences = new IdentityHashMap<>();
+      this.seenNamedTypes = new HashSet<>();
     }
 
     public int incrementAndGetNameIndex() {

--- a/avro-data/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-data/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -82,6 +82,10 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.*;
 
 public class AvroDataTest {
+  private static final String PROTOBUF_TYPE_TAG = "io.confluent.connect.protobuf.Tag";
+  private static final String PROTOBUF_TYPE_PROP = "io.confluent.connect.protobuf.Type";
+  private static final String AVRO_TYPE_ENUM = "io.confluent.connect.avro.Enum";
+
   private static final int TEST_SCALE = 2;
   private static final BigDecimal TEST_DECIMAL = new BigDecimal(new BigInteger("156"), TEST_SCALE);
   private static final byte[] TEST_DECIMAL_BYTES = new byte[]{0, -100};
@@ -219,7 +223,7 @@ public class AvroDataTest {
     GenericData.EnumSymbol avroObj = new GenericData.EnumSymbol(avroSchema, "one");
 
     Map connectPropsMap = ImmutableMap.of("connect.enum.doc","null",
-        "io.confluent.connect.avro.Enum","enum",
+        AVRO_TYPE_ENUM,"enum",
         "io.confluent.connect.avro.Enum.one", "one",
         "io.confluent.connect.avro.Enum.two","two",
         "io.confluent.connect.avro.Enum.three","three");
@@ -3580,6 +3584,939 @@ public class AvroDataTest {
     byte[] bytes = new byte[buffer.remaining()];
     buffer.duplicate().get(bytes);
     return bytes;
+  }
+
+  @Test
+  public void testFieldLevelParamsPreservedForSharedNamedType() {
+    Schema addressTag2 = SchemaBuilder.struct()
+        .name("Address")
+        .parameter(PROTOBUF_TYPE_TAG, "2")
+        .field("street", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema addressTag3 = SchemaBuilder.struct()
+        .name("Address")
+        .parameter(PROTOBUF_TYPE_TAG, "3")
+        .field("street", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema personSchema = SchemaBuilder.struct()
+        .name("Person")
+        .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("home_addr", addressTag2)
+        .field("work_addr", addressTag3)
+        .build();
+
+    org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(personSchema);
+    Schema roundTripped = avroData.toConnectSchema(avroSchema);
+
+    String homeTag = roundTripped.field("home_addr").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG);
+    String workTag = roundTripped.field("work_addr").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG);
+
+    assertEquals("2", homeTag);
+    assertEquals("3", workTag);
+  }
+
+  @Test
+  public void testFieldLevelParamsSharedTypeAtThreeFields() {
+    Schema addrTag2 = SchemaBuilder.struct()
+        .name("Address")
+        .parameter(PROTOBUF_TYPE_TAG, "2")
+        .field("line", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema addrTag3 = SchemaBuilder.struct()
+        .name("Address")
+        .parameter(PROTOBUF_TYPE_TAG, "3")
+        .field("line", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema addrTag4 = SchemaBuilder.struct()
+        .name("Address")
+        .parameter(PROTOBUF_TYPE_TAG, "4")
+        .field("line", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema company = SchemaBuilder.struct()
+        .name("Company")
+        .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("hq", addrTag2)
+        .field("warehouse", addrTag3)
+        .field("billing", addrTag4)
+        .build();
+
+    org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(company);
+    Schema roundTripped = avroData.toConnectSchema(avroSchema);
+
+    assertEquals("2", roundTripped.field("hq").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("3", roundTripped.field("warehouse").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("4", roundTripped.field("billing").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+  }
+
+  @Test
+  public void testFieldLevelParamsNestedSharedType() {
+    Schema addrTag2 = SchemaBuilder.struct()
+        .name("Address")
+        .parameter(PROTOBUF_TYPE_TAG, "2")
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema addrTag3 = SchemaBuilder.struct()
+        .name("Address")
+        .parameter(PROTOBUF_TYPE_TAG, "3")
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema customer = SchemaBuilder.struct()
+        .name("Customer")
+        .parameter(PROTOBUF_TYPE_TAG, "2")
+        .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("billing", addrTag2)
+        .field("shipping", addrTag3)
+        .build();
+    Schema order = SchemaBuilder.struct()
+        .name("Order")
+        .field("id", Schema.OPTIONAL_INT32_SCHEMA)
+        .field("customer", customer)
+        .build();
+
+    org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(order);
+    Schema roundTripped = avroData.toConnectSchema(avroSchema);
+
+    Schema rtCustomer = roundTripped.field("customer").schema();
+    assertEquals("2", rtCustomer.field("billing").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("3", rtCustomer.field("shipping").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+  }
+
+  @Test
+  public void testFieldLevelParamsWithMultipleParams() {
+    Schema addrTag2 = SchemaBuilder.struct()
+        .name("Address")
+        .parameter(PROTOBUF_TYPE_TAG, "2")
+        .parameter(PROTOBUF_TYPE_PROP, "MESSAGE")
+        .field("street", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema addrTag3 = SchemaBuilder.struct()
+        .name("Address")
+        .parameter(PROTOBUF_TYPE_TAG, "3")
+        .parameter(PROTOBUF_TYPE_PROP, "MESSAGE")
+        .field("street", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema parent = SchemaBuilder.struct()
+        .name("Parent")
+        .field("addr1", addrTag2)
+        .field("addr2", addrTag3)
+        .build();
+
+    org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(parent);
+    Schema roundTripped = avroData.toConnectSchema(avroSchema);
+
+    Map<String, String> addr1Params = roundTripped.field("addr1").schema().parameters();
+    Map<String, String> addr2Params = roundTripped.field("addr2").schema().parameters();
+
+    assertEquals("2", addr1Params.get(PROTOBUF_TYPE_TAG));
+    assertEquals("MESSAGE", addr1Params.get(PROTOBUF_TYPE_PROP));
+    assertEquals("3", addr2Params.get(PROTOBUF_TYPE_TAG));
+    assertEquals("MESSAGE", addr2Params.get(PROTOBUF_TYPE_PROP));
+  }
+
+  @Test
+  public void testFieldLevelParamsNoParamsNoChange() {
+    Schema inner = SchemaBuilder.struct()
+        .name("Inner")
+        .field("value", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema outer = SchemaBuilder.struct()
+        .name("Outer")
+        .field("a", inner)
+        .field("b", inner)
+        .build();
+
+    org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(outer);
+    Schema roundTripped = avroData.toConnectSchema(avroSchema);
+
+    assertNull(roundTripped.field("a").schema().parameters());
+    assertNull(roundTripped.field("b").schema().parameters());
+  }
+
+  @Test
+  public void testFieldLevelParamsDataRoundTrip() {
+    Schema addrTag2 = SchemaBuilder.struct()
+        .name("Address")
+        .parameter(PROTOBUF_TYPE_TAG, "2")
+        .field("street", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema addrTag3 = SchemaBuilder.struct()
+        .name("Address")
+        .parameter(PROTOBUF_TYPE_TAG, "3")
+        .field("street", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema personSchema = SchemaBuilder.struct()
+        .name("Person")
+        .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("home_addr", addrTag2)
+        .field("work_addr", addrTag3)
+        .build();
+
+    Struct homeAddr = new Struct(addrTag2)
+        .put("street", "123 Home St")
+        .put("city", "Hometown");
+    Struct workAddr = new Struct(addrTag3)
+        .put("street", "456 Work Ave")
+        .put("city", "Workville");
+    Struct person = new Struct(personSchema)
+        .put("name", "Alice")
+        .put("home_addr", homeAddr)
+        .put("work_addr", workAddr);
+
+    org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(personSchema);
+    GenericRecord avroRecord = (GenericRecord) avroData.fromConnectData(
+        personSchema, person);
+    assertNotNull(avroRecord);
+
+    SchemaAndValue roundTripped = avroData.toConnectData(avroSchema, avroRecord);
+    Schema rtSchema = roundTripped.schema();
+    Struct rtValue = (Struct) roundTripped.value();
+
+    assertEquals("2", rtSchema.field("home_addr").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("3", rtSchema.field("work_addr").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+
+    assertEquals("Alice", rtValue.getString("name"));
+    Struct rtHome = rtValue.getStruct("home_addr");
+    assertEquals("123 Home St", rtHome.getString("street"));
+    assertEquals("Hometown", rtHome.getString("city"));
+    Struct rtWork = rtValue.getStruct("work_addr");
+    assertEquals("456 Work Ave", rtWork.getString("street"));
+    assertEquals("Workville", rtWork.getString("city"));
+  }
+
+  @Test
+  public void testFieldLevelParamsRepeatedSharedType() {
+    Schema itemTag2 = SchemaBuilder.struct()
+        .name("Item")
+        .parameter(PROTOBUF_TYPE_TAG, "2")
+        .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema itemTag3 = SchemaBuilder.struct()
+        .name("Item")
+        .parameter(PROTOBUF_TYPE_TAG, "3")
+        .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema container = SchemaBuilder.struct()
+        .name("Container")
+        .field("primary", itemTag2)
+        .field("secondary", itemTag3)
+        .build();
+
+    org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(container);
+
+    org.apache.avro.Schema.Field primaryField = avroSchema.getField("primary");
+    org.apache.avro.Schema.Field secondaryField = avroSchema.getField("secondary");
+    assertNull("First occurrence should not have field-level connect.parameters",
+        primaryField.getObjectProp("connect.parameters"));
+    assertNotNull("Secondary field should have connect.parameters",
+        secondaryField.getObjectProp("connect.parameters"));
+
+    Schema roundTripped = avroData.toConnectSchema(avroSchema);
+    assertEquals("2", roundTripped.field("primary").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("3", roundTripped.field("secondary").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+  }
+
+  @Test
+  public void testFieldLevelParamsComplexEnvelopeRoundTrip() {
+    Schema enumSchema = SchemaBuilder.string()
+        .parameter("io.confluent.connect.protobuf.Enum", "Priority")
+        .parameter("io.confluent.connect.protobuf.Enum.PRIORITY_LOW", "0")
+        .parameter("io.confluent.connect.protobuf.Enum.PRIORITY_HIGH", "2")
+        .build();
+
+    Schema addrTag14 = SchemaBuilder.struct()
+        .name("Address")
+        .parameter(PROTOBUF_TYPE_TAG, "14")
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema addrTag15 = SchemaBuilder.struct()
+        .name("Address")
+        .parameter(PROTOBUF_TYPE_TAG, "15")
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema addrTag16 = SchemaBuilder.struct()
+        .name("Address")
+        .parameter(PROTOBUF_TYPE_TAG, "16")
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+
+    Schema record = SchemaBuilder.struct()
+        .name("MegaRecord")
+        .field("id", Schema.OPTIONAL_INT32_SCHEMA)
+        .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("active", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+        .field("score", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .field("priority", enumSchema)
+        .field("home_addr", addrTag14)
+        .field("work_addr", addrTag15)
+        .field("billing_addr", addrTag16)
+        .field("tags", SchemaBuilder.array(Schema.STRING_SCHEMA).optional().build())
+        .field("scores", SchemaBuilder.map(Schema.STRING_SCHEMA,
+            Schema.INT32_SCHEMA).optional().build())
+        .field("nickname", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+
+    Struct home = new Struct(addrTag14).put("city", "SF");
+    Struct work = new Struct(addrTag15).put("city", "NYC");
+    Struct billing = new Struct(addrTag16).put("city", "London");
+    Struct value = new Struct(record)
+        .put("id", 1)
+        .put("name", "Alice")
+        .put("active", true)
+        .put("score", 98.5)
+        .put("priority", "PRIORITY_HIGH")
+        .put("home_addr", home)
+        .put("work_addr", work)
+        .put("billing_addr", billing)
+        .put("tags", java.util.Arrays.asList("eng", "sr"))
+        .put("scores", ImmutableMap.of("math", 95))
+        .put("nickname", "Ali");
+
+    org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(record);
+    GenericRecord avroRecord = (GenericRecord) avroData.fromConnectData(record, value);
+
+    SchemaAndValue roundTripped = avroData.toConnectData(avroSchema, avroRecord);
+    Schema rtSchema = roundTripped.schema();
+    Struct rtValue = (Struct) roundTripped.value();
+
+    assertEquals("14", rtSchema.field("home_addr").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("15", rtSchema.field("work_addr").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("16", rtSchema.field("billing_addr").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+
+    assertEquals(Integer.valueOf(1), rtValue.getInt32("id"));
+    assertEquals("Alice", rtValue.getString("name"));
+    assertEquals(true, rtValue.getBoolean("active"));
+    assertEquals(98.5, rtValue.getFloat64("score"), 0.001);
+    assertEquals("PRIORITY_HIGH", rtValue.getString("priority"));
+    assertEquals("SF", rtValue.getStruct("home_addr").getString("city"));
+    assertEquals("NYC", rtValue.getStruct("work_addr").getString("city"));
+    assertEquals("London", rtValue.getStruct("billing_addr").getString("city"));
+    assertEquals(java.util.Arrays.asList("eng", "sr"), rtValue.getArray("tags"));
+    assertEquals(Integer.valueOf(95), rtValue.getMap("scores").get("math"));
+    assertEquals("Ali", rtValue.getString("nickname"));
+  }
+
+  @Test
+  public void testFieldLevelParamsSharedTypeInOptionalField() {
+    Schema addrTag2 = SchemaBuilder.struct()
+        .name("Address")
+        .optional()
+        .parameter(PROTOBUF_TYPE_TAG, "2")
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema addrTag3 = SchemaBuilder.struct()
+        .name("Address")
+        .optional()
+        .parameter(PROTOBUF_TYPE_TAG, "3")
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema parent = SchemaBuilder.struct()
+        .name("Parent")
+        .field("home", addrTag2)
+        .field("work", addrTag3)
+        .build();
+
+    Struct value = new Struct(parent)
+        .put("home", new Struct(addrTag2).put("city", "SF"))
+        .put("work", null);
+
+    org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(parent);
+    GenericRecord avroRecord = (GenericRecord) avroData.fromConnectData(parent, value);
+    SchemaAndValue rt = avroData.toConnectData(avroSchema, avroRecord);
+    Struct rtValue = (Struct) rt.value();
+
+    assertEquals("2", rt.schema().field("home").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("3", rt.schema().field("work").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("SF", rtValue.getStruct("home").getString("city"));
+    assertNull(rtValue.getStruct("work"));
+  }
+
+  @Test
+  public void testFieldLevelParamsSharedTypeInArray() {
+    Schema addrTag2 = SchemaBuilder.struct()
+        .name("Address")
+        .parameter(PROTOBUF_TYPE_TAG, "2")
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema addrTag3 = SchemaBuilder.struct()
+        .name("Address")
+        .parameter(PROTOBUF_TYPE_TAG, "3")
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema parent = SchemaBuilder.struct()
+        .name("Parent")
+        .field("primary", addrTag2)
+        .field("secondary", addrTag3)
+        .field("extras", SchemaBuilder.array(addrTag2).optional().build())
+        .build();
+
+    Struct a1 = new Struct(addrTag2).put("city", "A");
+    Struct a2 = new Struct(addrTag2).put("city", "B");
+    Struct value = new Struct(parent)
+        .put("primary", new Struct(addrTag2).put("city", "SF"))
+        .put("secondary", new Struct(addrTag3).put("city", "NYC"))
+        .put("extras", java.util.Arrays.asList(a1, a2));
+
+    org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(parent);
+    GenericRecord avroRecord = (GenericRecord) avroData.fromConnectData(parent, value);
+    SchemaAndValue rt = avroData.toConnectData(avroSchema, avroRecord);
+    Struct rtValue = (Struct) rt.value();
+
+    assertEquals("2", rt.schema().field("primary").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("3", rt.schema().field("secondary").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("SF", rtValue.getStruct("primary").getString("city"));
+    assertEquals("NYC", rtValue.getStruct("secondary").getString("city"));
+    java.util.List<?> extras = rtValue.getArray("extras");
+    assertEquals(2, extras.size());
+    assertEquals("A", ((Struct) extras.get(0)).getString("city"));
+    assertEquals("B", ((Struct) extras.get(1)).getString("city"));
+  }
+
+  @Test
+  public void testFieldLevelParamsSharedTypeInMapValue() {
+    Schema addrTag2 = SchemaBuilder.struct()
+        .name("Address")
+        .parameter(PROTOBUF_TYPE_TAG, "2")
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema addrTag3 = SchemaBuilder.struct()
+        .name("Address")
+        .parameter(PROTOBUF_TYPE_TAG, "3")
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema parent = SchemaBuilder.struct()
+        .name("Parent")
+        .field("primary", addrTag2)
+        .field("secondary", addrTag3)
+        .field("lookup", SchemaBuilder.map(Schema.STRING_SCHEMA, addrTag2).optional().build())
+        .build();
+
+    Struct value = new Struct(parent)
+        .put("primary", new Struct(addrTag2).put("city", "SF"))
+        .put("secondary", new Struct(addrTag3).put("city", "NYC"))
+        .put("lookup", ImmutableMap.of(
+            "hq", new Struct(addrTag2).put("city", "Austin")));
+
+    org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(parent);
+    GenericRecord avroRecord = (GenericRecord) avroData.fromConnectData(parent, value);
+    SchemaAndValue rt = avroData.toConnectData(avroSchema, avroRecord);
+    Struct rtValue = (Struct) rt.value();
+
+    assertEquals("2", rt.schema().field("primary").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("3", rt.schema().field("secondary").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("Austin", ((Struct) rtValue.getMap("lookup").get("hq")).getString("city"));
+  }
+
+  @Test
+  public void testFieldLevelParamsSharedEnumType() {
+    Schema statusTag5 = SchemaBuilder.string()
+        .name("Status")
+        .parameter(PROTOBUF_TYPE_TAG, "5")
+        .parameter(AVRO_TYPE_ENUM, "Status")
+        .parameter(AVRO_TYPE_ENUM + ".UNKNOWN", "0")
+        .parameter(AVRO_TYPE_ENUM + ".ACTIVE", "1")
+        .parameter(AVRO_TYPE_ENUM + ".INACTIVE", "2")
+        .build();
+    Schema statusTag6 = SchemaBuilder.string()
+        .name("Status")
+        .parameter(PROTOBUF_TYPE_TAG, "6")
+        .parameter(AVRO_TYPE_ENUM, "Status")
+        .parameter(AVRO_TYPE_ENUM + ".UNKNOWN", "0")
+        .parameter(AVRO_TYPE_ENUM + ".ACTIVE", "1")
+        .parameter(AVRO_TYPE_ENUM + ".INACTIVE", "2")
+        .build();
+    Schema parent = SchemaBuilder.struct()
+        .name("Order")
+        .field("id", Schema.INT32_SCHEMA)
+        .field("primary_status", statusTag5)
+        .field("secondary_status", statusTag6)
+        .build();
+
+    AvroDataConfig config = new AvroDataConfig.Builder()
+        .with(AvroDataConfig.ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG, true)
+        .build();
+    AvroData enhancedAvroData = new AvroData(config);
+
+    org.apache.avro.Schema avroSchema = enhancedAvroData.fromConnectSchema(parent);
+    Schema roundTripped = enhancedAvroData.toConnectSchema(avroSchema);
+
+    assertEquals("5", roundTripped.field("primary_status").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("6", roundTripped.field("secondary_status").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+  }
+
+  @Test
+  public void testFieldLevelParamsStrictAllTypesRoundTrip() {
+    AvroDataConfig config = new AvroDataConfig.Builder()
+        .with(AvroDataConfig.ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG, true)
+        .build();
+    AvroData enhanced = new AvroData(config);
+
+    // ── Shared enum at 2 fields (same Status enum, different Tags) ──
+    Schema statusTag5 = SchemaBuilder.string()
+        .name("Status")
+        .parameter(PROTOBUF_TYPE_TAG, "5")
+        .parameter(AVRO_TYPE_ENUM, "Status")
+        .parameter(AVRO_TYPE_ENUM + ".UNKNOWN", "0")
+        .parameter(AVRO_TYPE_ENUM + ".ACTIVE", "1")
+        .parameter(AVRO_TYPE_ENUM + ".INACTIVE", "2")
+        .build();
+    Schema statusTag6 = SchemaBuilder.string()
+        .name("Status")
+        .parameter(PROTOBUF_TYPE_TAG, "6")
+        .parameter(AVRO_TYPE_ENUM, "Status")
+        .parameter(AVRO_TYPE_ENUM + ".UNKNOWN", "0")
+        .parameter(AVRO_TYPE_ENUM + ".ACTIVE", "1")
+        .parameter(AVRO_TYPE_ENUM + ".INACTIVE", "2")
+        .build();
+
+    // ── Shared STRUCT at 3 fields (Address, different Tags) ──
+    Schema addrTag10 = SchemaBuilder.struct().name("Address").optional()
+        .parameter(PROTOBUF_TYPE_TAG, "10")
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("zip", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema addrTag11 = SchemaBuilder.struct().name("Address").optional()
+        .parameter(PROTOBUF_TYPE_TAG, "11")
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("zip", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema addrTag12 = SchemaBuilder.struct().name("Address").optional()
+        .parameter(PROTOBUF_TYPE_TAG, "12")
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("zip", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+
+    // ── Nested message with its own shared type ──
+    Schema metaSchema = SchemaBuilder.struct().name("Metadata").optional()
+        .parameter(PROTOBUF_TYPE_TAG, "20")
+        .field("source", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("ts", Schema.OPTIONAL_INT64_SCHEMA)
+        .build();
+
+    // ── Build the mega record ──
+    Schema megaRecord = SchemaBuilder.struct().name("MegaRecord")
+        // Primitives
+        .field("f_int32", Schema.OPTIONAL_INT32_SCHEMA)
+        .field("f_int64", Schema.OPTIONAL_INT64_SCHEMA)
+        .field("f_float32", Schema.OPTIONAL_FLOAT32_SCHEMA)
+        .field("f_float64", Schema.OPTIONAL_FLOAT64_SCHEMA)
+        .field("f_bool", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+        .field("f_string", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("f_bytes", Schema.OPTIONAL_BYTES_SCHEMA)
+        // Shared enum at 2 fields
+        .field("primary_status", statusTag5)
+        .field("secondary_status", statusTag6)
+        // Shared struct at 3 fields
+        .field("home_addr", addrTag10)
+        .field("work_addr", addrTag11)
+        .field("billing_addr", addrTag12)
+        // Repeated primitives
+        .field("tags", SchemaBuilder.array(Schema.STRING_SCHEMA).optional().build())
+        .field("scores_list", SchemaBuilder.array(Schema.INT32_SCHEMA).optional().build())
+        // Repeated shared struct
+        .field("extra_addrs", SchemaBuilder.array(addrTag10).optional().build())
+        // Map string→int
+        .field("scores_map", SchemaBuilder.map(
+            Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).optional().build())
+        // Map string→struct
+        .field("addr_lookup", SchemaBuilder.map(
+            Schema.STRING_SCHEMA, addrTag10).optional().build())
+        // Optional fields
+        .field("nickname", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("age", Schema.OPTIONAL_INT32_SCHEMA)
+        // Nested message
+        .field("meta", metaSchema)
+        .build();
+
+    // ── Build data ──
+    Struct home = new Struct(addrTag10).put("city", "SF").put("zip", "94105");
+    Struct work = new Struct(addrTag11).put("city", "NYC").put("zip", "10001");
+    Struct billing = new Struct(addrTag12).put("city", "London").put("zip", "SW1A");
+    Struct extra1 = new Struct(addrTag10).put("city", "Tokyo").put("zip", "100");
+    Struct extra2 = new Struct(addrTag10).put("city", "Berlin").put("zip", "10115");
+    Struct lookupAddr = new Struct(addrTag10).put("city", "Austin").put("zip", "73301");
+    Struct meta = new Struct(metaSchema).put("source", "api").put("ts", 1700000000L);
+
+    Struct value = new Struct(megaRecord)
+        .put("f_int32", 42)
+        .put("f_int64", 123456789L)
+        .put("f_float32", 3.14f)
+        .put("f_float64", 2.718281828)
+        .put("f_bool", true)
+        .put("f_string", "hello")
+        .put("f_bytes", java.nio.ByteBuffer.wrap(new byte[]{1, 2, 3}))
+        .put("primary_status", "ACTIVE")
+        .put("secondary_status", "INACTIVE")
+        .put("home_addr", home)
+        .put("work_addr", work)
+        .put("billing_addr", billing)
+        .put("tags", java.util.Arrays.asList("eng", "sr", "backend"))
+        .put("scores_list", java.util.Arrays.asList(95, 88, 72))
+        .put("extra_addrs", java.util.Arrays.asList(extra1, extra2))
+        .put("scores_map", ImmutableMap.of("math", 95, "science", 88))
+        .put("addr_lookup", ImmutableMap.of("hq", lookupAddr))
+        .put("nickname", "Ali")
+        .put("age", 30)
+        .put("meta", meta);
+
+    // ── Round-trip through AvroData ──
+    org.apache.avro.Schema avroSchema = enhanced.fromConnectSchema(megaRecord);
+    GenericRecord avroRecord = (GenericRecord) enhanced.fromConnectData(megaRecord, value);
+    SchemaAndValue rt = enhanced.toConnectData(avroSchema, avroRecord);
+    Schema rtSchema = rt.schema();
+    Struct rtValue = (Struct) rt.value();
+
+    // ── STRICT ASSERTIONS ──
+
+    // 1. Shared enum tags preserved
+    assertEquals("5", rtSchema.field("primary_status").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("6", rtSchema.field("secondary_status").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("ACTIVE", rtValue.getString("primary_status"));
+    assertEquals("INACTIVE", rtValue.getString("secondary_status"));
+
+    // 2. Shared struct tags preserved (3 fields)
+    assertEquals("10", rtSchema.field("home_addr").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("11", rtSchema.field("work_addr").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("12", rtSchema.field("billing_addr").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("SF", rtValue.getStruct("home_addr").getString("city"));
+    assertEquals("NYC", rtValue.getStruct("work_addr").getString("city"));
+    assertEquals("London", rtValue.getStruct("billing_addr").getString("city"));
+
+    // 3. All primitives
+    assertEquals(Integer.valueOf(42), rtValue.getInt32("f_int32"));
+    assertEquals(Long.valueOf(123456789L), rtValue.getInt64("f_int64"));
+    assertEquals(3.14f, rtValue.getFloat32("f_float32"), 0.001);
+    assertEquals(2.718281828, rtValue.getFloat64("f_float64"), 0.000001);
+    assertEquals(true, rtValue.getBoolean("f_bool"));
+    assertEquals("hello", rtValue.getString("f_string"));
+    assertNotNull(rtValue.getBytes("f_bytes"));
+
+    // 4. Repeated primitives
+    assertEquals(java.util.Arrays.asList("eng", "sr", "backend"), rtValue.getArray("tags"));
+    assertEquals(java.util.Arrays.asList(95, 88, 72), rtValue.getArray("scores_list"));
+
+    // 5. Repeated shared struct
+    java.util.List<?> extras = rtValue.getArray("extra_addrs");
+    assertEquals(2, extras.size());
+    assertEquals("Tokyo", ((Struct) extras.get(0)).getString("city"));
+    assertEquals("Berlin", ((Struct) extras.get(1)).getString("city"));
+
+    // 6. Map string→int
+    assertEquals(Integer.valueOf(95), rtValue.getMap("scores_map").get("math"));
+    assertEquals(Integer.valueOf(88), rtValue.getMap("scores_map").get("science"));
+
+    // 7. Map string→struct
+    Struct hqAddr = (Struct) rtValue.getMap("addr_lookup").get("hq");
+    assertEquals("Austin", hqAddr.getString("city"));
+
+    // 8. Optional fields (set)
+    assertEquals("Ali", rtValue.getString("nickname"));
+    assertEquals(Integer.valueOf(30), rtValue.getInt32("age"));
+
+    // 9. Nested message
+    Struct rtMeta = rtValue.getStruct("meta");
+    assertEquals("api", rtMeta.getString("source"));
+    assertEquals(Long.valueOf(1700000000L), rtMeta.getInt64("ts"));
+  }
+
+  @Test
+  public void testFieldLevelParamsStrictOptionalNullRoundTrip() {
+    AvroDataConfig config = new AvroDataConfig.Builder()
+        .with(AvroDataConfig.ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG, true)
+        .build();
+    AvroData enhanced = new AvroData(config);
+
+    Schema addrTag2 = SchemaBuilder.struct().name("Address").optional()
+        .parameter(PROTOBUF_TYPE_TAG, "2")
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema addrTag3 = SchemaBuilder.struct().name("Address").optional()
+        .parameter(PROTOBUF_TYPE_TAG, "3")
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema statusTag5 = SchemaBuilder.string().name("Status")
+        .parameter(PROTOBUF_TYPE_TAG, "5")
+        .parameter(AVRO_TYPE_ENUM, "Status")
+        .parameter(AVRO_TYPE_ENUM + ".ON", "0")
+        .parameter(AVRO_TYPE_ENUM + ".OFF", "1")
+        .build();
+    Schema statusTag6 = SchemaBuilder.string().name("Status")
+        .parameter(PROTOBUF_TYPE_TAG, "6")
+        .parameter(AVRO_TYPE_ENUM, "Status")
+        .parameter(AVRO_TYPE_ENUM + ".ON", "0")
+        .parameter(AVRO_TYPE_ENUM + ".OFF", "1")
+        .build();
+
+    Schema record = SchemaBuilder.struct().name("NullTest")
+        .field("home", addrTag2)
+        .field("work", addrTag3)
+        .field("status_a", statusTag5)
+        .field("status_b", statusTag6)
+        .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+
+    // All optional structs null, enums at defaults
+    Struct value = new Struct(record)
+        .put("home", null)
+        .put("work", null)
+        .put("status_a", "ON")
+        .put("status_b", "OFF")
+        .put("name", null);
+
+    org.apache.avro.Schema avroSchema = enhanced.fromConnectSchema(record);
+    GenericRecord avroRecord = (GenericRecord) enhanced.fromConnectData(record, value);
+    SchemaAndValue rt = enhanced.toConnectData(avroSchema, avroRecord);
+    Schema rtSchema = rt.schema();
+    Struct rtValue = (Struct) rt.value();
+
+    // Struct tags preserved even when values are null
+    assertEquals("2", rtSchema.field("home").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("3", rtSchema.field("work").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertNull(rtValue.getStruct("home"));
+    assertNull(rtValue.getStruct("work"));
+
+    // Enum tags preserved
+    assertEquals("5", rtSchema.field("status_a").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("6", rtSchema.field("status_b").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("ON", rtValue.getString("status_a"));
+    assertEquals("OFF", rtValue.getString("status_b"));
+
+    assertNull(rtValue.getString("name"));
+  }
+
+  @Test
+  public void testFieldLevelParamsNullValueForSharedType() {
+    Schema addrTag2 = SchemaBuilder.struct()
+        .name("Address")
+        .optional()
+        .parameter(PROTOBUF_TYPE_TAG, "2")
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema addrTag3 = SchemaBuilder.struct()
+        .name("Address")
+        .optional()
+        .parameter(PROTOBUF_TYPE_TAG, "3")
+        .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Schema parent = SchemaBuilder.struct()
+        .name("Parent")
+        .field("home", addrTag2)
+        .field("work", addrTag3)
+        .build();
+
+    Struct value = new Struct(parent)
+        .put("home", null)
+        .put("work", null);
+
+    org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(parent);
+    GenericRecord avroRecord = (GenericRecord) avroData.fromConnectData(parent, value);
+    SchemaAndValue rt = avroData.toConnectData(avroSchema, avroRecord);
+    Struct rtValue = (Struct) rt.value();
+
+    assertEquals("2", rt.schema().field("home").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals("3", rt.schema().field("work").schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertNull(rtValue.getStruct("home"));
+    assertNull(rtValue.getStruct("work"));
+  }
+
+  @Test
+  public void testFieldLevelParametersIgnoredWhenConnectMetaDataDisabled() {
+    final String fieldHome = "home";
+    final String fieldWork = "work";
+    final String fieldStreet = "street";
+    final String valueHomeSt = "Home St";
+    final String valueWorkAve = "Work Ave";
+
+    Schema homeFieldSchema = SchemaBuilder.struct()
+        .name("Address")
+        .field(fieldStreet, Schema.STRING_SCHEMA)
+        .parameter(PROTOBUF_TYPE_TAG, "7")
+        .build();
+
+    Schema workFieldSchema = SchemaBuilder.struct()
+        .name("Address")
+        .field(fieldStreet, Schema.STRING_SCHEMA)
+        .parameter(PROTOBUF_TYPE_TAG, "8")
+        .build();
+
+    Schema parent = SchemaBuilder.struct()
+        .name("Person")
+        .field(fieldHome, homeFieldSchema)
+        .field(fieldWork, workFieldSchema)
+        .build();
+
+    Struct homeAddr = new Struct(homeFieldSchema).put(fieldStreet, valueHomeSt);
+    Struct workAddr = new Struct(workFieldSchema).put(fieldStreet, valueWorkAve);
+    Struct value = new Struct(parent)
+        .put(fieldHome, homeAddr)
+        .put(fieldWork, workAddr);
+
+    org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(parent);
+    GenericRecord avroRecord = (GenericRecord) avroData.fromConnectData(parent, value);
+
+    AvroDataConfig configWithoutMetaData = new AvroDataConfig.Builder()
+        .with(AvroDataConfig.CONNECT_META_DATA_CONFIG, false)
+        .build();
+    AvroData avroDataNoMeta = new AvroData(configWithoutMetaData);
+
+    SchemaAndValue rt = avroDataNoMeta.toConnectData(avroSchema, avroRecord);
+
+    assertNull(rt.schema().field(fieldHome).schema().parameters());
+    assertNull(rt.schema().field(fieldWork).schema().parameters());
+
+    Struct rtValue = (Struct) rt.value();
+    assertEquals(valueHomeSt, rtValue.getStruct(fieldHome).getString(fieldStreet));
+    assertEquals(valueWorkAve, rtValue.getStruct(fieldWork).getString(fieldStreet));
+  }
+
+  @Test
+  public void testFieldLevelParamsWithScrubInvalidNames() {
+    final String schemaAddress = "com.example.Address-v1";
+    final String schemaPerson = "com.example.Person-v1";
+    final String fieldStreet = "street";
+    final String fieldHomeAddr = "home_addr";
+    final String fieldWorkAddr = "work_addr";
+    final String tag2 = "2";
+    final String tag3 = "3";
+
+    AvroDataConfig config = new AvroDataConfig.Builder()
+        .with(AvroDataConfig.SCRUB_INVALID_NAMES_CONFIG, true)
+        .build();
+    AvroData scrubbingAvroData = new AvroData(config);
+
+    Schema addrTag2 = SchemaBuilder.struct()
+        .name(schemaAddress)
+        .field(fieldStreet, Schema.STRING_SCHEMA)
+        .parameter(PROTOBUF_TYPE_TAG, tag2)
+        .build();
+
+    Schema addrTag3 = SchemaBuilder.struct()
+        .name(schemaAddress)
+        .field(fieldStreet, Schema.STRING_SCHEMA)
+        .parameter(PROTOBUF_TYPE_TAG, tag3)
+        .build();
+
+    Schema parent = SchemaBuilder.struct()
+        .name(schemaPerson)
+        .field(fieldHomeAddr, addrTag2)
+        .field(fieldWorkAddr, addrTag3)
+        .build();
+
+    org.apache.avro.Schema avroSchema = scrubbingAvroData.fromConnectSchema(parent);
+    Schema roundTripped = scrubbingAvroData.toConnectSchema(avroSchema);
+
+    assertEquals(tag2, roundTripped.field(fieldHomeAddr).schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+    assertEquals(tag3, roundTripped.field(fieldWorkAddr).schema()
+        .parameters().get(PROTOBUF_TYPE_TAG));
+  }
+
+  @Test
+  public void testFieldLevelParamsNotWrittenOnFirstOccurrence() {
+    final String schemaAddress = "Address";
+    final String schemaPerson = "Person";
+    final String fieldStreet = "street";
+    final String fieldHome = "home";
+    final String fieldWork = "work";
+    final String tag2 = "2";
+    final String tag3 = "3";
+
+    Schema addrTag2 = SchemaBuilder.struct()
+        .name(schemaAddress)
+        .field(fieldStreet, Schema.STRING_SCHEMA)
+        .parameter(PROTOBUF_TYPE_TAG, tag2)
+        .build();
+
+    Schema addrTag3 = SchemaBuilder.struct()
+        .name(schemaAddress)
+        .field(fieldStreet, Schema.STRING_SCHEMA)
+        .parameter(PROTOBUF_TYPE_TAG, tag3)
+        .build();
+
+    Schema parent = SchemaBuilder.struct()
+        .name(schemaPerson)
+        .field(fieldHome, addrTag2)
+        .field(fieldWork, addrTag3)
+        .build();
+
+    org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(parent);
+
+    org.apache.avro.Schema.Field homeField = avroSchema.getField(fieldHome);
+    org.apache.avro.Schema.Field workField = avroSchema.getField(fieldWork);
+
+    assertNull(homeField.getObjectProp(CONNECT_PARAMETERS_PROP));
+    assertNotNull(workField.getObjectProp(CONNECT_PARAMETERS_PROP));
+  }
+
+  @Test
+  public void testFieldLevelParamsNotWrittenWhenEmpty() {
+    final String schemaAddress = "Address";
+    final String schemaPerson = "Person";
+    final String fieldStreet = "street";
+    final String fieldHome = "home";
+    final String fieldWork = "work";
+
+    Schema addrWithInternalParam = SchemaBuilder.struct()
+        .name(schemaAddress)
+        .field(fieldStreet, Schema.STRING_SCHEMA)
+        .parameter(AvroData.AVRO_FIELD_DEFAULT_FLAG_PROP, "true")
+        .build();
+
+    Schema addrWithRealParam = SchemaBuilder.struct()
+        .name(schemaAddress)
+        .field(fieldStreet, Schema.STRING_SCHEMA)
+        .parameter(PROTOBUF_TYPE_TAG, "3")
+        .build();
+
+    Schema parent = SchemaBuilder.struct()
+        .name(schemaPerson)
+        .field(fieldHome, addrWithInternalParam)
+        .field(fieldWork, addrWithRealParam)
+        .build();
+
+    org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(parent);
+
+    org.apache.avro.Schema.Field homeField = avroSchema.getField(fieldHome);
+    org.apache.avro.Schema.Field workField = avroSchema.getField(fieldWork);
+
+    assertNull(homeField.getObjectProp(CONNECT_PARAMETERS_PROP));
+    assertNotNull(workField.getObjectProp(CONNECT_PARAMETERS_PROP));
   }
 
 }

--- a/kafka-connect-schema-backup-api/pom.xml
+++ b/kafka-connect-schema-backup-api/pom.xml
@@ -44,13 +44,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <release>8</release>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
                 <version>${spotless.maven.plugin.version}</version>

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufConverterBackupTest.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufConverterBackupTest.java
@@ -17,6 +17,7 @@ package io.confluent.connect.protobuf;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -24,10 +25,19 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
 import io.confluent.connect.schema.backup.api.BackupWrapper;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer;
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -43,14 +53,27 @@ public class ProtobufConverterBackupTest {
 
   private static final String TOPIC = "test-topic";
   private static final String SCHEMA_TYPE = "PROTOBUF";
+  private static final String SCHEMA_REGISTRY_URL_CONFIG = "schema.registry.url";
+  private static final String FAKE_SCHEMA_REGISTRY_URL = "http://fake-url";
+  private static final String SCHEMA_BACKUP_ENABLED_CONFIG = "schema.backup.enabled";
   private static final String FIELD_NAME = "name";
   private static final String FIELD_TEXT = "text";
   private static final String FIELD_VALUE = "value";
   private static final String FIELD_DATA = "data";
+  private static final String FIELD_KEY = "key";
+  private static final String FIELD_ID = "id";
+  private static final String FIELD_CITY = "city";
+  private static final String FIELD_HOST = "host";
+  private static final String FIELD_PORT = "port";
+  private static final String VALUE_ALICE = "Alice";
+  private static final String VALUE_BOB = "Bob";
 
   private final SchemaRegistryClient schemaRegistry;
   private final ProtobufConverter converter;
   private final ProtobufConverter plainConverter;
+  private KafkaProtobufSerializer<DynamicMessage> serializer;
+  private KafkaProtobufDeserializer<DynamicMessage> deserializer;
+  private int topicCounter = 0;
 
   public ProtobufConverterBackupTest() {
     schemaRegistry = new MockSchemaRegistryClient(
@@ -62,24 +85,56 @@ public class ProtobufConverterBackupTest {
   @Before
   public void setUp() {
     Map<String, Object> backupConfig = new HashMap<>();
-    backupConfig.put("schema.registry.url", "http://fake-url");
-    backupConfig.put("schema.backup.enabled", "true");
+    backupConfig.put(SCHEMA_REGISTRY_URL_CONFIG, FAKE_SCHEMA_REGISTRY_URL);
+    backupConfig.put(SCHEMA_BACKUP_ENABLED_CONFIG, "true");
     converter.configure(backupConfig, false);
 
-    plainConverter.configure(
-        Collections.singletonMap("schema.registry.url", "http://fake-url"),
-        false);
+    Map<String, Object> plainConfig =
+        Collections.singletonMap(SCHEMA_REGISTRY_URL_CONFIG, FAKE_SCHEMA_REGISTRY_URL);
+
+    plainConverter.configure(plainConfig, false);
+
+    serializer = new KafkaProtobufSerializer<>(schemaRegistry);
+    serializer.configure(plainConfig, false);
+
+    deserializer = new KafkaProtobufDeserializer<>(schemaRegistry);
+    deserializer.configure(plainConfig, false);
+  }
+
+  private String nextTopic() {
+    return TOPIC + "-" + (topicCounter++);
+  }
+
+  private void assertBackupRoundTrip(String topic, ProtobufSchema schema,
+      DynamicMessage message) {
+    byte[] originalBytes = serializer.serialize(topic, null, message, schema);
+    assertNotNull("Serialization should produce bytes", originalBytes);
+
+    SchemaAndValue wrapped = converter.toConnectData(topic, originalBytes);
+    assertEquals(BackupWrapper.NAME, wrapped.schema().name());
+    Struct wrapper = (Struct) wrapped.value();
+    assertNotNull("Raw schema should be captured",
+        wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA));
+
+    byte[] restoredBytes = converter.fromConnectData(
+        topic, wrapped.schema(), wrapped.value());
+    assertNotNull("Restored bytes should not be null", restoredBytes);
+
+    Message original = deserializer.deserialize(topic, originalBytes);
+    Message restored = deserializer.deserialize(topic, restoredBytes);
+    assertEquals("Restored protobuf message must equal original", original, restored);
+    assertFalse("Restored bytes should not be empty", restoredBytes.length == 0);
   }
 
   @Test
   public void testBackupToConnectDataWrapsMetadata() {
     Schema schema = SchemaBuilder.struct()
         .name("TestRecord")
-        .field("id", Schema.STRING_SCHEMA)
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
         .field("count", Schema.INT32_SCHEMA)
         .build();
     Struct value = new Struct(schema)
-        .put("id", "rec-1")
+        .put(FIELD_ID, "rec-1")
         .put("count", 10);
 
     byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
@@ -265,6 +320,651 @@ public class ProtobufConverterBackupTest {
         TOPIC, wrapped.schema(), wrapped.value());
 
     assertArrayEquals(originalBytes, restoredBytes);
+  }
+
+  @Test
+  public void testBackupRoundTripSharedMessageType() {
+    String topic = nextTopic();
+    String proto = "syntax = \"proto3\";\n"
+        + "package io.confluent.test;\n"
+        + "message Person {\n"
+        + "  string name = 1;\n"
+        + "  Address home_addr = 2;\n"
+        + "  Address work_addr = 3;\n"
+        + "}\n"
+        + "message Address {\n"
+        + "  string street = 1;\n"
+        + "  string city = 2;\n"
+        + "}\n";
+
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor personDesc = schema.toDescriptor();
+    Descriptor addressDesc = personDesc.findFieldByName("home_addr").getMessageType();
+
+    DynamicMessage homeAddr = DynamicMessage.newBuilder(addressDesc)
+        .setField(addressDesc.findFieldByName("street"), "123 Home St")
+        .setField(addressDesc.findFieldByName(FIELD_CITY), "Hometown")
+        .build();
+    DynamicMessage workAddr = DynamicMessage.newBuilder(addressDesc)
+        .setField(addressDesc.findFieldByName("street"), "456 Work Ave")
+        .setField(addressDesc.findFieldByName(FIELD_CITY), "Workville")
+        .build();
+    DynamicMessage person = DynamicMessage.newBuilder(personDesc)
+        .setField(personDesc.findFieldByName("name"), VALUE_ALICE)
+        .setField(personDesc.findFieldByName("home_addr"), homeAddr)
+        .setField(personDesc.findFieldByName("work_addr"), workAddr)
+        .build();
+
+    assertBackupRoundTrip(topic, schema, person);
+  }
+
+  @Test
+  public void testBackupRoundTripAllPrimitiveTypes() {
+    String topic = nextTopic();
+    String proto = "syntax = \"proto3\";\n"
+        + "package io.confluent.test;\n"
+        + "message AllPrimitives {\n"
+        + "  int32 int32_val = 1;\n"
+        + "  int64 int64_val = 2;\n"
+        + "  float float_val = 3;\n"
+        + "  double double_val = 4;\n"
+        + "  bool bool_val = 5;\n"
+        + "  string string_val = 6;\n"
+        + "  bytes bytes_val = 7;\n"
+        + "  uint32 uint32_val = 8;\n"
+        + "  uint64 uint64_val = 9;\n"
+        + "  sint32 sint32_val = 10;\n"
+        + "  sint64 sint64_val = 11;\n"
+        + "  fixed32 fixed32_val = 12;\n"
+        + "  fixed64 fixed64_val = 13;\n"
+        + "  sfixed32 sfixed32_val = 14;\n"
+        + "  sfixed64 sfixed64_val = 15;\n"
+        + "}\n";
+
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor desc = schema.toDescriptor();
+
+    DynamicMessage message = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName("int32_val"), 42)
+        .setField(desc.findFieldByName("int64_val"), 123456789L)
+        .setField(desc.findFieldByName("float_val"), 3.14f)
+        .setField(desc.findFieldByName("double_val"), 2.718281828)
+        .setField(desc.findFieldByName("bool_val"), true)
+        .setField(desc.findFieldByName("string_val"), "hello")
+        .setField(desc.findFieldByName("bytes_val"),
+            ByteString.copyFrom(new byte[]{0x01, 0x02, 0x03}))
+        .setField(desc.findFieldByName("uint32_val"), 100)
+        .setField(desc.findFieldByName("uint64_val"), 999999L)
+        .setField(desc.findFieldByName("sint32_val"), -42)
+        .setField(desc.findFieldByName("sint64_val"), -123456789L)
+        .setField(desc.findFieldByName("fixed32_val"), 77)
+        .setField(desc.findFieldByName("fixed64_val"), 88L)
+        .setField(desc.findFieldByName("sfixed32_val"), -77)
+        .setField(desc.findFieldByName("sfixed64_val"), -88L)
+        .build();
+
+    assertBackupRoundTrip(topic, schema, message);
+  }
+
+  @Test
+  public void testBackupRoundTripNestedMessages() {
+    String topic = nextTopic();
+    String proto = "syntax = \"proto3\";\n"
+        + "package io.confluent.test;\n"
+        + "message Order {\n"
+        + "  int32 id = 1;\n"
+        + "  Customer customer = 2;\n"
+        + "  Address shipping = 3;\n"
+        + "}\n"
+        + "message Customer {\n"
+        + "  string name = 1;\n"
+        + "  Address billing = 2;\n"
+        + "}\n"
+        + "message Address {\n"
+        + "  string street = 1;\n"
+        + "  string city = 2;\n"
+        + "  string zip = 3;\n"
+        + "}\n";
+
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor orderDesc = schema.toDescriptor();
+    Descriptor custDesc = orderDesc.findFieldByName("customer").getMessageType();
+    Descriptor addrDesc = orderDesc.findFieldByName("shipping").getMessageType();
+
+    DynamicMessage billingAddr = DynamicMessage.newBuilder(addrDesc)
+        .setField(addrDesc.findFieldByName("street"), "100 Bill Ln")
+        .setField(addrDesc.findFieldByName(FIELD_CITY), "Billtown")
+        .setField(addrDesc.findFieldByName("zip"), "11111")
+        .build();
+    DynamicMessage shippingAddr = DynamicMessage.newBuilder(addrDesc)
+        .setField(addrDesc.findFieldByName("street"), "200 Ship Rd")
+        .setField(addrDesc.findFieldByName(FIELD_CITY), "Shipville")
+        .setField(addrDesc.findFieldByName("zip"), "22222")
+        .build();
+    DynamicMessage customer = DynamicMessage.newBuilder(custDesc)
+        .setField(custDesc.findFieldByName("name"), VALUE_BOB)
+        .setField(custDesc.findFieldByName("billing"), billingAddr)
+        .build();
+    DynamicMessage order = DynamicMessage.newBuilder(orderDesc)
+        .setField(orderDesc.findFieldByName(FIELD_ID), 1001)
+        .setField(orderDesc.findFieldByName("customer"), customer)
+        .setField(orderDesc.findFieldByName("shipping"), shippingAddr)
+        .build();
+
+    assertBackupRoundTrip(topic, schema, order);
+  }
+
+  @Test
+  public void testBackupRoundTripRepeatedFields() {
+    String topic = nextTopic();
+    String proto = "syntax = \"proto3\";\n"
+        + "package io.confluent.test;\n"
+        + "message Classroom {\n"
+        + "  string name = 1;\n"
+        + "  repeated string students = 2;\n"
+        + "  repeated int32 scores = 3;\n"
+        + "  repeated Student enrollments = 4;\n"
+        + "}\n"
+        + "message Student {\n"
+        + "  string name = 1;\n"
+        + "  int32 grade = 2;\n"
+        + "}\n";
+
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor classDesc = schema.toDescriptor();
+    Descriptor studentDesc = classDesc.findFieldByName("enrollments").getMessageType();
+
+    DynamicMessage s1 = DynamicMessage.newBuilder(studentDesc)
+        .setField(studentDesc.findFieldByName("name"), VALUE_ALICE)
+        .setField(studentDesc.findFieldByName("grade"), 95)
+        .build();
+    DynamicMessage s2 = DynamicMessage.newBuilder(studentDesc)
+        .setField(studentDesc.findFieldByName("name"), VALUE_BOB)
+        .setField(studentDesc.findFieldByName("grade"), 88)
+        .build();
+
+    DynamicMessage classroom = DynamicMessage.newBuilder(classDesc)
+        .setField(classDesc.findFieldByName("name"), "Math 101")
+        .addRepeatedField(classDesc.findFieldByName("students"), VALUE_ALICE)
+        .addRepeatedField(classDesc.findFieldByName("students"), VALUE_BOB)
+        .addRepeatedField(classDesc.findFieldByName("students"), "Charlie")
+        .addRepeatedField(classDesc.findFieldByName("scores"), 95)
+        .addRepeatedField(classDesc.findFieldByName("scores"), 88)
+        .addRepeatedField(classDesc.findFieldByName("scores"), 72)
+        .addRepeatedField(classDesc.findFieldByName("enrollments"), s1)
+        .addRepeatedField(classDesc.findFieldByName("enrollments"), s2)
+        .build();
+
+    assertBackupRoundTrip(topic, schema, classroom);
+  }
+
+  @Test
+  public void testBackupRoundTripMapFields() {
+    String topic = nextTopic();
+    String proto = "syntax = \"proto3\";\n"
+        + "package io.confluent.test;\n"
+        + "message Config {\n"
+        + "  string name = 1;\n"
+        + "  map<string, string> properties = 2;\n"
+        + "  map<string, int32> counts = 3;\n"
+        + "  map<int32, string> id_names = 4;\n"
+        + "}\n";
+
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor desc = schema.toDescriptor();
+
+    FieldDescriptor propsField = desc.findFieldByName("properties");
+    Descriptor propsEntry = propsField.getMessageType();
+    FieldDescriptor countsField = desc.findFieldByName("counts");
+    Descriptor countsEntry = countsField.getMessageType();
+    FieldDescriptor idNamesField = desc.findFieldByName("id_names");
+    Descriptor idNamesEntry = idNamesField.getMessageType();
+
+    DynamicMessage.Builder builder = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName("name"), "test-config");
+
+    builder.addRepeatedField(propsField,
+        DynamicMessage.newBuilder(propsEntry)
+            .setField(propsEntry.findFieldByName(FIELD_KEY), FIELD_HOST)
+            .setField(propsEntry.findFieldByName("value"), "localhost")
+            .build());
+    builder.addRepeatedField(propsField,
+        DynamicMessage.newBuilder(propsEntry)
+            .setField(propsEntry.findFieldByName(FIELD_KEY), FIELD_PORT)
+            .setField(propsEntry.findFieldByName("value"), "8080")
+            .build());
+
+    builder.addRepeatedField(countsField,
+        DynamicMessage.newBuilder(countsEntry)
+            .setField(countsEntry.findFieldByName(FIELD_KEY), "errors")
+            .setField(countsEntry.findFieldByName("value"), 5)
+            .build());
+
+    builder.addRepeatedField(idNamesField,
+        DynamicMessage.newBuilder(idNamesEntry)
+            .setField(idNamesEntry.findFieldByName(FIELD_KEY), 1)
+            .setField(idNamesEntry.findFieldByName("value"), "first")
+            .build());
+
+    assertBackupRoundTrip(topic, schema, builder.build());
+  }
+
+  @Test
+  public void testBackupRoundTripEnumType() {
+    String topic = nextTopic();
+    String proto = "syntax = \"proto3\";\n"
+        + "package io.confluent.test;\n"
+        + "message Event {\n"
+        + "  string id = 1;\n"
+        + "  EventType type = 2;\n"
+        + "  Priority priority = 3;\n"
+        + "}\n"
+        + "enum EventType {\n"
+        + "  UNKNOWN = 0;\n"
+        + "  CLICK = 1;\n"
+        + "  VIEW = 2;\n"
+        + "  PURCHASE = 3;\n"
+        + "}\n"
+        + "enum Priority {\n"
+        + "  LOW = 0;\n"
+        + "  MEDIUM = 1;\n"
+        + "  HIGH = 2;\n"
+        + "}\n";
+
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor desc = schema.toDescriptor();
+
+    DynamicMessage event = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName(FIELD_ID), "evt-123")
+        .setField(desc.findFieldByName("type"),
+            desc.findFieldByName("type").getEnumType().findValueByName("PURCHASE"))
+        .setField(desc.findFieldByName("priority"),
+            desc.findFieldByName("priority").getEnumType().findValueByName("HIGH"))
+        .build();
+
+    assertBackupRoundTrip(topic, schema, event);
+  }
+
+  @Test
+  public void testBackupRoundTripOneofFields() {
+    String topic = nextTopic();
+    String proto = "syntax = \"proto3\";\n"
+        + "package io.confluent.test;\n"
+        + "message Notification {\n"
+        + "  string id = 1;\n"
+        + "  oneof channel {\n"
+        + "    string email = 2;\n"
+        + "    string sms = 3;\n"
+        + "    PushConfig push = 4;\n"
+        + "  }\n"
+        + "}\n"
+        + "message PushConfig {\n"
+        + "  string device_token = 1;\n"
+        + "  bool silent = 2;\n"
+        + "}\n";
+
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor notifDesc = schema.toDescriptor();
+    Descriptor pushDesc = notifDesc.findFieldByName("push").getMessageType();
+
+    // Test with string oneof branch
+    DynamicMessage emailNotif = DynamicMessage.newBuilder(notifDesc)
+        .setField(notifDesc.findFieldByName(FIELD_ID), "n-1")
+        .setField(notifDesc.findFieldByName("email"), "user@test.com")
+        .build();
+    assertBackupRoundTrip(topic, schema, emailNotif);
+
+    // Test with message oneof branch
+    String topic2 = nextTopic();
+    DynamicMessage pushNotif = DynamicMessage.newBuilder(notifDesc)
+        .setField(notifDesc.findFieldByName(FIELD_ID), "n-2")
+        .setField(notifDesc.findFieldByName("push"),
+            DynamicMessage.newBuilder(pushDesc)
+                .setField(pushDesc.findFieldByName("device_token"), "tok-abc")
+                .setField(pushDesc.findFieldByName("silent"), true)
+                .build())
+        .build();
+    assertBackupRoundTrip(topic2, schema, pushNotif);
+  }
+
+  @Test
+  public void testBackupRoundTripOptionalFields() {
+    String topic = nextTopic();
+    String proto = "syntax = \"proto3\";\n"
+        + "package io.confluent.test;\n"
+        + "message Profile {\n"
+        + "  string name = 1;\n"
+        + "  optional string nickname = 2;\n"
+        + "  optional int32 age = 3;\n"
+        + "  optional bool active = 4;\n"
+        + "  string email = 5;\n"
+        + "}\n";
+
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor desc = schema.toDescriptor();
+
+    // With optional fields set
+    DynamicMessage withOptionals = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName("name"), VALUE_ALICE)
+        .setField(desc.findFieldByName("nickname"), "Ali")
+        .setField(desc.findFieldByName("age"), 30)
+        .setField(desc.findFieldByName("active"), true)
+        .setField(desc.findFieldByName("email"), "alice@test.com")
+        .build();
+    assertBackupRoundTrip(topic, schema, withOptionals);
+
+    // With optional fields NOT set (defaults)
+    String topic2 = nextTopic();
+    DynamicMessage withoutOptionals = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName("name"), VALUE_BOB)
+        .setField(desc.findFieldByName("email"), "bob@test.com")
+        .build();
+    assertBackupRoundTrip(topic2, schema, withoutOptionals);
+  }
+
+  @Test
+  public void testBackupRoundTripNestedEnum() {
+    String topic = nextTopic();
+    String proto = "syntax = \"proto3\";\n"
+        + "package io.confluent.test;\n"
+        + "message Outer {\n"
+        + "  string label = 1;\n"
+        + "  Inner details = 2;\n"
+        + "  message Inner {\n"
+        + "    string value = 1;\n"
+        + "    enum Status {\n"
+        + "      DRAFT = 0;\n"
+        + "      PUBLISHED = 1;\n"
+        + "      ARCHIVED = 2;\n"
+        + "    }\n"
+        + "    Status status = 2;\n"
+        + "  }\n"
+        + "}\n";
+
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor outerDesc = schema.toDescriptor();
+    Descriptor innerDesc = outerDesc.findFieldByName("details").getMessageType();
+
+    DynamicMessage inner = DynamicMessage.newBuilder(innerDesc)
+        .setField(innerDesc.findFieldByName("value"), "content")
+        .setField(innerDesc.findFieldByName("status"),
+            innerDesc.findFieldByName("status").getEnumType()
+                .findValueByName("PUBLISHED"))
+        .build();
+    DynamicMessage outer = DynamicMessage.newBuilder(outerDesc)
+        .setField(outerDesc.findFieldByName("label"), "doc-1")
+        .setField(outerDesc.findFieldByName("details"), inner)
+        .build();
+
+    assertBackupRoundTrip(topic, schema, outer);
+  }
+
+  @Test
+  public void testBackupRoundTripSharedTypeAtThreeFields() {
+    String topic = nextTopic();
+    String proto = "syntax = \"proto3\";\n"
+        + "package io.confluent.test;\n"
+        + "message Company {\n"
+        + "  string name = 1;\n"
+        + "  Address hq = 2;\n"
+        + "  Address warehouse = 3;\n"
+        + "  Address billing = 4;\n"
+        + "}\n"
+        + "message Address {\n"
+        + "  string line1 = 1;\n"
+        + "  string city = 2;\n"
+        + "  string country = 3;\n"
+        + "}\n";
+
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor companyDesc = schema.toDescriptor();
+    Descriptor addrDesc = companyDesc.findFieldByName("hq").getMessageType();
+
+    DynamicMessage hq = DynamicMessage.newBuilder(addrDesc)
+        .setField(addrDesc.findFieldByName("line1"), "1 HQ Plaza")
+        .setField(addrDesc.findFieldByName(FIELD_CITY), "San Francisco")
+        .setField(addrDesc.findFieldByName("country"), "US")
+        .build();
+    DynamicMessage warehouse = DynamicMessage.newBuilder(addrDesc)
+        .setField(addrDesc.findFieldByName("line1"), "50 Warehouse Dr")
+        .setField(addrDesc.findFieldByName(FIELD_CITY), "Denver")
+        .setField(addrDesc.findFieldByName("country"), "US")
+        .build();
+    DynamicMessage billing = DynamicMessage.newBuilder(addrDesc)
+        .setField(addrDesc.findFieldByName("line1"), "PO Box 100")
+        .setField(addrDesc.findFieldByName(FIELD_CITY), "Austin")
+        .setField(addrDesc.findFieldByName("country"), "US")
+        .build();
+    DynamicMessage company = DynamicMessage.newBuilder(companyDesc)
+        .setField(companyDesc.findFieldByName("name"), "Confluent")
+        .setField(companyDesc.findFieldByName("hq"), hq)
+        .setField(companyDesc.findFieldByName("warehouse"), warehouse)
+        .setField(companyDesc.findFieldByName("billing"), billing)
+        .build();
+
+    assertBackupRoundTrip(topic, schema, company);
+  }
+
+  @Test
+  public void testBackupRoundTripNonContiguousTags() {
+    String topic = nextTopic();
+    String proto = "syntax = \"proto3\";\n"
+        + "package io.confluent.test;\n"
+        + "message Sparse {\n"
+        + "  string name = 1;\n"
+        + "  int32 code = 5;\n"
+        + "  bool active = 10;\n"
+        + "  string desc = 20;\n"
+        + "}\n";
+
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor desc = schema.toDescriptor();
+
+    DynamicMessage message = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName("name"), "sparse-test")
+        .setField(desc.findFieldByName("code"), 404)
+        .setField(desc.findFieldByName("active"), false)
+        .setField(desc.findFieldByName("desc"), "not found")
+        .build();
+
+    assertBackupRoundTrip(topic, schema, message);
+  }
+
+  @Test
+  public void testBackupRoundTripRepeatedNestedWithSharedType() {
+    String topic = nextTopic();
+    String proto = "syntax = \"proto3\";\n"
+        + "package io.confluent.test;\n"
+        + "message Team {\n"
+        + "  string name = 1;\n"
+        + "  repeated Member members = 2;\n"
+        + "}\n"
+        + "message Member {\n"
+        + "  string name = 1;\n"
+        + "  Role role = 2;\n"
+        + "}\n"
+        + "message Role {\n"
+        + "  string title = 1;\n"
+        + "  int32 level = 2;\n"
+        + "}\n";
+
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor teamDesc = schema.toDescriptor();
+    Descriptor memberDesc = teamDesc.findFieldByName("members").getMessageType();
+    Descriptor roleDesc = memberDesc.findFieldByName("role").getMessageType();
+
+    DynamicMessage r1 = DynamicMessage.newBuilder(roleDesc)
+        .setField(roleDesc.findFieldByName("title"), "Engineer")
+        .setField(roleDesc.findFieldByName("level"), 3)
+        .build();
+    DynamicMessage r2 = DynamicMessage.newBuilder(roleDesc)
+        .setField(roleDesc.findFieldByName("title"), "Manager")
+        .setField(roleDesc.findFieldByName("level"), 5)
+        .build();
+    DynamicMessage m1 = DynamicMessage.newBuilder(memberDesc)
+        .setField(memberDesc.findFieldByName("name"), VALUE_ALICE)
+        .setField(memberDesc.findFieldByName("role"), r1)
+        .build();
+    DynamicMessage m2 = DynamicMessage.newBuilder(memberDesc)
+        .setField(memberDesc.findFieldByName("name"), VALUE_BOB)
+        .setField(memberDesc.findFieldByName("role"), r2)
+        .build();
+    DynamicMessage team = DynamicMessage.newBuilder(teamDesc)
+        .setField(teamDesc.findFieldByName("name"), "Platform")
+        .addRepeatedField(teamDesc.findFieldByName("members"), m1)
+        .addRepeatedField(teamDesc.findFieldByName("members"), m2)
+        .build();
+
+    assertBackupRoundTrip(topic, schema, team);
+  }
+
+  @Test
+  public void testBackupRoundTripMapWithMessageValue() {
+    String topic = nextTopic();
+    String proto = "syntax = \"proto3\";\n"
+        + "package io.confluent.test;\n"
+        + "message Registry {\n"
+        + "  string id = 1;\n"
+        + "  map<string, Service> services = 2;\n"
+        + "}\n"
+        + "message Service {\n"
+        + "  string host = 1;\n"
+        + "  int32 port = 2;\n"
+        + "  bool healthy = 3;\n"
+        + "}\n";
+
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor regDesc = schema.toDescriptor();
+    FieldDescriptor svcField = regDesc.findFieldByName("services");
+    Descriptor entryDesc = svcField.getMessageType();
+    Descriptor svcDesc = entryDesc.findFieldByName("value").getMessageType();
+
+    DynamicMessage svc1 = DynamicMessage.newBuilder(svcDesc)
+        .setField(svcDesc.findFieldByName(FIELD_HOST), "api.local")
+        .setField(svcDesc.findFieldByName(FIELD_PORT), 8080)
+        .setField(svcDesc.findFieldByName("healthy"), true)
+        .build();
+    DynamicMessage svc2 = DynamicMessage.newBuilder(svcDesc)
+        .setField(svcDesc.findFieldByName(FIELD_HOST), "db.local")
+        .setField(svcDesc.findFieldByName(FIELD_PORT), 5432)
+        .setField(svcDesc.findFieldByName("healthy"), false)
+        .build();
+
+    DynamicMessage registry = DynamicMessage.newBuilder(regDesc)
+        .setField(regDesc.findFieldByName(FIELD_ID), "cluster-1")
+        .addRepeatedField(svcField,
+            DynamicMessage.newBuilder(entryDesc)
+                .setField(entryDesc.findFieldByName(FIELD_KEY), "api")
+                .setField(entryDesc.findFieldByName("value"), svc1)
+                .build())
+        .addRepeatedField(svcField,
+            DynamicMessage.newBuilder(entryDesc)
+                .setField(entryDesc.findFieldByName(FIELD_KEY), "database")
+                .setField(entryDesc.findFieldByName("value"), svc2)
+                .build())
+        .build();
+
+    assertBackupRoundTrip(topic, schema, registry);
+  }
+
+  @Test
+  public void testBackupRoundTripDefaultsAndEmpty() {
+    String topic = nextTopic();
+    String proto = "syntax = \"proto3\";\n"
+        + "package io.confluent.test;\n"
+        + "message Defaults {\n"
+        + "  string name = 1;\n"
+        + "  int32 count = 2;\n"
+        + "  bool flag = 3;\n"
+        + "  double rate = 4;\n"
+        + "}\n";
+
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor desc = schema.toDescriptor();
+
+    // All defaults (empty message — proto3 defaults are 0/""/false)
+    DynamicMessage empty = DynamicMessage.newBuilder(desc).build();
+    assertBackupRoundTrip(topic, schema, empty);
+  }
+
+  @Test
+  public void testBackupRoundTripComplexCombined() {
+    String topic = nextTopic();
+    String proto = "syntax = \"proto3\";\n"
+        + "package io.confluent.test;\n"
+        + "message ComplexRecord {\n"
+        + "  string id = 1;\n"
+        + "  repeated Tag tags = 2;\n"
+        + "  map<string, string> metadata = 3;\n"
+        + "  optional string description = 4;\n"
+        + "  Status status = 5;\n"
+        + "  oneof target {\n"
+        + "    string url = 6;\n"
+        + "    Endpoint endpoint = 7;\n"
+        + "  }\n"
+        + "  Endpoint primary = 8;\n"
+        + "  Endpoint secondary = 9;\n"
+        + "}\n"
+        + "message Tag {\n"
+        + "  string key = 1;\n"
+        + "  string value = 2;\n"
+        + "}\n"
+        + "message Endpoint {\n"
+        + "  string host = 1;\n"
+        + "  int32 port = 2;\n"
+        + "}\n"
+        + "enum Status {\n"
+        + "  UNKNOWN = 0;\n"
+        + "  ACTIVE = 1;\n"
+        + "  INACTIVE = 2;\n"
+        + "}\n";
+
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor recDesc = schema.toDescriptor();
+    Descriptor tagDesc = recDesc.findFieldByName("tags").getMessageType();
+    Descriptor epDesc = recDesc.findFieldByName("primary").getMessageType();
+    FieldDescriptor metaField = recDesc.findFieldByName("metadata");
+    Descriptor metaEntry = metaField.getMessageType();
+
+    DynamicMessage tag1 = DynamicMessage.newBuilder(tagDesc)
+        .setField(tagDesc.findFieldByName(FIELD_KEY), "env")
+        .setField(tagDesc.findFieldByName("value"), "prod")
+        .build();
+    DynamicMessage tag2 = DynamicMessage.newBuilder(tagDesc)
+        .setField(tagDesc.findFieldByName(FIELD_KEY), "region")
+        .setField(tagDesc.findFieldByName("value"), "us-west")
+        .build();
+    DynamicMessage primary = DynamicMessage.newBuilder(epDesc)
+        .setField(epDesc.findFieldByName(FIELD_HOST), "primary.local")
+        .setField(epDesc.findFieldByName(FIELD_PORT), 443)
+        .build();
+    DynamicMessage secondary = DynamicMessage.newBuilder(epDesc)
+        .setField(epDesc.findFieldByName(FIELD_HOST), "secondary.local")
+        .setField(epDesc.findFieldByName(FIELD_PORT), 8443)
+        .build();
+    DynamicMessage oneofEndpoint = DynamicMessage.newBuilder(epDesc)
+        .setField(epDesc.findFieldByName(FIELD_HOST), "target.local")
+        .setField(epDesc.findFieldByName(FIELD_PORT), 9090)
+        .build();
+
+    DynamicMessage record = DynamicMessage.newBuilder(recDesc)
+        .setField(recDesc.findFieldByName(FIELD_ID), "rec-complex")
+        .addRepeatedField(recDesc.findFieldByName("tags"), tag1)
+        .addRepeatedField(recDesc.findFieldByName("tags"), tag2)
+        .addRepeatedField(metaField,
+            DynamicMessage.newBuilder(metaEntry)
+                .setField(metaEntry.findFieldByName(FIELD_KEY), "owner")
+                .setField(metaEntry.findFieldByName("value"), "team-a")
+                .build())
+        .setField(recDesc.findFieldByName("description"), "complex test")
+        .setField(recDesc.findFieldByName("status"),
+            recDesc.findFieldByName("status").getEnumType().findValueByName("ACTIVE"))
+        .setField(recDesc.findFieldByName("endpoint"), oneofEndpoint)
+        .setField(recDesc.findFieldByName("primary"), primary)
+        .setField(recDesc.findFieldByName("secondary"), secondary)
+        .build();
+
+    assertBackupRoundTrip(topic, schema, record);
   }
 
   @Test


### PR DESCRIPTION
What
----
- Fix Avro named-type deduplication losing per-field `connect.parameters` (e.g. Protobuf `Tag`)
    when the same named type (RECORD, ENUM, FIXED) is used at multiple fields.
    When Avro deduplicates a named type, the 2nd+ occurrence becomes a bare name reference
    that drops `connect.parameters`. This caused Protobuf backup/restore to fail with
    `Field number X has already been used` when the same message type appeared at multiple
    fields with different tags (e.g. `Address home_addr = 7; Address work_addr = 8;`).

- Store `connect.parameters` as an Avro **field-level property** via `field.addProp()` on
    deduplicated named-type fields, and read them back on the reverse path (Avro to Connect),
    overriding type-level parameters where they differ. Additive and backward compatible:
    old code transparently ignores unknown Avro field properties (Avro spec), old data
    without field-level properties falls back to type-level parameters (existing behavior).

- Field-level properties are only written on the 2nd+ occurrence of a named type (checked
    via `cycleReferences`), so first-occurrence fields are unchanged and existing schema
    equality assertions are preserved.

- Covers all named Avro types subject to deduplication: RECORD, ENUM, and FIXED, including
    UNION branches containing named types (i.e. optional fields).

Checklist
------------------
- **[N]** Contains customer facing changes? Including API/behavior changes
- **[N]** Is this change gated behind config(s)?
    - No config needed. The fix is always active and backward compatible.
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - 14 new `AvroDataTest` round-trip tests: shared struct (2/3 fields), shared enum,
      nested shared types, optional/null, repeated, map with struct values, all primitives,
      and a strict-validation test exercising every type in one round-trip.
    - 15 new `ProtobufConverterBackupTest` round-trip tests: all 15 primitive types,
      nested messages, repeated, maps, enums, oneof, optional, non-contiguous tags,
      shared types at 3 fields, and a combined complex test.
    - E2E validated in Docker (Connect 8.3.0): Protobuf with shared Address at 3 fields,
      shared Status enum at 2 fields, SR references across 3 subjects, all primitives,
      repeated, map, optional, oneof, tombstone. Round-tripped through both AvroFormat
      and ParquetFormat.
- **[N]** Does this change require modifying existing system tests or adding new system tests?
- **[N]** Must this be released together with other change(s), either in this repo or another one?

References
----------
JIRA: INIT-5113

Backup and Restore feature. Fixes Issue (Protobuf shared message type at multiple fields).
**Root cause:** Avro spec defines named types inline on first occurrence and uses bare name
references for subsequent occurrences, which loses `connect.parameters` containing
Protobuf field tags.

Test & Review
-------------

# Unit tests (504 total )

Backward compatibility:

| Writer | Reader | Behavior |
|--------|--------|----------|
| Old | Old | Tag lost on 2nd ref (existing bug) |
| New | Old | Field prop ignored by old code (Avro spec) |
| Old | New | No field prop, falls back to type-level params |
| **New** | **New** | **Field-level params override, correct round-trip** |

Open questions / Follow-ups
--------------------------
- `kafka-connect-avro-data` JAR is bundled in multiple classpaths (worker serde-tools,
  S3 plugin lib, confluent-security). All must be updated for the fix to take effect in
  the full backup/restore pipeline.
- ParquetFormat uses Avro schemas internally, so this fix applies to both AvroFormat and
  ParquetFormat without additional changes.
