### PR TITLE
Enforce association lifecycle invariants

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/AssociationCreateOrUpdateInfo.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/AssociationCreateOrUpdateInfo.java
@@ -152,24 +152,37 @@ public class AssociationCreateOrUpdateInfo {
   }
 
   /**
-   * Applies defaults for association creation or upsert.
-   * For CREATE: schema implies frozen STRONG; frozen=false or WEAK with schema are rejected.
-   * For UPSERT: schema implies non-frozen STRONG; frozen and lifecycle are only defaulted if null.
+   * Applies defaults for an association that does not yet exist. Only call this while creating
+   * the association: an upsert that updates an existing one keeps that association's stored
+   * lifecycle and would be wrongly rejected here for carrying a schema.
+   *
+   * <p>For a create op a schema implies frozen STRONG, and frozen=false or WEAK alongside a
+   * schema are rejected. For an upsert op no schema is accepted at all, since a schema implies
+   * a topic-owned STRONG association and those can only be created together with the topic.
+   * Either way frozen and lifecycle are defaulted when null.
+   *
+   * <p>The matching check on an explicit STRONG lifecycle lives in the registry, which can
+   * exempt subjects in IMPORT mode.
+   *
+   * @param isCreate whether this is a create op rather than an upsert op
    */
   public void applyDefaults(boolean isCreate) {
+    if (!isCreate && getSchema() != null) {
+      throw new IllegalPropertyException(
+          "schema", "cannot be provided when adding an association to an existing topic; "
+              + "an association with a schema must be created with the topic");
+    }
     if (getSchema() != null) {
       if (getLifecycle() == LifecyclePolicy.WEAK) {
         throw new IllegalPropertyException(
             "lifecycle", "cannot be WEAK when schema is provided");
       }
-      if (getFrozen() != null && getFrozen() != isCreate) {
+      if (Boolean.FALSE.equals(getFrozen())) {
         throw new IllegalPropertyException(
-            "frozen", isCreate
-                ? "cannot be false when schema is provided for create"
-                : "cannot be true when creating via upsert; use create instead");
+            "frozen", "cannot be false when a schema is provided");
       }
       setLifecycle(LifecyclePolicy.STRONG);
-      setFrozen(isCreate);
+      setFrozen(true);
     } else {
       if (getFrozen() == null) {
         setFrozen(false);

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/AssociationCreateOrUpdateOp.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/AssociationCreateOrUpdateOp.java
@@ -143,24 +143,37 @@ public abstract class AssociationCreateOrUpdateOp extends AssociationOp {
   }
 
   /**
-   * Applies defaults for association creation or upsert.
-   * For CREATE: schema implies frozen STRONG; frozen=false or WEAK with schema are rejected.
-   * For UPSERT: schema implies non-frozen STRONG; frozen and lifecycle are only defaulted if null.
+   * Applies defaults for an association that does not yet exist. Only call this while creating
+   * the association: an upsert that updates an existing one keeps that association's stored
+   * lifecycle and would be wrongly rejected here for carrying a schema.
+   *
+   * <p>For a create op a schema implies frozen STRONG, and frozen=false or WEAK alongside a
+   * schema are rejected. For an upsert op no schema is accepted at all, since a schema implies
+   * a topic-owned STRONG association and those can only be created together with the topic.
+   * Either way frozen and lifecycle are defaulted when null.
+   *
+   * <p>The matching check on an explicit STRONG lifecycle lives in the registry, which can
+   * exempt subjects in IMPORT mode.
+   *
+   * @param isCreate whether this is a create op rather than an upsert op
    */
   public void applyDefaults(boolean isCreate) {
+    if (!isCreate && getSchema() != null) {
+      throw new IllegalPropertyException(
+          "schema", "cannot be provided when adding an association to an existing topic; "
+              + "an association with a schema must be created with the topic");
+    }
     if (getSchema() != null) {
       if (getLifecycle() == LifecyclePolicy.WEAK) {
         throw new IllegalPropertyException(
             "lifecycle", "cannot be WEAK when schema is provided");
       }
-      if (getFrozen() != null && getFrozen() != isCreate) {
+      if (Boolean.FALSE.equals(getFrozen())) {
         throw new IllegalPropertyException(
-            "frozen", isCreate
-                ? "cannot be false when schema is provided for create"
-                : "cannot be true when creating via upsert; use create instead");
+            "frozen", "cannot be false when a schema is provided");
       }
       setLifecycle(LifecyclePolicy.STRONG);
-      setFrozen(isCreate);
+      setFrozen(true);
     } else {
       if (getFrozen() == null) {
         setFrozen(false);

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/AssociationCreateOrUpdateRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/AssociationCreateOrUpdateRequest.java
@@ -30,6 +30,7 @@ import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -59,12 +60,23 @@ public class AssociationCreateOrUpdateRequest {
 
   public AssociationCreateOrUpdateRequest(
       AssociationOpRequest request, AssociationOp op) {
+    this(request, ImmutableList.of((AssociationCreateOrUpdateOp) op));
+  }
+
+  /**
+   * Builds a single request carrying every op in {@code ops}, so that a batch can apply them
+   * as a unit. Repeated association types are rejected when the request is applied.
+   */
+  public AssociationCreateOrUpdateRequest(
+      AssociationOpRequest request, List<? extends AssociationCreateOrUpdateOp> ops) {
     this(
         request.getResourceName(),
         request.getResourceNamespace(),
         request.getResourceId(),
         request.getResourceType(),
-        ImmutableList.of(new AssociationCreateOrUpdateInfo((AssociationCreateOrUpdateOp) op))
+        ops.stream()
+            .map(AssociationCreateOrUpdateInfo::new)
+            .collect(Collectors.toList())
     );
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/AssociationOpRequest.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/AssociationOpRequest.java
@@ -28,8 +28,10 @@ import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.IllegalPropertyException;
 import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -141,6 +143,16 @@ public class AssociationOpRequest {
     return JacksonMapper.INSTANCE.writeValueAsString(this);
   }
 
+  private static String associationTypeOf(AssociationOp op) {
+    if (op instanceof AssociationCreateOrUpdateOp) {
+      return ((AssociationCreateOrUpdateOp) op).getAssociationType();
+    }
+    if (op instanceof AssociationDeleteOp) {
+      return ((AssociationDeleteOp) op).getAssociationType();
+    }
+    return null;
+  }
+
   // Validates resource fields, then for each op: validates the op, defaults
   // the subject to :.ns:name-type for STRONG associations, and enforces that
   // frozen associations use the default subject.
@@ -161,8 +173,16 @@ public class AssociationOpRequest {
     if (getAssociations() == null || getAssociations().isEmpty()) {
       throw new IllegalPropertyException("associations", "cannot be null or empty");
     }
+    Set<String> associationTypes = new HashSet<>();
     for (AssociationOp op : getAssociations()) {
       op.validate(dryRun);
+      String associationType = associationTypeOf(op);
+      if (associationType != null && !associationTypes.add(associationType)) {
+        throw new IllegalPropertyException(
+            "associationType",
+            "may only appear once per request, but '" + associationType + "' appears more"
+                + " than once");
+      }
       if (op instanceof AssociationCreateOrUpdateOp) {
         AssociationCreateOrUpdateOp createOrUpdateOp = (AssociationCreateOrUpdateOp) op;
         if (op instanceof AssociationCreateOp) {

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/AssociationsRequestTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/AssociationsRequestTest.java
@@ -213,6 +213,105 @@ public class AssociationsRequestTest {
     info.validate(false, false);
   }
 
+  // An upsert may only create a WEAK association: a STRONG association is owned by its topic
+  // and has to be created with it, and a schema implies STRONG.
+
+  @Test(expected = IllegalPropertyException.class)
+  public void testUpsertInfoCreatingWithSchemaAndSubjectThrows() {
+    RegisterSchemaRequest schema = new RegisterSchemaRequest();
+    schema.setSchema("{\"type\":\"string\"}");
+    AssociationCreateOrUpdateInfo info = new AssociationCreateOrUpdateInfo(
+        "test-subject", null, null, null, schema, null);
+    info.applyDefaults(false);
+  }
+
+  @Test(expected = IllegalPropertyException.class)
+  public void testUpsertInfoCreatingWithSchemaAndStrongLifecycleThrows() {
+    RegisterSchemaRequest schema = new RegisterSchemaRequest();
+    schema.setSchema("{\"type\":\"string\"}");
+    AssociationCreateOrUpdateInfo info = new AssociationCreateOrUpdateInfo(
+        "test-subject", null, LifecyclePolicy.STRONG, null, schema, null);
+    info.applyDefaults(false);
+  }
+
+  @Test(expected = IllegalPropertyException.class)
+  public void testUpsertInfoCreatingWithSchemaAndNoSubjectThrows() {
+    RegisterSchemaRequest schema = new RegisterSchemaRequest();
+    schema.setSchema("{\"type\":\"string\"}");
+    AssociationCreateOrUpdateInfo info = new AssociationCreateOrUpdateInfo(
+        null, null, null, null, schema, null);
+    info.applyDefaults(false);
+  }
+
+  /**
+   * An explicit STRONG lifecycle without a schema is left alone here: the registry rejects it,
+   * so that subjects in IMPORT mode can be exempted.
+   */
+  @Test
+  public void testUpsertInfoCreatingWithStrongLifecycleAndNoSchemaIsLeftToRegistry() {
+    AssociationCreateOrUpdateInfo info = new AssociationCreateOrUpdateInfo(
+        "test-subject", null, LifecyclePolicy.STRONG, null, null, null);
+    info.applyDefaults(false);
+    assertEquals(LifecyclePolicy.STRONG, info.getLifecycle());
+    assertEquals(Boolean.FALSE, info.getFrozen());
+  }
+
+  @Test
+  public void testUpsertInfoCreatingFrozenStrongKeepsFrozenForImport() {
+    AssociationCreateOrUpdateInfo info = new AssociationCreateOrUpdateInfo(
+        "test-subject", null, LifecyclePolicy.STRONG, true, null, null);
+    info.applyDefaults(false);
+    assertEquals(LifecyclePolicy.STRONG, info.getLifecycle());
+    assertEquals(Boolean.TRUE, info.getFrozen());
+  }
+
+  @Test
+  public void testUpsertInfoCreatingWeakDoesNotThrow() {
+    AssociationCreateOrUpdateInfo info = new AssociationCreateOrUpdateInfo(
+        "test-subject", null, null, null, null, null);
+    info.applyDefaults(false);
+    assertEquals(LifecyclePolicy.WEAK, info.getLifecycle());
+    assertEquals(Boolean.FALSE, info.getFrozen());
+  }
+
+  @Test
+  public void testCreateInfoWithSchemaAndSubjectStillDefaultsToStrongFrozen() {
+    RegisterSchemaRequest schema = new RegisterSchemaRequest();
+    schema.setSchema("{\"type\":\"string\"}");
+    AssociationCreateOrUpdateInfo info = new AssociationCreateOrUpdateInfo(
+        "test-subject", null, null, null, schema, null);
+    info.applyDefaults(true);
+    assertEquals(LifecyclePolicy.STRONG, info.getLifecycle());
+    assertEquals(Boolean.TRUE, info.getFrozen());
+  }
+
+  @Test(expected = IllegalPropertyException.class)
+  public void testUpsertOpCreatingWithSchemaAndSubjectThrows() {
+    RegisterSchemaRequest schema = new RegisterSchemaRequest();
+    schema.setSchema("{\"type\":\"string\"}");
+    AssociationUpsertOp op = new AssociationUpsertOp(
+        "test-subject", null, null, null, schema, null);
+    op.applyDefaults(false);
+  }
+
+  @Test(expected = IllegalPropertyException.class)
+  public void testUpsertOpCreatingWithSchemaAndNoSubjectThrows() {
+    RegisterSchemaRequest schema = new RegisterSchemaRequest();
+    schema.setSchema("{\"type\":\"string\"}");
+    AssociationUpsertOp op = new AssociationUpsertOp(
+        null, null, null, null, schema, null);
+    op.applyDefaults(false);
+  }
+
+  @Test
+  public void testUpsertOpCreatingWithStrongLifecycleAndNoSchemaIsLeftToRegistry() {
+    AssociationUpsertOp op = new AssociationUpsertOp(
+        "test-subject", null, LifecyclePolicy.STRONG, null, null, null);
+    op.applyDefaults(false);
+    assertEquals(LifecyclePolicy.STRONG, op.getLifecycle());
+    assertEquals(Boolean.FALSE, op.getFrozen());
+  }
+
   // Requirement #3: Default subject + subject required
 
   @Test

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -32,6 +32,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.ErrorMessage;
 import io.confluent.kafka.schemaregistry.client.rest.entities.ExtendedSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.LifecyclePolicy;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
+import io.confluent.kafka.schemaregistry.client.rest.entities.OpType;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Rule;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
@@ -43,6 +44,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.requests.Associati
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationBatchRequest;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationBatchResponse;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationCreateOrUpdateInfo;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationCreateOrUpdateOp;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationCreateOrUpdateRequest;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationDeleteOp;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationGetRequest;
@@ -2052,21 +2054,11 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
           request.getResourceName(), request.getResourceNamespace(),
           request.getResourceType(), new ArrayList<>(infosByType.keySet()), null);
       // The fallback can return entries from multiple resourceIds sharing (name, namespace,
-      // type) — e.g. an orphan from a deleted topic alongside a live one. Keep the
-      // most-recently-updated entry per type so equivalence compares against the live one.
-      assocsByType = fallback.stream()
-          .collect(Collectors.toMap(Association::getAssociationType, a -> a,
-              (a, b) -> {
-                Long timestampA = a.getUpdateTimestamp();
-                Long timestampB = b.getUpdateTimestamp();
-                if (timestampA == null) {
-                  return b;
-                }
-                if (timestampB == null) {
-                  return a;
-                }
-                return timestampA >= timestampB ? a : b;
-              }));
+      // type) — e.g. an orphan from a deleted topic alongside a live one. Narrow to a single
+      // resource so equivalence, subject-change and frozen checks all compare against the same
+      // one rather than a composite stitched from several.
+      assocsByType = mostRecentlyUpdatedResource(fallback).stream()
+          .collect(Collectors.toMap(Association::getAssociationType, a -> a));
     } else {
       // By-resourceId guarantees one row per associationType. Keep fail-fast on duplicates
       assocsByType = associations.stream()
@@ -2126,6 +2118,15 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
       }
 
       if (association == null) {
+        // A STRONG association is owned by its topic and can only be created together with the
+        // topic, never by an upsert. Subjects in IMPORT mode are exempt, since cluster linking
+        // replicates associations that were already established on the source.
+        if (!isCreate && effectiveLifecycle == LifecyclePolicy.STRONG
+            && (qualifiedSubject == null || getModeInScope(qualifiedSubject) != Mode.IMPORT)) {
+          throw new IllegalPropertyException(
+              "lifecycle", "cannot be STRONG when creating an association; "
+                  + "STRONG associations must be created with the topic");
+        }
         if (Boolean.TRUE.equals(info.getFrozen()) && qualifiedSubject != null
             && getModeInScope(qualifiedSubject) != Mode.IMPORT) {
           if (isCreate && info.getSchema() == null) {
@@ -2192,12 +2193,25 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
       }
     }
 
+    checkUniformLifecycle(request);
+
     for (AssociationCreateOrUpdateInfo info : request.getAssociations()) {
       String unqualifiedSubject = info.getSubject();
       QualifiedSubject qs = QualifiedSubject.createFromUnqualified(tenant(), unqualifiedSubject);
       String qualifiedSubject = qs.toQualifiedSubject();
       String associationType = info.getAssociationType();
       Association association = assocsByType.get(associationType);
+      // A subject in IMPORT mode is being replicated and its versions arrive on their own, so a
+      // schema passed alongside the association would be dropped rather than registered.
+      // Rejecting it here also keeps the check below honest: with no schema to register, the
+      // association is only accepted once the subject's versions have actually landed.
+      if (info.getSchema() != null && getModeInScope(qualifiedSubject) == Mode.IMPORT) {
+        log.debug("Rejecting schema for subject '{}' because it is in IMPORT mode",
+            qualifiedSubject);
+        throw new IllegalPropertyException(
+            "schema", "cannot be provided while subject '" + unqualifiedSubject
+                + "' is in IMPORT mode");
+      }
       if (info.getSchema() == null && getLatestVersion(qualifiedSubject) == null) {
         throw new NoActiveSubjectVersionExistsException(unqualifiedSubject);
       }
@@ -2298,6 +2312,105 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
             .map(AssociationValue::toAssociationEntity)
             .collect(Collectors.toList()),
         registeredSchemas);
+  }
+
+  /**
+   * Keeps only the associations belonging to the most-recently-updated resource, so that
+   * entries from several resources sharing a name and namespace are never treated as one.
+   */
+  private static List<Association> mostRecentlyUpdatedResource(List<Association> associations) {
+    if (associations.isEmpty()) {
+      return associations;
+    }
+    // Timestamps alone do not order these: two resources can be written within the same
+    // millisecond, and the list arrives sorted by name/type, which would let the winner depend
+    // on association type. Fall through to the creation time and then the id so the choice is
+    // always defined.
+    Comparator<Association> byRecency = Comparator
+        .comparing(Association::getUpdateTimestamp, Comparator.nullsFirst(Long::compareTo))
+        .thenComparing(Association::getCreateTimestamp, Comparator.nullsFirst(Long::compareTo))
+        .thenComparing(Association::getResourceId, Comparator.nullsFirst(String::compareTo));
+    String resourceId = associations.stream()
+        .max(byRecency)
+        .map(Association::getResourceId)
+        .orElse(null);
+    return associations.stream()
+        .filter(a -> Objects.equals(a.getResourceId(), resourceId))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Rejects a request that would leave a resource holding associations of more than one
+   * lifecycle. A topic is either topic-owned (STRONG) or shared (WEAK) across all of its
+   * association types, never a mix of the two.
+   *
+   * <p>The lifecycle considered for each type is the one the resource would end up with: taken
+   * from the request where it supplies one, from the request's existing association where it
+   * does not, and from the stored association for types the request leaves alone. A request
+   * that converts every type at once therefore passes this check.
+   *
+   * <p>Passing this check is not on its own enough to repair a resource that is already mixed,
+   * and for some shapes no request can: promoting a shared subject to STRONG is refused when
+   * that subject carries other associations, and demoting a topic-owned association is refused
+   * when it uses the default subject or is frozen. Such a resource has to be taken apart with a
+   * delete.
+   *
+   * <p>A batch mutation applies a run of adjacent create-or-update ops as one request, so this
+   * sees every type in that run together and a batch can convert them all at once. A run ends
+   * at a change of op type or a repeat of an association type, so successive ops on the same
+   * type still apply one after another. Runs are applied in order, so a sequence that is only
+   * uniform once a later op has run — a conversion split either side of a delete, say — is
+   * rejected.
+   */
+  private void checkUniformLifecycle(AssociationCreateOrUpdateRequest request)
+      throws SchemaRegistryException {
+    Map<String, LifecyclePolicy> lifecycleByType = currentLifecyclesByType(
+        request.getResourceId(), request.getResourceName(),
+        request.getResourceNamespace(), request.getResourceType());
+    for (AssociationCreateOrUpdateInfo info : request.getAssociations()) {
+      LifecyclePolicy lifecycle = info.getLifecycle() != null
+          ? info.getLifecycle()
+          : lifecycleByType.get(info.getAssociationType());
+      if (lifecycle != null) {
+        lifecycleByType.put(info.getAssociationType(), lifecycle);
+      }
+    }
+    if (new HashSet<>(lifecycleByType.values()).size() > 1) {
+      String detail = lifecycleByType.entrySet().stream()
+          .map(e -> e.getKey() + "=" + e.getValue())
+          .collect(Collectors.joining(", "));
+      // The conflict can come from stored associations the caller never sent, so record which
+      // resource it was and what the combined state looked like.
+      log.warn("Rejecting association request for resource '{}' in namespace '{}': "
+              + "mixed lifecycles {}",
+          request.getResourceName(), request.getResourceNamespace(), detail);
+      throw new IllegalPropertyException(
+          "lifecycle", "all associations for a resource must have the same lifecycle, but got "
+              + detail);
+    }
+  }
+
+  /**
+   * Returns the stored lifecycle of every association type on a resource. At the validate phase
+   * the caller may not yet have a resourceId, so the resource is matched by (name, namespace)
+   * instead — narrowed to a single resource, since several can share a name and namespace.
+   */
+  private Map<String, LifecyclePolicy> currentLifecyclesByType(
+      String resourceId, String resourceName, String resourceNamespace, String resourceType)
+      throws SchemaRegistryException {
+    List<Association> existing;
+    if (resourceId != null) {
+      existing = getAssociationsByResourceId(
+          resourceId, resourceType, Collections.emptyList(), null);
+    } else {
+      existing = mostRecentlyUpdatedResource(getAssociationsByResourceName(
+          resourceName, resourceNamespace, resourceType, Collections.emptyList(), null));
+    }
+    Map<String, LifecyclePolicy> lifecycleByType = new LinkedHashMap<>();
+    for (Association association : existing) {
+      lifecycleByType.put(association.getAssociationType(), association.getLifecycle());
+    }
+    return lifecycleByType;
   }
 
   protected void checkDeleteAssociation(
@@ -2433,19 +2546,15 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
       try {
         req.validate(dryRun);
         Map<String, Schema> schemas = new HashMap<>();
-        for (AssociationOp op : req.getAssociations()) {
-          switch (op.getType()) {
-            case CREATE:
-              AssociationResponse createResp = createAssociation(context, dryRun,
-                  new AssociationCreateOrUpdateRequest(req, op));
-              collectSchemas(createResp, schemas);
-              break;
-            case UPSERT:
-              AssociationResponse upsertResp = createOrUpdateAssociation(context, dryRun,
-                  new AssociationCreateOrUpdateRequest(req, op));
-              collectSchemas(upsertResp, schemas);
-              break;
-            case DELETE:
+        List<? extends AssociationOp> ops = req.getAssociations();
+        // A run of adjacent create-or-update ops is applied as one request rather than one at
+        // a time. Validation there sees every association type in the run at once, so a batch
+        // can convert them together, and nothing is written until all of them have passed.
+        int index = 0;
+        while (index < ops.size()) {
+          AssociationOp op = ops.get(index);
+          if (!(op instanceof AssociationCreateOrUpdateOp)) {
+            if (op instanceof AssociationDeleteOp) {
               AssociationDeleteOp deleteOp = (AssociationDeleteOp) op;
               deleteAssociations(
                   req.getResourceId(),
@@ -2453,10 +2562,38 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
                   Collections.singletonList(deleteOp.getAssociationType()),
                   Boolean.TRUE.equals(deleteOp.getCascadeLifecycle()), dryRun
               );
-              break;
-            default:
-              break;
+            }
+            index++;
+            continue;
           }
+          // A run ends at a change of op type, and also at a repeat of an association type:
+          // a request may only carry one entry per type, and successive ops on the same type
+          // are meant to apply one after another rather than collapse into a single request.
+          List<AssociationCreateOrUpdateOp> run = new ArrayList<>();
+          Set<String> typesInRun = new HashSet<>();
+          AssociationCreateOrUpdateOp first = (AssociationCreateOrUpdateOp) op;
+          run.add(first);
+          typesInRun.add(first.getAssociationType());
+          int end = index + 1;
+          while (end < ops.size()
+              && ops.get(end).getType() == op.getType()
+              && ops.get(end) instanceof AssociationCreateOrUpdateOp) {
+            AssociationCreateOrUpdateOp next = (AssociationCreateOrUpdateOp) ops.get(end);
+            if (!typesInRun.add(next.getAssociationType())) {
+              break;
+            }
+            run.add(next);
+            end++;
+          }
+          if (log.isDebugEnabled()) {
+            log.debug("Applying {} {} op(s) as one request for resource '{}': types {}",
+                run.size(), op.getType(), req.getResourceName(), typesInRun);
+          }
+          AssociationResponse response = createOrUpdateAssociation(context, dryRun,
+              new AssociationCreateOrUpdateRequest(req, run),
+              op.getType() == OpType.CREATE);
+          collectSchemas(response, schemas);
+          index = end;
         }
         List<Association> associations = null;
         if (!dryRun) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -2036,7 +2036,9 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
       String associationType = info.getAssociationType();
       if (infosByType.containsKey(associationType)) {
         throw new IllegalPropertyException(
-            "associationType", "Duplicate association type: " + associationType);
+            "associationType",
+            "may only appear once per request, but '" + associationType + "' appears more"
+                + " than once");
       }
       infosByType.put(associationType, info);
     }
@@ -2053,10 +2055,9 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
       List<Association> fallback = getAssociationsByResourceName(
           request.getResourceName(), request.getResourceNamespace(),
           request.getResourceType(), new ArrayList<>(infosByType.keySet()), null);
-      // The fallback can return entries from multiple resourceIds sharing (name, namespace,
-      // type) — e.g. an orphan from a deleted topic alongside a live one. Narrow to a single
-      // resource so equivalence, subject-change and frozen checks all compare against the same
-      // one rather than a composite stitched from several.
+      // The fallback matches on (name, namespace, type) and so can span resourceIds. Narrow to
+      // a single resource, otherwise the equivalence, subject-change and frozen checks below
+      // could each be comparing against a different one.
       assocsByType = mostRecentlyUpdatedResource(fallback).stream()
           .collect(Collectors.toMap(Association::getAssociationType, a -> a));
     } else {
@@ -2340,27 +2341,12 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
   }
 
   /**
-   * Rejects a request that would leave a resource holding associations of more than one
-   * lifecycle. A topic is either topic-owned (STRONG) or shared (WEAK) across all of its
-   * association types, never a mix of the two.
+   * Rejects a request that would leave a resource holding more than one lifecycle: a topic is
+   * either topic-owned (STRONG) or shared (WEAK) across all of its association types.
    *
-   * <p>The lifecycle considered for each type is the one the resource would end up with: taken
-   * from the request where it supplies one, from the request's existing association where it
-   * does not, and from the stored association for types the request leaves alone. A request
-   * that converts every type at once therefore passes this check.
-   *
-   * <p>Passing this check is not on its own enough to repair a resource that is already mixed,
-   * and for some shapes no request can: promoting a shared subject to STRONG is refused when
-   * that subject carries other associations, and demoting a topic-owned association is refused
-   * when it uses the default subject or is frozen. Such a resource has to be taken apart with a
-   * delete.
-   *
-   * <p>A batch mutation applies a run of adjacent create-or-update ops as one request, so this
-   * sees every type in that run together and a batch can convert them all at once. A run ends
-   * at a change of op type or a repeat of an association type, so successive ops on the same
-   * type still apply one after another. Runs are applied in order, so a sequence that is only
-   * uniform once a later op has run — a conversion split either side of a delete, say — is
-   * rejected.
+   * <p>Each type is judged by the lifecycle it would end up with — from the request where it
+   * supplies one, otherwise from the stored association — so converting every type at once is
+   * allowed, while converting only one of several is not.
    */
   private void checkUniformLifecycle(AssociationCreateOrUpdateRequest request)
       throws SchemaRegistryException {
@@ -2566,28 +2552,18 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
             index++;
             continue;
           }
-          // A run ends at a change of op type, and also at a repeat of an association type:
-          // a request may only carry one entry per type, and successive ops on the same type
-          // are meant to apply one after another rather than collapse into a single request.
           List<AssociationCreateOrUpdateOp> run = new ArrayList<>();
-          Set<String> typesInRun = new HashSet<>();
-          AssociationCreateOrUpdateOp first = (AssociationCreateOrUpdateOp) op;
-          run.add(first);
-          typesInRun.add(first.getAssociationType());
+          run.add((AssociationCreateOrUpdateOp) op);
           int end = index + 1;
           while (end < ops.size()
               && ops.get(end).getType() == op.getType()
               && ops.get(end) instanceof AssociationCreateOrUpdateOp) {
-            AssociationCreateOrUpdateOp next = (AssociationCreateOrUpdateOp) ops.get(end);
-            if (!typesInRun.add(next.getAssociationType())) {
-              break;
-            }
-            run.add(next);
+            run.add((AssociationCreateOrUpdateOp) ops.get(end));
             end++;
           }
           if (log.isDebugEnabled()) {
-            log.debug("Applying {} {} op(s) as one request for resource '{}': types {}",
-                run.size(), op.getType(), req.getResourceName(), typesInRun);
+            log.debug("Applying {} {} op(s) as one request for resource '{}'",
+                run.size(), op.getType(), req.getResourceName());
           }
           AssociationResponse response = createOrUpdateAssociation(context, dryRun,
               new AssociationCreateOrUpdateRequest(req, run),

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
@@ -95,7 +95,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
             new AssociationCreateOrUpdateInfo(
                 subject2,
                 "value",
-                LifecyclePolicy.STRONG,
+                LifecyclePolicy.WEAK,
                 false,
                 null,
                 null
@@ -119,7 +119,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertEquals("key", response.getAssociations().get(0).getAssociationType());
     assertEquals(LifecyclePolicy.WEAK, response.getAssociations().get(0).getLifecycle());
     assertEquals("value", response.getAssociations().get(1).getAssociationType());
-    assertEquals(LifecyclePolicy.STRONG, response.getAssociations().get(1).getLifecycle());
+    assertEquals(LifecyclePolicy.WEAK, response.getAssociations().get(1).getLifecycle());
 
     // Verify createTs and updateTs are set after creation
     List<Association> createdAssociations = restApp.restClient.getAssociationsByResourceId(
@@ -153,7 +153,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertEquals(resourceName, associations.get(0).getResourceName());
     assertEquals(resourceNamespace, associations.get(0).getResourceNamespace());
     assertEquals("value", associations.get(0).getAssociationType());
-    assertEquals(LifecyclePolicy.STRONG, associations.get(0).getLifecycle());
+    assertEquals(LifecyclePolicy.WEAK, associations.get(0).getLifecycle());
 
     associations = restApp.restClient.getAssociationsByResourceId(
         RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
@@ -168,7 +168,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertEquals(resourceName, associations.get(1).getResourceName());
     assertEquals(resourceNamespace, associations.get(1).getResourceNamespace());
     assertEquals("value", associations.get(1).getAssociationType());
-    assertEquals(LifecyclePolicy.STRONG, associations.get(1).getLifecycle());
+    assertEquals(LifecyclePolicy.WEAK, associations.get(1).getLifecycle());
 
     associations = restApp.restClient.getAssociationsByResourceName(
         RestService.DEFAULT_REQUEST_PROPERTIES, resourceName, "-", "topic",
@@ -183,7 +183,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertEquals(resourceName, associations.get(1).getResourceName());
     assertEquals(resourceNamespace, associations.get(1).getResourceNamespace());
     assertEquals("value", associations.get(1).getAssociationType());
-    assertEquals(LifecyclePolicy.STRONG, associations.get(1).getLifecycle());
+    assertEquals(LifecyclePolicy.WEAK, associations.get(1).getLifecycle());
 
     associations = restApp.restClient.getAssociationsByResourceName(
         RestService.DEFAULT_REQUEST_PROPERTIES, resourceName, resourceNamespace, "topic",
@@ -198,7 +198,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertEquals(resourceName, associations.get(1).getResourceName());
     assertEquals(resourceNamespace, associations.get(1).getResourceNamespace());
     assertEquals("value", associations.get(1).getAssociationType());
-    assertEquals(LifecyclePolicy.STRONG, associations.get(1).getLifecycle());
+    assertEquals(LifecyclePolicy.WEAK, associations.get(1).getLifecycle());
 
     associations = restApp.restClient.getAssociationsByResourceName(
         RestService.DEFAULT_REQUEST_PROPERTIES, "-", resourceNamespace, "topic",
@@ -213,8 +213,9 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertEquals(resourceName, associations.get(1).getResourceName());
     assertEquals(resourceNamespace, associations.get(1).getResourceNamespace());
     assertEquals("value", associations.get(1).getAssociationType());
-    assertEquals(LifecyclePolicy.STRONG, associations.get(1).getLifecycle());
+    assertEquals(LifecyclePolicy.WEAK, associations.get(1).getLifecycle());
 
+    // Promote both types together: a resource cannot hold a mix of lifecycles
     request = new AssociationCreateOrUpdateRequest(
         resourceName,
         resourceNamespace,
@@ -224,6 +225,14 @@ public class RestApiAssociationTest extends ClusterTestHarness {
             new AssociationCreateOrUpdateInfo(
                 subject1,
                 "key",
+                LifecyclePolicy.STRONG,
+                false,
+                null,
+                null
+            ),
+            new AssociationCreateOrUpdateInfo(
+                subject2,
+                "value",
                 LifecyclePolicy.STRONG,
                 false,
                 null,
@@ -1231,7 +1240,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
             new AssociationCreateOp(
                 subject2,
                 "value",
-                LifecyclePolicy.STRONG,
+                LifecyclePolicy.WEAK,
                 false,
                 null,
                 null
@@ -1275,7 +1284,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertEquals("key", result1.getResult().getAssociations().get(0).getAssociationType());
     assertEquals(LifecyclePolicy.WEAK, result1.getResult().getAssociations().get(0).getLifecycle());
     assertEquals("value", result1.getResult().getAssociations().get(1).getAssociationType());
-    assertEquals(LifecyclePolicy.STRONG, result1.getResult().getAssociations().get(1).getLifecycle());
+    assertEquals(LifecyclePolicy.WEAK, result1.getResult().getAssociations().get(1).getLifecycle());
 
     // Verify second result (1 association)
     AssociationResult result2 = batchResponse.getResults().get(1);
@@ -1331,7 +1340,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
             new AssociationCreateOp(
                 subject2,
                 "value",
-                LifecyclePolicy.STRONG,
+                LifecyclePolicy.WEAK,
                 false,
                 null,
                 null
@@ -1801,10 +1810,12 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertEquals("key", initialAssociations.get(0).getAssociationType());
 
     // Now create a SINGLE AssociationOpRequest with all three operation types:
-    // - CREATE "value" (new association)
     // - UPSERT "key" (update lifecycle from WEAK to STRONG)
+    // - CREATE "value" (new association)
     // - DELETE "key" (delete the existing association)
-    // The operations are processed in order, so final state will have only "value"
+    // The operations are processed in order, so final state will have only "value".
+    // "key" is promoted before "value" is added so the resource never holds a mix of
+    // lifecycles, which is rejected.
     List<AssociationOpRequest> requests = new ArrayList<>();
     requests.add(new AssociationOpRequest(
         resourceName,
@@ -1812,20 +1823,20 @@ public class RestApiAssociationTest extends ClusterTestHarness {
         resourceId,
         "topic",
         ImmutableList.of(
-            // CREATE: Add new "value" association (schema already registered)
-            new AssociationCreateOp(
-                valueSubject,
-                "value",
-                LifecyclePolicy.STRONG,
-                false,
-                null,
-                null
-            ),
             // UPSERT: Update existing "key" association
             new AssociationUpsertOp(
                 keySubject,
                 "key",
                 LifecyclePolicy.STRONG,  // Change from WEAK to STRONG
+                false,
+                null,
+                null
+            ),
+            // CREATE: Add new "value" association (schema already registered)
+            new AssociationCreateOp(
+                valueSubject,
+                "value",
+                LifecyclePolicy.STRONG,
                 false,
                 null,
                 null
@@ -1905,7 +1916,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
             new AssociationCreateOrUpdateInfo(
                 subject2,
                 "value",
-                LifecyclePolicy.STRONG,
+                LifecyclePolicy.WEAK,
                 false,
                 null,
                 null
@@ -1975,7 +1986,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertNotNull(schema2.getAssociations());
     assertEquals(1, schema2.getAssociations().size());
     assertEquals("value", schema2.getAssociations().get(0).getAssociationType());
-    assertEquals(LifecyclePolicy.STRONG, schema2.getAssociations().get(0).getLifecycle());
+    assertEquals(LifecyclePolicy.WEAK, schema2.getAssociations().get(0).getLifecycle());
     assertEquals(resourceId1, schema2.getAssociations().get(0).getResourceId());
   }
 
@@ -1994,8 +2005,9 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     restApp.restClient.registerSchema(allSchemas.get(1), subject2);
     restApp.restClient.registerSchema(allSchemas.get(2), subject3);
 
-    // Create associations with different lifecycle policies
-    AssociationCreateOrUpdateRequest request = new AssociationCreateOrUpdateRequest(
+    // Create associations with different lifecycle policies. They go on separate resources:
+    // a single resource cannot hold a mix of lifecycles.
+    AssociationCreateOrUpdateRequest weakRequest = new AssociationCreateOrUpdateRequest(
         resourceName,
         resourceNamespace,
         resourceId,
@@ -2008,7 +2020,19 @@ public class RestApiAssociationTest extends ClusterTestHarness {
                 false,
                 null,
                 null
-            ),
+            )
+        )
+    );
+
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, weakRequest);
+
+    AssociationCreateOrUpdateRequest strongRequest = new AssociationCreateOrUpdateRequest(
+        resourceName + "-strong",
+        resourceNamespace,
+        resourceId + "-strong",
+        "topic",
+        ImmutableList.of(
             new AssociationCreateOrUpdateInfo(
                 subject2,
                 "value",
@@ -2021,7 +2045,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     );
 
     restApp.restClient.createAssociation(
-        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, request);
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, strongRequest);
 
     // lifecycle=WEAK → only subject1 returned (subject2 is STRONG, subject3 unassociated)
     List<ExtendedSchema> weakSchemas = restApp.restClient.getSchemas(
@@ -2634,10 +2658,438 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertNotNull(response.getResults().get(0).getError());
   }
 
+  // Requirement: a resource is either topic-owned (STRONG) or shared (WEAK) across all of its
+  // association types, never a mix of the two.
+
+  @Test
+  public void testCreateMixedLifecyclesInOneRequestFails() throws Exception {
+    String subject = "mixed-shared-subject";
+    String resourceName = "topic1";
+    String resourceNamespace = "default";
+    String resourceId = "mixed-one-request-123";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
+
+    restApp.restClient.registerSchema(allSchemas.get(0), subject);
+
+    RegisterSchemaRequest schemaRequest = new RegisterSchemaRequest();
+    schemaRequest.setSchema(allSchemas.get(1));
+
+    // key is shared (WEAK), value is topic-owned (STRONG via schema)
+    AssociationCreateOrUpdateRequest request = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(
+            new AssociationCreateOrUpdateInfo(subject, "key", null, null, null, null),
+            new AssociationCreateOrUpdateInfo(null, "value", null, null, schemaRequest, null)));
+
+    assertThrows(Exception.class, () ->
+        restApp.restClient.createAssociation(
+            RestService.DEFAULT_REQUEST_PROPERTIES, null, false, request));
+
+    List<Association> associations = restApp.restClient.getAssociationsByResourceId(
+        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
+        ImmutableList.of("key", "value"), null, 0, -1);
+    assertTrue(associations.isEmpty());
+  }
+
+  @Test
+  public void testAddWeakWhenStrongExistsForOtherTypeFails() throws Exception {
+    String subject = "add-weak-shared-subject";
+    String resourceName = "topic1";
+    String resourceNamespace = "default";
+    String resourceId = "mixed-add-weak-123";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
+
+    // Topic-owned association on value
+    RegisterSchemaRequest schemaRequest = new RegisterSchemaRequest();
+    schemaRequest.setSchema(allSchemas.get(0));
+    AssociationCreateOrUpdateRequest valueRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            null, "value", null, null, schemaRequest, null)));
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, valueRequest);
+
+    // Now add a shared association on key — the resource would be mixed
+    restApp.restClient.registerSchema(allSchemas.get(1), subject);
+    AssociationUpsertOp upsertOp = new AssociationUpsertOp(
+        subject, "key", null, null, null, null);
+    AssociationOpRequest opRequest = new AssociationOpRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        Collections.singletonList(upsertOp));
+    AssociationBatchRequest batchRequest = new AssociationBatchRequest(
+        Collections.singletonList(opRequest));
+
+    AssociationBatchResponse response = restApp.restClient.mutateAssociations(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, batchRequest);
+    assertNotNull(response.getResults().get(0).getError());
+
+    List<Association> associations = restApp.restClient.getAssociationsByResourceId(
+        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
+        ImmutableList.of("key", "value"), null, 0, -1);
+    assertEquals(1, associations.size());
+    assertEquals("value", associations.get(0).getAssociationType());
+  }
+
+  @Test
+  public void testAddStrongWhenWeakExistsForOtherTypeFails() throws Exception {
+    String keySubject = "add-strong-key-subject";
+    String valueSubject = "add-strong-value-subject";
+    String resourceName = "topic1";
+    String resourceNamespace = "default";
+    String resourceId = "mixed-add-strong-123";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
+
+    // Shared association on key
+    restApp.restClient.registerSchema(allSchemas.get(0), keySubject);
+    AssociationCreateOrUpdateRequest keyRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            keySubject, "key", LifecyclePolicy.WEAK, null, null, null)));
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, keyRequest);
+
+    // Now add a topic-owned association on value — the resource would be mixed
+    restApp.restClient.registerSchema(allSchemas.get(1), valueSubject);
+    AssociationCreateOrUpdateRequest valueRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            valueSubject, "value", LifecyclePolicy.STRONG, false, null, null)));
+
+    assertThrows(Exception.class, () ->
+        restApp.restClient.createAssociation(
+            RestService.DEFAULT_REQUEST_PROPERTIES, null, false, valueRequest));
+
+    List<Association> associations = restApp.restClient.getAssociationsByResourceId(
+        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
+        ImmutableList.of("key", "value"), null, 0, -1);
+    assertEquals(1, associations.size());
+    assertEquals("key", associations.get(0).getAssociationType());
+  }
+
+  /** Changing one type's lifecycle so it diverges from its sibling is rejected too. */
+  @Test
+  public void testUpdatingLifecycleToDivergeFromSiblingFails() throws Exception {
+    String keySubject = "diverge-key-subject";
+    String valueSubject = "diverge-value-subject";
+    String resourceName = "topic1";
+    String resourceNamespace = "default";
+    String resourceId = "mixed-diverge-123";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
+
+    restApp.restClient.registerSchema(allSchemas.get(0), keySubject);
+    restApp.restClient.registerSchema(allSchemas.get(1), valueSubject);
+
+    AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(
+            new AssociationCreateOrUpdateInfo(
+                keySubject, "key", LifecyclePolicy.WEAK, null, null, null),
+            new AssociationCreateOrUpdateInfo(
+                valueSubject, "value", LifecyclePolicy.WEAK, null, null, null)));
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
+
+    // Promote only the value association to STRONG — the resource would be mixed
+    AssociationCreateOrUpdateRequest upsertRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            valueSubject, "value", LifecyclePolicy.STRONG, null, null, null)));
+
+    assertThrows(Exception.class, () ->
+        restApp.restClient.createOrUpdateAssociation(
+            RestService.DEFAULT_REQUEST_PROPERTIES, null, false, upsertRequest));
+
+    List<Association> associations = restApp.restClient.getAssociationsByResourceId(
+        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
+        ImmutableList.of("key", "value"), null, 0, -1);
+    assertEquals(2, associations.size());
+    associations.forEach(a -> assertEquals(LifecyclePolicy.WEAK, a.getLifecycle()));
+  }
+
+  /**
+   * At the validate phase the caller may not yet have a resourceId, so the resource is matched
+   * by (name, namespace). The conflict has to be caught there rather than only on apply.
+   */
+  @Test
+  public void testDryRunSeesMixedLifecycleAgainstExistingSibling() throws Exception {
+    String valueSubject = "dryrun-value-subject";
+    String keySubject = "dryrun-key-subject";
+    String resourceName = "dryRunMixedTopic";
+    String resourceNamespace = "default";
+    String resourceId = "dryrun-mixed-123";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
+
+    restApp.restClient.registerSchema(allSchemas.get(0), valueSubject);
+    restApp.restClient.registerSchema(allSchemas.get(1), keySubject);
+
+    AssociationCreateOrUpdateRequest valueRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            valueSubject, "value", LifecyclePolicy.STRONG, false, null, null)));
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, valueRequest);
+
+    // Validate phase: no resourceId yet, so the sibling is found by (name, namespace)
+    AssociationCreateOrUpdateRequest dryRunRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, null, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            keySubject, "key", LifecyclePolicy.WEAK, false, null, null)));
+
+    assertThrows(Exception.class, () ->
+        restApp.restClient.createAssociation(
+            RestService.DEFAULT_REQUEST_PROPERTIES, null, true, dryRunRequest));
+  }
+
+  /**
+   * Two resources can share a name and namespace — an orphan from a deleted topic alongside a
+   * live one. The validate phase must not stitch their types together into a mix that never
+   * existed on either.
+   */
+  @Test
+  public void testDryRunDoesNotMixLifecyclesAcrossResourcesSharingAName() throws Exception {
+    String orphanSubject = "orphan-key-subject";
+    String liveSubject = "live-value-subject";
+    String resourceName = "sharedNameTopic";
+    String resourceNamespace = "default";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
+
+    restApp.restClient.registerSchema(allSchemas.get(0), orphanSubject);
+    restApp.restClient.registerSchema(allSchemas.get(1), liveSubject);
+
+    // Older resource, STRONG on key. The ids are ordered so the live resource wins whether
+    // recency or the id tie-break decides, keeping the test independent of write timing.
+    AssociationCreateOrUpdateRequest orphanRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, "shared-name-a-orphan", "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            orphanSubject, "key", LifecyclePolicy.STRONG, false, null, null)));
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, orphanRequest);
+
+    // Newer resource with the same name/namespace, WEAK on value
+    AssociationCreateOrUpdateRequest liveRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, "shared-name-z-live", "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            liveSubject, "value", LifecyclePolicy.WEAK, false, null, null)));
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, liveRequest);
+
+    // Validate with no resourceId: only the newer resource counts, so this is uniform WEAK.
+    // Merging per type across resources would see key=STRONG, value=WEAK and wrongly reject.
+    AssociationCreateOrUpdateRequest dryRunRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, null, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            liveSubject, "value", LifecyclePolicy.WEAK, false, null, null)));
+
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, true, dryRunRequest);
+  }
+
+  /**
+   * A batch is checked against the state its ops project, so it can convert every type at once
+   * — the same capability a single request through the create-or-update endpoint has.
+   */
+  @Test
+  public void testBatchConvertingAllTypesTogetherSucceeds() throws Exception {
+    String keySubject = "batch-convert-key-subject";
+    String valueSubject = "batch-convert-value-subject";
+    String resourceName = "batchConvertTopic";
+    String resourceNamespace = "default";
+    String resourceId = "batch-convert-123";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
+
+    restApp.restClient.registerSchema(allSchemas.get(0), keySubject);
+    restApp.restClient.registerSchema(allSchemas.get(1), valueSubject);
+
+    AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(
+            new AssociationCreateOrUpdateInfo(
+                keySubject, "key", LifecyclePolicy.WEAK, null, null, null),
+            new AssociationCreateOrUpdateInfo(
+                valueSubject, "value", LifecyclePolicy.WEAK, null, null, null)));
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
+
+    // Converting one type at a time leaves the resource transiently mixed; the batch is
+    // accepted because its projected end state is uniform.
+    AssociationOpRequest opRequest = new AssociationOpRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(
+            new AssociationUpsertOp(
+                keySubject, "key", LifecyclePolicy.STRONG, null, null, null),
+            new AssociationUpsertOp(
+                valueSubject, "value", LifecyclePolicy.STRONG, null, null, null)));
+    AssociationBatchResponse response = restApp.restClient.mutateAssociations(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
+        new AssociationBatchRequest(Collections.singletonList(opRequest)));
+    assertNull(response.getResults().get(0).getError());
+
+    List<Association> associations = restApp.restClient.getAssociationsByResourceId(
+        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
+        ImmutableList.of("key", "value"), null, 0, -1);
+    assertEquals(2, associations.size());
+    associations.forEach(a -> assertEquals(LifecyclePolicy.STRONG, a.getLifecycle()));
+  }
+
+  /**
+   * Successive ops on the same association type are separate steps, not one request: a run
+   * ends where a type repeats, so two evolutions of the same subject both apply in order.
+   */
+  @Test
+  public void testBatchRepeatedAssociationTypeAppliesInOrder() throws Exception {
+    String subject = "dup-run-subject";
+    String resourceName = "dupRunTopic";
+    String resourceNamespace = "default";
+    String resourceId = "dup-run-123";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(3);
+
+    restApp.restClient.registerSchema(allSchemas.get(0), subject);
+    AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            subject, "value", LifecyclePolicy.STRONG, false, null, null)));
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
+
+    RegisterSchemaRequest second = new RegisterSchemaRequest();
+    second.setSchema(allSchemas.get(1));
+    RegisterSchemaRequest third = new RegisterSchemaRequest();
+    third.setSchema(allSchemas.get(2));
+
+    AssociationOpRequest opRequest = new AssociationOpRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(
+            new AssociationUpsertOp(subject, "value", null, null, second, null),
+            new AssociationUpsertOp(subject, "value", null, null, third, null)));
+    AssociationBatchResponse response = restApp.restClient.mutateAssociations(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
+        new AssociationBatchRequest(Collections.singletonList(opRequest)));
+    assertNull(response.getResults().get(0).getError());
+
+    // Both evolutions landed rather than colliding as a duplicate association type
+    assertEquals(ImmutableList.of(1, 2, 3), restApp.restClient.getAllVersions(subject));
+  }
+
+  /**
+   * Runs are applied in order and there is no rollback across them, so a later run failing
+   * leaves the earlier ones persisted — the caller's intent is partially applied. Each run is
+   * validated against the resource's full state before writing, though, so what remains is
+   * always uniform, never the mixed state the invariant forbids.
+   */
+  @Test
+  public void testBatchLaterRunFailingLeavesEarlierRunUniform() throws Exception {
+    String keySubject = "partial-run-key-subject";
+    String valueSubject = "partial-run-value-subject";
+    String resourceName = "partialRunTopic";
+    String resourceNamespace = "default";
+    String resourceId = "partial-run-123";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
+
+    restApp.restClient.registerSchema(allSchemas.get(0), keySubject);
+    restApp.restClient.registerSchema(allSchemas.get(1), valueSubject);
+
+    // CREATE and UPSERT are different op types, so these form two runs. The first succeeds;
+    // the second is refused because an upsert may not create a STRONG association.
+    AssociationOpRequest opRequest = new AssociationOpRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(
+            new AssociationCreateOp(
+                keySubject, "key", LifecyclePolicy.WEAK, false, null, null),
+            new AssociationUpsertOp(
+                valueSubject, "value", LifecyclePolicy.STRONG, null, null, null)));
+    AssociationBatchResponse response = restApp.restClient.mutateAssociations(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
+        new AssociationBatchRequest(Collections.singletonList(opRequest)));
+    assertNotNull(response.getResults().get(0).getError());
+
+    // The first run stands and the resource is left uniform, not mixed
+    List<Association> associations = restApp.restClient.getAssociationsByResourceId(
+        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
+        ImmutableList.of("key", "value"), null, 0, -1);
+    assertEquals(1, associations.size());
+    assertEquals("key", associations.get(0).getAssociationType());
+    assertEquals(LifecyclePolicy.WEAK, associations.get(0).getLifecycle());
+  }
+
+  /**
+   * A run of adjacent ops is validated as a unit and nothing is written unless all of it
+   * passes, so a run that would leave the resource mixed commits none of its ops.
+   */
+  @Test
+  public void testBatchProjectingMixedLifecycleCommitsNothing() throws Exception {
+    String keySubject = "batch-residue-key-subject";
+    String valueSubject = "batch-residue-value-subject";
+    String resourceName = "batchResidueTopic";
+    String resourceNamespace = "default";
+    String resourceId = "batch-residue-123";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
+
+    restApp.restClient.registerSchema(allSchemas.get(0), keySubject);
+    restApp.restClient.registerSchema(allSchemas.get(1), valueSubject);
+
+    AssociationOpRequest opRequest = new AssociationOpRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(
+            new AssociationUpsertOp(
+                keySubject, "key", LifecyclePolicy.WEAK, null, null, null),
+            new AssociationUpsertOp(
+                valueSubject, "value", LifecyclePolicy.STRONG, null, null, null)));
+    AssociationBatchResponse response = restApp.restClient.mutateAssociations(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
+        new AssociationBatchRequest(Collections.singletonList(opRequest)));
+    assertNotNull(response.getResults().get(0).getError());
+
+    // Neither op was committed, so no partially-applied residue is left behind
+    List<Association> associations = restApp.restClient.getAssociationsByResourceId(
+        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
+        ImmutableList.of("key", "value"), null, 0, -1);
+    assertTrue(associations.isEmpty());
+  }
+
+  /** A request that converts every type at once keeps the resource uniform, so it is allowed. */
+  @Test
+  public void testConvertingAllTypesTogetherSucceeds() throws Exception {
+    String keySubject = "convert-key-subject";
+    String valueSubject = "convert-value-subject";
+    String resourceName = "topic1";
+    String resourceNamespace = "default";
+    String resourceId = "mixed-convert-123";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
+
+    restApp.restClient.registerSchema(allSchemas.get(0), keySubject);
+    restApp.restClient.registerSchema(allSchemas.get(1), valueSubject);
+
+    AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(
+            new AssociationCreateOrUpdateInfo(
+                keySubject, "key", LifecyclePolicy.WEAK, null, null, null),
+            new AssociationCreateOrUpdateInfo(
+                valueSubject, "value", LifecyclePolicy.WEAK, null, null, null)));
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
+
+    AssociationCreateOrUpdateRequest upsertRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(
+            new AssociationCreateOrUpdateInfo(
+                keySubject, "key", LifecyclePolicy.STRONG, null, null, null),
+            new AssociationCreateOrUpdateInfo(
+                valueSubject, "value", LifecyclePolicy.STRONG, null, null, null)));
+    restApp.restClient.createOrUpdateAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, upsertRequest);
+
+    List<Association> associations = restApp.restClient.getAssociationsByResourceId(
+        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
+        ImmutableList.of("key", "value"), null, 0, -1);
+    assertEquals(2, associations.size());
+    associations.forEach(a -> assertEquals(LifecyclePolicy.STRONG, a.getLifecycle()));
+  }
+
   // Requirement: Frozen/non-frozen consistency at resource level
 
   @Test
-  public void testCreateFrozenThenUpsertNonFrozenSucceeds() throws Exception {
+  public void testCreateFrozenThenCreateNonFrozenSucceeds() throws Exception {
     String resourceName = "topic1";
     String resourceNamespace = "default";
     String resourceId = "frozen-consistency-123";
@@ -2655,15 +3107,16 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     restApp.restClient.createAssociation(
         RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
 
-    // Now upsert a non-frozen association for the same resource — should succeed
+    // Now create a non-frozen STRONG association for the same resource — should succeed.
+    // This uses the create path: an upsert may not create a STRONG association.
     restApp.restClient.registerSchema(allSchemas.get(1), "value-subject");
-    AssociationCreateOrUpdateRequest upsertRequest = new AssociationCreateOrUpdateRequest(
+    AssociationCreateOrUpdateRequest secondRequest = new AssociationCreateOrUpdateRequest(
         resourceName, resourceNamespace, resourceId, "topic",
         ImmutableList.of(new AssociationCreateOrUpdateInfo(
             "value-subject", "value", LifecyclePolicy.STRONG, false, null, null)));
 
-    restApp.restClient.createOrUpdateAssociation(
-        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, upsertRequest);
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, secondRequest);
 
     // Verify both exist with different frozen states
     List<Association> associations = restApp.restClient.getAssociationsByResourceId(
@@ -2917,8 +3370,12 @@ public class RestApiAssociationTest extends ClusterTestHarness {
             RestService.DEFAULT_REQUEST_PROPERTIES, null, false, upsertRequest));
   }
 
+  /**
+   * An upsert carrying only a schema would have to create a topic-owned STRONG association on
+   * the default subject, which is only allowed when the association is created with the topic.
+   */
   @Test
-  public void testUpsertCreatingNewWithSchemaAppliesUpsertDefaults() throws Exception {
+  public void testUpsertCreatingNewWithSchemaAndNoSubjectFails() throws Exception {
     String resourceName = "topic1";
     String resourceNamespace = "default";
     String resourceId = "upsert-new-schema-123";
@@ -2927,22 +3384,19 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     RegisterSchemaRequest schemaRequest = new RegisterSchemaRequest();
     schemaRequest.setSchema(allSchemas.get(0));
 
-    // Upsert with schema, no existing association — should apply UPSERT defaults
     AssociationCreateOrUpdateRequest upsertRequest = new AssociationCreateOrUpdateRequest(
         resourceName, resourceNamespace, resourceId, "topic",
         ImmutableList.of(new AssociationCreateOrUpdateInfo(
             null, "value", null, null, schemaRequest, null)));
-    restApp.restClient.createOrUpdateAssociation(
-        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, upsertRequest);
 
-    // Verify it was created as non-frozen STRONG with default subject
+    assertThrows(Exception.class, () ->
+        restApp.restClient.createOrUpdateAssociation(
+            RestService.DEFAULT_REQUEST_PROPERTIES, null, false, upsertRequest));
+
     List<Association> associations = restApp.restClient.getAssociationsByResourceId(
         RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
         Collections.singletonList("value"), null, 0, -1);
-    assertEquals(1, associations.size());
-    assertEquals(":.default:topic1-value", associations.get(0).getSubject());
-    assertEquals(LifecyclePolicy.STRONG, associations.get(0).getLifecycle());
-    assertFalse(associations.get(0).isFrozen());
+    assertTrue(associations.isEmpty());
   }
 
   @Test
@@ -2961,6 +3415,155 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertThrows(Exception.class, () ->
         restApp.restClient.createOrUpdateAssociation(
             RestService.DEFAULT_REQUEST_PROPERTIES, null, false, upsertRequest));
+  }
+
+  // An upsert may only create a WEAK association: a STRONG association is owned by its topic
+  // and has to be created with it, and a schema implies STRONG.
+
+  @Test
+  public void testUpsertCreatingNewWithSchemaAndSubjectFails() throws Exception {
+    String subject = "byo-subject-no-lifecycle";
+    String resourceName = "topic1";
+    String resourceNamespace = "default";
+    String resourceId = "upsert-byo-nolifecycle-123";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
+
+    restApp.restClient.registerSchema(allSchemas.get(0), subject);
+
+    RegisterSchemaRequest schemaRequest = new RegisterSchemaRequest();
+    schemaRequest.setSchema(allSchemas.get(1));
+
+    AssociationCreateOrUpdateRequest upsertRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            subject, "value", null, null, schemaRequest, null)));
+
+    assertThrows(Exception.class, () ->
+        restApp.restClient.createOrUpdateAssociation(
+            RestService.DEFAULT_REQUEST_PROPERTIES, null, false, upsertRequest));
+
+    // Nothing was created and the schema was not registered
+    List<Association> associations = restApp.restClient.getAssociationsByResourceId(
+        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
+        Collections.singletonList("value"), null, 0, -1);
+    assertTrue(associations.isEmpty());
+    assertEquals(Collections.singletonList(1), restApp.restClient.getAllVersions(subject));
+  }
+
+  @Test
+  public void testUpsertCreatingNewWithSchemaAndStrongLifecycleFails() throws Exception {
+    String subject = "byo-subject-strong";
+    String resourceName = "topic1";
+    String resourceNamespace = "default";
+    String resourceId = "upsert-byo-strong-123";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
+
+    restApp.restClient.registerSchema(allSchemas.get(0), subject);
+
+    RegisterSchemaRequest schemaRequest = new RegisterSchemaRequest();
+    schemaRequest.setSchema(allSchemas.get(1));
+
+    AssociationCreateOrUpdateRequest upsertRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            subject, "value", LifecyclePolicy.STRONG, null, schemaRequest, null)));
+
+    assertThrows(Exception.class, () ->
+        restApp.restClient.createOrUpdateAssociation(
+            RestService.DEFAULT_REQUEST_PROPERTIES, null, false, upsertRequest));
+
+    List<Association> associations = restApp.restClient.getAssociationsByResourceId(
+        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
+        Collections.singletonList("value"), null, 0, -1);
+    assertTrue(associations.isEmpty());
+  }
+
+  @Test
+  public void testUpsertCreatingNewStrongWithoutSchemaFails() throws Exception {
+    String subject = "byo-subject-strong-noschema";
+    String resourceName = "topic1";
+    String resourceNamespace = "default";
+    String resourceId = "upsert-byo-strong-noschema-123";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(1);
+
+    restApp.restClient.registerSchema(allSchemas.get(0), subject);
+
+    AssociationCreateOrUpdateRequest upsertRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            subject, "value", LifecyclePolicy.STRONG, null, null, null)));
+
+    assertThrows(Exception.class, () ->
+        restApp.restClient.createOrUpdateAssociation(
+            RestService.DEFAULT_REQUEST_PROPERTIES, null, false, upsertRequest));
+  }
+
+  @Test
+  public void testUpsertCreatingNewWeakSucceeds() throws Exception {
+    String subject = "byo-subject-weak";
+    String resourceName = "topic1";
+    String resourceNamespace = "default";
+    String resourceId = "upsert-byo-weak-123";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(1);
+
+    restApp.restClient.registerSchema(allSchemas.get(0), subject);
+
+    AssociationCreateOrUpdateRequest upsertRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            subject, "value", null, null, null, null)));
+    restApp.restClient.createOrUpdateAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, upsertRequest);
+
+    List<Association> associations = restApp.restClient.getAssociationsByResourceId(
+        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
+        Collections.singletonList("value"), null, 0, -1);
+    assertEquals(1, associations.size());
+    assertEquals(subject, associations.get(0).getSubject());
+    assertEquals(LifecyclePolicy.WEAK, associations.get(0).getLifecycle());
+    assertFalse(associations.get(0).isFrozen());
+  }
+
+  /**
+   * The subject already carries a WEAK association from another resource. Silently promoting to
+   * STRONG would make this fail with "an association already exists for subject", masking the
+   * real reason, which is that the upsert cannot create an association carrying a schema.
+   */
+  @Test
+  public void testUpsertWithSchemaOnSharedSubjectReportsSchemaNotSubjectConflict()
+      throws Exception {
+    String subject = "shared-subject";
+    String resourceNamespace = "default";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
+
+    restApp.restClient.registerSchema(allSchemas.get(0), subject);
+
+    // Pre-existing WEAK association on the shared subject, from a different resource
+    AssociationCreateOrUpdateRequest weakRequest = new AssociationCreateOrUpdateRequest(
+        "topic1", resourceNamespace, "shared-subject-owner-123", "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            subject, "value", LifecyclePolicy.WEAK, null, null, null)));
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, weakRequest);
+
+    RegisterSchemaRequest schemaRequest = new RegisterSchemaRequest();
+    schemaRequest.setSchema(allSchemas.get(1));
+
+    AssociationUpsertOp upsertOp = new AssociationUpsertOp(
+        subject, "value", null, null, schemaRequest, null);
+    AssociationOpRequest opRequest = new AssociationOpRequest(
+        "topic2", resourceNamespace, "shared-subject-alter-123", "topic",
+        Collections.singletonList(upsertOp));
+    AssociationBatchRequest batchRequest = new AssociationBatchRequest(
+        Collections.singletonList(opRequest));
+
+    AssociationBatchResponse response = restApp.restClient.mutateAssociations(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, batchRequest);
+    assertNotNull(response.getResults().get(0).getError());
+    String message = response.getResults().get(0).getError().getMessage();
+    assertTrue(message.contains("schema"), "unexpected error message: " + message);
+    assertFalse(message.contains("already exists for subject"),
+        "should not report a subject conflict: " + message);
   }
 
   @Test
@@ -3068,6 +3671,81 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertThrows(Exception.class, () ->
         restApp.restClient.createAssociation(
             RestService.DEFAULT_REQUEST_PROPERTIES, null, false, request));
+  }
+
+  /**
+   * A subject in IMPORT mode receives its versions by replication, so a schema sent with the
+   * association would be dropped instead of registered. It is rejected rather than ignored.
+   */
+  @Test
+  public void testImportAssociationWithSchemaFails() throws Exception {
+    String resourceName = "topic6";
+    String resourceNamespace = "default";
+    String resourceId = "import-with-schema-123";
+    String defaultValueSubject = ":." + resourceNamespace + ":" + resourceName + "-value";
+    String schemaString = TestUtils.getRandomCanonicalAvroString(1).get(0);
+
+    restApp.restClient.setMode("IMPORT", defaultValueSubject, true);
+
+    RegisterSchemaRequest schemaRequest = new RegisterSchemaRequest();
+    schemaRequest.setSchema(schemaString);
+
+    AssociationCreateOrUpdateRequest request = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            null, "value", null, null, schemaRequest, null)));
+
+    assertThrows(Exception.class, () ->
+        restApp.restClient.createAssociation(
+            RestService.DEFAULT_REQUEST_PROPERTIES, null, false, request));
+
+    // Neither the association nor the subject was created
+    List<Association> associations = restApp.restClient.getAssociationsByResourceId(
+        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
+        Collections.singletonList("value"), null, 0, -1);
+    assertTrue(associations.isEmpty());
+  }
+
+  /**
+   * Updating an existing association: a schema sent while the subject is in IMPORT mode is
+   * rejected instead of reported as a success that registered nothing.
+   */
+  @Test
+  public void testImportMutateExistingAssociationWithSchemaFails() throws Exception {
+    String resourceName = "topic7";
+    String resourceNamespace = "default";
+    String resourceId = "import-mutate-schema-123";
+    String subject = "import-mutate-subject";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
+
+    // Establish the association while the subject is writable
+    restApp.restClient.registerSchema(allSchemas.get(0), subject);
+    AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            subject, "value", LifecyclePolicy.STRONG, false, null, null)));
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
+
+    restApp.restClient.setMode("IMPORT", subject, true);
+
+    RegisterSchemaRequest schemaRequest = new RegisterSchemaRequest();
+    schemaRequest.setSchema(allSchemas.get(1));
+
+    AssociationUpsertOp upsertOp = new AssociationUpsertOp(
+        subject, "value", null, null, schemaRequest, null);
+    AssociationOpRequest opRequest = new AssociationOpRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        Collections.singletonList(upsertOp));
+    AssociationBatchRequest batchRequest = new AssociationBatchRequest(
+        Collections.singletonList(opRequest));
+
+    AssociationBatchResponse response = restApp.restClient.mutateAssociations(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, batchRequest);
+    assertNotNull(response.getResults().get(0).getError());
+
+    // The schema was rejected, not silently dropped
+    assertEquals(Collections.singletonList(1), restApp.restClient.getAllVersions(subject));
   }
 
   @Test

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
@@ -1760,9 +1760,9 @@ public class RestApiAssociationTest extends ClusterTestHarness {
   }
 
   @Test
-  public void testMutateAssociationsWithAllOpTypesInSingleRequest() throws Exception {
-    // This test exercises CREATE, UPSERT, and DELETE operations in a SINGLE AssociationOpRequest
-    // (i.e., all three operation types for the same resource in one request)
+  public void testMutateAssociationsWithAllOpTypesInSingleBatch() throws Exception {
+    // This test exercises CREATE, UPSERT, and DELETE operations in a single batch
+    // (all three operation types for the same resource in one mutateAssociations call)
     String keySubject = "mutateKeySubject";
     String valueSubject = "mutateValueSubject";
     String resourceName = "mutateSingleTopic";
@@ -1809,11 +1809,8 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertEquals(1, initialAssociations.size());
     assertEquals("key", initialAssociations.get(0).getAssociationType());
 
-    // Now create a SINGLE AssociationOpRequest with all three operation types:
-    // - UPSERT "key" (update lifecycle from WEAK to STRONG)
-    // - CREATE "value" (new association)
-    // - DELETE "key" (delete the existing association)
-    // The operations are processed in order, so final state will have only "value".
+    // All three operation types in one batch. A request may only carry one op per association
+    // type, so the DELETE of "key" goes in a second request against the same resource.
     // "key" is promoted before "value" is added so the resource never holds a mix of
     // lifecycles, which is rejected.
     List<AssociationOpRequest> requests = new ArrayList<>();
@@ -1840,10 +1837,16 @@ public class RestApiAssociationTest extends ClusterTestHarness {
                 false,
                 null,
                 null
-            ),
-            // DELETE: Delete the "key" association
-            new AssociationDeleteOp("key")
+            )
         )
+    ));
+    requests.add(new AssociationOpRequest(
+        resourceName,
+        resourceNamespace,
+        resourceId,
+        "topic",
+        // DELETE: Delete the "key" association
+        ImmutableList.of(new AssociationDeleteOp("key"))
     ));
 
     AssociationBatchRequest batchRequest = new AssociationBatchRequest(requests);
@@ -1854,9 +1857,10 @@ public class RestApiAssociationTest extends ClusterTestHarness {
 
     // Verify batch response
     assertNotNull(batchResponse);
-    assertEquals(1, batchResponse.getResults().size());
+    assertEquals(2, batchResponse.getResults().size());
+    assertNull(batchResponse.getResults().get(0).getError());
 
-    AssociationResult result = batchResponse.getResults().get(0);
+    AssociationResult result = batchResponse.getResults().get(1);
     assertNull(result.getError());
     assertNotNull(result.getResult());
     assertEquals(resourceId, result.getResult().getResourceId());
@@ -2841,29 +2845,28 @@ public class RestApiAssociationTest extends ClusterTestHarness {
   }
 
   /**
-   * Two resources can share a name and namespace — an orphan from a deleted topic alongside a
-   * live one. The validate phase must not stitch their types together into a mix that never
-   * existed on either.
+   * Matching by name and namespace can span resourceIds. The validate phase must not stitch
+   * their types together into a mix that never existed on either resource.
    */
   @Test
   public void testDryRunDoesNotMixLifecyclesAcrossResourcesSharingAName() throws Exception {
-    String orphanSubject = "orphan-key-subject";
+    String olderSubject = "older-key-subject";
     String liveSubject = "live-value-subject";
     String resourceName = "sharedNameTopic";
     String resourceNamespace = "default";
     List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
 
-    restApp.restClient.registerSchema(allSchemas.get(0), orphanSubject);
+    restApp.restClient.registerSchema(allSchemas.get(0), olderSubject);
     restApp.restClient.registerSchema(allSchemas.get(1), liveSubject);
 
     // Older resource, STRONG on key. The ids are ordered so the live resource wins whether
     // recency or the id tie-break decides, keeping the test independent of write timing.
-    AssociationCreateOrUpdateRequest orphanRequest = new AssociationCreateOrUpdateRequest(
-        resourceName, resourceNamespace, "shared-name-a-orphan", "topic",
+    AssociationCreateOrUpdateRequest olderRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, "shared-name-a-older", "topic",
         ImmutableList.of(new AssociationCreateOrUpdateInfo(
-            orphanSubject, "key", LifecyclePolicy.STRONG, false, null, null)));
+            olderSubject, "key", LifecyclePolicy.STRONG, false, null, null)));
     restApp.restClient.createAssociation(
-        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, orphanRequest);
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, olderRequest);
 
     // Newer resource with the same name/namespace, WEAK on value
     AssociationCreateOrUpdateRequest liveRequest = new AssociationCreateOrUpdateRequest(
@@ -2932,11 +2935,12 @@ public class RestApiAssociationTest extends ClusterTestHarness {
   }
 
   /**
-   * Successive ops on the same association type are separate steps, not one request: a run
-   * ends where a type repeats, so two evolutions of the same subject both apply in order.
+   * A request may carry at most one op per association type. Nothing can legitimately send
+   * more — a topic config key appears once per incrementalAlterConfigs request — so this is
+   * rejected rather than applied in sequence.
    */
   @Test
-  public void testBatchRepeatedAssociationTypeAppliesInOrder() throws Exception {
+  public void testBatchRepeatedAssociationTypeIsRejected() throws Exception {
     String subject = "dup-run-subject";
     String resourceName = "dupRunTopic";
     String resourceNamespace = "default";
@@ -2964,11 +2968,46 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     AssociationBatchResponse response = restApp.restClient.mutateAssociations(
         RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
         new AssociationBatchRequest(Collections.singletonList(opRequest)));
-    assertNull(response.getResults().get(0).getError());
+    assertNotNull(response.getResults().get(0).getError());
 
-    // Both evolutions landed rather than colliding as a duplicate association type
-    assertEquals(ImmutableList.of(1, 2, 3), restApp.restClient.getAllVersions(subject));
+    // Rejected before anything was applied, so no new version was registered
+    assertEquals(Collections.singletonList(1), restApp.restClient.getAllVersions(subject));
   }
+
+  /** A delete counts towards the one-op-per-type rule as well. */
+  @Test
+  public void testBatchUpsertAndDeleteOfSameTypeIsRejected() throws Exception {
+    String subject = "dup-delete-subject";
+    String resourceName = "dupDeleteTopic";
+    String resourceNamespace = "default";
+    String resourceId = "dup-delete-123";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(1);
+
+    restApp.restClient.registerSchema(allSchemas.get(0), subject);
+    AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            subject, "value", LifecyclePolicy.WEAK, false, null, null)));
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
+
+    AssociationOpRequest opRequest = new AssociationOpRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(
+            new AssociationUpsertOp(subject, "value", LifecyclePolicy.WEAK, null, null, null),
+            new AssociationDeleteOp("value")));
+    AssociationBatchResponse response = restApp.restClient.mutateAssociations(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
+        new AssociationBatchRequest(Collections.singletonList(opRequest)));
+    assertNotNull(response.getResults().get(0).getError());
+
+    // The association is untouched
+    List<Association> associations = restApp.restClient.getAssociationsByResourceId(
+        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
+        Collections.singletonList("value"), null, 0, -1);
+    assertEquals(1, associations.size());
+  }
+
 
   /**
    * Runs are applied in order and there is no rollback across them, so a later run failing

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistryTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistryTest.java
@@ -568,17 +568,18 @@ public class KafkaSchemaRegistryTest extends ClusterTestHarness {
     kafkaSchemaRegistry.init();
 
     // 6 resources: topic0+topic1 in lkc1, topic0+topic2 in lkc2, topic0+topic3 in lkc3
-    // Each resource gets two associations (key/value), mixing STRONG and WEAK lifecycles.
+    // Each resource gets two associations (key/value). A resource cannot mix lifecycles, so
+    // the lifecycle varies between resources rather than within one.
     // Subjects are unique per resource to satisfy the one-STRONG-per-subject constraint.
     int schemaFieldCount = 1;
     String[][] resources = {
         // resourceName, namespace, resourceId, keyLifecycle, valueLifecycle
-        {"topic0", "lkc1", "id-lkc1-topic0", "WEAK",   "STRONG"},
-        {"topic1", "lkc1", "id-lkc1-topic1", "STRONG", "WEAK"},
-        {"topic0", "lkc2", "id-lkc2-topic0", "WEAK",   "STRONG"},
-        {"topic2", "lkc2", "id-lkc2-topic2", "STRONG", "WEAK"},
-        {"topic0", "lkc3", "id-lkc3-topic0", "WEAK",   "STRONG"},
-        {"topic3", "lkc3", "id-lkc3-topic3", "STRONG", "WEAK"},
+        {"topic0", "lkc1", "id-lkc1-topic0", "WEAK",   "WEAK"},
+        {"topic1", "lkc1", "id-lkc1-topic1", "STRONG", "STRONG"},
+        {"topic0", "lkc2", "id-lkc2-topic0", "WEAK",   "WEAK"},
+        {"topic2", "lkc2", "id-lkc2-topic2", "STRONG", "STRONG"},
+        {"topic0", "lkc3", "id-lkc3-topic0", "WEAK",   "WEAK"},
+        {"topic3", "lkc3", "id-lkc3-topic3", "STRONG", "STRONG"},
     };
     for (String[] r : resources) {
       String resourceName = r[0], namespace = r[1], resourceId = r[2];
@@ -613,7 +614,7 @@ public class KafkaSchemaRegistryTest extends ClusterTestHarness {
     assertTrue(all.stream().anyMatch(a -> "lkc2".equals(a.getResourceNamespace())));
     assertTrue(all.stream().anyMatch(a -> "lkc3".equals(a.getResourceNamespace())));
 
-    // lkc1 namespace: topic0/lkc1 (key=WEAK, value=STRONG) + topic1/lkc1 (key=STRONG, value=WEAK)
+    // lkc1 namespace: topic0/lkc1 (both WEAK) + topic1/lkc1 (both STRONG)
     List<Association> lkc1 = kafkaSchemaRegistry.getAssociationsByResourceNamespace(
         "lkc1", "topic", Collections.emptyList(), null);
     assertEquals(4, lkc1.size());
@@ -621,11 +622,11 @@ public class KafkaSchemaRegistryTest extends ClusterTestHarness {
     assertTrue(lkc1.stream().anyMatch(a ->
         "topic0".equals(a.getResourceName()) && "key".equals(a.getAssociationType()) && LifecyclePolicy.WEAK == a.getLifecycle()));
     assertTrue(lkc1.stream().anyMatch(a ->
-        "topic0".equals(a.getResourceName()) && "value".equals(a.getAssociationType()) && LifecyclePolicy.STRONG == a.getLifecycle()));
+        "topic0".equals(a.getResourceName()) && "value".equals(a.getAssociationType()) && LifecyclePolicy.WEAK == a.getLifecycle()));
     assertTrue(lkc1.stream().anyMatch(a ->
         "topic1".equals(a.getResourceName()) && "key".equals(a.getAssociationType()) && LifecyclePolicy.STRONG == a.getLifecycle()));
     assertTrue(lkc1.stream().anyMatch(a ->
-        "topic1".equals(a.getResourceName()) && "value".equals(a.getAssociationType()) && LifecyclePolicy.WEAK == a.getLifecycle()));
+        "topic1".equals(a.getResourceName()) && "value".equals(a.getAssociationType()) && LifecyclePolicy.STRONG == a.getLifecycle()));
 
     // lkc1 filtered to "key" associations only: topic0/key (WEAK) + topic1/key (STRONG)
     List<Association> lkc1Keys = kafkaSchemaRegistry.getAssociationsByResourceNamespace(
@@ -638,7 +639,7 @@ public class KafkaSchemaRegistryTest extends ClusterTestHarness {
     assertTrue(lkc1Keys.stream().anyMatch(a ->
         "topic1".equals(a.getResourceName()) && LifecyclePolicy.STRONG == a.getLifecycle()));
 
-    // lkc2 namespace: topic0/lkc2 (key=WEAK, value=STRONG) + topic2/lkc2 (key=STRONG, value=WEAK)
+    // lkc2 namespace: topic0/lkc2 (both WEAK) + topic2/lkc2 (both STRONG)
     List<Association> lkc2 = kafkaSchemaRegistry.getAssociationsByResourceNamespace(
         "lkc2", "topic", Collections.emptyList(), null);
     assertEquals(4, lkc2.size());
@@ -646,13 +647,13 @@ public class KafkaSchemaRegistryTest extends ClusterTestHarness {
     assertTrue(lkc2.stream().anyMatch(a ->
         "topic0".equals(a.getResourceName()) && "key".equals(a.getAssociationType()) && LifecyclePolicy.WEAK == a.getLifecycle()));
     assertTrue(lkc2.stream().anyMatch(a ->
-        "topic0".equals(a.getResourceName()) && "value".equals(a.getAssociationType()) && LifecyclePolicy.STRONG == a.getLifecycle()));
+        "topic0".equals(a.getResourceName()) && "value".equals(a.getAssociationType()) && LifecyclePolicy.WEAK == a.getLifecycle()));
     assertTrue(lkc2.stream().anyMatch(a ->
         "topic2".equals(a.getResourceName()) && "key".equals(a.getAssociationType()) && LifecyclePolicy.STRONG == a.getLifecycle()));
     assertTrue(lkc2.stream().anyMatch(a ->
-        "topic2".equals(a.getResourceName()) && "value".equals(a.getAssociationType()) && LifecyclePolicy.WEAK == a.getLifecycle()));
+        "topic2".equals(a.getResourceName()) && "value".equals(a.getAssociationType()) && LifecyclePolicy.STRONG == a.getLifecycle()));
 
-    // lkc3 namespace: topic0/lkc3 (key=WEAK, value=STRONG) + topic3/lkc3 (key=STRONG, value=WEAK)
+    // lkc3 namespace: topic0/lkc3 (both WEAK) + topic3/lkc3 (both STRONG)
     List<Association> lkc3 = kafkaSchemaRegistry.getAssociationsByResourceNamespace(
         "lkc3", "topic", Collections.emptyList(), null);
     assertEquals(4, lkc3.size());
@@ -660,11 +661,11 @@ public class KafkaSchemaRegistryTest extends ClusterTestHarness {
     assertTrue(lkc3.stream().anyMatch(a ->
         "topic0".equals(a.getResourceName()) && "key".equals(a.getAssociationType()) && LifecyclePolicy.WEAK == a.getLifecycle()));
     assertTrue(lkc3.stream().anyMatch(a ->
-        "topic0".equals(a.getResourceName()) && "value".equals(a.getAssociationType()) && LifecyclePolicy.STRONG == a.getLifecycle()));
+        "topic0".equals(a.getResourceName()) && "value".equals(a.getAssociationType()) && LifecyclePolicy.WEAK == a.getLifecycle()));
     assertTrue(lkc3.stream().anyMatch(a ->
         "topic3".equals(a.getResourceName()) && "key".equals(a.getAssociationType()) && LifecyclePolicy.STRONG == a.getLifecycle()));
     assertTrue(lkc3.stream().anyMatch(a ->
-        "topic3".equals(a.getResourceName()) && "value".equals(a.getAssociationType()) && LifecyclePolicy.WEAK == a.getLifecycle()));
+        "topic3".equals(a.getResourceName()) && "value".equals(a.getAssociationType()) && LifecyclePolicy.STRONG == a.getLifecycle()));
   }
 
   @Test


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----

Fixes DGS-24501, DGS-24537, DGS-24538, DGS-24539, DGS-24582, DGS-24631, DGS-24646


Seven association bugs reduce to three invariants that weren't being enforced. Each is                                                                                            
  fixed at the point the invariant belongs rather than at the symptom.                                                                                                              
                                                                                                                                                                                    
  ## Invariant 1 — an upsert may not create a topic-owned (STRONG) association                                                                                                      
                                                                                                                                                                                    
  A STRONG association is owned by its topic and can only be created together with the                                                                                              
  topic. Previously an upsert could create one, and would promote to STRONG on its own                                                                                              
  whenever a schema was supplied.                                                                                                                                                   
                                                                                                                                                                                    
  - **DGS-24537** — `IncrementalAlterConfigs` created a topic-owned association on a                                                                                                
    vanilla topic. Now rejected.                                                                                                                                                    
  - **DGS-24646** — `SET key={subject, schema}` silently created a STRONG association the                                                                                           
    caller never asked for. Now rejected.                                                                                                                                           
  - **DGS-24538** — that silent promotion then collided with the subject's existing WEAK                                                                                            
    associations and surfaced as `An association already exists for subject '...'`, which                                                                                           
    is not the real reason. The request now fails on its actual cause.                                                                                                              
                                                                                                                                                                                    
  Enforced in two places: the schema half in `applyDefaults` on the request entities, the                                                                                           
  lifecycle half in `AbstractSchemaRegistry` where the subject's mode is known.                                                                                                     
  **Subjects in IMPORT mode are exempt**, so cluster linking can still replicate an                                                                                                 
  established frozen STRONG association to a destination.                                                                                                                           
                                                                                                                                                                                    
  Evolving the schema of an association that already exists — the common alter-configs                                                                                              
  flow — is unaffected, since these defaults only apply while creating.

                                                                                                        
                                                                                                                                                                                    
  ## Invariant 2 — a subject in IMPORT mode receives its versions by replication                                                                                                    
                                                                                                                                                                                    
  - **DGS-24631** — a schema passed alongside an association was silently dropped, so the                                                                                           
    call reported success having registered nothing. Now rejected.                                                                                                                  
  - **DGS-24582** — the association was created against a subject that didn't exist yet.                                                                                            
    The existing "subject must have an active version" guard was correct but was skipped                                                                                            
    whenever a schema was supplied; with a schema no longer accepted during IMPORT, that                                                                                            
    guard applies and the association is refused until the subject's versions land.                                                                                                 
                                                                                                                                                                                    
  ## Invariant 3 — a resource has one lifecycle across all association types                                                                                                        
                                                                                                                                                                                    
  A topic is either topic-owned (STRONG) or shared (WEAK), never a mix.                                                                                                             
                                                                                                                                                                                    
  - **DGS-24501** — `CreateAssociation` accepted a shared key plus a topic-owned value in                                                                                           
    one request.                                                                                                                                                                    
  - **DGS-24539** — `IncrementalAlterConfigs` added a shared association to a topic that                                                                                            
    already had a topic-owned one.                                                                                                                                                  
                                                                                                                                                                                    
  `checkUniformLifecycle` computes the lifecycle the resource would *end up* with per type                                                                                          
  — from the request where it supplies one, from the existing association where it does                                                                                             
  not, and from storage for types the request leaves alone — and rejects anything that                                                                                              
  leaves the resource mixed. Converting every type in one request is therefore allowed.  

Two details that make this work:                                                                                                                                                  
                                                                                                                                                                                    
  - The pre-existing lookup is narrowed to the association types named in the request, so                                                                                           
    a sibling type is invisible to it. The check re-queries all types, which is what makes                                                                                          
    DGS-24539 detectable.                                                                                                                                                           
  - At the validate phase the caller may not yet have a resourceId, so the resource is                                                                                              
    matched by (name, namespace). Several resources can share those — an orphan from a                                                                                              
    deleted topic beside a live one — so `mostRecentlyUpdatedResource` narrows to one                                                                                               
    resource before evaluating. Merging per type instead would stitch types across                                                                                                  
    resources and report a mix that never existed. The pre-existing by-name fallback now                                                                                            
    goes through the same helper, so the equivalence, subject-change and frozen checks all                                                                                          
    judge the same resource.                                                                                                                                                        
                                                                                                                                                                                                                                                                         
                                                                                                                                                                                    
  ## Behavior changes                                                                                                                                                               
                                                                                                                                                                                    
  - Creating an association through `IncrementalAlterConfigs` while passing a schema now                                                                                            
    fails; topic-owned associations must be created with the topic.                                                                                                                 
  - An upsert that creates an association and explicitly asks for STRONG now fails outside                                                                                          
    IMPORT mode.                                                                                                                                                                    
  - Passing a schema while the subject is in IMPORT mode now errors instead of being                                                                                                
    ignored.                                                                                                                                                                        
  - A resource holding mixed lifecycles rejects any update that leaves it mixed.

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
