### PR TITLE
Add shared base for KIP-1356 IQv2 headers-aware integration tests

### DIFF
--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeaderAwareStoreRecoversRekeyedKeyIntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeaderAwareStoreRecoversRekeyedKeyIntegrationTest.java
@@ -199,8 +199,9 @@ public class HeaderAwareStoreRecoversRekeyedKeyIntegrationTest
           "header-aware store recovers the stored key's own schema, not the in-flight OrderKey id");
       assertEquals("cust-1", report.get("reconstructedValue").toString(),
           "customerId round-trips correctly");
-    } finally {
       closeStreams(streams);
+    } finally {
+      closeStreamsQuietly(streams);
     }
   }
 

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeaderAwareStoreRecoversRekeyedKeyIntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeaderAwareStoreRecoversRekeyedKeyIntegrationTest.java
@@ -17,42 +17,20 @@
 package io.confluent.kafka.streams.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.confluent.kafka.schemaregistry.ClusterTestHarness;
-import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
-import io.confluent.kafka.serializers.KafkaAvroDeserializer;
-import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
-import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import io.confluent.kafka.serializers.schema.id.HeaderSchemaIdSerializer;
 import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Produced;
@@ -90,7 +68,8 @@ import org.junit.jupiter.api.Test;
  * opposite of a plain, non-header store keyed by a header-mode serde, which would reconstruct the key
  * under the in-flight {@code OrderKey} id and get it wrong.)
  */
-public class HeaderAwareStoreRecoversRekeyedKeyIntegrationTest extends ClusterTestHarness {
+public class HeaderAwareStoreRecoversRekeyedKeyIntegrationTest
+    extends HeadersIQv2IntegrationTestBase {
 
   private static final Duration WINDOW_SIZE = Duration.ofMinutes(5);
   private static final Duration RETENTION_PERIOD = Duration.ofHours(1);
@@ -113,10 +92,6 @@ public class HeaderAwareStoreRecoversRekeyedKeyIntegrationTest extends ClusterTe
           + "\"namespace\":\"io.confluent.kafka.streams.integration\","
           + "\"fields\":[{\"name\":\"reconstructedKeySchema\",\"type\":\"string\"},"
           + "{\"name\":\"reconstructedValue\",\"type\":\"string\"}]}");
-
-  public HeaderAwareStoreRecoversRekeyedKeyIntegrationTest() {
-    super(1, true);
-  }
 
   @Test
   public void keyValueStore_recoversRekeyedKeyWithItsOwnSchema() throws Exception {
@@ -354,113 +329,5 @@ public class HeaderAwareStoreRecoversRekeyedKeyIntegrationTest extends ClusterTe
     GenericRecord value = new GenericData.Record(ORDER_VALUE_SCHEMA);
     value.put("customerId", customerId);
     return value;
-  }
-
-  private void createTopics(String... topicNames) throws Exception {
-    Properties adminProps = new Properties();
-    adminProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
-    try (AdminClient admin = AdminClient.create(adminProps)) {
-      List<NewTopic> topics = Arrays.stream(topicNames)
-          .map(name -> new NewTopic(name, 1, (short) 1))
-          .collect(Collectors.toList());
-      admin.createTopics(topics).all().get(30, TimeUnit.SECONDS);
-    }
-  }
-
-  private GenericAvroSerde createKeySerde() {
-    GenericAvroSerde serde = new GenericAvroSerde();
-    Map<String, Object> config = new HashMap<>();
-    config.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
-    config.put(AbstractKafkaSchemaSerDeConfig.KEY_SCHEMA_ID_SERIALIZER,
-        HeaderSchemaIdSerializer.class.getName());
-    serde.configure(config, true);
-    return serde;
-  }
-
-  private GenericAvroSerde createValueSerde() {
-    GenericAvroSerde serde = new GenericAvroSerde();
-    Map<String, Object> config = new HashMap<>();
-    config.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
-    config.put(AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_SERIALIZER,
-        HeaderSchemaIdSerializer.class.getName());
-    serde.configure(config, false);
-    return serde;
-  }
-
-  private Properties createProducerProps() {
-    Properties props = new Properties();
-    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
-    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName());
-    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName());
-    props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
-    props.put(AbstractKafkaSchemaSerDeConfig.KEY_SCHEMA_ID_SERIALIZER,
-        HeaderSchemaIdSerializer.class.getName());
-    props.put(AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_SERIALIZER,
-        HeaderSchemaIdSerializer.class.getName());
-    return props;
-  }
-
-  private Properties createStreamsProps(String appId) {
-    Properties props = new Properties();
-    props.put(StreamsConfig.APPLICATION_ID_CONFIG, appId);
-    props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
-    props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
-    return props;
-  }
-
-  private KafkaStreams startStreamsAndAwaitRunning(Topology topology, String appId)
-      throws Exception {
-    CountDownLatch startedLatch = new CountDownLatch(1);
-    KafkaStreams streams = new KafkaStreams(topology, createStreamsProps(appId));
-    streams.cleanUp();
-    streams.setStateListener((newState, oldState) -> {
-      if (newState == KafkaStreams.State.RUNNING) {
-        startedLatch.countDown();
-      }
-    });
-    streams.start();
-    boolean running = false;
-    try {
-      running = startedLatch.await(30, TimeUnit.SECONDS);
-      assertTrue(running, "KafkaStreams should reach RUNNING state");
-      return streams;
-    } finally {
-      if (!running) {
-        closeStreams(streams);
-      }
-    }
-  }
-
-  private void closeStreams(KafkaStreams streams) {
-    if (streams != null) {
-      streams.close(Duration.ofSeconds(10));
-    }
-  }
-
-  private List<ConsumerRecord<GenericRecord, GenericRecord>> consumeRecords(
-      String topic, String groupId, int expectedCount) {
-    Properties props = new Properties();
-    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
-    props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
-    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
-    props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
-    props.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, false);
-
-    List<ConsumerRecord<GenericRecord, GenericRecord>> results = new ArrayList<>();
-    try (KafkaConsumer<GenericRecord, GenericRecord> consumer = new KafkaConsumer<>(props)) {
-      consumer.subscribe(Collections.singletonList(topic));
-      long deadline = System.currentTimeMillis() + 30_000;
-      while (results.size() < expectedCount && System.currentTimeMillis() < deadline) {
-        ConsumerRecords<GenericRecord, GenericRecord> records = consumer.poll(Duration.ofMillis(500));
-        for (ConsumerRecord<GenericRecord, GenericRecord> record : records) {
-          results.add(record);
-        }
-      }
-    }
-    assertEquals(expectedCount, results.size(),
-        "Expected " + expectedCount + " records from " + topic + " but got " + results.size());
-    return results;
   }
 }

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeadersIQv2IntegrationTestBase.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeadersIQv2IntegrationTestBase.java
@@ -39,9 +39,11 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -55,6 +57,7 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
+import org.junit.jupiter.api.AfterEach;
 
 /**
  * Shared infrastructure for the KIP-1356 headers-aware IQv2 integration tests. Holds the boilerplate
@@ -72,12 +75,41 @@ import org.apache.kafka.streams.Topology;
  */
 public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness {
 
-    /** GUID bytes the producer wrote for the key / value schema, captured on send (see below). */
-    private byte[] expectedKeyGuid;
-    private byte[] expectedValueGuid;
+    /**
+     * The schema-id GUID bytes a producer wrote into a record's {@code __key_schema_id} /
+     * {@code __value_schema_id} headers, captured on send by {@link #sendAndCapture} so a later IQv2
+     * result can be asserted byte-for-byte equal to what that record produced. Either field is
+     * {@code null} when the record carried no corresponding header (a tombstone writes no value
+     * header). Capturing per record -- rather than into a shared field -- lets a subclass that
+     * produces more than one key or value schema assert each result against its own GUID.
+     */
+    protected static final class CapturedSchemaIds {
+        private final byte[] keyGuid;
+        private final byte[] valueGuid;
+
+        private CapturedSchemaIds(byte[] keyGuid, byte[] valueGuid) {
+            this.keyGuid = keyGuid;
+            this.valueGuid = valueGuid;
+        }
+    }
+
+    /**
+     * Serdes handed to the topology. Streams does not close serdes passed via
+     * {@code Consumed.with}/{@code Produced.with}/{@code StoreBuilder}, so each would leak its
+     * {@code CachedSchemaRegistryClient} HTTP connection pool -- we close them ourselves in teardown.
+     */
+    private final List<GenericAvroSerde> createdSerdes = new ArrayList<>();
 
     protected HeadersIQv2IntegrationTestBase() {
         super(1, true);
+    }
+
+    @AfterEach
+    public void closeSerdes() {
+        for (GenericAvroSerde serde : createdSerdes) {
+            serde.close();
+        }
+        createdSerdes.clear();
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -91,7 +123,7 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
     protected void createTopicsWithPartitions(int numPartitions, String... topicNames)
         throws Exception {
         Properties adminProps = new Properties();
-        adminProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
+        adminProps.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
         try (AdminClient admin = AdminClient.create(adminProps)) {
             List<NewTopic> topics = Arrays.stream(topicNames)
                 .map(name -> new NewTopic(name, numPartitions, (short) 1))
@@ -111,6 +143,7 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
         config.put(AbstractKafkaSchemaSerDeConfig.KEY_SCHEMA_ID_SERIALIZER,
             HeaderSchemaIdSerializer.class.getName());
         serde.configure(config, true);
+        createdSerdes.add(serde);
         return serde;
     }
 
@@ -121,6 +154,7 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
         config.put(AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_SERIALIZER,
             HeaderSchemaIdSerializer.class.getName());
         serde.configure(config, false);
+        createdSerdes.add(serde);
         return serde;
     }
 
@@ -165,18 +199,30 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
     protected KafkaStreams startStreamsAndAwaitRunning(Topology topology, String appId,
         int timeoutSeconds, Integer commitIntervalMs) throws Exception {
         CountDownLatch startedLatch = new CountDownLatch(1);
+        AtomicReference<KafkaStreams.State> lastState =
+            new AtomicReference<>(KafkaStreams.State.CREATED);
         KafkaStreams streams = new KafkaStreams(topology, createStreamsProps(appId, commitIntervalMs));
-        streams.cleanUp();
-        streams.setStateListener((newState, oldState) -> {
-            if (newState == KafkaStreams.State.RUNNING) {
-                startedLatch.countDown();
-            }
-        });
-        streams.start();
         boolean running = false;
         try {
-            running = startedLatch.await(timeoutSeconds, TimeUnit.SECONDS);
-            assertTrue(running, "KafkaStreams should reach RUNNING state");
+            streams.cleanUp();
+            streams.setStateListener((newState, oldState) -> {
+                lastState.set(newState);
+                // Count down on RUNNING and on any shutdown/error state, so a startup failure fails
+                // fast with the observed state instead of waiting out the whole timeout.
+                if (newState == KafkaStreams.State.RUNNING
+                    || newState.hasStartedOrFinishedShuttingDown()) {
+                    startedLatch.countDown();
+                }
+            });
+            streams.start();
+            boolean reached = startedLatch.await(timeoutSeconds, TimeUnit.SECONDS);
+            assertTrue(reached,
+                "KafkaStreams did not reach RUNNING within " + timeoutSeconds
+                    + "s (last observed state: " + lastState.get() + ")");
+            assertEquals(KafkaStreams.State.RUNNING, lastState.get(),
+                "KafkaStreams should reach RUNNING state (last observed state: "
+                    + lastState.get() + ")");
+            running = true;
             return streams;
         } finally {
             if (!running) {
@@ -187,7 +233,8 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
 
     protected void closeStreams(KafkaStreams streams) {
         if (streams != null) {
-            streams.close(Duration.ofSeconds(10));
+            assertTrue(streams.close(Duration.ofSeconds(10)),
+                "KafkaStreams.close() timed out before shutting down cleanly");
         }
     }
 
@@ -196,43 +243,42 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
     // ---------------------------------------------------------------------------------------------
 
     /**
-     * Sends {@code record} synchronously and captures the schema-id GUID bytes the serializer wrote
-     * into the record's headers, so later IQv2 results can be asserted byte-equal to what was
-     * produced. A tombstone (null value) writes no value header and leaves the captured value GUID
-     * untouched.
+     * Sends {@code record} synchronously and returns the schema-id GUID bytes the serializer wrote
+     * into the record's headers, so the IQv2 result for this record can be asserted byte-equal to
+     * what was produced. A tombstone (null value) writes no value header, so the returned value GUID
+     * is {@code null}.
      */
-    protected void sendAndCapture(KafkaProducer<GenericRecord, GenericRecord> producer,
+    protected CapturedSchemaIds sendAndCapture(KafkaProducer<GenericRecord, GenericRecord> producer,
         ProducerRecord<GenericRecord, GenericRecord> record) throws Exception {
         producer.send(record).get();
         Header keyHeader = record.headers().lastHeader(SchemaId.KEY_SCHEMA_ID_HEADER);
-        if (keyHeader != null) {
-            expectedKeyGuid = keyHeader.value().clone();
-        }
+        byte[] keyGuid = keyHeader != null ? keyHeader.value().clone() : null;
         Header valueHeader = record.headers().lastHeader(SchemaId.VALUE_SCHEMA_ID_HEADER);
-        if (valueHeader != null) {
-            expectedValueGuid = valueHeader.value().clone();
-        }
+        byte[] valueGuid = valueHeader != null ? valueHeader.value().clone() : null;
+        return new CapturedSchemaIds(keyGuid, valueGuid);
     }
 
-    protected void produce(String topic, GenericRecord key, GenericRecord value, long timestamp)
-        throws Exception {
-        try (KafkaProducer<GenericRecord, GenericRecord> producer =
-                 new KafkaProducer<>(createProducerProps())) {
-            sendAndCapture(producer, new ProducerRecord<>(topic, null, timestamp, key, value));
-            producer.flush();
-        }
-    }
-
-    protected void produceAll(String topic, List<GenericRecord> keys, List<GenericRecord> values,
+    /** Produces a single record and returns the GUIDs its serializer wrote (see {@link #sendAndCapture}). */
+    protected CapturedSchemaIds produce(String topic, GenericRecord key, GenericRecord value,
         long timestamp) throws Exception {
         try (KafkaProducer<GenericRecord, GenericRecord> producer =
                  new KafkaProducer<>(createProducerProps())) {
-            for (int i = 0; i < keys.size(); i++) {
-                sendAndCapture(producer,
-                    new ProducerRecord<>(topic, null, timestamp, keys.get(i), values.get(i)));
-            }
-            producer.flush();
+            return sendAndCapture(producer, new ProducerRecord<>(topic, null, timestamp, key, value));
         }
+    }
+
+    /** Produces one record per key/value pair and returns the captured GUIDs in produce order. */
+    protected List<CapturedSchemaIds> produceAll(String topic, List<GenericRecord> keys,
+        List<GenericRecord> values, long timestamp) throws Exception {
+        List<CapturedSchemaIds> captured = new ArrayList<>();
+        try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                 new KafkaProducer<>(createProducerProps())) {
+            for (int i = 0; i < keys.size(); i++) {
+                captured.add(sendAndCapture(producer,
+                    new ProducerRecord<>(topic, null, timestamp, keys.get(i), values.get(i))));
+            }
+        }
+        return captured;
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -262,8 +308,8 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
                 }
             }
         }
-        assertEquals(expectedCount, results.size(),
-            "Expected " + expectedCount + " records from " + topic
+        assertTrue(results.size() >= expectedCount,
+            "Expected at least " + expectedCount + " records from " + topic
                 + " but got " + results.size() + " within 30s");
         return results;
     }
@@ -274,22 +320,26 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
 
     /**
      * Asserts the record carries a well-formed 17-byte {@code MAGIC_BYTE_V1} schema-id GUID in both
-     * the {@code __key_schema_id} and {@code __value_schema_id} headers and, once a producer has
-     * recorded the GUID it wrote (via {@link #sendAndCapture}), that the bytes are exactly those
-     * produced.
+     * the {@code __key_schema_id} and {@code __value_schema_id} headers and that the bytes are
+     * exactly the GUIDs {@code expected} captured when this record was produced (via
+     * {@link #produce}/{@link #produceAll}). A {@code null} {@code expected} or a missing captured
+     * GUID fails, rather than silently degrading to a format-only check.
      */
-    protected void assertSchemaIdHeaders(Headers headers, String context) {
+    protected void assertSchemaIdHeaders(Headers headers, CapturedSchemaIds expected,
+        String context) {
+        assertNotNull(expected,
+            context + ": no captured schema-id GUIDs -- produce the record via produce/produceAll");
         byte[] keyBytes = assertGuidHeader(headers, SchemaId.KEY_SCHEMA_ID_HEADER, "Key", context);
-        if (expectedKeyGuid != null) {
-            assertArrayEquals(expectedKeyGuid, keyBytes,
-                context + ": Key GUID header should equal the GUID the producer wrote");
-        }
+        assertNotNull(expected.keyGuid,
+            context + ": no produced key GUID captured -- produce a record before asserting");
+        assertArrayEquals(expected.keyGuid, keyBytes,
+            context + ": Key GUID header should equal the GUID the producer wrote");
         byte[] valueBytes =
             assertGuidHeader(headers, SchemaId.VALUE_SCHEMA_ID_HEADER, "Value", context);
-        if (expectedValueGuid != null) {
-            assertArrayEquals(expectedValueGuid, valueBytes,
-                context + ": Value GUID header should equal the GUID the producer wrote");
-        }
+        assertNotNull(expected.valueGuid,
+            context + ": no produced value GUID captured -- produce a record before asserting");
+        assertArrayEquals(expected.valueGuid, valueBytes,
+            context + ": Value GUID header should equal the GUID the producer wrote");
     }
 
     private static byte[] assertGuidHeader(Headers headers, String headerName, String which,

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeadersIQv2IntegrationTestBase.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeadersIQv2IntegrationTestBase.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.streams.integration;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.confluent.kafka.schemaregistry.ClusterTestHarness;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import io.confluent.kafka.serializers.schema.id.HeaderSchemaIdSerializer;
+import io.confluent.kafka.serializers.schema.id.SchemaId;
+import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+
+/**
+ * Shared infrastructure for the KIP-1356 headers-aware IQv2 integration tests. Holds the boilerplate
+ * that would otherwise be copy-pasted across every store-type-specific test: topic creation,
+ * header-mode Avro serdes, a {@link KafkaStreams} start/await/close lifecycle, an output-topic
+ * completion-barrier consumer, and the schema-id GUID header assertion.
+ *
+ * <p>Every concrete test produces records whose schema-id GUID is carried in the
+ * {@code __key_schema_id} / {@code __value_schema_id} headers (via {@link HeaderSchemaIdSerializer}).
+ * When a record is produced through {@link #sendAndCapture}, the exact GUID bytes the serializer wrote
+ * are captured, so {@link #assertSchemaIdHeaders} can assert that the bytes returned by an IQv2 query
+ * are byte-for-byte the GUID that was produced -- not merely a well-formed one.
+ *
+ * <p>Runs against a real 1-broker cluster + embedded Schema Registry ({@code super(1, true)}).
+ */
+public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness {
+
+    /** GUID bytes the producer wrote for the key / value schema, captured on send (see below). */
+    private byte[] expectedKeyGuid;
+    private byte[] expectedValueGuid;
+
+    protected HeadersIQv2IntegrationTestBase() {
+        super(1, true);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Topics
+    // ---------------------------------------------------------------------------------------------
+
+    protected void createTopics(String... topicNames) throws Exception {
+        createTopicsWithPartitions(1, topicNames);
+    }
+
+    protected void createTopicsWithPartitions(int numPartitions, String... topicNames)
+        throws Exception {
+        Properties adminProps = new Properties();
+        adminProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
+        try (AdminClient admin = AdminClient.create(adminProps)) {
+            List<NewTopic> topics = Arrays.stream(topicNames)
+                .map(name -> new NewTopic(name, numPartitions, (short) 1))
+                .collect(Collectors.toList());
+            admin.createTopics(topics).all().get(30, TimeUnit.SECONDS);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Header-mode serdes and client configs
+    // ---------------------------------------------------------------------------------------------
+
+    protected GenericAvroSerde createKeySerde() {
+        GenericAvroSerde serde = new GenericAvroSerde();
+        Map<String, Object> config = new HashMap<>();
+        config.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
+        config.put(AbstractKafkaSchemaSerDeConfig.KEY_SCHEMA_ID_SERIALIZER,
+            HeaderSchemaIdSerializer.class.getName());
+        serde.configure(config, true);
+        return serde;
+    }
+
+    protected GenericAvroSerde createValueSerde() {
+        GenericAvroSerde serde = new GenericAvroSerde();
+        Map<String, Object> config = new HashMap<>();
+        config.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
+        config.put(AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_SERIALIZER,
+            HeaderSchemaIdSerializer.class.getName());
+        serde.configure(config, false);
+        return serde;
+    }
+
+    protected Properties createProducerProps() {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName());
+        props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
+        props.put(AbstractKafkaSchemaSerDeConfig.KEY_SCHEMA_ID_SERIALIZER,
+            HeaderSchemaIdSerializer.class.getName());
+        props.put(AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_SERIALIZER,
+            HeaderSchemaIdSerializer.class.getName());
+        return props;
+    }
+
+    protected Properties createStreamsProps(String appId, Integer commitIntervalMs) {
+        Properties props = new Properties();
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, appId);
+        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
+        props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
+        if (commitIntervalMs != null) {
+            props.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, commitIntervalMs);
+        }
+        return props;
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Streams lifecycle
+    // ---------------------------------------------------------------------------------------------
+
+    protected KafkaStreams startStreamsAndAwaitRunning(Topology topology, String appId)
+        throws Exception {
+        return startStreamsAndAwaitRunning(topology, appId, 30, null);
+    }
+
+    protected KafkaStreams startStreamsAndAwaitRunning(Topology topology, String appId,
+        int timeoutSeconds) throws Exception {
+        return startStreamsAndAwaitRunning(topology, appId, timeoutSeconds, null);
+    }
+
+    protected KafkaStreams startStreamsAndAwaitRunning(Topology topology, String appId,
+        int timeoutSeconds, Integer commitIntervalMs) throws Exception {
+        CountDownLatch startedLatch = new CountDownLatch(1);
+        KafkaStreams streams = new KafkaStreams(topology, createStreamsProps(appId, commitIntervalMs));
+        streams.cleanUp();
+        streams.setStateListener((newState, oldState) -> {
+            if (newState == KafkaStreams.State.RUNNING) {
+                startedLatch.countDown();
+            }
+        });
+        streams.start();
+        boolean running = false;
+        try {
+            running = startedLatch.await(timeoutSeconds, TimeUnit.SECONDS);
+            assertTrue(running, "KafkaStreams should reach RUNNING state");
+            return streams;
+        } finally {
+            if (!running) {
+                closeStreams(streams);
+            }
+        }
+    }
+
+    protected void closeStreams(KafkaStreams streams) {
+        if (streams != null) {
+            streams.close(Duration.ofSeconds(10));
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Producing (captures the produced schema-id GUID for byte-equality assertions)
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Sends {@code record} synchronously and captures the schema-id GUID bytes the serializer wrote
+     * into the record's headers, so later IQv2 results can be asserted byte-equal to what was
+     * produced. A tombstone (null value) writes no value header and leaves the captured value GUID
+     * untouched.
+     */
+    protected void sendAndCapture(KafkaProducer<GenericRecord, GenericRecord> producer,
+        ProducerRecord<GenericRecord, GenericRecord> record) throws Exception {
+        producer.send(record).get();
+        Header keyHeader = record.headers().lastHeader(SchemaId.KEY_SCHEMA_ID_HEADER);
+        if (keyHeader != null) {
+            expectedKeyGuid = keyHeader.value().clone();
+        }
+        Header valueHeader = record.headers().lastHeader(SchemaId.VALUE_SCHEMA_ID_HEADER);
+        if (valueHeader != null) {
+            expectedValueGuid = valueHeader.value().clone();
+        }
+    }
+
+    protected void produce(String topic, GenericRecord key, GenericRecord value, long timestamp)
+        throws Exception {
+        try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                 new KafkaProducer<>(createProducerProps())) {
+            sendAndCapture(producer, new ProducerRecord<>(topic, null, timestamp, key, value));
+            producer.flush();
+        }
+    }
+
+    protected void produceAll(String topic, List<GenericRecord> keys, List<GenericRecord> values,
+        long timestamp) throws Exception {
+        try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                 new KafkaProducer<>(createProducerProps())) {
+            for (int i = 0; i < keys.size(); i++) {
+                sendAndCapture(producer,
+                    new ProducerRecord<>(topic, null, timestamp, keys.get(i), values.get(i)));
+            }
+            producer.flush();
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Consuming (output-topic completion barrier)
+    // ---------------------------------------------------------------------------------------------
+
+    protected List<ConsumerRecord<GenericRecord, GenericRecord>> consumeRecords(
+        String topic, String groupId, int expectedCount) {
+        Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
+        props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
+        props.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, false);
+
+        List<ConsumerRecord<GenericRecord, GenericRecord>> results = new ArrayList<>();
+        try (KafkaConsumer<GenericRecord, GenericRecord> consumer = new KafkaConsumer<>(props)) {
+            consumer.subscribe(Collections.singletonList(topic));
+            long deadline = System.currentTimeMillis() + 30_000;
+            while (results.size() < expectedCount && System.currentTimeMillis() < deadline) {
+                ConsumerRecords<GenericRecord, GenericRecord> records =
+                    consumer.poll(Duration.ofMillis(500));
+                for (ConsumerRecord<GenericRecord, GenericRecord> record : records) {
+                    results.add(record);
+                }
+            }
+        }
+        assertEquals(expectedCount, results.size(),
+            "Expected " + expectedCount + " records from " + topic
+                + " but got " + results.size() + " within 30s");
+        return results;
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Header assertions
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Asserts the record carries a well-formed 17-byte {@code MAGIC_BYTE_V1} schema-id GUID in both
+     * the {@code __key_schema_id} and {@code __value_schema_id} headers and, once a producer has
+     * recorded the GUID it wrote (via {@link #sendAndCapture}), that the bytes are exactly those
+     * produced.
+     */
+    protected void assertSchemaIdHeaders(Headers headers, String context) {
+        byte[] keyBytes = assertGuidHeader(headers, SchemaId.KEY_SCHEMA_ID_HEADER, "Key", context);
+        if (expectedKeyGuid != null) {
+            assertArrayEquals(expectedKeyGuid, keyBytes,
+                context + ": Key GUID header should equal the GUID the producer wrote");
+        }
+        byte[] valueBytes =
+            assertGuidHeader(headers, SchemaId.VALUE_SCHEMA_ID_HEADER, "Value", context);
+        if (expectedValueGuid != null) {
+            assertArrayEquals(expectedValueGuid, valueBytes,
+                context + ": Value GUID header should equal the GUID the producer wrote");
+        }
+    }
+
+    private static byte[] assertGuidHeader(Headers headers, String headerName, String which,
+        String context) {
+        Header header = headers.lastHeader(headerName);
+        assertNotNull(header, context + ": should have " + headerName + " header");
+        byte[] bytes = header.value();
+        assertEquals(17, bytes.length, context + ": " + which + " GUID header should be 17 bytes");
+        assertEquals(SchemaId.MAGIC_BYTE_V1, bytes[0],
+            context + ": " + which + " header should have V1 magic byte");
+        return bytes;
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Misc
+    // ---------------------------------------------------------------------------------------------
+
+    protected static void sleepQuietly(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeadersIQv2IntegrationTestBase.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeadersIQv2IntegrationTestBase.java
@@ -274,6 +274,12 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
         }
     }
 
+    /**
+     * Closes {@code streams} and asserts it shut down cleanly within the timeout. Call this as the
+     * last statement of the test body -- never from a {@code finally}, where a close timeout would
+     * throw an {@link AssertionError} that replaces whatever actually failed the test. Use
+     * {@link #closeStreamsQuietly} in a {@code finally}.
+     */
     protected void closeStreams(KafkaStreams streams) {
         if (streams != null) {
             assertTrue(streams.close(Duration.ofSeconds(10)),
@@ -282,11 +288,12 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
     }
 
     /**
-     * Closes {@code streams} best-effort without asserting on a clean shutdown -- for teardown and
-     * the start-failure path, where a close timeout must not replace the error that actually failed
-     * the test. Success-path callers should use {@link #closeStreams} to assert a clean shutdown.
+     * Closes {@code streams} best-effort without asserting on a clean shutdown -- for {@code finally}
+     * blocks, teardown and the start-failure path, where a close timeout must not replace the error
+     * that actually failed the test. Closing an already-closed instance is a no-op, so this is safe
+     * to call in a {@code finally} whose {@code try} ended in {@link #closeStreams}.
      */
-    private static void closeStreamsQuietly(KafkaStreams streams) {
+    protected static void closeStreamsQuietly(KafkaStreams streams) {
         if (streams != null) {
             try {
                 streams.close(Duration.ofSeconds(10));

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeadersIQv2IntegrationTestBase.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeadersIQv2IntegrationTestBase.java
@@ -60,6 +60,7 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.junit.jupiter.api.AfterEach;
 
 /**
@@ -231,6 +232,19 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
 
     protected KafkaStreams startStreamsAndAwaitRunning(Topology topology, String appId,
         int timeoutSeconds, Integer commitIntervalMs) throws Exception {
+        return startStreamsAndAwaitRunning(topology, appId, timeoutSeconds, commitIntervalMs, null);
+    }
+
+    /**
+     * Starts {@code topology} with {@code restoreListener} attached before {@code start()}, so a
+     * restart that must rebuild its state from the changelog can assert the restore actually
+     * happened. Exists so a restore test does not hand-roll its own start block: an inline copy
+     * loses the terminal-state count-down below (a failed restore then blocks for the whole timeout
+     * and reports no observed state) and leaves the instance untracked, so teardown never closes it.
+     */
+    protected KafkaStreams startStreamsAndAwaitRunning(Topology topology, String appId,
+        int timeoutSeconds, Integer commitIntervalMs, StateRestoreListener restoreListener)
+        throws Exception {
         CountDownLatch startedLatch = new CountDownLatch(1);
         AtomicReference<KafkaStreams.State> lastState =
             new AtomicReference<>(KafkaStreams.State.CREATED);
@@ -243,6 +257,11 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
         boolean running = false;
         try {
             streams.cleanUp();
+            if (restoreListener != null) {
+                // Must be attached before start(), or the restore it is meant to observe can be
+                // under way (or over) before the listener is registered.
+                streams.setGlobalStateRestoreListener(restoreListener);
+            }
             streams.setStateListener((newState, oldState) -> {
                 lastState.set(newState);
                 // Count down on RUNNING and on any shutdown/error state, so a startup failure fails

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeadersIQv2IntegrationTestBase.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeadersIQv2IntegrationTestBase.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
@@ -41,6 +42,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -101,12 +103,26 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
      */
     private final List<GenericAvroSerde> createdSerdes = new ArrayList<>();
 
+    /**
+     * Every {@link KafkaStreams} instance handed out by {@link #startStreamsAndAwaitRunning}. A test
+     * that fails before its own {@link #closeStreams} would otherwise leak the instance's state-dir
+     * lock and StreamThreads for the rest of the fork JVM, so teardown closes any that are still open.
+     */
+    private final List<KafkaStreams> startedStreams = new ArrayList<>();
+
     protected HeadersIQv2IntegrationTestBase() {
         super(1, true);
     }
 
     @AfterEach
-    public void closeSerdes() {
+    public void closeStreamsAndSerdes() {
+        // Close streams before serdes: a StreamThread still shutting down can lazily rebuild a
+        // serde's Schema Registry HTTP pool on its next serialize, re-leaking a pool we just closed.
+        for (KafkaStreams streams : startedStreams) {
+            closeStreamsQuietly(streams);
+        }
+        startedStreams.clear();
+
         RuntimeException firstError = null;
         for (GenericAvroSerde serde : createdSerdes) {
             try {
@@ -156,8 +172,10 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
         config.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
         config.put(AbstractKafkaSchemaSerDeConfig.KEY_SCHEMA_ID_SERIALIZER,
             HeaderSchemaIdSerializer.class.getName());
-        serde.configure(config, true);
+        // Track before configure: GenericAvroSerde.configure builds the serializer's client first,
+        // so if the deserializer's configure throws, the serde must already be tracked to be closed.
         createdSerdes.add(serde);
+        serde.configure(config, true);
         return serde;
     }
 
@@ -167,8 +185,9 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
         config.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
         config.put(AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_SERIALIZER,
             HeaderSchemaIdSerializer.class.getName());
-        serde.configure(config, false);
+        // Track before configure: see createKeySerde.
         createdSerdes.add(serde);
+        serde.configure(config, false);
         return serde;
     }
 
@@ -220,6 +239,7 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
         // otherwise flip lastState away from RUNNING and spuriously fail the start assertion.
         AtomicBoolean reachedRunning = new AtomicBoolean(false);
         KafkaStreams streams = new KafkaStreams(topology, createStreamsProps(appId, commitIntervalMs));
+        startedStreams.add(streams);
         boolean running = false;
         try {
             streams.cleanUp();
@@ -245,8 +265,11 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
             running = true;
             return streams;
         } finally {
+            // Close quietly on the failure path: the start assertion above is the error worth
+            // reporting, and close() on an instance that never reached RUNNING will usually time out
+            // too -- asserting on that here would throw from finally and mask the real cause.
             if (!running) {
-                closeStreams(streams);
+                closeStreamsQuietly(streams);
             }
         }
     }
@@ -255,6 +278,21 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
         if (streams != null) {
             assertTrue(streams.close(Duration.ofSeconds(10)),
                 "KafkaStreams.close() timed out before shutting down cleanly");
+        }
+    }
+
+    /**
+     * Closes {@code streams} best-effort without asserting on a clean shutdown -- for teardown and
+     * the start-failure path, where a close timeout must not replace the error that actually failed
+     * the test. Success-path callers should use {@link #closeStreams} to assert a clean shutdown.
+     */
+    private static void closeStreamsQuietly(KafkaStreams streams) {
+        if (streams != null) {
+            try {
+                streams.close(Duration.ofSeconds(10));
+            } catch (RuntimeException e) {
+                // Best-effort cleanup; nothing actionable if a wedged StreamThread refuses to stop.
+            }
         }
     }
 
@@ -290,7 +328,10 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
     /** Produces one record per key/value pair and returns the captured GUIDs in produce order. */
     protected List<CapturedSchemaIds> produceAll(String topic, List<GenericRecord> keys,
         List<GenericRecord> values, long timestamp) throws Exception {
-        assertEquals(keys.size(), values.size(), "produceAll requires one value per key");
+        if (keys.size() != values.size()) {
+            throw new IllegalArgumentException("produceAll requires one value per key, but got "
+                + keys.size() + " keys and " + values.size() + " values");
+        }
         List<CapturedSchemaIds> captured = new ArrayList<>();
         try (KafkaProducer<GenericRecord, GenericRecord> producer =
                  new KafkaProducer<>(createProducerProps())) {
@@ -306,33 +347,65 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
     // Consuming (output-topic completion barrier)
     // ---------------------------------------------------------------------------------------------
 
+    /** Reads {@code expectedCount} records off {@code topic} as Avro {@link GenericRecord} values. */
     protected List<ConsumerRecord<GenericRecord, GenericRecord>> consumeRecords(
         String topic, String groupId, int expectedCount) {
+        return consumeRecords(topic, groupId, expectedCount, KafkaAvroDeserializer.class);
+    }
+
+    /**
+     * Reads {@code expectedCount} records off {@code topic}, deserializing values with
+     * {@code valueDeserializerClass}. Keys are always Avro {@link GenericRecord}; pass
+     * {@code ByteArrayDeserializer.class} to read a raw topic (e.g. a changelog) whose value bytes
+     * carry the schema-id header being asserted. Safe to call more than once with the same
+     * {@code groupId}: auto-commit is off, so a second call re-reads from {@code earliest}.
+     */
+    protected <V> List<ConsumerRecord<GenericRecord, V>> consumeRecords(
+        String topic, String groupId, int expectedCount, Class<?> valueDeserializerClass) {
         Properties props = new Properties();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
         props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        // Do not commit on close: a second call with the same groupId must re-read from earliest
+        // rather than resume past a committed offset and read nothing.
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
-        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializerClass.getName());
         props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
         props.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, false);
 
-        List<ConsumerRecord<GenericRecord, GenericRecord>> results = new ArrayList<>();
-        try (KafkaConsumer<GenericRecord, GenericRecord> consumer = new KafkaConsumer<>(props)) {
+        List<ConsumerRecord<GenericRecord, V>> results = new ArrayList<>();
+        try (KafkaConsumer<GenericRecord, V> consumer = new KafkaConsumer<>(props)) {
             consumer.subscribe(Collections.singletonList(topic));
             long deadline = System.currentTimeMillis() + 30_000;
             while (results.size() < expectedCount && System.currentTimeMillis() < deadline) {
-                ConsumerRecords<GenericRecord, GenericRecord> records =
+                ConsumerRecords<GenericRecord, V> records =
                     consumer.poll(Duration.ofMillis(500));
-                for (ConsumerRecord<GenericRecord, GenericRecord> record : records) {
+                for (ConsumerRecord<GenericRecord, V> record : records) {
                     results.add(record);
                 }
             }
         }
         assertTrue(results.size() >= expectedCount,
             "Expected at least " + expectedCount + " records from " + topic
-                + " but got " + results.size() + " within 30s");
+                + " but got " + results.size() + " within 30s" + describeStreamsStates());
         return results;
+    }
+
+    /**
+     * Renders the current state of every {@link KafkaStreams} this base started, for appending to a
+     * barrier-timeout message: a StreamThread that died mid-test shuts the client down silently
+     * (default {@code SHUTDOWN_CLIENT}), which otherwise surfaces only as "got 0 records".
+     */
+    private String describeStreamsStates() {
+        if (startedStreams.isEmpty()) {
+            return "";
+        }
+        List<KafkaStreams.State> states = new ArrayList<>();
+        for (KafkaStreams streams : startedStreams) {
+            states.add(streams.state());
+        }
+        return " (KafkaStreams states: " + states + ")";
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -367,6 +440,23 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
             context + ": Value GUID header should equal the GUID the producer wrote");
     }
 
+    /**
+     * Asserts the record carries a well-formed key schema-id GUID header equal to the key GUID
+     * {@code expected} captured when this record was produced. Unlike {@link #assertSchemaIdHeaders}
+     * this checks only the key header, so it applies to a tombstone (null-value record), which
+     * carries a key GUID but no value header.
+     */
+    protected void assertKeySchemaIdHeader(Headers headers, CapturedSchemaIds expected,
+        String context) {
+        assertNotNull(expected,
+            context + ": no captured schema-id GUIDs -- produce the record via produce/produceAll");
+        byte[] keyBytes = assertGuidHeader(headers, SchemaId.KEY_SCHEMA_ID_HEADER, "Key", context);
+        assertNotNull(expected.keyGuid,
+            context + ": no produced key GUID captured -- produce a record before asserting");
+        assertArrayEquals(expected.keyGuid, keyBytes,
+            context + ": Key GUID header should equal the GUID the producer wrote");
+    }
+
     private static byte[] assertGuidHeader(Headers headers, String headerName, String which,
         String context) {
         Header header = headers.lastHeader(headerName);
@@ -381,6 +471,22 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
     // ---------------------------------------------------------------------------------------------
     // Misc
     // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Polls {@code condition} until it holds, failing if {@code timeoutMs} elapses first. Prefer this
+     * to a fixed {@code Thread.sleep} for waiting on an observable outcome (e.g. a changelog record
+     * having landed): it returns as soon as the condition holds and names what it was waiting for.
+     */
+    protected static void awaitCondition(BooleanSupplier condition, long timeoutMs,
+        String description) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (!condition.getAsBoolean()) {
+            if (System.currentTimeMillis() >= deadline) {
+                fail(description + " not satisfied within " + timeoutMs + "ms");
+            }
+            sleepQuietly(50);
+        }
+    }
 
     protected static void sleepQuietly(long millis) {
         try {

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeadersIQv2IntegrationTestBase.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeadersIQv2IntegrationTestBase.java
@@ -457,6 +457,19 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
             context + ": Key GUID header should equal the GUID the producer wrote");
     }
 
+    /**
+     * Asserts the record carries a well-formed 17-byte {@code MAGIC_BYTE_V1} schema-id GUID in both
+     * the {@code __key_schema_id} and {@code __value_schema_id} headers, without checking the GUID
+     * value. Use this for a record whose producing GUID this test does not hold -- an IQv2/IQv1
+     * query result, or an output/changelog record in a test that produces inline rather than through
+     * {@link #produce}/{@link #produceAll}. When the producing GUID is available, prefer the
+     * stricter {@link #assertSchemaIdHeaders(Headers, CapturedSchemaIds, String)}.
+     */
+    protected void assertWellFormedSchemaIdHeaders(Headers headers, String context) {
+        assertGuidHeader(headers, SchemaId.KEY_SCHEMA_ID_HEADER, "Key", context);
+        assertGuidHeader(headers, SchemaId.VALUE_SCHEMA_ID_HEADER, "Value", context);
+    }
+
     private static byte[] assertGuidHeader(Headers headers, String headerName, String which,
         String context) {
         Header header = headers.lastHeader(headerName);

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeadersIQv2IntegrationTestBase.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeadersIQv2IntegrationTestBase.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.avro.generic.GenericRecord;
@@ -106,10 +107,23 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
 
     @AfterEach
     public void closeSerdes() {
+        RuntimeException firstError = null;
         for (GenericAvroSerde serde : createdSerdes) {
-            serde.close();
+            try {
+                serde.close();
+            } catch (RuntimeException e) {
+                // Keep closing the rest so a single failing serde can't leak the others.
+                if (firstError == null) {
+                    firstError = e;
+                } else {
+                    firstError.addSuppressed(e);
+                }
+            }
         }
         createdSerdes.clear();
+        if (firstError != null) {
+            throw firstError;
+        }
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -201,6 +215,10 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
         CountDownLatch startedLatch = new CountDownLatch(1);
         AtomicReference<KafkaStreams.State> lastState =
             new AtomicReference<>(KafkaStreams.State.CREATED);
+        // Record that RUNNING was observed, rather than re-reading lastState after the latch:
+        // RUNNING -> REBALANCING is a valid transition, so a benign follow-up rebalance could
+        // otherwise flip lastState away from RUNNING and spuriously fail the start assertion.
+        AtomicBoolean reachedRunning = new AtomicBoolean(false);
         KafkaStreams streams = new KafkaStreams(topology, createStreamsProps(appId, commitIntervalMs));
         boolean running = false;
         try {
@@ -209,8 +227,10 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
                 lastState.set(newState);
                 // Count down on RUNNING and on any shutdown/error state, so a startup failure fails
                 // fast with the observed state instead of waiting out the whole timeout.
-                if (newState == KafkaStreams.State.RUNNING
-                    || newState.hasStartedOrFinishedShuttingDown()) {
+                if (newState == KafkaStreams.State.RUNNING) {
+                    reachedRunning.set(true);
+                    startedLatch.countDown();
+                } else if (newState.hasStartedOrFinishedShuttingDown()) {
                     startedLatch.countDown();
                 }
             });
@@ -219,9 +239,9 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
             assertTrue(reached,
                 "KafkaStreams did not reach RUNNING within " + timeoutSeconds
                     + "s (last observed state: " + lastState.get() + ")");
-            assertEquals(KafkaStreams.State.RUNNING, lastState.get(),
-                "KafkaStreams should reach RUNNING state (last observed state: "
-                    + lastState.get() + ")");
+            assertTrue(reachedRunning.get(),
+                "KafkaStreams entered a shutdown state before reaching RUNNING (last observed "
+                    + "state: " + lastState.get() + ")");
             running = true;
             return streams;
         } finally {
@@ -270,6 +290,7 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
     /** Produces one record per key/value pair and returns the captured GUIDs in produce order. */
     protected List<CapturedSchemaIds> produceAll(String topic, List<GenericRecord> keys,
         List<GenericRecord> values, long timestamp) throws Exception {
+        assertEquals(keys.size(), values.size(), "produceAll requires one value per key");
         List<CapturedSchemaIds> captured = new ArrayList<>();
         try (KafkaProducer<GenericRecord, GenericRecord> producer =
                  new KafkaProducer<>(createProducerProps())) {
@@ -324,6 +345,10 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
      * exactly the GUIDs {@code expected} captured when this record was produced (via
      * {@link #produce}/{@link #produceAll}). A {@code null} {@code expected} or a missing captured
      * GUID fails, rather than silently degrading to a format-only check.
+     *
+     * <p>This asserts a value-bearing record: both a key and a value GUID must have been captured.
+     * It is not applicable to tombstones -- a null-value record captures no value GUID (see
+     * {@link CapturedSchemaIds}) and would fail the value-header assertion here.
      */
     protected void assertSchemaIdHeaders(Headers headers, CapturedSchemaIds expected,
         String context) {

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/StatelessHeaderIntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/StatelessHeaderIntegrationTest.java
@@ -67,7 +67,8 @@ public class StatelessHeaderIntegrationTest extends HeadersIQv2IntegrationTestBa
    * Verifies that header-based schema IDs survive every stateless operator that re-serializes
    * records: filter, mapValues, map, selectKey, flatMapValues, and branch. Each operator's output
    * is written to its own topic via {@code .to(...)} so re-serialization is forced; we then assert
-   * the schema-ID headers are present on each output topic.
+   * each output record's schema-ID headers are byte-for-byte the GUIDs the producer wrote to the
+   * input topic.
    */
   @Test
   public void shouldPreserveHeadersAcrossStatelessOperators() throws Exception {
@@ -120,17 +121,21 @@ public class StatelessHeaderIntegrationTest extends HeadersIQv2IntegrationTestBa
       GenericRecord value = new GenericData.Record(valueSchema);
       value.put("temperature", 42.0);
       value.put("timestamp", System.currentTimeMillis());
-      produce(INPUT_TOPIC, key, value, System.currentTimeMillis());
+      CapturedSchemaIds produced = produce(INPUT_TOPIC, key, value, System.currentTimeMillis());
 
       for (String outputTopic : Arrays.asList(
           filterOutput, mapValuesOutput, mapOutput, selectKeyOutput, flatMapValuesOutput,
           branchHotOutput)) {
         ConsumerRecord<GenericRecord, GenericRecord> result =
             consumeRecords(outputTopic, "stateless-" + outputTopic + "-consumer", 1).get(0);
-        assertWellFormedSchemaIdHeaders(result.headers(), outputTopic);
+        // Every operator here is identity, so the re-serialized output must carry the exact GUID
+        // bytes the producer wrote: a schema GUID is a content hash, so re-registering the same
+        // schema under each output topic's own subject yields the same GUID.
+        assertSchemaIdHeaders(result.headers(), produced, outputTopic);
       }
-    } finally {
       closeStreams(streams);
+    } finally {
+      closeStreamsQuietly(streams);
     }
   }
 }

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/StatelessHeaderIntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/StatelessHeaderIntegrationTest.java
@@ -16,44 +16,17 @@
 
 package io.confluent.kafka.streams.integration;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import io.confluent.kafka.schemaregistry.ClusterTestHarness;
-import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
-import io.confluent.kafka.serializers.KafkaAvroDeserializer;
-import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
-import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import io.confluent.kafka.serializers.schema.id.HeaderSchemaIdSerializer;
-import io.confluent.kafka.serializers.schema.id.SchemaId;
 import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.header.Header;
-import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.Branched;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
@@ -65,7 +38,7 @@ import org.junit.jupiter.api.Test;
  * {@link GenericAvroSerde} configured to use {@link HeaderSchemaIdSerializer} for header-based
  * schema ID transport. Both keys and values use Avro with header-based schema IDs.
  */
-public class StatelessHeaderIntegrationTest extends ClusterTestHarness {
+public class StatelessHeaderIntegrationTest extends HeadersIQv2IntegrationTestBase {
 
   private static final String INPUT_TOPIC = "sensor-readings-input";
 
@@ -90,10 +63,6 @@ public class StatelessHeaderIntegrationTest extends ClusterTestHarness {
           + "]"
           + "}";
 
-  public StatelessHeaderIntegrationTest() {
-    super(1, true);
-  }
-
   /**
    * Verifies that header-based schema IDs survive every stateless operator that re-serializes
    * records: filter, mapValues, map, selectKey, flatMapValues, and branch. Each operator's output
@@ -112,37 +81,11 @@ public class StatelessHeaderIntegrationTest extends ClusterTestHarness {
     Schema keySchema = new Schema.Parser().parse(KEY_SCHEMA_JSON);
     Schema valueSchema = new Schema.Parser().parse(VALUE_SCHEMA_JSON);
 
-    Properties adminProps = new Properties();
-    adminProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
-    try (AdminClient admin = AdminClient.create(adminProps)) {
-      admin.createTopics(Arrays.asList(
-          new NewTopic(INPUT_TOPIC, 1, (short) 1),
-          new NewTopic(filterOutput, 1, (short) 1),
-          new NewTopic(mapValuesOutput, 1, (short) 1),
-          new NewTopic(mapOutput, 1, (short) 1),
-          new NewTopic(selectKeyOutput, 1, (short) 1),
-          new NewTopic(flatMapValuesOutput, 1, (short) 1),
-          new NewTopic(branchHotOutput, 1, (short) 1)
-      )).all().get(30, TimeUnit.SECONDS);
-    }
+    createTopics(INPUT_TOPIC, filterOutput, mapValuesOutput, mapOutput, selectKeyOutput,
+        flatMapValuesOutput, branchHotOutput);
 
-    Map<String, Object> keySerdeConfig = new HashMap<>();
-    keySerdeConfig.put(
-        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
-    keySerdeConfig.put(
-        AbstractKafkaSchemaSerDeConfig.KEY_SCHEMA_ID_SERIALIZER,
-        HeaderSchemaIdSerializer.class.getName());
-    GenericAvroSerde keySerde = new GenericAvroSerde();
-    keySerde.configure(keySerdeConfig, true);
-
-    Map<String, Object> valueSerdeConfig = new HashMap<>();
-    valueSerdeConfig.put(
-        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
-    valueSerdeConfig.put(
-        AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_SERIALIZER,
-        HeaderSchemaIdSerializer.class.getName());
-    GenericAvroSerde valueSerde = new GenericAvroSerde();
-    valueSerde.configure(valueSerdeConfig, false);
+    GenericAvroSerde keySerde = createKeySerde();
+    GenericAvroSerde valueSerde = createValueSerde();
 
     StreamsBuilder builder = new StreamsBuilder();
     KStream<GenericRecord, GenericRecord> source =
@@ -169,107 +112,25 @@ public class StatelessHeaderIntegrationTest extends ClusterTestHarness {
             Branched.withConsumer(
                 s -> s.to(branchHotOutput, Produced.with(keySerde, valueSerde))));
 
-    Properties streamsProps = new Properties();
-    streamsProps.put(
-        StreamsConfig.APPLICATION_ID_CONFIG, "stateless-operators-integration-test");
-    streamsProps.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
-    streamsProps.put(
-        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
-
-    KafkaStreams streams = null;
+    KafkaStreams streams =
+        startStreamsAndAwaitRunning(builder.build(), "stateless-operators-integration-test");
     try {
-      CountDownLatch startedLatch = new CountDownLatch(1);
-      streams = new KafkaStreams(builder.build(), streamsProps);
-      streams.setStateListener(
-          (newState, oldState) -> {
-            if (newState == KafkaStreams.State.RUNNING) {
-              startedLatch.countDown();
-            }
-          });
-      streams.start();
-      assertTrue(
-          startedLatch.await(30, TimeUnit.SECONDS), "KafkaStreams should reach RUNNING state");
-
-      Properties producerProps = new Properties();
-      producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
-      producerProps.put(
-          ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName());
-      producerProps.put(
-          ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName());
-      producerProps.put(
-          AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
-      producerProps.put(
-          AbstractKafkaSchemaSerDeConfig.KEY_SCHEMA_ID_SERIALIZER,
-          HeaderSchemaIdSerializer.class.getName());
-      producerProps.put(
-          AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_SERIALIZER,
-          HeaderSchemaIdSerializer.class.getName());
-
-      try (KafkaProducer<GenericRecord, GenericRecord> producer =
-               new KafkaProducer<>(producerProps)) {
-        GenericRecord key = new GenericData.Record(keySchema);
-        key.put("sensorId", "sensor-1");
-        GenericRecord value = new GenericData.Record(valueSchema);
-        value.put("temperature", 42.0);
-        value.put("timestamp", System.currentTimeMillis());
-        producer.send(new ProducerRecord<>(INPUT_TOPIC, key, value)).get();
-        producer.flush();
-      }
+      GenericRecord key = new GenericData.Record(keySchema);
+      key.put("sensorId", "sensor-1");
+      GenericRecord value = new GenericData.Record(valueSchema);
+      value.put("temperature", 42.0);
+      value.put("timestamp", System.currentTimeMillis());
+      produce(INPUT_TOPIC, key, value, System.currentTimeMillis());
 
       for (String outputTopic : Arrays.asList(
-          filterOutput, mapValuesOutput, mapOutput, selectKeyOutput, flatMapValuesOutput, branchHotOutput)) {
+          filterOutput, mapValuesOutput, mapOutput, selectKeyOutput, flatMapValuesOutput,
+          branchHotOutput)) {
         ConsumerRecord<GenericRecord, GenericRecord> result =
-            consumeFirstRecord(outputTopic, "stateless-" + outputTopic + "-consumer");
-        assertNotNull(result, "Expected one record on " + outputTopic);
-        assertSchemaIdHeaders(result.headers(), outputTopic);
+            consumeRecords(outputTopic, "stateless-" + outputTopic + "-consumer", 1).get(0);
+        assertWellFormedSchemaIdHeaders(result.headers(), outputTopic);
       }
     } finally {
-      if (streams != null) {
-        streams.close(Duration.ofSeconds(10));
-      }
+      closeStreams(streams);
     }
-  }
-
-  private ConsumerRecord<GenericRecord, GenericRecord> consumeFirstRecord(
-      String topic, String groupId) {
-    Properties consumerProps = new Properties();
-    consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
-    consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-    consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-    consumerProps.put(
-        ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
-    consumerProps.put(
-        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
-    consumerProps.put(
-        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
-    consumerProps.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, false);
-
-    try (KafkaConsumer<GenericRecord, GenericRecord> consumer =
-             new KafkaConsumer<>(consumerProps)) {
-      consumer.subscribe(Collections.singletonList(topic));
-      long deadline = System.currentTimeMillis() + 30_000;
-      while (System.currentTimeMillis() < deadline) {
-        ConsumerRecords<GenericRecord, GenericRecord> records =
-            consumer.poll(Duration.ofMillis(500));
-        if (!records.isEmpty()) {
-          return records.iterator().next();
-        }
-      }
-    }
-    return null;
-  }
-
-  private void assertSchemaIdHeaders(Headers headers, String context) {
-    Header keySchemaIdHeader = headers.lastHeader(SchemaId.KEY_SCHEMA_ID_HEADER);
-    assertNotNull(keySchemaIdHeader, context + ": should have __key_schema_id header");
-    byte[] keyHeaderBytes = keySchemaIdHeader.value();
-    assertEquals(17, keyHeaderBytes.length, context + ": Key GUID header should be 17 bytes");
-    assertEquals(SchemaId.MAGIC_BYTE_V1, keyHeaderBytes[0], context + ": Key header should have V1 magic byte");
-
-    Header valueSchemaIdHeader = headers.lastHeader(SchemaId.VALUE_SCHEMA_ID_HEADER);
-    assertNotNull(valueSchemaIdHeader, context + ": should have __value_schema_id header");
-    byte[] valueHeaderBytes = valueSchemaIdHeader.value();
-    assertEquals(17, valueHeaderBytes.length, context + ": Value GUID header should be 17 bytes");
-    assertEquals(SchemaId.MAGIC_BYTE_V1, valueHeaderBytes[0], context + ": Value header should have V1 magic byte");
   }
 }

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIntegrationTest.java
@@ -210,8 +210,9 @@ public class TimestampedKeyValueStoreWithHeadersIntegrationTest
             assertEquals(50L, word2Result.value().get("count"), "IQv1: word-2 count should be 50");
             assertWellFormedSchemaIdHeaders(word2Result.headers(), "IQv1 get word-2");
 
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -344,8 +345,9 @@ public class TimestampedKeyValueStoreWithHeadersIntegrationTest
             // APPROXIMATE NUM ENTRIES
             assertTrue(store.approximateNumEntries() >= 4, "approximateNumEntries should be at least 4");
 
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -520,8 +522,9 @@ public class TimestampedKeyValueStoreWithHeadersIntegrationTest
             // Test IQv1 approximateNumEntries()
             assertTrue(store.approximateNumEntries() >= 5, "IQv1 approximateNumEntries should be at least 5");
 
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -570,8 +573,9 @@ public class TimestampedKeyValueStoreWithHeadersIntegrationTest
                 "Store state checks should pass (isOpen=true, persistent=true, name matches)");
             assertEquals("state-store", results.get(0).key().get("word").toString());
 
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -787,8 +791,9 @@ public class TimestampedKeyValueStoreWithHeadersIntegrationTest
                 "Deleted keys should include word-1, word-99, word-3, word-4 but got: "
                     + deletedKeys);
 
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -817,8 +822,11 @@ public class TimestampedKeyValueStoreWithHeadersIntegrationTest
                 producer.flush();
             }
             consumeRecords(outputTopic, "restore-pre-consumer", 3, KafkaAvroDeserializer.class);
-        } finally {
+            // Assert the clean shutdown here: the restart below reuses this application.id and
+            // state dir, so a timed-out close would resurface as a confusing cleanUp() failure.
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
 
         // Restart with the same APPLICATION_ID; cleanUp() wipes the local state dir so the store
@@ -844,8 +852,9 @@ public class TimestampedKeyValueStoreWithHeadersIntegrationTest
             assertNotNull(word3, "Restored store should contain word-3");
             assertEquals(30L, word3.value().get("count"));
             assertWellFormedSchemaIdHeaders(word3.headers(), "Restored word-3");
-        } finally {
             closeStreams(restoredStreams);
+        } finally {
+            closeStreamsQuietly(restoredStreams);
         }
     }
 
@@ -927,8 +936,9 @@ public class TimestampedKeyValueStoreWithHeadersIntegrationTest
             }
             assertTrue(partitions.size() > 1,
                 "Changelog records should span multiple partitions but only saw: " + partitions);
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIntegrationTest.java
@@ -21,48 +21,27 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.confluent.kafka.schemaregistry.ClusterTestHarness;
-import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
-import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
-import io.confluent.kafka.serializers.KafkaAvroSerializer;
-import io.confluent.kafka.serializers.schema.id.HeaderSchemaIdSerializer;
 import io.confluent.kafka.serializers.schema.id.SchemaId;
 import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Header;
-import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsBuilder;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Produced;
@@ -85,7 +64,8 @@ import org.junit.jupiter.api.Test;
  * Integration test for {@link TimestampedKeyValueStoreWithHeaders} that verifies store operations
  * work correctly with header-based schema ID transport.
  */
-public class TimestampedKeyValueStoreWithHeadersIntegrationTest extends ClusterTestHarness {
+public class TimestampedKeyValueStoreWithHeadersIntegrationTest
+    extends HeadersIQv2IntegrationTestBase {
 
     private static final String INPUT_TOPIC = "word-plaintext-input";
     private static final String OUTPUT_TOPIC = "word-count-output";
@@ -114,10 +94,6 @@ public class TimestampedKeyValueStoreWithHeadersIntegrationTest extends ClusterT
 
     private final Schema keySchema = new Schema.Parser().parse(KEY_SCHEMA_JSON);
     private final Schema valueSchema = new Schema.Parser().parse(VALUE_SCHEMA_JSON);
-
-    public TimestampedKeyValueStoreWithHeadersIntegrationTest() {
-        super(1, true);
-    }
 
     /**
      * Test KeyValueStore operations (put, get, delete, putIfAbsent, putAll) with header-based schema ID transport.
@@ -232,7 +208,7 @@ public class TimestampedKeyValueStoreWithHeadersIntegrationTest extends ClusterT
             ValueTimestampHeaders<GenericRecord> word2Result = store.get(createKey("word-2"));
             assertNotNull(word2Result, "IQv1: word-2 should exist in store");
             assertEquals(50L, word2Result.value().get("count"), "IQv1: word-2 count should be 50");
-            assertSchemaIdHeaders(word2Result.headers(), "IQv1 get word-2");
+            assertWellFormedSchemaIdHeaders(word2Result.headers(), "IQv1 get word-2");
 
         } finally {
             closeStreams(streams);
@@ -318,23 +294,23 @@ public class TimestampedKeyValueStoreWithHeadersIntegrationTest extends ClusterT
             ValueTimestampHeaders<GenericRecord> word2Result = store.get(createKey("word-2"));
             assertNotNull(word2Result, "IQv1: word-2 should exist in store");
             assertEquals(50L, word2Result.value().get("count"), "IQv1: word-2 count should be 50");
-            assertSchemaIdHeaders(word2Result.headers(), "IQv1 get word-2");
+            assertWellFormedSchemaIdHeaders(word2Result.headers(), "IQv1 get word-2");
 
             // Verify PUT_ALL: all 3 word entries should exist
             ValueTimestampHeaders<GenericRecord> word3Result = store.get(createKey("word-3"));
             assertNotNull(word3Result, "IQv1: word-3 should exist in store");
             assertEquals(25L, word3Result.value().get("count"), "IQv1: word-3 count should be 25");
-            assertSchemaIdHeaders(word3Result.headers(), "IQv1 get word-3");
+            assertWellFormedSchemaIdHeaders(word3Result.headers(), "IQv1 get word-3");
 
             ValueTimestampHeaders<GenericRecord> word4Result = store.get(createKey("word-4"));
             assertNotNull(word4Result, "IQv1: word-4 should exist in store");
             assertEquals(50L, word4Result.value().get("count"), "IQv1: word-4 count should be 50");
-            assertSchemaIdHeaders(word4Result.headers(), "IQv1 get word-4");
+            assertWellFormedSchemaIdHeaders(word4Result.headers(), "IQv1 get word-4");
 
             ValueTimestampHeaders<GenericRecord> word5Result = store.get(createKey("word-5"));
             assertNotNull(word5Result, "IQv1: word-5 should exist in store");
             assertEquals(75L, word5Result.value().get("count"), "IQv1: word-5 count should be 75");
-            assertSchemaIdHeaders(word5Result.headers(), "IQv1 get word-5");
+            assertWellFormedSchemaIdHeaders(word5Result.headers(), "IQv1 get word-5");
 
             // GET non-existent key
             assertNull(store.get(createKey("word-99")), "IQv1: word-99 should return null");
@@ -522,7 +498,7 @@ public class TimestampedKeyValueStoreWithHeadersIntegrationTest extends ClusterT
                 while (allIter.hasNext()) {
                     KeyValue<GenericRecord, ValueTimestampHeaders<GenericRecord>> kv = allIter.next();
                     assertNotNull(kv.value, "IQv1 all() value should not be null");
-                    assertSchemaIdHeaders(kv.value.headers(), "IQv1 all() entry " + count);
+                    assertWellFormedSchemaIdHeaders(kv.value.headers(), "IQv1 all() entry " + count);
                     count++;
                 }
                 assertEquals(5, count, "IQv1 all() should return 5 entries");
@@ -535,7 +511,7 @@ public class TimestampedKeyValueStoreWithHeadersIntegrationTest extends ClusterT
                 while (rangeIter.hasNext()) {
                     KeyValue<GenericRecord, ValueTimestampHeaders<GenericRecord>> kv = rangeIter.next();
                     rangeKeys.add(kv.key.get("word").toString());
-                    assertSchemaIdHeaders(kv.value.headers(), "IQv1 range() " + kv.key.get("word"));
+                    assertWellFormedSchemaIdHeaders(kv.value.headers(), "IQv1 range() " + kv.key.get("word"));
                 }
                 assertEquals(Arrays.asList("word-2", "word-3", "word-4"), rangeKeys,
                     "IQv1 range(word-2, word-4) should return word-2, word-3, word-4");
@@ -857,17 +833,17 @@ public class TimestampedKeyValueStoreWithHeadersIntegrationTest extends ClusterT
             ValueTimestampHeaders<GenericRecord> word1 = store.get(createKey("word-1"));
             assertNotNull(word1, "Restored store should contain word-1");
             assertEquals(10L, word1.value().get("count"));
-            assertSchemaIdHeaders(word1.headers(), "Restored word-1");
+            assertWellFormedSchemaIdHeaders(word1.headers(), "Restored word-1");
 
             ValueTimestampHeaders<GenericRecord> word2 = store.get(createKey("word-2"));
             assertNotNull(word2, "Restored store should contain word-2");
             assertEquals(20L, word2.value().get("count"));
-            assertSchemaIdHeaders(word2.headers(), "Restored word-2");
+            assertWellFormedSchemaIdHeaders(word2.headers(), "Restored word-2");
 
             ValueTimestampHeaders<GenericRecord> word3 = store.get(createKey("word-3"));
             assertNotNull(word3, "Restored store should contain word-3");
             assertEquals(30L, word3.value().get("count"));
-            assertSchemaIdHeaders(word3.headers(), "Restored word-3");
+            assertWellFormedSchemaIdHeaders(word3.headers(), "Restored word-3");
         } finally {
             closeStreams(restoredStreams);
         }
@@ -920,24 +896,9 @@ public class TimestampedKeyValueStoreWithHeadersIntegrationTest extends ClusterT
             .process(() -> new WordCountProcessor(storeName), storeName)
             .to(outputTopic, Produced.with(keySerde, valueSerde));
 
-        Properties streamsProps = createStreamsProps(appId);
         // Low commit interval forces the cache to flush into the changelog topic.
-        streamsProps.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 1000);
-
-        KafkaStreams streams = null;
+        KafkaStreams streams = startStreamsAndAwaitRunning(builder.build(), appId, 30, 1000);
         try {
-            CountDownLatch startedLatch = new CountDownLatch(1);
-            streams = new KafkaStreams(builder.build(), streamsProps);
-            streams.cleanUp();
-            streams.setStateListener((newState, oldState) -> {
-                if (newState == KafkaStreams.State.RUNNING) {
-                    startedLatch.countDown();
-                }
-            });
-            streams.start();
-            assertTrue(startedLatch.await(30, TimeUnit.SECONDS),
-                "KafkaStreams should reach RUNNING state");
-
             try (KafkaProducer<GenericRecord, GenericRecord> producer =
                      new KafkaProducer<>(createProducerProps())) {
                 for (int i = 1; i <= numKeys; i++) {
@@ -947,11 +908,11 @@ public class TimestampedKeyValueStoreWithHeadersIntegrationTest extends ClusterT
                 producer.flush();
             }
 
-            // Wait for outputs so we know the topology processed them, then briefly wait for the
-            // commit-driven cache flush (commit.interval.ms = 1s) to hit the changelog.
+            // Wait for the outputs so we know the topology processed them; the changelog read below
+            // then polls until the commit-driven cache flush (commit.interval.ms = 1s) lands the
+            // records -- no fixed sleep needed since consumeRecords already waits for numKeys.
             consumeRecords(outputTopic, "multi-partition-output-consumer", numKeys,
                 KafkaAvroDeserializer.class);
-            Thread.sleep(2000);
 
             List<ConsumerRecord<GenericRecord, byte[]>> changelogRecords =
                 consumeRecords(changelogTopic, "multi-partition-changelog-consumer", numKeys,
@@ -960,7 +921,7 @@ public class TimestampedKeyValueStoreWithHeadersIntegrationTest extends ClusterT
             Set<Integer> partitions = new HashSet<>();
             for (ConsumerRecord<GenericRecord, byte[]> record : changelogRecords) {
                 partitions.add(record.partition());
-                assertSchemaIdHeaders(record.headers(),
+                assertWellFormedSchemaIdHeaders(record.headers(),
                     "changelog partition=" + record.partition()
                         + " key=" + record.key().get("word"));
             }
@@ -968,17 +929,6 @@ public class TimestampedKeyValueStoreWithHeadersIntegrationTest extends ClusterT
                 "Changelog records should span multiple partitions but only saw: " + partitions);
         } finally {
             closeStreams(streams);
-        }
-    }
-
-    private void createTopicsWithPartitions(int numPartitions, String... topicNames) throws Exception {
-        Properties adminProps = new Properties();
-        adminProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
-        try (AdminClient admin = AdminClient.create(adminProps)) {
-            List<NewTopic> topics = Arrays.stream(topicNames)
-                .map(name -> new NewTopic(name, numPartitions, (short) 1))
-                .collect(Collectors.toList());
-            admin.createTopics(topics).all().get(30, TimeUnit.SECONDS);
         }
     }
 
@@ -1435,140 +1385,9 @@ public class TimestampedKeyValueStoreWithHeadersIntegrationTest extends ClusterT
     }
 
 
-    private void createTopics(String... topicNames) throws Exception {
-        Properties adminProps = new Properties();
-        adminProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
-        try (AdminClient admin = AdminClient.create(adminProps)) {
-            List<NewTopic> topics = Arrays.stream(topicNames)
-                .map(name -> new NewTopic(name, 1, (short) 1))
-                .collect(Collectors.toList());
-            admin.createTopics(topics).all().get(30, TimeUnit.SECONDS);
-        }
-    }
-
-    private GenericAvroSerde createKeySerde() {
-        GenericAvroSerde serde = new GenericAvroSerde();
-        Map<String, Object> config = new HashMap<>();
-        config.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
-        config.put(AbstractKafkaSchemaSerDeConfig.KEY_SCHEMA_ID_SERIALIZER,
-            HeaderSchemaIdSerializer.class.getName());
-        serde.configure(config, true);
-        return serde;
-    }
-
-    private GenericAvroSerde createValueSerde() {
-        GenericAvroSerde serde = new GenericAvroSerde();
-        Map<String, Object> config = new HashMap<>();
-        config.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
-        config.put(AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_SERIALIZER,
-            HeaderSchemaIdSerializer.class.getName());
-        serde.configure(config, false);
-        return serde;
-    }
-
-    private Properties createStreamsProps(String appId) {
-        Properties props = new Properties();
-        props.put(StreamsConfig.APPLICATION_ID_CONFIG, appId);
-        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
-        props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
-        return props;
-    }
-
-    private Properties createProducerProps() {
-        Properties props = new Properties();
-        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
-        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName());
-        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName());
-        props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
-        props.put(AbstractKafkaSchemaSerDeConfig.KEY_SCHEMA_ID_SERIALIZER,
-            HeaderSchemaIdSerializer.class.getName());
-        props.put(AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_SERIALIZER,
-            HeaderSchemaIdSerializer.class.getName());
-        return props;
-    }
-
-    private KafkaStreams startStreamsAndAwaitRunning(Topology topology, String appId) throws Exception {
-        return startStreamsAndAwaitRunning(topology, appId, 30);
-    }
-
-    private KafkaStreams startStreamsAndAwaitRunning(
-        Topology topology, String appId, int timeoutSeconds) throws Exception {
-        CountDownLatch startedLatch = new CountDownLatch(1);
-        KafkaStreams streams = new KafkaStreams(topology, createStreamsProps(appId));
-        streams.cleanUp();
-        final java.util.concurrent.atomic.AtomicReference<KafkaStreams.State> lastState =
-            new java.util.concurrent.atomic.AtomicReference<>(KafkaStreams.State.CREATED);
-        streams.setStateListener((newState, oldState) -> {
-            lastState.set(newState);
-            if (newState == KafkaStreams.State.RUNNING) {
-                startedLatch.countDown();
-            }
-        });
-        streams.start();
-        boolean running = false;
-        try {
-            running = startedLatch.await(timeoutSeconds, TimeUnit.SECONDS);
-            assertTrue(running,
-                "KafkaStreams should reach RUNNING state (last observed state: "
-                    + lastState.get() + ")");
-            return streams;
-        } finally {
-            if (!running) {
-                closeStreams(streams);
-            }
-        }
-    }
-
-    private void closeStreams(KafkaStreams streams) {
-        if (streams != null) {
-            streams.close(Duration.ofSeconds(10));
-        }
-    }
-
-    private <V> List<ConsumerRecord<GenericRecord, V>> consumeRecords(
-        String topic, String groupId, int expectedCount, Class<?> valueDeserializerClass) {
-        Properties props = new Properties();
-        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
-        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
-        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializerClass.getName());
-        props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
-        props.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, false);
-
-        List<ConsumerRecord<GenericRecord, V>> results = new ArrayList<>();
-        try (KafkaConsumer<GenericRecord, V> consumer = new KafkaConsumer<>(props)) {
-            consumer.subscribe(Collections.singletonList(topic));
-            long deadline = System.currentTimeMillis() + 30_000;
-            while (results.size() < expectedCount && System.currentTimeMillis() < deadline) {
-                ConsumerRecords<GenericRecord, V> records = consumer.poll(Duration.ofMillis(500));
-                for (ConsumerRecord<GenericRecord, V> record : records) {
-                    results.add(record);
-                }
-            }
-        }
-        assertEquals(expectedCount, results.size(),
-            "Expected " + expectedCount + " records from " + topic
-                + " but got " + results.size() + " within 30s");
-        return results;
-    }
-
-    private void assertSchemaIdHeaders(ConsumerRecord<GenericRecord, GenericRecord> record, String context) {
-        assertSchemaIdHeaders(record.headers(), context);
-    }
-
-    private void assertSchemaIdHeaders(Headers headers, String context) {
-        Header keySchemaIdHeader = headers.lastHeader(SchemaId.KEY_SCHEMA_ID_HEADER);
-        assertNotNull(keySchemaIdHeader, context + ": should have __key_schema_id header");
-        byte[] keyHeaderBytes = keySchemaIdHeader.value();
-        assertEquals(17, keyHeaderBytes.length, context + ": Key GUID header should be 17 bytes");
-        assertEquals(SchemaId.MAGIC_BYTE_V1, keyHeaderBytes[0], context + ": Key header should have V1 magic byte");
-
-        Header valueSchemaIdHeader = headers.lastHeader(SchemaId.VALUE_SCHEMA_ID_HEADER);
-        assertNotNull(valueSchemaIdHeader, context + ": should have __value_schema_id header");
-        byte[] valueHeaderBytes = valueSchemaIdHeader.value();
-        assertEquals(17, valueHeaderBytes.length, context + ": Value GUID header should be 17 bytes");
-        assertEquals(SchemaId.MAGIC_BYTE_V1, valueHeaderBytes[0], context + ": Value header should have V1 magic byte");
+    private void assertSchemaIdHeaders(ConsumerRecord<GenericRecord, GenericRecord> record,
+        String context) {
+        assertWellFormedSchemaIdHeaders(record.headers(), context);
     }
 
     private GenericRecord createKey(String word) {
@@ -1596,7 +1415,7 @@ public class TimestampedKeyValueStoreWithHeadersIntegrationTest extends ClusterT
             KeyValue<GenericRecord, ValueTimestampHeaders<GenericRecord>> kv = iter.next();
             keys.add(kv.key.get("word").toString());
             counts.add((Long) kv.value.value().get("count"));
-            assertSchemaIdHeaders(kv.value.headers(), assertionContext + " entry " + idx);
+            assertWellFormedSchemaIdHeaders(kv.value.headers(), assertionContext + " entry " + idx);
             idx++;
         }
         assertEquals(expectedKeys.size(), idx, assertionContext + " number of records");


### PR DESCRIPTION
What
----
Adds `HeadersIQv2IntegrationTestBase`, the shared fixture for the KIP-1356 headers-aware
IQv2 test suites, and migrates the three existing header tests onto it.

The base owns what every one of these suites otherwise copy-pastes:

- **Cluster + serdes** — 1-broker cluster with an embedded Schema Registry, and Avro serdes
  configured for header-mode schema ids (`HeaderSchemaIdSerializer`), so every produced record
  carries its schema-id GUID in `__key_schema_id` / `__value_schema_id`.
- **Per-record GUID capture** — `produce` / `produceAll` return the exact GUID bytes the
  serializer wrote for that record, so `assertSchemaIdHeaders` can assert an IQv2 result is
  byte-for-byte the GUID that record produced, not merely a well-formed 17-byte
  `MAGIC_BYTE_V1` one. Captures are per record rather than shared, so a subclass producing more
  than one schema can assert each result against its own GUID.
- **Streams lifecycle** — start/await-RUNNING/close. Start fails fast on a terminal state and
  reports the last observed state instead of waiting out the timeout; every instance it starts is
  tracked and closed in teardown; `closeStreams` asserts a clean shutdown, `closeStreamsQuietly`
  is the variant that is safe to call from a `finally` (a close timeout there would replace the
  error that actually failed the test). An overload takes a `StateRestoreListener` so a
  restore test can prove the store was rebuilt from the changelog without hand-rolling its own
  start block.
- **Serde cleanup** — Streams does not close serdes passed via `Consumed.with` / `Produced.with` /
  `StoreBuilder`, so each would leak a `CachedSchemaRegistryClient` HTTP pool; the base closes them.
- **Output-topic completion barrier** and the schema-id header assertions.

Migrating `StatelessHeaderIntegrationTest`, `TimestampedKeyValueStoreWithHeadersIntegrationTest`
and `HeaderAwareStoreRecoversRekeyedKeyIntegrationTest` onto it removes 504 lines of duplicated
setup (67 added back).

Test-only change; no production code is touched.

Checklist
------------------
- **[N]** Contains customer facing changes? Including API/behavior changes
- **[N/A]** Is this change gated behind config(s)?
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - This PR is test infrastructure; the suites that consume it are #4462 and #4464.
- **[N]** Does this change require modifying existing system tests or adding new system tests?
- **[N]** Must this be released together with other change(s), either in this repo or another one?

References
----------
JIRA:
- KIP-1271 (header-aware state stores) / KIP-1356 (headers-aware IQv2 queries)
- Consumed by #4462 (KV store) and #4464 (window/session stores), which are stacked on this branch.

Test & Review
------------
```
mvn -pl streams-integration-tests verify
```
11 integration tests, green locally (the three migrated suites: 1 + 3 + 7).

Review note: the interesting file is `HeadersIQv2IntegrationTestBase.java`; the other three files
are mechanical deletions of the helpers it replaces.

Open questions / Follow-ups
--------------------------
