### PR TITLE
Add KIP-1356 IQv2 headers-aware KV-store integration tests

### DIFF
--- a/streams-integration-tests/pom.xml
+++ b/streams-integration-tests/pom.xml
@@ -141,6 +141,11 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -39,6 +40,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -46,6 +48,8 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
@@ -67,6 +71,9 @@ import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.TimestampedKeyValueStoreWithHeaders;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * KIP-1356 IQv2 integration test for the timestamped key-value store with headers.
@@ -124,6 +131,11 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
 
     // A fixed, explicit base timestamp so each record's timestamp is known and assertable.
     private static final long BASE_TIMESTAMP = 1_600_000_000_000L;
+
+    // Memoized, header-mode key serializer used only to compute a key's partition for IQv2 routing
+    // (see assertPointReturnsNull). It matches the producer's serializer, so it yields the same key
+    // bytes and therefore the same partition the record was written to.
+    private Serializer<GenericRecord> keyPartitionSerializer;
 
     // ---------------------------------------------------------------------------------------------
     // TimestampedKeyWithHeadersQuery (point)
@@ -288,16 +300,67 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         }
     }
 
+    @Test
+    public void shouldPreserveFullHeaderSetIncludingDuplicatesAndEmpty() throws Exception {
+        String input = "iqv2-headerset-input";
+        String output = "iqv2-headerset-output";
+        String storeName = "iqv2-headerset-store";
+        String appId = "iqv2-headerset-test";
+
+        createTopics(input, output);
+        // Caching disabled so both query paths read the store-served record directly.
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, false), appId, 30, null);
+        try {
+            // A header set no serde would produce on its own: an arbitrary user header, a duplicate
+            // key ("trace" twice, distinct values), and a zero-length value. The serde adds the
+            // schema-id headers during send(); snapshot the full produced set (in order) afterward so
+            // the round-trip below is asserted against exactly what was written -- count, order,
+            // duplicate key and empty value included, and nothing spurious added. An implementation
+            // that special-cased the __*_schema_id keys, collapsed the duplicate to lastHeader,
+            // dropped the empty value, or reordered would fail here.
+            List<String> producedHeaders;
+            try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                     new KafkaProducer<>(createProducerProps())) {
+                ProducerRecord<GenericRecord, GenericRecord> record = new ProducerRecord<>(
+                    input, null, BASE_TIMESTAMP, createKey("word-1"), createValue(10L));
+                record.headers().add(SEQ_HEADER, "word-1".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("trace", "A".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("trace", "B".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("empty", new byte[0]);
+                producer.send(record).get();
+                producer.flush();
+                producedHeaders = headerEntries(record.headers());
+            }
+            consumeRecords(output, appId + "-barrier", 1);
+
+            ReadOnlyRecord<GenericRecord, GenericRecord> point =
+                queryPointExpectPresent(streams, storeName, createKey("word-1"), false);
+            assertEquals(producedHeaders, headerEntries(point.headers()),
+                "point query should return the full produced header set -- order, the duplicate "
+                    + "'trace' key, the empty value and the schema-id headers -- and nothing else");
+
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> range = queryRange(
+                streams, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 1);
+            assertEquals(producedHeaders, headerEntries(range.get(0).headers()),
+                "range query should return the full produced header set");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
     // ---------------------------------------------------------------------------------------------
     // TimestampedRangeWithHeadersQuery (range / scan)
     // ---------------------------------------------------------------------------------------------
 
-    @Test
-    public void shouldQueryRangeWithBounds() throws Exception {
-        String input = "iqv2-range-input";
-        String output = "iqv2-range-output";
-        String storeName = "iqv2-range-store";
-        String appId = "iqv2-range-test";
+    @ParameterizedTest(name = "range {0}")
+    @MethodSource("rangeCases")
+    public void shouldQueryRange(String label, String lowerWord, String upperWord,
+        List<String> expectedWords) throws Exception {
+        String input = "iqv2-range-" + label + "-input";
+        String output = "iqv2-range-" + label + "-output";
+        String storeName = "iqv2-range-" + label + "-store";
+        String appId = "iqv2-range-" + label + "-test";
 
         // Caching disabled: a range header-query reads the store directly (it never consults the
         // cache), so writes must be store-served -- this makes them visible immediately.
@@ -307,18 +370,45 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             Arrays.asList(10L, 20L, 30L, 40L, 50L),
             false, null);
         try {
-            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
-                streams, storeName,
-                TimestampedRangeWithHeadersQuery
-                    .<GenericRecord, GenericRecord>withRange(createKey("word-2"), createKey("word-4"))
-                    .withAscendingKeys(),
-                3);
-            List<String> words = wordsOf(records);
-            assertEquals(Arrays.asList("word-2", "word-3", "word-4"), words, "range [word-2, word-4]");
-            assertHeadersOnEach(records, "IQv2 range");
+            TimestampedRangeWithHeadersQuery<GenericRecord, GenericRecord> query;
+            if (lowerWord == null && upperWord == null) {
+                query = TimestampedRangeWithHeadersQuery.withNoBounds();
+            } else if (lowerWord != null && upperWord != null) {
+                query = TimestampedRangeWithHeadersQuery.withRange(
+                    createKey(lowerWord), createKey(upperWord));
+            } else if (lowerWord != null) {
+                query = TimestampedRangeWithHeadersQuery.withLowerBound(createKey(lowerWord));
+            } else {
+                query = TimestampedRangeWithHeadersQuery.withUpperBound(createKey(upperWord));
+            }
+            // Pin the order so the assertion checks the contract, not the store's incidental
+            // iteration order (a bare bound is ResultOrder.ANY).
+            query = query.withAscendingKeys();
+
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records =
+                queryRange(streams, storeName, query, expectedWords.size());
+            assertEquals(expectedWords, wordsOf(records), "range " + label);
+            assertHeadersOnEach(records, "IQv2 range " + label);
         } finally {
             closeStreams(streams);
         }
+    }
+
+    /**
+     * Cases for {@link #shouldQueryRange}: {@code (label, lower-bound word or null, upper-bound word
+     * or null, expected words)}, all against the same populated set {@code word-1..word-5}. Replaces
+     * the four near-identical bounds/scan/lower/upper range tests.
+     */
+    private static Stream<Arguments> rangeCases() {
+        return Stream.of(
+            Arguments.of("bounds", "word-2", "word-4",
+                Arrays.asList("word-2", "word-3", "word-4")),
+            Arguments.of("scan-all", null, null,
+                Arrays.asList("word-1", "word-2", "word-3", "word-4", "word-5")),
+            Arguments.of("lower-only", "word-3", null,
+                Arrays.asList("word-3", "word-4", "word-5")),
+            Arguments.of("upper-only", null, "word-2",
+                Arrays.asList("word-1", "word-2")));
     }
 
     @Test
@@ -363,86 +453,6 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             assertEquals(Arrays.asList("word-2", "word-1"), wordsOf(boundedDesc),
                 "bounded descending [word-1, word-2]");
             assertHeadersOnEach(boundedDesc, "IQv2 bounded descending");
-        } finally {
-            closeStreams(streams);
-        }
-    }
-
-    @Test
-    public void shouldScanAllWithNoBounds() throws Exception {
-        String input = "iqv2-scan-input";
-        String output = "iqv2-scan-output";
-        String storeName = "iqv2-scan-store";
-        String appId = "iqv2-scan-test";
-
-        // Caching disabled: range header-queries bypass the cache and read the store directly.
-        KafkaStreams streams = startAndPopulate(
-            storeName, input, output, appId,
-            Arrays.asList("word-1", "word-2", "word-3"), Arrays.asList(10L, 20L, 30L),
-            false, null);
-        try {
-            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
-                streams, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 3);
-            // Compare as a sorted List (not a Set) so a scan that emitted a duplicate key would fail.
-            List<String> words = wordsOf(records);
-            Collections.sort(words);
-            assertEquals(Arrays.asList("word-1", "word-2", "word-3"), words,
-                "scan should return exactly the three keys, each once");
-            assertHeadersOnEach(records, "IQv2 scan");
-        } finally {
-            closeStreams(streams);
-        }
-    }
-
-    @Test
-    public void shouldQueryLowerBoundOnly() throws Exception {
-        String input = "iqv2-lower-input";
-        String output = "iqv2-lower-output";
-        String storeName = "iqv2-lower-store";
-        String appId = "iqv2-lower-test";
-
-        // Caching disabled: range header-queries bypass the cache and read the store directly.
-        KafkaStreams streams = startAndPopulate(
-            storeName, input, output, appId,
-            Arrays.asList("word-1", "word-2", "word-3", "word-4"),
-            Arrays.asList(10L, 20L, 30L, 40L),
-            false, null);
-        try {
-            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
-                streams, storeName,
-                TimestampedRangeWithHeadersQuery
-                    .<GenericRecord, GenericRecord>withLowerBound(createKey("word-3"))
-                    .withAscendingKeys(),
-                2);
-            assertEquals(Arrays.asList("word-3", "word-4"), wordsOf(records), "lower bound word-3");
-            assertHeadersOnEach(records, "IQv2 lower bound");
-        } finally {
-            closeStreams(streams);
-        }
-    }
-
-    @Test
-    public void shouldQueryUpperBoundOnly() throws Exception {
-        String input = "iqv2-upper-input";
-        String output = "iqv2-upper-output";
-        String storeName = "iqv2-upper-store";
-        String appId = "iqv2-upper-test";
-
-        // Caching disabled: range header-queries bypass the cache and read the store directly.
-        KafkaStreams streams = startAndPopulate(
-            storeName, input, output, appId,
-            Arrays.asList("word-1", "word-2", "word-3", "word-4"),
-            Arrays.asList(10L, 20L, 30L, 40L),
-            false, null);
-        try {
-            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
-                streams, storeName,
-                TimestampedRangeWithHeadersQuery
-                    .<GenericRecord, GenericRecord>withUpperBound(createKey("word-2"))
-                    .withAscendingKeys(),
-                2);
-            assertEquals(Arrays.asList("word-1", "word-2"), wordsOf(records), "upper bound word-2");
-            assertHeadersOnEach(records, "IQv2 upper bound");
         } finally {
             closeStreams(streams);
         }
@@ -725,13 +735,29 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         Map<Integer, QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>>> partitionResults =
             result.getPartitionResults();
         assertFalse(partitionResults.isEmpty(), context + " query should return a partition result");
-        QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> pr =
-            partitionResults.values().iterator().next();
-        // Assert success first: getOnlyPartitionResult() filters out FAILED results too, so a query
+        // Inspect the key's own partition, not an arbitrary one: the key resides in exactly one
+        // partition, and a different partition's (also-absent) result would pass this vacuously.
+        int keyPartition = streams.queryMetadataForKey(
+            storeName, createKey(word), keyPartitionSerializer()).partition();
+        QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> pr = partitionResults.get(keyPartition);
+        assertNotNull(pr, context + " should have a result for the key's partition (" + keyPartition + ")");
+        // Assert success next: getOnlyPartitionResult() filters out FAILED results too, so a query
         // that failed outright would otherwise masquerade as a legitimate "absent key" null.
         assertTrue(pr.isSuccess(), context + " query should succeed but failed: "
             + (pr.isFailure() ? pr.getFailureReason() + ": " + pr.getFailureMessage() : ""));
         assertNull(pr.getResult(), context + " should yield a null result");
+    }
+
+    /**
+     * A configured, header-mode key serializer (matching the producer's) for computing a key's
+     * partition via {@link KafkaStreams#queryMetadataForKey}. Memoized because each
+     * {@link #createKeySerde()} builds its own Schema Registry client.
+     */
+    private Serializer<GenericRecord> keyPartitionSerializer() {
+        if (keyPartitionSerializer == null) {
+            keyPartitionSerializer = createKeySerde().serializer();
+        }
+        return keyPartitionSerializer;
     }
 
     private List<ReadOnlyRecord<GenericRecord, GenericRecord>> queryRange(
@@ -798,6 +824,20 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             context + ": " + SEQ_HEADER + " header should carry this record's own key");
     }
 
+    /**
+     * Renders headers as an ordered {@code key=base64(value)} list, preserving insertion order and
+     * duplicate keys, so two header sets can be compared for exact equality -- count, order,
+     * duplicates and byte-exact values (including a zero-length value, which base64s to {@code ""}).
+     */
+    private static List<String> headerEntries(Headers headers) {
+        List<String> entries = new ArrayList<>();
+        for (Header h : headers) {
+            entries.add(h.key() + "=" + (h.value() == null
+                ? "<null>" : Base64.getEncoder().encodeToString(h.value())));
+        }
+        return entries;
+    }
+
     // ---------------------------------------------------------------------------------------------
     // Topology + populate helpers
     // ---------------------------------------------------------------------------------------------
@@ -861,11 +901,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
 
     /** Produces a tombstone (null value) for {@code word}, deleting it from the header-aware store. */
     private void produceTombstone(String topic, String word) throws Exception {
-        try (KafkaProducer<GenericRecord, GenericRecord> producer =
-                 new KafkaProducer<>(createProducerProps())) {
-            sendAndCapture(producer, new ProducerRecord<>(topic, createKey(word), (GenericRecord) null));
-            producer.flush();
-        }
+        produce(topic, createKey(word), null, BASE_TIMESTAMP);
     }
 
     /**

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
@@ -153,8 +153,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             assertPointQuery(streams, storeName, "word-1", 10L, false);
             assertPointQuery(streams, storeName, "word-2", 20L, false);
             assertPointQuery(streams, storeName, "word-3", 30L, false);
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -174,8 +175,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         try {
             assertPointQuery(streams, storeName, "word-1", 10L, true);
             assertPointQuery(streams, storeName, "word-2", 20L, true);
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -232,8 +234,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             assertNotNull(phase, "re-put word-1: should carry the new record's phase header");
             assertEquals("after", new String(phase.value(), StandardCharsets.UTF_8),
                 "re-put word-1: query should return the re-put's headers, not the pre-tombstone ones");
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -262,8 +265,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             // covers skipCache). Asserting success first stops a failed skipCache query passing as null.
             assertPointReturnsNull(streams, storeName, "word-1",
                 "skipCache before flush (empty store)", true);
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -307,8 +311,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 queryRange(streams, storeName, query, expectedWords.size());
             assertEquals(expectedWords, wordsOf(records), "range " + label);
             assertHeadersOnEach(records, "IQv2 range " + label);
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -371,8 +376,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             assertEquals(Arrays.asList("word-2", "word-1"), wordsOf(boundedDesc),
                 "bounded descending [word-1, word-2]");
             assertHeadersOnEach(boundedDesc, "IQv2 bounded descending");
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -396,8 +402,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 TimestampedRangeWithHeadersQuery.withLowerBound(createKey("word-9")), 0);
             assertTrue(none.isEmpty(),
                 "range with a lower bound past the last key should return no records");
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -447,8 +454,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             }
             assertTrue(served.isEmpty(),
                 "range query must not serve unflushed cached entries but returned: " + served);
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -481,8 +489,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             assertThrows(IllegalStateException.class,
                 () -> range.get(0).headers().add("x", new byte[]{1}),
                 "range query should return read-only headers");
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -530,8 +539,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 streams, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 1);
             assertEquals(producedHeaders, headerEntries(range.get(0).headers()),
                 "range query should return the full produced header set");
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -554,8 +564,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             produceRecords(input, Arrays.asList("word-1", "word-2", "word-3"),
                 Arrays.asList(10L, 20L, 30L));
             consumeRecords(output, "iqv2-restore-pre", 3);
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
 
         // Restart with the same APPLICATION_ID; cleanUp() wipes the local state dir so the store must
@@ -611,8 +622,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             assertTrue(restoredCount.get() > 0,
                 "store should have been restored from the changelog (restored "
                     + restoredCount.get() + " records)");
-        } finally {
             closeStreams(restored);
+        } finally {
+            closeStreamsQuietly(restored);
         }
     }
 
@@ -670,12 +682,24 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 sleepQuietly(200);
             }
 
+            // Assert the distinct key set, not just the count: returning one key twice and dropping
+            // another would keep the size at numKeys but change the set.
+            Set<String> expectedKeys = new HashSet<>();
+            for (int i = 1; i <= numKeys; i++) {
+                expectedKeys.add("word-" + i);
+            }
+            Set<String> actualKeys = all.stream()
+                .map(r -> r.key().get("word").toString())
+                .collect(Collectors.toSet());
             assertEquals(numKeys, all.size(), "should read every key across partitions");
+            assertEquals(expectedKeys, actualKeys,
+                "should read every distinct key across partitions (none dropped or duplicated)");
             assertTrue(partitionsSeen.size() > 1,
                 "records should span more than one partition but saw: " + partitionsSeen);
             assertHeadersOnEach(all, "IQv2 multi-partition scan");
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -759,6 +783,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         TimestampedRangeWithHeadersQuery<GenericRecord, GenericRecord> query, int expected) {
         long deadline = System.currentTimeMillis() + QUERY_DEADLINE_MS;
         List<ReadOnlyRecord<GenericRecord, GenericRecord>> out = new ArrayList<>();
+        boolean sawSuccess = false;
         String lastFailure = null;
         while (System.currentTimeMillis() < deadline) {
             out.clear();
@@ -767,6 +792,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             QueryResult<ReadOnlyRecordIterator<GenericRecord, GenericRecord>> pr =
                 result.getOnlyPartitionResult();
             if (pr != null && pr.isSuccess() && pr.getResult() != null) {
+                sawSuccess = true;
                 try (ReadOnlyRecordIterator<GenericRecord, GenericRecord> it = pr.getResult()) {
                     while (it.hasNext()) {
                         out.add(it.next());
@@ -780,8 +806,11 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             }
             sleepQuietly(200);
         }
-        assertEquals(expected, out.size(), "IQv2 range query returned an unexpected count"
+        // Require at least one successful query: otherwise an expected==0 caller would pass on a query
+        // that failed on every attempt (e.g. an unsupported query type), reading as assertEquals(0, 0).
+        assertTrue(sawSuccess, "IQv2 range query never succeeded within 30s"
             + (lastFailure != null ? " (last failure: " + lastFailure + ")" : ""));
+        assertEquals(expected, out.size(), "IQv2 range query returned an unexpected count");
         return out;
     }
 
@@ -870,7 +899,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             return streams;
         } finally {
             if (!populated) {
-                closeStreams(streams);
+                closeStreamsQuietly(streams);
             }
         }
     }

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
@@ -36,8 +36,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -690,7 +688,6 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         // be rebuilt from the changelog. Attach a StateRestoreListener BEFORE start() to prove the
         // rebuild actually happened: cleanUp() clears local state but not committed offsets, so
         // without this the restart could silently reprocess the input and pass with no restore at all.
-        // (The base start helper can't set a restore listener, so this instance is started inline.)
         AtomicLong restoredCount = new AtomicLong(0);
         StateRestoreListener restoreListener = new StateRestoreListener() {
             @Override
@@ -708,27 +705,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 }
             }
         };
-        // Construct, configure and start inside the try: this instance is created here rather than
-        // through the base helper, so it is not in the base's startedStreams and teardown will not
-        // close it. If cleanUp() or start() threw outside the try, nothing would ever close it and
-        // its state-directory lock and StreamThreads would leak for the rest of the fork JVM.
-        KafkaStreams restored = null;
+        KafkaStreams restored = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, true), appId, 90, null, restoreListener);
         try {
-            restored = new KafkaStreams(
-                buildTopology(input, output, storeName, true), createStreamsProps(appId, null));
-            restored.cleanUp();
-            restored.setGlobalStateRestoreListener(restoreListener);
-            CountDownLatch restoredRunning = new CountDownLatch(1);
-            restored.setStateListener((newState, oldState) -> {
-                if (newState == KafkaStreams.State.RUNNING) {
-                    restoredRunning.countDown();
-                }
-            });
-            restored.start();
-
-            assertTrue(restoredRunning.await(90, TimeUnit.SECONDS),
-                "restored KafkaStreams should reach RUNNING");
-
             ReadOnlyRecord<GenericRecord, GenericRecord> word1 =
                 queryPointExpectPresent(restored, storeName, createKey("word-1"), false);
             assertEquals(10L, word1.value().get("count"), "restored word-1 value");

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
@@ -59,6 +59,9 @@ import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.ReadOnlyRecord;
 import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.query.FailureReason;
+import org.apache.kafka.streams.query.Position;
+import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.query.StateQueryRequest;
 import org.apache.kafka.streams.query.StateQueryResult;
@@ -123,10 +126,12 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
     private static final String SEQ_HEADER = "seq";
 
     // Per-record captures, keyed by word, so each IQv2 result is asserted against its own record's
-    // produced schema-id GUIDs (see HeadersIQv2IntegrationTestBase#assertSchemaIdHeaders) and its
-    // own produced timestamp -- not a single shared value that every record would trivially match.
+    // produced schema-id GUIDs (see HeadersIQv2IntegrationTestBase#assertSchemaIdHeaders), its own
+    // produced count and its own produced timestamp -- not a single shared value that every record
+    // would trivially match.
     private final Map<String, CapturedSchemaIds> capturedByWord = new HashMap<>();
     private final Map<String, Long> timestampByWord = new HashMap<>();
+    private final Map<String, Long> countByWord = new HashMap<>();
 
     // A fixed, explicit base timestamp so each record's timestamp is known and assertable.
     private static final long BASE_TIMESTAMP = 1_600_000_000_000L;
@@ -205,6 +210,10 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             produceTombstone(input, "word-1");
             consumeRecords(output, appId + "-post", 2);
             assertPointReturnsNull(streams, storeName, "word-1", "tombstoned key", false);
+            // The range path is pinned to drop a tombstoned key by
+            // shouldDropTombstonedKeyFromRangeScan rather than here: caching is enabled in this test,
+            // and a range header-query reads the store without consulting the record cache, so the
+            // still-unflushed delete would not be visible to a scan run at this point.
 
             // A key that was never written is likewise absent.
             assertPointReturnsNull(streams, storeName, "no-such-word", "never-written key", false);
@@ -222,6 +231,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 reput.headers().add("phase", "after".getBytes(StandardCharsets.UTF_8));
                 capturedByWord.put("word-1", sendAndCapture(producer, reput));
                 timestampByWord.put("word-1", reputTs);
+                countByWord.put("word-1", 99L);
                 producer.flush();
             }
             consumeRecords(output, appId + "-reput", 3);
@@ -271,6 +281,67 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         }
     }
 
+    /**
+     * Covers the position-bound path for both header queries. Every other test here uses the default
+     * unbounded position, so neither {@code withPositionBound(...)} nor
+     * {@link StateQueryResult#getPosition()} would otherwise be exercised at all.
+     */
+    @Test
+    public void shouldReportPositionAndRejectQueryBoundedBeyondIt() throws Exception {
+        String input = "iqv2-position-input";
+        String output = "iqv2-position-output";
+        String storeName = "iqv2-position-store";
+        String appId = "iqv2-position-test";
+
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Collections.singletonList("word-1"), Collections.singletonList(10L), false, null);
+        try {
+            // A query served under the default (unbounded) bound reports the position the store had
+            // reached when it answered.
+            StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> unbounded =
+                streams.query(StateQueryRequest.inStore(storeName)
+                    .withQuery(TimestampedKeyWithHeadersQuery
+                        .<GenericRecord, GenericRecord>withKey(createKey("word-1"))));
+            Position position = unbounded.getPosition();
+            assertNotNull(position, "unbounded query should report a position");
+            assertTrue(position.getTopics().contains(input),
+                "reported position should cover the input topic but was: " + position);
+
+            // A bound at an offset the store cannot have reached must fail the query with
+            // NOT_UP_TO_BOUND rather than quietly serving a result from behind the bound.
+            PositionBound beyond = PositionBound.at(
+                Position.emptyPosition().withComponent(input, 0, Long.MAX_VALUE));
+            assertNotUpToBound(streams.query(StateQueryRequest.inStore(storeName)
+                .withQuery(TimestampedKeyWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withKey(createKey("word-1")))
+                .withPositionBound(beyond)), "point query");
+            assertNotUpToBound(streams.query(StateQueryRequest.inStore(storeName)
+                .withQuery(TimestampedRangeWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withNoBounds())
+                .withPositionBound(beyond)), "range query");
+            closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
+        }
+    }
+
+    /**
+     * Asserts every partition result failed with {@link FailureReason#NOT_UP_TO_BOUND} -- checking
+     * the reason, not merely that the query failed, so an unrelated failure can't pass as coverage.
+     */
+    private static <R> void assertNotUpToBound(StateQueryResult<R> result, String context) {
+        Map<Integer, QueryResult<R>> partitionResults = result.getPartitionResults();
+        assertFalse(partitionResults.isEmpty(), context + " should return a partition result");
+        for (Map.Entry<Integer, QueryResult<R>> e : partitionResults.entrySet()) {
+            QueryResult<R> pr = e.getValue();
+            assertTrue(pr.isFailure(), context
+                + " bounded beyond the store's position should fail on partition " + e.getKey());
+            assertEquals(FailureReason.NOT_UP_TO_BOUND, pr.getFailureReason(),
+                context + " should fail with NOT_UP_TO_BOUND on partition " + e.getKey());
+        }
+    }
+
     // ---------------------------------------------------------------------------------------------
     // TimestampedRangeWithHeadersQuery (range / scan)
     // ---------------------------------------------------------------------------------------------
@@ -310,7 +381,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             List<ReadOnlyRecord<GenericRecord, GenericRecord>> records =
                 queryRange(streams, storeName, query, expectedWords.size());
             assertEquals(expectedWords, wordsOf(records), "range " + label);
-            assertHeadersOnEach(records, "IQv2 range " + label);
+            assertRecordsMatchProduced(records, "IQv2 range " + label);
             closeStreams(streams);
         } finally {
             closeStreamsQuietly(streams);
@@ -355,7 +426,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                     .<GenericRecord, GenericRecord>withNoBounds().withAscendingKeys(),
                 3);
             assertEquals(Arrays.asList("word-1", "word-2", "word-3"), wordsOf(asc), "ascending keys");
-            assertHeadersOnEach(asc, "IQv2 ascending");
+            assertRecordsMatchProduced(asc, "IQv2 ascending");
 
             List<ReadOnlyRecord<GenericRecord, GenericRecord>> desc = queryRange(
                 streams, storeName,
@@ -363,7 +434,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                     .<GenericRecord, GenericRecord>withNoBounds().withDescendingKeys(),
                 3);
             assertEquals(Arrays.asList("word-3", "word-2", "word-1"), wordsOf(desc), "descending keys");
-            assertHeadersOnEach(desc, "IQv2 descending");
+            assertRecordsMatchProduced(desc, "IQv2 descending");
 
             // Bounded + descending: the ordering flip must also apply to a bounded range, not just a
             // full scan -- guards against an ordering bug that only surfaces on the bounded path.
@@ -375,7 +446,53 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 2);
             assertEquals(Arrays.asList("word-2", "word-1"), wordsOf(boundedDesc),
                 "bounded descending [word-1, word-2]");
-            assertHeadersOnEach(boundedDesc, "IQv2 bounded descending");
+            assertRecordsMatchProduced(boundedDesc, "IQv2 bounded descending");
+            closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
+        }
+    }
+
+    /**
+     * Pins the range path to drop a tombstoned key, not just the point path -- every other range test
+     * here runs against a store where nothing was ever deleted.
+     *
+     * <p>Caching is disabled so the delete is store-visible. A range header-query reads the store
+     * directly and does not consult the record cache, so with caching enabled the tombstone would
+     * still be sitting unflushed in the cache and the scan would return the stale entry -- which
+     * would make this a test of cache-flush timing rather than of the store contract.
+     */
+    @Test
+    public void shouldDropTombstonedKeyFromRangeScan() throws Exception {
+        String input = "iqv2-range-tombstone-input";
+        String output = "iqv2-range-tombstone-output";
+        String storeName = "iqv2-range-tombstone-store";
+        String appId = "iqv2-range-tombstone-test";
+
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Arrays.asList("word-1", "word-2", "word-3"), Arrays.asList(10L, 20L, 30L), false, null);
+        try {
+            // Positive control: all three keys are visible to the range path before any delete, so a
+            // post-delete scan that returns fewer keys is doing so because of the tombstone.
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> before = queryRange(
+                streams, storeName, TimestampedRangeWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withNoBounds().withAscendingKeys(), 3);
+            assertEquals(Arrays.asList("word-1", "word-2", "word-3"), wordsOf(before),
+                "range scan before tombstone");
+            assertRecordsMatchProduced(before, "range before tombstone");
+
+            // The processor forwards the null-value record too, so a 4th output record marks the
+            // tombstone as applied to the store.
+            produceTombstone(input, "word-2");
+            consumeRecords(output, appId + "-post", 4);
+
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> after = queryRange(
+                streams, storeName, TimestampedRangeWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withNoBounds().withAscendingKeys(), 2);
+            assertEquals(Arrays.asList("word-1", "word-3"), wordsOf(after),
+                "range scan should drop the tombstoned key");
+            assertRecordsMatchProduced(after, "range after tombstone");
             closeStreams(streams);
         } finally {
             closeStreamsQuietly(streams);
@@ -591,18 +708,24 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 }
             }
         };
-        KafkaStreams restored = new KafkaStreams(
-            buildTopology(input, output, storeName, true), createStreamsProps(appId, null));
-        restored.cleanUp();
-        restored.setGlobalStateRestoreListener(restoreListener);
-        CountDownLatch restoredRunning = new CountDownLatch(1);
-        restored.setStateListener((newState, oldState) -> {
-            if (newState == KafkaStreams.State.RUNNING) {
-                restoredRunning.countDown();
-            }
-        });
-        restored.start();
+        // Construct, configure and start inside the try: this instance is created here rather than
+        // through the base helper, so it is not in the base's startedStreams and teardown will not
+        // close it. If cleanUp() or start() threw outside the try, nothing would ever close it and
+        // its state-directory lock and StreamThreads would leak for the rest of the fork JVM.
+        KafkaStreams restored = null;
         try {
+            restored = new KafkaStreams(
+                buildTopology(input, output, storeName, true), createStreamsProps(appId, null));
+            restored.cleanUp();
+            restored.setGlobalStateRestoreListener(restoreListener);
+            CountDownLatch restoredRunning = new CountDownLatch(1);
+            restored.setStateListener((newState, oldState) -> {
+                if (newState == KafkaStreams.State.RUNNING) {
+                    restoredRunning.countDown();
+                }
+            });
+            restored.start();
+
             assertTrue(restoredRunning.await(90, TimeUnit.SECONDS),
                 "restored KafkaStreams should reach RUNNING");
 
@@ -615,7 +738,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 restored, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 3);
             assertEquals(new HashSet<>(Arrays.asList("word-1", "word-2", "word-3")),
                 new HashSet<>(wordsOf(all)), "restored scan keys");
-            assertHeadersOnEach(all, "restored scan");
+            assertRecordsMatchProduced(all, "restored scan");
 
             // Pin that the store was genuinely rebuilt from the changelog, not repopulated by a
             // silent reprocess of the input topic.
@@ -696,7 +819,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 "should read every distinct key across partitions (none dropped or duplicated)");
             assertTrue(partitionsSeen.size() > 1,
                 "records should span more than one partition but saw: " + partitionsSeen);
-            assertHeadersOnEach(all, "IQv2 multi-partition scan");
+            assertRecordsMatchProduced(all, "IQv2 multi-partition scan");
             closeStreams(streams);
         } finally {
             closeStreamsQuietly(streams);
@@ -820,12 +943,23 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             .collect(Collectors.toList());
     }
 
-    private void assertHeadersOnEach(
+    /**
+     * Asserts every record in a range/scan result matches what was produced for its own key: value,
+     * timestamp and headers. The point-query path checks all three (see {@link #assertPointQuery}),
+     * so the range path must too -- otherwise a range that returned the right key and headers but
+     * another entry's value or timestamp would pass unnoticed.
+     */
+    private void assertRecordsMatchProduced(
         List<ReadOnlyRecord<GenericRecord, GenericRecord>> records, String context) {
         for (int i = 0; i < records.size(); i++) {
             ReadOnlyRecord<GenericRecord, GenericRecord> record = records.get(i);
             String word = record.key().get("word").toString();
-            assertRecordHeaders(record, word, context + " entry " + i);
+            String entryContext = context + " entry " + i;
+            Long expectedCount = countByWord.get(word);
+            assertNotNull(expectedCount, entryContext + ": no produced count for " + word);
+            assertEquals(expectedCount, record.value().get("count"), entryContext + " value");
+            assertEquals(timestampByWord.get(word), record.timestamp(), entryContext + " timestamp");
+            assertRecordHeaders(record, word, entryContext);
         }
     }
 
@@ -917,6 +1051,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 record.headers().add(SEQ_HEADER, word.getBytes(StandardCharsets.UTF_8));
                 capturedByWord.put(word, sendAndCapture(producer, record));
                 timestampByWord.put(word, timestamp);
+                countByWord.put(word, counts.get(i));
             }
             producer.flush();
         }

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
@@ -17,6 +17,7 @@
 package io.confluent.kafka.streams.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -102,7 +103,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
     // carries the same schema-id GUIDs. Capture them once when producing and assert that IQv2
     // results come back byte-equal to what was produced (see
     // HeadersIQv2IntegrationTestBase#assertSchemaIdHeaders).
-    private CapturedSchemaIds valueSchemaIds;
+    private CapturedSchemaIds producedSchemaIds;
 
     // ---------------------------------------------------------------------------------------------
     // TimestampedKeyWithHeadersQuery (point)
@@ -362,6 +363,31 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         }
     }
 
+    @Test
+    public void shouldReturnEmptyForRangeWithNoMatches() throws Exception {
+        String input = "iqv2-emptyrange-input";
+        String output = "iqv2-emptyrange-output";
+        String storeName = "iqv2-emptyrange-store";
+        String appId = "iqv2-emptyrange-test";
+
+        // Caching disabled: range header-queries bypass the cache and read the store directly.
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Arrays.asList("word-1", "word-2", "word-3"), Arrays.asList(10L, 20L, 30L),
+            false, null);
+        try {
+            // A lower bound past the last stored key selects nothing: the query must still succeed
+            // and return an empty iterator -- not fail, and not spuriously return the stored keys.
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> none = queryRange(
+                streams, storeName,
+                TimestampedRangeWithHeadersQuery.withLowerBound(createKey("word-9")), 0);
+            assertTrue(none.isEmpty(),
+                "range with a lower bound past the last key should return no records");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
     // ---------------------------------------------------------------------------------------------
     // Restore-from-changelog and multi-partition
     // ---------------------------------------------------------------------------------------------
@@ -393,7 +419,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             ReadOnlyRecord<GenericRecord, GenericRecord> word1 =
                 queryPointExpectPresent(restored, storeName, createKey("word-1"), false);
             assertEquals(10L, word1.value().get("count"), "restored word-1 value");
-            assertSchemaIdHeaders(word1.headers(), valueSchemaIds, "restored word-1");
+            assertSchemaIdHeaders(word1.headers(), producedSchemaIds, "restored word-1");
 
             List<ReadOnlyRecord<GenericRecord, GenericRecord>> all = queryRange(
                 restored, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 3);
@@ -480,6 +506,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             query = query.skipCache();
         }
         long deadline = System.currentTimeMillis() + 30_000;
+        String lastFailure = null;
         while (System.currentTimeMillis() < deadline) {
             StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> result =
                 streams.query(StateQueryRequest.inStore(storeName).withQuery(query));
@@ -487,9 +514,13 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             if (pr != null && pr.isSuccess() && pr.getResult() != null) {
                 return pr.getResult();
             }
+            if (pr != null && pr.isFailure()) {
+                lastFailure = pr.getFailureReason() + ": " + pr.getFailureMessage();
+            }
             sleepQuietly(200);
         }
-        throw new AssertionError("IQv2 point query never returned a result for key " + key);
+        throw new AssertionError("IQv2 point query never returned a result for key " + key
+            + (lastFailure != null ? " (last failure: " + lastFailure + ")" : ""));
     }
 
     private void assertPointQuery(KafkaStreams streams, String storeName, String word,
@@ -499,7 +530,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         assertEquals(word, record.key().get("word").toString(), "IQv2 point key " + word);
         assertEquals(expectedCount, record.value().get("count"), "IQv2 point value " + word);
         assertTrue(record.timestamp() >= 0, "IQv2 point timestamp should be non-negative: " + word);
-        assertSchemaIdHeaders(record.headers(), valueSchemaIds,
+        assertSchemaIdHeaders(record.headers(), producedSchemaIds,
             "IQv2 point " + word + (skipCache ? " (skipCache)" : ""));
     }
 
@@ -513,8 +544,11 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> result =
             streams.query(StateQueryRequest.inStore(storeName)
                 .withQuery(TimestampedKeyWithHeadersQuery.withKey(createKey(word))));
+        Map<Integer, QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>>> partitionResults =
+            result.getPartitionResults();
+        assertFalse(partitionResults.isEmpty(), context + " query should return a partition result");
         QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> pr =
-            result.getPartitionResults().values().iterator().next();
+            partitionResults.values().iterator().next();
         assertTrue(pr.isSuccess(), context + " query should succeed");
         assertNull(pr.getResult(), context + " should yield a null result");
     }
@@ -538,6 +572,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         TimestampedRangeWithHeadersQuery<GenericRecord, GenericRecord> query, int expected) {
         long deadline = System.currentTimeMillis() + 30_000;
         List<ReadOnlyRecord<GenericRecord, GenericRecord>> out = new ArrayList<>();
+        String lastFailure = null;
         while (System.currentTimeMillis() < deadline) {
             out.clear();
             StateQueryResult<ReadOnlyRecordIterator<GenericRecord, GenericRecord>> result =
@@ -553,10 +588,13 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 if (out.size() >= expected) {
                     return out;
                 }
+            } else if (pr != null && pr.isFailure()) {
+                lastFailure = pr.getFailureReason() + ": " + pr.getFailureMessage();
             }
             sleepQuietly(200);
         }
-        assertEquals(expected, out.size(), "IQv2 range query returned an unexpected count");
+        assertEquals(expected, out.size(), "IQv2 range query returned an unexpected count"
+            + (lastFailure != null ? " (last failure: " + lastFailure + ")" : ""));
         return out;
     }
 
@@ -569,7 +607,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
     private void assertHeadersOnEach(
         List<ReadOnlyRecord<GenericRecord, GenericRecord>> records, String context) {
         for (int i = 0; i < records.size(); i++) {
-            assertSchemaIdHeaders(records.get(i).headers(), valueSchemaIds, context + " entry " + i);
+            assertSchemaIdHeaders(records.get(i).headers(), producedSchemaIds, context + " entry " + i);
         }
     }
 
@@ -620,7 +658,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         try (KafkaProducer<GenericRecord, GenericRecord> producer =
                  new KafkaProducer<>(createProducerProps())) {
             for (int i = 0; i < words.size(); i++) {
-                valueSchemaIds = sendAndCapture(producer, new ProducerRecord<>(
+                producedSchemaIds = sendAndCapture(producer, new ProducerRecord<>(
                     topic, createKey(words.get(i)), createValue(counts.get(i), "PUT")));
             }
             producer.flush();

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -39,6 +40,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -46,6 +48,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
@@ -67,6 +70,9 @@ import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.TimestampedKeyValueStoreWithHeaders;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * KIP-1356 IQv2 integration test for the timestamped key-value store with headers.
@@ -288,16 +294,67 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         }
     }
 
+    @Test
+    public void shouldPreserveFullHeaderSetIncludingDuplicatesAndEmpty() throws Exception {
+        String input = "iqv2-headerset-input";
+        String output = "iqv2-headerset-output";
+        String storeName = "iqv2-headerset-store";
+        String appId = "iqv2-headerset-test";
+
+        createTopics(input, output);
+        // Caching disabled so both query paths read the store-served record directly.
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, false), appId, 30, null);
+        try {
+            // A header set no serde would produce on its own: an arbitrary user header, a duplicate
+            // key ("trace" twice, distinct values), and a zero-length value. The serde adds the
+            // schema-id headers during send(); snapshot the full produced set (in order) afterward so
+            // the round-trip below is asserted against exactly what was written -- count, order,
+            // duplicate key and empty value included, and nothing spurious added. An implementation
+            // that special-cased the __*_schema_id keys, collapsed the duplicate to lastHeader,
+            // dropped the empty value, or reordered would fail here.
+            List<String> producedHeaders;
+            try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                     new KafkaProducer<>(createProducerProps())) {
+                ProducerRecord<GenericRecord, GenericRecord> record = new ProducerRecord<>(
+                    input, null, BASE_TIMESTAMP, createKey("word-1"), createValue(10L));
+                record.headers().add(SEQ_HEADER, "word-1".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("trace", "A".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("trace", "B".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("empty", new byte[0]);
+                producer.send(record).get();
+                producer.flush();
+                producedHeaders = headerEntries(record.headers());
+            }
+            consumeRecords(output, appId + "-barrier", 1);
+
+            ReadOnlyRecord<GenericRecord, GenericRecord> point =
+                queryPointExpectPresent(streams, storeName, createKey("word-1"), false);
+            assertEquals(producedHeaders, headerEntries(point.headers()),
+                "point query should return the full produced header set -- order, the duplicate "
+                    + "'trace' key, the empty value and the schema-id headers -- and nothing else");
+
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> range = queryRange(
+                streams, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 1);
+            assertEquals(producedHeaders, headerEntries(range.get(0).headers()),
+                "range query should return the full produced header set");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
     // ---------------------------------------------------------------------------------------------
     // TimestampedRangeWithHeadersQuery (range / scan)
     // ---------------------------------------------------------------------------------------------
 
-    @Test
-    public void shouldQueryRangeWithBounds() throws Exception {
-        String input = "iqv2-range-input";
-        String output = "iqv2-range-output";
-        String storeName = "iqv2-range-store";
-        String appId = "iqv2-range-test";
+    @ParameterizedTest(name = "range {0}")
+    @MethodSource("rangeCases")
+    public void shouldQueryRange(String label, String lowerWord, String upperWord,
+        List<String> expectedWords) throws Exception {
+        String input = "iqv2-range-" + label + "-input";
+        String output = "iqv2-range-" + label + "-output";
+        String storeName = "iqv2-range-" + label + "-store";
+        String appId = "iqv2-range-" + label + "-test";
 
         // Caching disabled: a range header-query reads the store directly (it never consults the
         // cache), so writes must be store-served -- this makes them visible immediately.
@@ -307,18 +364,45 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             Arrays.asList(10L, 20L, 30L, 40L, 50L),
             false, null);
         try {
-            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
-                streams, storeName,
-                TimestampedRangeWithHeadersQuery
-                    .<GenericRecord, GenericRecord>withRange(createKey("word-2"), createKey("word-4"))
-                    .withAscendingKeys(),
-                3);
-            List<String> words = wordsOf(records);
-            assertEquals(Arrays.asList("word-2", "word-3", "word-4"), words, "range [word-2, word-4]");
-            assertHeadersOnEach(records, "IQv2 range");
+            TimestampedRangeWithHeadersQuery<GenericRecord, GenericRecord> query;
+            if (lowerWord == null && upperWord == null) {
+                query = TimestampedRangeWithHeadersQuery.withNoBounds();
+            } else if (lowerWord != null && upperWord != null) {
+                query = TimestampedRangeWithHeadersQuery.withRange(
+                    createKey(lowerWord), createKey(upperWord));
+            } else if (lowerWord != null) {
+                query = TimestampedRangeWithHeadersQuery.withLowerBound(createKey(lowerWord));
+            } else {
+                query = TimestampedRangeWithHeadersQuery.withUpperBound(createKey(upperWord));
+            }
+            // Pin the order so the assertion checks the contract, not the store's incidental
+            // iteration order (a bare bound is ResultOrder.ANY).
+            query = query.withAscendingKeys();
+
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records =
+                queryRange(streams, storeName, query, expectedWords.size());
+            assertEquals(expectedWords, wordsOf(records), "range " + label);
+            assertHeadersOnEach(records, "IQv2 range " + label);
         } finally {
             closeStreams(streams);
         }
+    }
+
+    /**
+     * Cases for {@link #shouldQueryRange}: {@code (label, lower-bound word or null, upper-bound word
+     * or null, expected words)}, all against the same populated set {@code word-1..word-5}. Replaces
+     * the four near-identical bounds/scan/lower/upper range tests.
+     */
+    private static Stream<Arguments> rangeCases() {
+        return Stream.of(
+            Arguments.of("bounds", "word-2", "word-4",
+                Arrays.asList("word-2", "word-3", "word-4")),
+            Arguments.of("scan-all", null, null,
+                Arrays.asList("word-1", "word-2", "word-3", "word-4", "word-5")),
+            Arguments.of("lower-only", "word-3", null,
+                Arrays.asList("word-3", "word-4", "word-5")),
+            Arguments.of("upper-only", null, "word-2",
+                Arrays.asList("word-1", "word-2")));
     }
 
     @Test
@@ -363,86 +447,6 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             assertEquals(Arrays.asList("word-2", "word-1"), wordsOf(boundedDesc),
                 "bounded descending [word-1, word-2]");
             assertHeadersOnEach(boundedDesc, "IQv2 bounded descending");
-        } finally {
-            closeStreams(streams);
-        }
-    }
-
-    @Test
-    public void shouldScanAllWithNoBounds() throws Exception {
-        String input = "iqv2-scan-input";
-        String output = "iqv2-scan-output";
-        String storeName = "iqv2-scan-store";
-        String appId = "iqv2-scan-test";
-
-        // Caching disabled: range header-queries bypass the cache and read the store directly.
-        KafkaStreams streams = startAndPopulate(
-            storeName, input, output, appId,
-            Arrays.asList("word-1", "word-2", "word-3"), Arrays.asList(10L, 20L, 30L),
-            false, null);
-        try {
-            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
-                streams, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 3);
-            // Compare as a sorted List (not a Set) so a scan that emitted a duplicate key would fail.
-            List<String> words = wordsOf(records);
-            Collections.sort(words);
-            assertEquals(Arrays.asList("word-1", "word-2", "word-3"), words,
-                "scan should return exactly the three keys, each once");
-            assertHeadersOnEach(records, "IQv2 scan");
-        } finally {
-            closeStreams(streams);
-        }
-    }
-
-    @Test
-    public void shouldQueryLowerBoundOnly() throws Exception {
-        String input = "iqv2-lower-input";
-        String output = "iqv2-lower-output";
-        String storeName = "iqv2-lower-store";
-        String appId = "iqv2-lower-test";
-
-        // Caching disabled: range header-queries bypass the cache and read the store directly.
-        KafkaStreams streams = startAndPopulate(
-            storeName, input, output, appId,
-            Arrays.asList("word-1", "word-2", "word-3", "word-4"),
-            Arrays.asList(10L, 20L, 30L, 40L),
-            false, null);
-        try {
-            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
-                streams, storeName,
-                TimestampedRangeWithHeadersQuery
-                    .<GenericRecord, GenericRecord>withLowerBound(createKey("word-3"))
-                    .withAscendingKeys(),
-                2);
-            assertEquals(Arrays.asList("word-3", "word-4"), wordsOf(records), "lower bound word-3");
-            assertHeadersOnEach(records, "IQv2 lower bound");
-        } finally {
-            closeStreams(streams);
-        }
-    }
-
-    @Test
-    public void shouldQueryUpperBoundOnly() throws Exception {
-        String input = "iqv2-upper-input";
-        String output = "iqv2-upper-output";
-        String storeName = "iqv2-upper-store";
-        String appId = "iqv2-upper-test";
-
-        // Caching disabled: range header-queries bypass the cache and read the store directly.
-        KafkaStreams streams = startAndPopulate(
-            storeName, input, output, appId,
-            Arrays.asList("word-1", "word-2", "word-3", "word-4"),
-            Arrays.asList(10L, 20L, 30L, 40L),
-            false, null);
-        try {
-            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
-                streams, storeName,
-                TimestampedRangeWithHeadersQuery
-                    .<GenericRecord, GenericRecord>withUpperBound(createKey("word-2"))
-                    .withAscendingKeys(),
-                2);
-            assertEquals(Arrays.asList("word-1", "word-2"), wordsOf(records), "upper bound word-2");
-            assertHeadersOnEach(records, "IQv2 upper bound");
         } finally {
             closeStreams(streams);
         }
@@ -725,13 +729,22 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         Map<Integer, QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>>> partitionResults =
             result.getPartitionResults();
         assertFalse(partitionResults.isEmpty(), context + " query should return a partition result");
-        QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> pr =
-            partitionResults.values().iterator().next();
-        // Assert success first: getOnlyPartitionResult() filters out FAILED results too, so a query
-        // that failed outright would otherwise masquerade as a legitimate "absent key" null.
-        assertTrue(pr.isSuccess(), context + " query should succeed but failed: "
-            + (pr.isFailure() ? pr.getFailureReason() + ": " + pr.getFailureMessage() : ""));
-        assertNull(pr.getResult(), context + " should yield a null result");
+        // The key lives in exactly one partition, but rather than hand-pick it (queryMetadataForKey
+        // returns NOT_AVAILABLE for this PAPI addStateStore store, so partitionResults.get(-1) is
+        // null), assert every returned partition result directly. Checking all of them -- not one
+        // resolved partition -- is strictly stronger: a lingering value in ANY partition fails the
+        // assertion instead of being missed.
+        for (Map.Entry<Integer, QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>>> e
+            : partitionResults.entrySet()) {
+            QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> pr = e.getValue();
+            // Assert success first: getResult() is null for a FAILED result too, so a query that
+            // failed outright would otherwise masquerade as a legitimate "absent key" null.
+            assertTrue(pr.isSuccess(), context + " query should succeed but failed on partition "
+                + e.getKey() + ": "
+                + (pr.isFailure() ? pr.getFailureReason() + ": " + pr.getFailureMessage() : ""));
+            assertNull(pr.getResult(),
+                context + " should yield a null result on partition " + e.getKey());
+        }
     }
 
     private List<ReadOnlyRecord<GenericRecord, GenericRecord>> queryRange(
@@ -798,6 +811,20 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             context + ": " + SEQ_HEADER + " header should carry this record's own key");
     }
 
+    /**
+     * Renders headers as an ordered {@code key=base64(value)} list, preserving insertion order and
+     * duplicate keys, so two header sets can be compared for exact equality -- count, order,
+     * duplicates and byte-exact values (including a zero-length value, which base64s to {@code ""}).
+     */
+    private static List<String> headerEntries(Headers headers) {
+        List<String> entries = new ArrayList<>();
+        for (Header h : headers) {
+            entries.add(h.key() + "=" + (h.value() == null
+                ? "<null>" : Base64.getEncoder().encodeToString(h.value())));
+        }
+        return entries;
+    }
+
     // ---------------------------------------------------------------------------------------------
     // Topology + populate helpers
     // ---------------------------------------------------------------------------------------------
@@ -861,11 +888,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
 
     /** Produces a tombstone (null value) for {@code word}, deleting it from the header-aware store. */
     private void produceTombstone(String topic, String word) throws Exception {
-        try (KafkaProducer<GenericRecord, GenericRecord> producer =
-                 new KafkaProducer<>(createProducerProps())) {
-            sendAndCapture(producer, new ProducerRecord<>(topic, createKey(word), (GenericRecord) null));
-            producer.flush();
-        }
+        produce(topic, createKey(word), null, BASE_TIMESTAMP);
     }
 
     /**

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
@@ -1,0 +1,695 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.streams.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.confluent.kafka.serializers.schema.id.HeaderSchemaIdSerializer;
+import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.ReadOnlyRecord;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.query.StateQueryRequest;
+import org.apache.kafka.streams.query.StateQueryResult;
+import org.apache.kafka.streams.query.TimestampedKeyWithHeadersQuery;
+import org.apache.kafka.streams.query.TimestampedRangeWithHeadersQuery;
+import org.apache.kafka.streams.state.ReadOnlyRecordIterator;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.TimestampedKeyValueStoreWithHeaders;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
+import org.junit.jupiter.api.Test;
+
+/**
+ * KIP-1356 IQv2 integration test for the timestamped key-value store with headers.
+ *
+ * <p>Verifies that the headers-aware IQv2 query types —
+ * {@link TimestampedKeyWithHeadersQuery} (point) and {@link TimestampedRangeWithHeadersQuery}
+ * (range / scan) — return the record headers persisted by a KIP-1271
+ * {@link TimestampedKeyValueStoreWithHeaders}. In particular, records are produced with the
+ * schema-id GUID carried in the {@code __key_schema_id} / {@code __value_schema_id} headers (via
+ * {@link HeaderSchemaIdSerializer}); this test asserts those 17-byte {@code MAGIC_BYTE_V1} GUID
+ * headers survive the store and come back through each IQv2 query as a
+ * {@link ReadOnlyRecord} / {@link ReadOnlyRecordIterator}.
+ *
+ * <p>Shared cluster/serde/lifecycle infrastructure lives in {@link HeadersIQv2IntegrationTestBase}.
+ */
+public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
+    extends HeadersIQv2IntegrationTestBase {
+
+    private static final String KEY_SCHEMA_JSON =
+        "{"
+            + "\"type\":\"record\","
+            + "\"name\":\"WordKey\","
+            + "\"namespace\":\"io.confluent.kafka.streams.integration\","
+            + "\"fields\":["
+            + "  {\"name\":\"word\",\"type\":\"string\"}"
+            + "]"
+            + "}";
+
+    private static final String VALUE_SCHEMA_JSON =
+        "{"
+            + "\"type\":\"record\","
+            + "\"name\":\"WordValue\","
+            + "\"namespace\":\"io.confluent.kafka.streams.integration\","
+            + "\"fields\":["
+            + "  {\"name\":\"count\",\"type\":\"long\"},"
+            + "  {\"name\":\"operation\",\"type\":\"string\",\"default\":\"PUT\"}"
+            + "]"
+            + "}";
+
+    private final Schema keySchema = new Schema.Parser().parse(KEY_SCHEMA_JSON);
+    private final Schema valueSchema = new Schema.Parser().parse(VALUE_SCHEMA_JSON);
+
+    // Every record in each test shares this one key/value schema, so every value-bearing record
+    // carries the same schema-id GUIDs. Capture them once when producing and assert that IQv2
+    // results come back byte-equal to what was produced (see
+    // HeadersIQv2IntegrationTestBase#assertSchemaIdHeaders).
+    private CapturedSchemaIds valueSchemaIds;
+
+    // ---------------------------------------------------------------------------------------------
+    // TimestampedKeyWithHeadersQuery (point)
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldQueryPointWithHeaders() throws Exception {
+        String input = "iqv2-point-input";
+        String output = "iqv2-point-output";
+        String storeName = "iqv2-point-store";
+        String appId = "iqv2-point-test";
+
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Arrays.asList("word-1", "word-2", "word-3"), Arrays.asList(10L, 20L, 30L),
+            true, null);
+        try {
+            assertPointQuery(streams, storeName, "word-1", 10L, false);
+            assertPointQuery(streams, storeName, "word-2", 20L, false);
+            assertPointQuery(streams, storeName, "word-3", 30L, false);
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    @Test
+    public void shouldQueryPointSkipCache() throws Exception {
+        String input = "iqv2-skipcache-input";
+        String output = "iqv2-skipcache-output";
+        String storeName = "iqv2-skipcache-store";
+        String appId = "iqv2-skipcache-test";
+
+        // Low commit interval so the cache flushes into the underlying store, making the
+        // skipCache (store-served) read visible.
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Arrays.asList("word-1", "word-2"), Arrays.asList(10L, 20L),
+            true, 500);
+        try {
+            assertPointQuery(streams, storeName, "word-1", 10L, true);
+            assertPointQuery(streams, storeName, "word-2", 20L, true);
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    @Test
+    public void shouldReturnNullAfterTombstoningHeaderedKey() throws Exception {
+        String input = "iqv2-tombstone-input";
+        String output = "iqv2-tombstone-output";
+        String storeName = "iqv2-tombstone-store";
+        String appId = "iqv2-tombstone-test";
+
+        createTopics(input, output);
+        // Caching enabled + default commit interval: nothing flushes during the test, so the put and
+        // the later delete are both served from the record cache (read-your-writes/read-your-deletes).
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, true), appId, 30, null);
+        try {
+            // Populate word-1 and confirm the header-aware store serves it back with its schema-id
+            // headers -- establishing that there is a genuinely headered entry to remove.
+            produceRecords(input, Collections.singletonList("word-1"), Collections.singletonList(10L));
+            consumeRecords(output, appId + "-pre", 1);
+            assertPointQuery(streams, storeName, "word-1", 10L, false);
+
+            // Tombstone word-1 (null value). The header-aware store must drop the previously-headered
+            // entry so the point query stops returning it.
+            produceTombstone(input, "word-1");
+            consumeRecords(output, appId + "-post", 2);
+            assertPointReturnsNull(streams, storeName, "word-1", "tombstoned key");
+
+            // A key that was never written is likewise absent.
+            assertPointReturnsNull(streams, storeName, "no-such-word", "never-written key");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    @Test
+    public void shouldServeCacheHitBeforeFlushWithHeaders() throws Exception {
+        String input = "iqv2-cachehit-input";
+        String output = "iqv2-cachehit-output";
+        String storeName = "iqv2-cachehit-store";
+        String appId = "iqv2-cachehit-test";
+
+        createTopics(input, output);
+        // Caching enabled + a very large commit interval so nothing is committed/flushed during the
+        // test: the record lives only in the record cache (the persistent store stays empty).
+        int tenMinutes = (int) Duration.ofMinutes(10).toMillis();
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, true), appId, 30, tenMinutes);
+        try {
+            produceRecords(input, Collections.singletonList("word-1"), Collections.singletonList(10L));
+            consumeRecords(output, appId + "-barrier", 1);
+
+            // Read-your-writes: the not-yet-flushed record is served from the cache, with headers.
+            assertPointQuery(streams, storeName, "word-1", 10L, false);
+
+            // skipCache bypasses the cache and reads the persistent store, which is still empty; a null
+            // result positively proves the read above was genuinely cache-served (and covers skipCache).
+            assertNull(queryPointOnce(streams, storeName, createKey("word-1"), true),
+                "skipCache should read the empty store and return null before any flush");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // TimestampedRangeWithHeadersQuery (range / scan)
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldQueryRangeWithBounds() throws Exception {
+        String input = "iqv2-range-input";
+        String output = "iqv2-range-output";
+        String storeName = "iqv2-range-store";
+        String appId = "iqv2-range-test";
+
+        // Caching disabled: a range header-query reads the store directly (it never consults the
+        // cache), so writes must be store-served -- this makes them visible immediately.
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Arrays.asList("word-1", "word-2", "word-3", "word-4", "word-5"),
+            Arrays.asList(10L, 20L, 30L, 40L, 50L),
+            false, null);
+        try {
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
+                streams, storeName,
+                TimestampedRangeWithHeadersQuery.withRange(createKey("word-2"), createKey("word-4")),
+                3);
+            List<String> words = wordsOf(records);
+            assertEquals(Arrays.asList("word-2", "word-3", "word-4"), words, "range [word-2, word-4]");
+            assertHeadersOnEach(records, "IQv2 range");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    @Test
+    public void shouldQueryRangeAscendingAndDescending() throws Exception {
+        String input = "iqv2-order-input";
+        String output = "iqv2-order-output";
+        String storeName = "iqv2-order-store";
+        String appId = "iqv2-order-test";
+
+        // Caching disabled: range header-queries bypass the cache and read the store directly.
+        // Produce the keys out of order so the asc/desc assertions prove the query orders results by
+        // serialized key, not by insertion order.
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Arrays.asList("word-2", "word-3", "word-1"), Arrays.asList(20L, 30L, 10L),
+            false, null);
+        try {
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> asc = queryRange(
+                streams, storeName,
+                TimestampedRangeWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withNoBounds().withAscendingKeys(),
+                3);
+            assertEquals(Arrays.asList("word-1", "word-2", "word-3"), wordsOf(asc), "ascending keys");
+            assertHeadersOnEach(asc, "IQv2 ascending");
+
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> desc = queryRange(
+                streams, storeName,
+                TimestampedRangeWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withNoBounds().withDescendingKeys(),
+                3);
+            assertEquals(Arrays.asList("word-3", "word-2", "word-1"), wordsOf(desc), "descending keys");
+            assertHeadersOnEach(desc, "IQv2 descending");
+
+            // Bounded + descending: the ordering flip must also apply to a bounded range, not just a
+            // full scan -- guards against an ordering bug that only surfaces on the bounded path.
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> boundedDesc = queryRange(
+                streams, storeName,
+                TimestampedRangeWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withRange(createKey("word-1"), createKey("word-2"))
+                    .withDescendingKeys(),
+                2);
+            assertEquals(Arrays.asList("word-2", "word-1"), wordsOf(boundedDesc),
+                "bounded descending [word-1, word-2]");
+            assertHeadersOnEach(boundedDesc, "IQv2 bounded descending");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    @Test
+    public void shouldScanAllWithNoBounds() throws Exception {
+        String input = "iqv2-scan-input";
+        String output = "iqv2-scan-output";
+        String storeName = "iqv2-scan-store";
+        String appId = "iqv2-scan-test";
+
+        // Caching disabled: range header-queries bypass the cache and read the store directly.
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Arrays.asList("word-1", "word-2", "word-3"), Arrays.asList(10L, 20L, 30L),
+            false, null);
+        try {
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
+                streams, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 3);
+            // Compare as a sorted List (not a Set) so a scan that emitted a duplicate key would fail.
+            List<String> words = wordsOf(records);
+            Collections.sort(words);
+            assertEquals(Arrays.asList("word-1", "word-2", "word-3"), words,
+                "scan should return exactly the three keys, each once");
+            assertHeadersOnEach(records, "IQv2 scan");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    @Test
+    public void shouldQueryLowerBoundOnly() throws Exception {
+        String input = "iqv2-lower-input";
+        String output = "iqv2-lower-output";
+        String storeName = "iqv2-lower-store";
+        String appId = "iqv2-lower-test";
+
+        // Caching disabled: range header-queries bypass the cache and read the store directly.
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Arrays.asList("word-1", "word-2", "word-3", "word-4"),
+            Arrays.asList(10L, 20L, 30L, 40L),
+            false, null);
+        try {
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
+                streams, storeName,
+                TimestampedRangeWithHeadersQuery.withLowerBound(createKey("word-3")), 2);
+            assertEquals(Arrays.asList("word-3", "word-4"), wordsOf(records), "lower bound word-3");
+            assertHeadersOnEach(records, "IQv2 lower bound");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    @Test
+    public void shouldQueryUpperBoundOnly() throws Exception {
+        String input = "iqv2-upper-input";
+        String output = "iqv2-upper-output";
+        String storeName = "iqv2-upper-store";
+        String appId = "iqv2-upper-test";
+
+        // Caching disabled: range header-queries bypass the cache and read the store directly.
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Arrays.asList("word-1", "word-2", "word-3", "word-4"),
+            Arrays.asList(10L, 20L, 30L, 40L),
+            false, null);
+        try {
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
+                streams, storeName,
+                TimestampedRangeWithHeadersQuery.withUpperBound(createKey("word-2")), 2);
+            assertEquals(Arrays.asList("word-1", "word-2"), wordsOf(records), "upper bound word-2");
+            assertHeadersOnEach(records, "IQv2 upper bound");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Restore-from-changelog and multi-partition
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldRestoreFromChangelogThenQueryIQv2WithHeaders() throws Exception {
+        String input = "iqv2-restore-input";
+        String output = "iqv2-restore-output";
+        String storeName = "iqv2-restore-store";
+        String appId = "iqv2-restore-test";
+
+        createTopics(input, output);
+
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, true), appId, 30, null);
+        try {
+            produceRecords(input, Arrays.asList("word-1", "word-2", "word-3"),
+                Arrays.asList(10L, 20L, 30L));
+            consumeRecords(output, "iqv2-restore-pre", 3);
+        } finally {
+            closeStreams(streams);
+        }
+
+        // Restart with the same APPLICATION_ID; cleanUp() wipes the local state dir so the store
+        // must be rebuilt from the changelog. The restored entries must still carry their headers.
+        KafkaStreams restored = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, true), appId, 90, null);
+        try {
+            ReadOnlyRecord<GenericRecord, GenericRecord> word1 =
+                queryPointExpectPresent(restored, storeName, createKey("word-1"), false);
+            assertEquals(10L, word1.value().get("count"), "restored word-1 value");
+            assertSchemaIdHeaders(word1.headers(), valueSchemaIds, "restored word-1");
+
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> all = queryRange(
+                restored, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 3);
+            assertEquals(new HashSet<>(Arrays.asList("word-1", "word-2", "word-3")),
+                new HashSet<>(wordsOf(all)), "restored scan keys");
+            assertHeadersOnEach(all, "restored scan");
+        } finally {
+            closeStreams(restored);
+        }
+    }
+
+    @Test
+    public void shouldQueryAcrossPartitionsWithHeaders() throws Exception {
+        String input = "iqv2-mp-input";
+        String output = "iqv2-mp-output";
+        String storeName = "iqv2-mp-store";
+        String appId = "iqv2-mp-test";
+        int numPartitions = 3;
+        int numKeys = 9;
+
+        createTopicsWithPartitions(numPartitions, input, output);
+
+        List<String> words = new ArrayList<>();
+        List<Long> counts = new ArrayList<>();
+        for (int i = 1; i <= numKeys; i++) {
+            words.add("word-" + i);
+            counts.add(i * 10L);
+        }
+
+        // Caching disabled: the scan reads each partition's store directly, so writes are visible
+        // immediately without waiting for a cache flush.
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, false), appId, 30, null);
+        try {
+            produceRecords(input, words, counts);
+            consumeRecords(output, "iqv2-mp-consumer", numKeys);
+
+            // Scan every locally-available partition; collect and assert headers on every record.
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> all = new ArrayList<>();
+            Set<Integer> partitionsSeen = new HashSet<>();
+            long deadline = System.currentTimeMillis() + 30_000;
+            while (System.currentTimeMillis() < deadline) {
+                all.clear();
+                partitionsSeen.clear();
+                StateQueryResult<ReadOnlyRecordIterator<GenericRecord, GenericRecord>> result =
+                    streams.query(StateQueryRequest.inStore(storeName)
+                        .withQuery(TimestampedRangeWithHeadersQuery.withNoBounds()));
+                for (Map.Entry<Integer, QueryResult<ReadOnlyRecordIterator<GenericRecord, GenericRecord>>> e :
+                    result.getPartitionResults().entrySet()) {
+                    QueryResult<ReadOnlyRecordIterator<GenericRecord, GenericRecord>> pr = e.getValue();
+                    if (pr.isSuccess() && pr.getResult() != null) {
+                        try (ReadOnlyRecordIterator<GenericRecord, GenericRecord> it = pr.getResult()) {
+                            while (it.hasNext()) {
+                                all.add(it.next());
+                                partitionsSeen.add(e.getKey());
+                            }
+                        }
+                    }
+                }
+                if (all.size() >= numKeys) {
+                    break;
+                }
+                sleepQuietly(200);
+            }
+
+            assertEquals(numKeys, all.size(), "should read every key across partitions");
+            assertTrue(partitionsSeen.size() > 1,
+                "records should span more than one partition but saw: " + partitionsSeen);
+            assertHeadersOnEach(all, "IQv2 multi-partition scan");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // IQv2 query helpers
+    // ---------------------------------------------------------------------------------------------
+
+    private ReadOnlyRecord<GenericRecord, GenericRecord> queryPointExpectPresent(
+        KafkaStreams streams, String storeName, GenericRecord key, boolean skipCache) {
+        TimestampedKeyWithHeadersQuery<GenericRecord, GenericRecord> query =
+            TimestampedKeyWithHeadersQuery.withKey(key);
+        if (skipCache) {
+            query = query.skipCache();
+        }
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (System.currentTimeMillis() < deadline) {
+            StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> result =
+                streams.query(StateQueryRequest.inStore(storeName).withQuery(query));
+            QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> pr = result.getOnlyPartitionResult();
+            if (pr != null && pr.isSuccess() && pr.getResult() != null) {
+                return pr.getResult();
+            }
+            sleepQuietly(200);
+        }
+        throw new AssertionError("IQv2 point query never returned a result for key " + key);
+    }
+
+    private void assertPointQuery(KafkaStreams streams, String storeName, String word,
+        long expectedCount, boolean skipCache) {
+        ReadOnlyRecord<GenericRecord, GenericRecord> record =
+            queryPointExpectPresent(streams, storeName, createKey(word), skipCache);
+        assertEquals(word, record.key().get("word").toString(), "IQv2 point key " + word);
+        assertEquals(expectedCount, record.value().get("count"), "IQv2 point value " + word);
+        assertTrue(record.timestamp() >= 0, "IQv2 point timestamp should be non-negative: " + word);
+        assertSchemaIdHeaders(record.headers(), valueSchemaIds,
+            "IQv2 point " + word + (skipCache ? " (skipCache)" : ""));
+    }
+
+    /**
+     * Asserts a point query for {@code word} succeeds but yields a null result. A success-with-null is
+     * filtered out of {@link StateQueryResult#getOnlyPartitionResult()} (which returns null), so this
+     * inspects the per-partition result directly to distinguish "succeeded, absent" from a failure.
+     */
+    private void assertPointReturnsNull(KafkaStreams streams, String storeName, String word,
+        String context) {
+        StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> result =
+            streams.query(StateQueryRequest.inStore(storeName)
+                .withQuery(TimestampedKeyWithHeadersQuery.withKey(createKey(word))));
+        QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> pr =
+            result.getPartitionResults().values().iterator().next();
+        assertTrue(pr.isSuccess(), context + " query should succeed");
+        assertNull(pr.getResult(), context + " should yield a null result");
+    }
+
+    /** Single point query, no retry. Returns null for an absent/tombstoned key (or empty store). */
+    private ReadOnlyRecord<GenericRecord, GenericRecord> queryPointOnce(
+        KafkaStreams streams, String storeName, GenericRecord key, boolean skipCache) {
+        TimestampedKeyWithHeadersQuery<GenericRecord, GenericRecord> query =
+            TimestampedKeyWithHeadersQuery.withKey(key);
+        if (skipCache) {
+            query = query.skipCache();
+        }
+        StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> result =
+            streams.query(StateQueryRequest.inStore(storeName).withQuery(query));
+        QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> pr = result.getOnlyPartitionResult();
+        return pr == null ? null : pr.getResult();
+    }
+
+    private List<ReadOnlyRecord<GenericRecord, GenericRecord>> queryRange(
+        KafkaStreams streams, String storeName,
+        TimestampedRangeWithHeadersQuery<GenericRecord, GenericRecord> query, int expected) {
+        long deadline = System.currentTimeMillis() + 30_000;
+        List<ReadOnlyRecord<GenericRecord, GenericRecord>> out = new ArrayList<>();
+        while (System.currentTimeMillis() < deadline) {
+            out.clear();
+            StateQueryResult<ReadOnlyRecordIterator<GenericRecord, GenericRecord>> result =
+                streams.query(StateQueryRequest.inStore(storeName).withQuery(query));
+            QueryResult<ReadOnlyRecordIterator<GenericRecord, GenericRecord>> pr =
+                result.getOnlyPartitionResult();
+            if (pr != null && pr.isSuccess() && pr.getResult() != null) {
+                try (ReadOnlyRecordIterator<GenericRecord, GenericRecord> it = pr.getResult()) {
+                    while (it.hasNext()) {
+                        out.add(it.next());
+                    }
+                }
+                if (out.size() >= expected) {
+                    return out;
+                }
+            }
+            sleepQuietly(200);
+        }
+        assertEquals(expected, out.size(), "IQv2 range query returned an unexpected count");
+        return out;
+    }
+
+    private static List<String> wordsOf(List<ReadOnlyRecord<GenericRecord, GenericRecord>> records) {
+        return records.stream()
+            .map(r -> r.key().get("word").toString())
+            .collect(Collectors.toList());
+    }
+
+    private void assertHeadersOnEach(
+        List<ReadOnlyRecord<GenericRecord, GenericRecord>> records, String context) {
+        for (int i = 0; i < records.size(); i++) {
+            assertSchemaIdHeaders(records.get(i).headers(), valueSchemaIds, context + " entry " + i);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Topology + populate helpers
+    // ---------------------------------------------------------------------------------------------
+
+    private Topology buildTopology(String input, String output, String storeName,
+        boolean cachingEnabled) {
+        GenericAvroSerde keySerde = createKeySerde();
+        GenericAvroSerde valueSerde = createValueSerde();
+        StoreBuilder<TimestampedKeyValueStoreWithHeaders<GenericRecord, GenericRecord>> storeBuilder =
+            Stores.timestampedKeyValueStoreWithHeadersBuilder(
+                Stores.persistentTimestampedKeyValueStoreWithHeaders(storeName), keySerde, valueSerde);
+        storeBuilder = cachingEnabled
+            ? storeBuilder.withCachingEnabled()
+            : storeBuilder.withCachingDisabled();
+
+        StreamsBuilder builder = new StreamsBuilder();
+        builder
+            .addStateStore(storeBuilder)
+            .stream(input, Consumed.with(keySerde, valueSerde))
+            .process(() -> new PutProcessor(storeName), storeName)
+            .to(output, Produced.with(keySerde, valueSerde));
+        return builder.build();
+    }
+
+    private KafkaStreams startAndPopulate(String storeName, String input, String output, String appId,
+        List<String> words, List<Long> counts, boolean cachingEnabled, Integer commitIntervalMs)
+        throws Exception {
+        createTopics(input, output);
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, cachingEnabled), appId, 30, commitIntervalMs);
+        boolean populated = false;
+        try {
+            produceRecords(input, words, counts);
+            consumeRecords(output, appId + "-populate-consumer", words.size());
+            populated = true;
+            return streams;
+        } finally {
+            if (!populated) {
+                closeStreams(streams);
+            }
+        }
+    }
+
+    private void produceRecords(String topic, List<String> words, List<Long> counts) throws Exception {
+        try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                 new KafkaProducer<>(createProducerProps())) {
+            for (int i = 0; i < words.size(); i++) {
+                valueSchemaIds = sendAndCapture(producer, new ProducerRecord<>(
+                    topic, createKey(words.get(i)), createValue(counts.get(i), "PUT")));
+            }
+            producer.flush();
+        }
+    }
+
+    /** Produces a tombstone (null value) for {@code word}, deleting it from the header-aware store. */
+    private void produceTombstone(String topic, String word) throws Exception {
+        try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                 new KafkaProducer<>(createProducerProps())) {
+            sendAndCapture(producer, new ProducerRecord<>(topic, createKey(word), (GenericRecord) null));
+            producer.flush();
+        }
+    }
+
+    /**
+     * Processor that stores each incoming record (value, timestamp, headers) into the header-aware
+     * store and forwards the stored record downstream, so the output topic acts as a completion
+     * barrier for the produced batch.
+     */
+    private static class PutProcessor
+        implements Processor<GenericRecord, GenericRecord, GenericRecord, GenericRecord> {
+
+        private final String storeName;
+        private ProcessorContext<GenericRecord, GenericRecord> context;
+        private TimestampedKeyValueStoreWithHeaders<GenericRecord, GenericRecord> store;
+
+        PutProcessor(String storeName) {
+            this.storeName = storeName;
+        }
+
+        @Override
+        public void init(ProcessorContext<GenericRecord, GenericRecord> context) {
+            this.context = context;
+            this.store = context.getStateStore(storeName);
+        }
+
+        @Override
+        public void process(Record<GenericRecord, GenericRecord> record) {
+            if (record.value() == null) {
+                // Tombstone the header-aware entry (mirrors the window/session writers' null handling)
+                // and forward the null-value record so the output topic still acts as a completion
+                // barrier for the batch.
+                store.put(record.key(), null);
+                context.forward(record);
+                return;
+            }
+            store.put(record.key(),
+                ValueTimestampHeaders.make(record.value(), record.timestamp(), record.headers()));
+            ValueTimestampHeaders<GenericRecord> stored = store.get(record.key());
+            context.forward(new Record<>(
+                record.key(), stored.value(), stored.timestamp(), stored.headers()));
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Avro record factories (schema-specific; the shared infrastructure lives in the base class)
+    // ---------------------------------------------------------------------------------------------
+
+    private GenericRecord createKey(String word) {
+        GenericRecord key = new GenericData.Record(keySchema);
+        key.put("word", word);
+        return key;
+    }
+
+    private GenericRecord createValue(long count, String operation) {
+        GenericRecord value = new GenericData.Record(valueSchema);
+        value.put("count", count);
+        value.put("operation", operation);
+        return value;
+    }
+}

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
@@ -279,67 +279,6 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         }
     }
 
-    /**
-     * Covers the position-bound path for both header queries. Every other test here uses the default
-     * unbounded position, so neither {@code withPositionBound(...)} nor
-     * {@link StateQueryResult#getPosition()} would otherwise be exercised at all.
-     */
-    @Test
-    public void shouldReportPositionAndRejectQueryBoundedBeyondIt() throws Exception {
-        String input = "iqv2-position-input";
-        String output = "iqv2-position-output";
-        String storeName = "iqv2-position-store";
-        String appId = "iqv2-position-test";
-
-        KafkaStreams streams = startAndPopulate(
-            storeName, input, output, appId,
-            Collections.singletonList("word-1"), Collections.singletonList(10L), false, null);
-        try {
-            // A query served under the default (unbounded) bound reports the position the store had
-            // reached when it answered.
-            StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> unbounded =
-                streams.query(StateQueryRequest.inStore(storeName)
-                    .withQuery(TimestampedKeyWithHeadersQuery
-                        .<GenericRecord, GenericRecord>withKey(createKey("word-1"))));
-            Position position = unbounded.getPosition();
-            assertNotNull(position, "unbounded query should report a position");
-            assertTrue(position.getTopics().contains(input),
-                "reported position should cover the input topic but was: " + position);
-
-            // A bound at an offset the store cannot have reached must fail the query with
-            // NOT_UP_TO_BOUND rather than quietly serving a result from behind the bound.
-            PositionBound beyond = PositionBound.at(
-                Position.emptyPosition().withComponent(input, 0, Long.MAX_VALUE));
-            assertNotUpToBound(streams.query(StateQueryRequest.inStore(storeName)
-                .withQuery(TimestampedKeyWithHeadersQuery
-                    .<GenericRecord, GenericRecord>withKey(createKey("word-1")))
-                .withPositionBound(beyond)), "point query");
-            assertNotUpToBound(streams.query(StateQueryRequest.inStore(storeName)
-                .withQuery(TimestampedRangeWithHeadersQuery
-                    .<GenericRecord, GenericRecord>withNoBounds())
-                .withPositionBound(beyond)), "range query");
-            closeStreams(streams);
-        } finally {
-            closeStreamsQuietly(streams);
-        }
-    }
-
-    /**
-     * Asserts every partition result failed with {@link FailureReason#NOT_UP_TO_BOUND} -- checking
-     * the reason, not merely that the query failed, so an unrelated failure can't pass as coverage.
-     */
-    private static <R> void assertNotUpToBound(StateQueryResult<R> result, String context) {
-        Map<Integer, QueryResult<R>> partitionResults = result.getPartitionResults();
-        assertFalse(partitionResults.isEmpty(), context + " should return a partition result");
-        for (Map.Entry<Integer, QueryResult<R>> e : partitionResults.entrySet()) {
-            QueryResult<R> pr = e.getValue();
-            assertTrue(pr.isFailure(), context
-                + " bounded beyond the store's position should fail on partition " + e.getKey());
-            assertEquals(FailureReason.NOT_UP_TO_BOUND, pr.getFailureReason(),
-                context + " should fail with NOT_UP_TO_BOUND on partition " + e.getKey());
-        }
-    }
-
     // ---------------------------------------------------------------------------------------------
     // TimestampedRangeWithHeadersQuery (range / scan)
     // ---------------------------------------------------------------------------------------------
@@ -657,6 +596,71 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             closeStreams(streams);
         } finally {
             closeStreamsQuietly(streams);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Position bounds (point + range)
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Covers the position-bound path for both header queries. Every other test here uses the default
+     * unbounded position, so neither {@code withPositionBound(...)} nor
+     * {@link StateQueryResult#getPosition()} would otherwise be exercised at all.
+     */
+    @Test
+    public void shouldReportPositionAndRejectQueryBoundedBeyondIt() throws Exception {
+        String input = "iqv2-position-input";
+        String output = "iqv2-position-output";
+        String storeName = "iqv2-position-store";
+        String appId = "iqv2-position-test";
+
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Collections.singletonList("word-1"), Collections.singletonList(10L), false, null);
+        try {
+            // A query served under the default (unbounded) bound reports the position the store had
+            // reached when it answered.
+            StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> unbounded =
+                streams.query(StateQueryRequest.inStore(storeName)
+                    .withQuery(TimestampedKeyWithHeadersQuery
+                        .<GenericRecord, GenericRecord>withKey(createKey("word-1"))));
+            Position position = unbounded.getPosition();
+            assertNotNull(position, "unbounded query should report a position");
+            assertTrue(position.getTopics().contains(input),
+                "reported position should cover the input topic but was: " + position);
+
+            // A bound at an offset the store cannot have reached must fail the query with
+            // NOT_UP_TO_BOUND rather than quietly serving a result from behind the bound.
+            PositionBound beyond = PositionBound.at(
+                Position.emptyPosition().withComponent(input, 0, Long.MAX_VALUE));
+            assertNotUpToBound(streams.query(StateQueryRequest.inStore(storeName)
+                .withQuery(TimestampedKeyWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withKey(createKey("word-1")))
+                .withPositionBound(beyond)), "point query");
+            assertNotUpToBound(streams.query(StateQueryRequest.inStore(storeName)
+                .withQuery(TimestampedRangeWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withNoBounds())
+                .withPositionBound(beyond)), "range query");
+            closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
+        }
+    }
+
+    /**
+     * Asserts every partition result failed with {@link FailureReason#NOT_UP_TO_BOUND} -- checking
+     * the reason, not merely that the query failed, so an unrelated failure can't pass as coverage.
+     */
+    private static <R> void assertNotUpToBound(StateQueryResult<R> result, String context) {
+        Map<Integer, QueryResult<R>> partitionResults = result.getPartitionResults();
+        assertFalse(partitionResults.isEmpty(), context + " should return a partition result");
+        for (Map.Entry<Integer, QueryResult<R>> e : partitionResults.entrySet()) {
+            QueryResult<R> pr = e.getValue();
+            assertTrue(pr.isFailure(), context
+                + " bounded beyond the store's position should fail on partition " + e.getKey());
+            assertEquals(FailureReason.NOT_UP_TO_BOUND, pr.getFailureReason(),
+                context + " should fail with NOT_UP_TO_BOUND on partition " + e.getKey());
         }
     }
 

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
@@ -18,30 +18,40 @@ package io.confluent.kafka.streams.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.confluent.kafka.serializers.schema.id.HeaderSchemaIdSerializer;
 import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Header;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.ReadOnlyRecord;
@@ -91,19 +101,29 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             + "\"name\":\"WordValue\","
             + "\"namespace\":\"io.confluent.kafka.streams.integration\","
             + "\"fields\":["
-            + "  {\"name\":\"count\",\"type\":\"long\"},"
-            + "  {\"name\":\"operation\",\"type\":\"string\",\"default\":\"PUT\"}"
+            + "  {\"name\":\"count\",\"type\":\"long\"}"
             + "]"
             + "}";
 
     private final Schema keySchema = new Schema.Parser().parse(KEY_SCHEMA_JSON);
     private final Schema valueSchema = new Schema.Parser().parse(VALUE_SCHEMA_JSON);
 
-    // Every record in each test shares this one key/value schema, so every value-bearing record
-    // carries the same schema-id GUIDs. Capture them once when producing and assert that IQv2
-    // results come back byte-equal to what was produced (see
-    // HeadersIQv2IntegrationTestBase#assertSchemaIdHeaders).
-    private CapturedSchemaIds producedSchemaIds;
+    /**
+     * A distinct user header attached to every produced record, carrying that record's own key
+     * ({@code seq=<word>}). Because it differs per record -- unlike the schema-id GUIDs, which are
+     * byte-identical for every record since they all share one schema -- asserting it on each IQv2
+     * result proves the store returned <em>this</em> record's headers, not another record's.
+     */
+    private static final String SEQ_HEADER = "seq";
+
+    // Per-record captures, keyed by word, so each IQv2 result is asserted against its own record's
+    // produced schema-id GUIDs (see HeadersIQv2IntegrationTestBase#assertSchemaIdHeaders) and its
+    // own produced timestamp -- not a single shared value that every record would trivially match.
+    private final Map<String, CapturedSchemaIds> capturedByWord = new HashMap<>();
+    private final Map<String, Long> timestampByWord = new HashMap<>();
+
+    // A fixed, explicit base timestamp so each record's timestamp is known and assertable.
+    private static final long BASE_TIMESTAMP = 1_600_000_000_000L;
 
     // ---------------------------------------------------------------------------------------------
     // TimestampedKeyWithHeadersQuery (point)
@@ -173,10 +193,36 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             // entry so the point query stops returning it.
             produceTombstone(input, "word-1");
             consumeRecords(output, appId + "-post", 2);
-            assertPointReturnsNull(streams, storeName, "word-1", "tombstoned key");
+            assertPointReturnsNull(streams, storeName, "word-1", "tombstoned key", false);
 
             // A key that was never written is likewise absent.
-            assertPointReturnsNull(streams, storeName, "no-such-word", "never-written key");
+            assertPointReturnsNull(streams, storeName, "no-such-word", "never-written key", false);
+
+            // Re-put word-1 after the tombstone with a NEW record carrying a distinguishing header
+            // (phase=after). The pre-tombstone record had no such header, so a store that lingered
+            // the old headers instead of taking the re-put's would fail the phase assertion below --
+            // this pins that a re-put comes back with its own headers, not the pre-tombstone ones.
+            long reputTs = BASE_TIMESTAMP + 100;
+            try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                     new KafkaProducer<>(createProducerProps())) {
+                ProducerRecord<GenericRecord, GenericRecord> reput = new ProducerRecord<>(
+                    input, null, reputTs, createKey("word-1"), createValue(99L));
+                reput.headers().add(SEQ_HEADER, "word-1".getBytes(StandardCharsets.UTF_8));
+                reput.headers().add("phase", "after".getBytes(StandardCharsets.UTF_8));
+                capturedByWord.put("word-1", sendAndCapture(producer, reput));
+                timestampByWord.put("word-1", reputTs);
+                producer.flush();
+            }
+            consumeRecords(output, appId + "-reput", 3);
+
+            ReadOnlyRecord<GenericRecord, GenericRecord> afterReput =
+                queryPointExpectPresent(streams, storeName, createKey("word-1"), false);
+            assertEquals(99L, afterReput.value().get("count"), "re-put word-1 value");
+            assertRecordHeaders(afterReput, "word-1", "re-put word-1");
+            Header phase = afterReput.headers().lastHeader("phase");
+            assertNotNull(phase, "re-put word-1: should carry the new record's phase header");
+            assertEquals("after", new String(phase.value(), StandardCharsets.UTF_8),
+                "re-put word-1: query should return the re-put's headers, not the pre-tombstone ones");
         } finally {
             closeStreams(streams);
         }
@@ -202,10 +248,41 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             // Read-your-writes: the not-yet-flushed record is served from the cache, with headers.
             assertPointQuery(streams, storeName, "word-1", 10L, false);
 
-            // skipCache bypasses the cache and reads the persistent store, which is still empty; a null
-            // result positively proves the read above was genuinely cache-served (and covers skipCache).
-            assertNull(queryPointOnce(streams, storeName, createKey("word-1"), true),
-                "skipCache should read the empty store and return null before any flush");
+            // skipCache bypasses the cache and reads the persistent store, which is still empty; a
+            // successful null result positively proves the read above was genuinely cache-served (and
+            // covers skipCache). Asserting success first stops a failed skipCache query passing as null.
+            assertPointReturnsNull(streams, storeName, "word-1",
+                "skipCache before flush (empty store)", true);
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    @Test
+    public void shouldReturnReadOnlyHeaders() throws Exception {
+        String input = "iqv2-readonly-input";
+        String output = "iqv2-readonly-output";
+        String storeName = "iqv2-readonly-store";
+        String appId = "iqv2-readonly-test";
+
+        // Caching disabled so the range query (which bypasses the cache) sees the store-served record.
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Collections.singletonList("word-1"), Collections.singletonList(10L), false, null);
+        try {
+            // The query marks the returned headers read-only on both the point and range paths, so
+            // an attempt to mutate them must throw.
+            ReadOnlyRecord<GenericRecord, GenericRecord> point =
+                queryPointExpectPresent(streams, storeName, createKey("word-1"), false);
+            assertThrows(IllegalStateException.class,
+                () -> point.headers().add("x", new byte[]{1}),
+                "point query should return read-only headers");
+
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> range = queryRange(
+                streams, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 1);
+            assertThrows(IllegalStateException.class,
+                () -> range.get(0).headers().add("x", new byte[]{1}),
+                "range query should return read-only headers");
         } finally {
             closeStreams(streams);
         }
@@ -232,7 +309,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         try {
             List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
                 streams, storeName,
-                TimestampedRangeWithHeadersQuery.withRange(createKey("word-2"), createKey("word-4")),
+                TimestampedRangeWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withRange(createKey("word-2"), createKey("word-4"))
+                    .withAscendingKeys(),
                 3);
             List<String> words = wordsOf(records);
             assertEquals(Arrays.asList("word-2", "word-3", "word-4"), words, "range [word-2, word-4]");
@@ -331,7 +410,10 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         try {
             List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
                 streams, storeName,
-                TimestampedRangeWithHeadersQuery.withLowerBound(createKey("word-3")), 2);
+                TimestampedRangeWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withLowerBound(createKey("word-3"))
+                    .withAscendingKeys(),
+                2);
             assertEquals(Arrays.asList("word-3", "word-4"), wordsOf(records), "lower bound word-3");
             assertHeadersOnEach(records, "IQv2 lower bound");
         } finally {
@@ -355,7 +437,10 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         try {
             List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
                 streams, storeName,
-                TimestampedRangeWithHeadersQuery.withUpperBound(createKey("word-2")), 2);
+                TimestampedRangeWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withUpperBound(createKey("word-2"))
+                    .withAscendingKeys(),
+                2);
             assertEquals(Arrays.asList("word-1", "word-2"), wordsOf(records), "upper bound word-2");
             assertHeadersOnEach(records, "IQv2 upper bound");
         } finally {
@@ -388,6 +473,57 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         }
     }
 
+    @Test
+    public void shouldNotServeRangeFromCacheBeforeFlush() throws Exception {
+        String input = "iqv2-rangecache-input";
+        String output = "iqv2-rangecache-output";
+        String storeName = "iqv2-rangecache-store";
+        String appId = "iqv2-rangecache-test";
+
+        createTopics(input, output);
+        // Caching enabled + a very large commit interval so nothing flushes during the test: the
+        // records live only in the record cache; the persistent store stays empty.
+        int tenMinutes = (int) Duration.ofMinutes(10).toMillis();
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, true), appId, 30, tenMinutes);
+        try {
+            produceRecords(input, Arrays.asList("word-1", "word-2", "word-3"),
+                Arrays.asList(10L, 20L, 30L));
+            consumeRecords(output, appId + "-barrier", 3);
+
+            // Positive control: a point query serves the not-yet-flushed records from the cache, so
+            // they are genuinely present -- just unflushed.
+            assertPointQuery(streams, storeName, "word-1", 10L, false);
+
+            // The range path bypasses the cache and reads the still-empty persistent store, so it
+            // must return nothing. This turns the "range never consults the cache" comment on the
+            // range tests into an asserted guarantee, catching a future change that starts consulting
+            // the cache. Emptiness is asserted from a single successful query -- there is nothing to
+            // wait for.
+            StateQueryResult<ReadOnlyRecordIterator<GenericRecord, GenericRecord>> result =
+                streams.query(StateQueryRequest.inStore(storeName)
+                    .withQuery(TimestampedRangeWithHeadersQuery.withNoBounds()));
+            QueryResult<ReadOnlyRecordIterator<GenericRecord, GenericRecord>> pr =
+                result.getOnlyPartitionResult();
+            assertNotNull(pr, "range query should return a partition result");
+            assertTrue(pr.isSuccess(), "range query should succeed but failed: "
+                + (pr.isFailure() ? pr.getFailureReason() + ": " + pr.getFailureMessage() : ""));
+            List<String> served = new ArrayList<>();
+            ReadOnlyRecordIterator<GenericRecord, GenericRecord> iter = pr.getResult();
+            if (iter != null) {
+                try (ReadOnlyRecordIterator<GenericRecord, GenericRecord> it = iter) {
+                    while (it.hasNext()) {
+                        served.add(it.next().key().get("word").toString());
+                    }
+                }
+            }
+            assertTrue(served.isEmpty(),
+                "range query must not serve unflushed cached entries but returned: " + served);
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
     // ---------------------------------------------------------------------------------------------
     // Restore-from-changelog and multi-partition
     // ---------------------------------------------------------------------------------------------
@@ -411,21 +547,59 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             closeStreams(streams);
         }
 
-        // Restart with the same APPLICATION_ID; cleanUp() wipes the local state dir so the store
-        // must be rebuilt from the changelog. The restored entries must still carry their headers.
-        KafkaStreams restored = startStreamsAndAwaitRunning(
-            buildTopology(input, output, storeName, true), appId, 90, null);
+        // Restart with the same APPLICATION_ID; cleanUp() wipes the local state dir so the store must
+        // be rebuilt from the changelog. Attach a StateRestoreListener BEFORE start() to prove the
+        // rebuild actually happened: cleanUp() clears local state but not committed offsets, so
+        // without this the restart could silently reprocess the input and pass with no restore at all.
+        // (The base start helper can't set a restore listener, so this instance is started inline.)
+        AtomicLong restoredCount = new AtomicLong(0);
+        StateRestoreListener restoreListener = new StateRestoreListener() {
+            @Override
+            public void onRestoreStart(TopicPartition tp, String store, long start, long end) {
+            }
+
+            @Override
+            public void onBatchRestored(TopicPartition tp, String store, long end, long batch) {
+            }
+
+            @Override
+            public void onRestoreEnd(TopicPartition tp, String store, long totalRestored) {
+                if (store.equals(storeName)) {
+                    restoredCount.addAndGet(totalRestored);
+                }
+            }
+        };
+        KafkaStreams restored = new KafkaStreams(
+            buildTopology(input, output, storeName, true), createStreamsProps(appId, null));
+        restored.cleanUp();
+        restored.setGlobalStateRestoreListener(restoreListener);
+        CountDownLatch restoredRunning = new CountDownLatch(1);
+        restored.setStateListener((newState, oldState) -> {
+            if (newState == KafkaStreams.State.RUNNING) {
+                restoredRunning.countDown();
+            }
+        });
+        restored.start();
         try {
+            assertTrue(restoredRunning.await(90, TimeUnit.SECONDS),
+                "restored KafkaStreams should reach RUNNING");
+
             ReadOnlyRecord<GenericRecord, GenericRecord> word1 =
                 queryPointExpectPresent(restored, storeName, createKey("word-1"), false);
             assertEquals(10L, word1.value().get("count"), "restored word-1 value");
-            assertSchemaIdHeaders(word1.headers(), producedSchemaIds, "restored word-1");
+            assertRecordHeaders(word1, "word-1", "restored word-1");
 
             List<ReadOnlyRecord<GenericRecord, GenericRecord>> all = queryRange(
                 restored, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 3);
             assertEquals(new HashSet<>(Arrays.asList("word-1", "word-2", "word-3")),
                 new HashSet<>(wordsOf(all)), "restored scan keys");
             assertHeadersOnEach(all, "restored scan");
+
+            // Pin that the store was genuinely rebuilt from the changelog, not repopulated by a
+            // silent reprocess of the input topic.
+            assertTrue(restoredCount.get() > 0,
+                "store should have been restored from the changelog (restored "
+                    + restoredCount.get() + " records)");
         } finally {
             closeStreams(restored);
         }
@@ -527,11 +701,11 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         long expectedCount, boolean skipCache) {
         ReadOnlyRecord<GenericRecord, GenericRecord> record =
             queryPointExpectPresent(streams, storeName, createKey(word), skipCache);
+        String context = "IQv2 point " + word + (skipCache ? " (skipCache)" : "");
         assertEquals(word, record.key().get("word").toString(), "IQv2 point key " + word);
         assertEquals(expectedCount, record.value().get("count"), "IQv2 point value " + word);
-        assertTrue(record.timestamp() >= 0, "IQv2 point timestamp should be non-negative: " + word);
-        assertSchemaIdHeaders(record.headers(), producedSchemaIds,
-            "IQv2 point " + word + (skipCache ? " (skipCache)" : ""));
+        assertEquals(timestampByWord.get(word), record.timestamp(), "IQv2 point timestamp " + word);
+        assertRecordHeaders(record, word, context);
     }
 
     /**
@@ -540,31 +714,24 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
      * inspects the per-partition result directly to distinguish "succeeded, absent" from a failure.
      */
     private void assertPointReturnsNull(KafkaStreams streams, String storeName, String word,
-        String context) {
-        StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> result =
-            streams.query(StateQueryRequest.inStore(storeName)
-                .withQuery(TimestampedKeyWithHeadersQuery.withKey(createKey(word))));
-        Map<Integer, QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>>> partitionResults =
-            result.getPartitionResults();
-        assertFalse(partitionResults.isEmpty(), context + " query should return a partition result");
-        QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> pr =
-            partitionResults.values().iterator().next();
-        assertTrue(pr.isSuccess(), context + " query should succeed");
-        assertNull(pr.getResult(), context + " should yield a null result");
-    }
-
-    /** Single point query, no retry. Returns null for an absent/tombstoned key (or empty store). */
-    private ReadOnlyRecord<GenericRecord, GenericRecord> queryPointOnce(
-        KafkaStreams streams, String storeName, GenericRecord key, boolean skipCache) {
+        String context, boolean skipCache) {
         TimestampedKeyWithHeadersQuery<GenericRecord, GenericRecord> query =
-            TimestampedKeyWithHeadersQuery.withKey(key);
+            TimestampedKeyWithHeadersQuery.withKey(createKey(word));
         if (skipCache) {
             query = query.skipCache();
         }
         StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> result =
             streams.query(StateQueryRequest.inStore(storeName).withQuery(query));
-        QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> pr = result.getOnlyPartitionResult();
-        return pr == null ? null : pr.getResult();
+        Map<Integer, QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>>> partitionResults =
+            result.getPartitionResults();
+        assertFalse(partitionResults.isEmpty(), context + " query should return a partition result");
+        QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> pr =
+            partitionResults.values().iterator().next();
+        // Assert success first: getOnlyPartitionResult() filters out FAILED results too, so a query
+        // that failed outright would otherwise masquerade as a legitimate "absent key" null.
+        assertTrue(pr.isSuccess(), context + " query should succeed but failed: "
+            + (pr.isFailure() ? pr.getFailureReason() + ": " + pr.getFailureMessage() : ""));
+        assertNull(pr.getResult(), context + " should yield a null result");
     }
 
     private List<ReadOnlyRecord<GenericRecord, GenericRecord>> queryRange(
@@ -607,8 +774,28 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
     private void assertHeadersOnEach(
         List<ReadOnlyRecord<GenericRecord, GenericRecord>> records, String context) {
         for (int i = 0; i < records.size(); i++) {
-            assertSchemaIdHeaders(records.get(i).headers(), producedSchemaIds, context + " entry " + i);
+            ReadOnlyRecord<GenericRecord, GenericRecord> record = records.get(i);
+            String word = record.key().get("word").toString();
+            assertRecordHeaders(record, word, context + " entry " + i);
         }
+    }
+
+    /**
+     * Asserts the record carries the exact headers produced for {@code word}: the schema-id GUIDs
+     * byte-equal to what that record's serializer wrote, and the distinct {@code seq} header equal to
+     * the word itself. The {@code seq} check is what makes this a per-record fidelity assertion -- a
+     * store that returned another record's headers, or one shared {@code Headers} instance for every
+     * entry, would carry the wrong {@code seq} and fail here.
+     */
+    private void assertRecordHeaders(ReadOnlyRecord<GenericRecord, GenericRecord> record,
+        String word, String context) {
+        CapturedSchemaIds expected = capturedByWord.get(word);
+        assertNotNull(expected, context + ": no captured schema-id GUIDs for " + word);
+        assertSchemaIdHeaders(record.headers(), expected, context);
+        Header seq = record.headers().lastHeader(SEQ_HEADER);
+        assertNotNull(seq, context + ": missing " + SEQ_HEADER + " header");
+        assertEquals(word, new String(seq.value(), StandardCharsets.UTF_8),
+            context + ": " + SEQ_HEADER + " header should carry this record's own key");
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -658,8 +845,15 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         try (KafkaProducer<GenericRecord, GenericRecord> producer =
                  new KafkaProducer<>(createProducerProps())) {
             for (int i = 0; i < words.size(); i++) {
-                producedSchemaIds = sendAndCapture(producer, new ProducerRecord<>(
-                    topic, createKey(words.get(i)), createValue(counts.get(i), "PUT")));
+                String word = words.get(i);
+                long timestamp = BASE_TIMESTAMP + i;
+                ProducerRecord<GenericRecord, GenericRecord> record = new ProducerRecord<>(
+                    topic, null, timestamp, createKey(word), createValue(counts.get(i)));
+                // Distinct per-record user header so each IQv2 result can be checked against its own
+                // record -- see SEQ_HEADER. The serde adds the schema-id headers during send().
+                record.headers().add(SEQ_HEADER, word.getBytes(StandardCharsets.UTF_8));
+                capturedByWord.put(word, sendAndCapture(producer, record));
+                timestampByWord.put(word, timestamp);
             }
             producer.flush();
         }
@@ -724,10 +918,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         return key;
     }
 
-    private GenericRecord createValue(long count, String operation) {
+    private GenericRecord createValue(long count) {
         GenericRecord value = new GenericData.Record(valueSchema);
         value.put("count", count);
-        value.put("operation", operation);
         return value;
     }
 }

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
@@ -131,6 +131,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
     // A fixed, explicit base timestamp so each record's timestamp is known and assertable.
     private static final long BASE_TIMESTAMP = 1_600_000_000_000L;
 
+    // How long the IQv2 query helpers poll for a result to become locally available before failing.
+    private static final long QUERY_DEADLINE_MS = 30_000;
+
     // ---------------------------------------------------------------------------------------------
     // TimestampedKeyWithHeadersQuery (point)
     // ---------------------------------------------------------------------------------------------
@@ -259,85 +262,6 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             // covers skipCache). Asserting success first stops a failed skipCache query passing as null.
             assertPointReturnsNull(streams, storeName, "word-1",
                 "skipCache before flush (empty store)", true);
-        } finally {
-            closeStreams(streams);
-        }
-    }
-
-    @Test
-    public void shouldReturnReadOnlyHeaders() throws Exception {
-        String input = "iqv2-readonly-input";
-        String output = "iqv2-readonly-output";
-        String storeName = "iqv2-readonly-store";
-        String appId = "iqv2-readonly-test";
-
-        // Caching disabled so the range query (which bypasses the cache) sees the store-served record.
-        KafkaStreams streams = startAndPopulate(
-            storeName, input, output, appId,
-            Collections.singletonList("word-1"), Collections.singletonList(10L), false, null);
-        try {
-            // The query marks the returned headers read-only on both the point and range paths, so
-            // an attempt to mutate them must throw.
-            ReadOnlyRecord<GenericRecord, GenericRecord> point =
-                queryPointExpectPresent(streams, storeName, createKey("word-1"), false);
-            assertThrows(IllegalStateException.class,
-                () -> point.headers().add("x", new byte[]{1}),
-                "point query should return read-only headers");
-
-            List<ReadOnlyRecord<GenericRecord, GenericRecord>> range = queryRange(
-                streams, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 1);
-            assertThrows(IllegalStateException.class,
-                () -> range.get(0).headers().add("x", new byte[]{1}),
-                "range query should return read-only headers");
-        } finally {
-            closeStreams(streams);
-        }
-    }
-
-    @Test
-    public void shouldPreserveFullHeaderSetIncludingDuplicatesAndEmpty() throws Exception {
-        String input = "iqv2-headerset-input";
-        String output = "iqv2-headerset-output";
-        String storeName = "iqv2-headerset-store";
-        String appId = "iqv2-headerset-test";
-
-        createTopics(input, output);
-        // Caching disabled so both query paths read the store-served record directly.
-        KafkaStreams streams = startStreamsAndAwaitRunning(
-            buildTopology(input, output, storeName, false), appId, 30, null);
-        try {
-            // A header set no serde would produce on its own: an arbitrary user header, a duplicate
-            // key ("trace" twice, distinct values), and a zero-length value. The serde adds the
-            // schema-id headers during send(); snapshot the full produced set (in order) afterward so
-            // the round-trip below is asserted against exactly what was written -- count, order,
-            // duplicate key and empty value included, and nothing spurious added. An implementation
-            // that special-cased the __*_schema_id keys, collapsed the duplicate to lastHeader,
-            // dropped the empty value, or reordered would fail here.
-            List<String> producedHeaders;
-            try (KafkaProducer<GenericRecord, GenericRecord> producer =
-                     new KafkaProducer<>(createProducerProps())) {
-                ProducerRecord<GenericRecord, GenericRecord> record = new ProducerRecord<>(
-                    input, null, BASE_TIMESTAMP, createKey("word-1"), createValue(10L));
-                record.headers().add(SEQ_HEADER, "word-1".getBytes(StandardCharsets.UTF_8));
-                record.headers().add("trace", "A".getBytes(StandardCharsets.UTF_8));
-                record.headers().add("trace", "B".getBytes(StandardCharsets.UTF_8));
-                record.headers().add("empty", new byte[0]);
-                producer.send(record).get();
-                producer.flush();
-                producedHeaders = headerEntries(record.headers());
-            }
-            consumeRecords(output, appId + "-barrier", 1);
-
-            ReadOnlyRecord<GenericRecord, GenericRecord> point =
-                queryPointExpectPresent(streams, storeName, createKey("word-1"), false);
-            assertEquals(producedHeaders, headerEntries(point.headers()),
-                "point query should return the full produced header set -- order, the duplicate "
-                    + "'trace' key, the empty value and the schema-id headers -- and nothing else");
-
-            List<ReadOnlyRecord<GenericRecord, GenericRecord>> range = queryRange(
-                streams, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 1);
-            assertEquals(producedHeaders, headerEntries(range.get(0).headers()),
-                "range query should return the full produced header set");
         } finally {
             closeStreams(streams);
         }
@@ -529,6 +453,89 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
     }
 
     // ---------------------------------------------------------------------------------------------
+    // Header contract (point + range)
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldReturnReadOnlyHeaders() throws Exception {
+        String input = "iqv2-readonly-input";
+        String output = "iqv2-readonly-output";
+        String storeName = "iqv2-readonly-store";
+        String appId = "iqv2-readonly-test";
+
+        // Caching disabled so the range query (which bypasses the cache) sees the store-served record.
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Collections.singletonList("word-1"), Collections.singletonList(10L), false, null);
+        try {
+            // The query marks the returned headers read-only on both the point and range paths, so
+            // an attempt to mutate them must throw.
+            ReadOnlyRecord<GenericRecord, GenericRecord> point =
+                queryPointExpectPresent(streams, storeName, createKey("word-1"), false);
+            assertThrows(IllegalStateException.class,
+                () -> point.headers().add("x", new byte[]{1}),
+                "point query should return read-only headers");
+
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> range = queryRange(
+                streams, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 1);
+            assertThrows(IllegalStateException.class,
+                () -> range.get(0).headers().add("x", new byte[]{1}),
+                "range query should return read-only headers");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    @Test
+    public void shouldPreserveFullHeaderSetIncludingDuplicatesAndEmpty() throws Exception {
+        String input = "iqv2-headerset-input";
+        String output = "iqv2-headerset-output";
+        String storeName = "iqv2-headerset-store";
+        String appId = "iqv2-headerset-test";
+
+        createTopics(input, output);
+        // Caching disabled so both query paths read the store-served record directly.
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, false), appId, 30, null);
+        try {
+            // A header set no serde would produce on its own: an arbitrary user header, a duplicate
+            // key ("trace" twice, distinct values), and a zero-length value. The serde adds the
+            // schema-id headers during send(); snapshot the full produced set (in order) afterward so
+            // the round-trip below is asserted against exactly what was written -- count, order,
+            // duplicate key and empty value included, and nothing spurious added. An implementation
+            // that special-cased the __*_schema_id keys, collapsed the duplicate to lastHeader,
+            // dropped the empty value, or reordered would fail here.
+            List<String> producedHeaders;
+            try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                     new KafkaProducer<>(createProducerProps())) {
+                ProducerRecord<GenericRecord, GenericRecord> record = new ProducerRecord<>(
+                    input, null, BASE_TIMESTAMP, createKey("word-1"), createValue(10L));
+                record.headers().add(SEQ_HEADER, "word-1".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("trace", "A".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("trace", "B".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("empty", new byte[0]);
+                producer.send(record).get();
+                producer.flush();
+                producedHeaders = headerEntries(record.headers());
+            }
+            consumeRecords(output, appId + "-barrier", 1);
+
+            ReadOnlyRecord<GenericRecord, GenericRecord> point =
+                queryPointExpectPresent(streams, storeName, createKey("word-1"), false);
+            assertEquals(producedHeaders, headerEntries(point.headers()),
+                "point query should return the full produced header set -- order, the duplicate "
+                    + "'trace' key, the empty value and the schema-id headers -- and nothing else");
+
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> range = queryRange(
+                streams, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 1);
+            assertEquals(producedHeaders, headerEntries(range.get(0).headers()),
+                "range query should return the full produced header set");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
     // Restore-from-changelog and multi-partition
     // ---------------------------------------------------------------------------------------------
 
@@ -638,7 +645,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             // Scan every locally-available partition; collect and assert headers on every record.
             List<ReadOnlyRecord<GenericRecord, GenericRecord>> all = new ArrayList<>();
             Set<Integer> partitionsSeen = new HashSet<>();
-            long deadline = System.currentTimeMillis() + 30_000;
+            long deadline = System.currentTimeMillis() + QUERY_DEADLINE_MS;
             while (System.currentTimeMillis() < deadline) {
                 all.clear();
                 partitionsSeen.clear();
@@ -683,7 +690,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         if (skipCache) {
             query = query.skipCache();
         }
-        long deadline = System.currentTimeMillis() + 30_000;
+        long deadline = System.currentTimeMillis() + QUERY_DEADLINE_MS;
         String lastFailure = null;
         while (System.currentTimeMillis() < deadline) {
             StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> result =
@@ -750,7 +757,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
     private List<ReadOnlyRecord<GenericRecord, GenericRecord>> queryRange(
         KafkaStreams streams, String storeName,
         TimestampedRangeWithHeadersQuery<GenericRecord, GenericRecord> query, int expected) {
-        long deadline = System.currentTimeMillis() + 30_000;
+        long deadline = System.currentTimeMillis() + QUERY_DEADLINE_MS;
         List<ReadOnlyRecord<GenericRecord, GenericRecord>> out = new ArrayList<>();
         String lastFailure = null;
         while (System.currentTimeMillis() < deadline) {


### PR DESCRIPTION
What
----
Adds `TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest` (17 tests): IQv2 coverage for the
two headers-aware KV-store query types, `TimestampedKeyWithHeadersQuery` (point) and
`TimestampedRangeWithHeadersQuery` (range/scan), against a real KIP-1271
`TimestampedKeyValueStoreWithHeaders`.

Each record is produced with a distinct `seq` user header alongside the schema-id GUIDs, and the
captured GUID/count/timestamp are kept per key — so every assertion checks that the query returned
*this* record's value, timestamp and headers, not another entry's.

- **Point** — hit; `skipCache`; cache hit before flush (with a `skipCache` read of the still-empty
  store as a positive control); tombstone removes the entry, and a re-put afterwards comes back
  with the new record's headers rather than the pre-tombstone ones.
- **Range** — parameterized over bounds / scan-all / lower-only / upper-only; ascending and
  descending, including bounded descending; empty range; unflushed writes invisible; a tombstoned
  key is dropped from the scan.
- **Header contract (point + range)** — returned headers are read-only; the full produced header
  set round-trips exactly, including a duplicate key, a zero-length value, and ordering.
- **Position bounds (point + range)** — a served query reports its position; a bound the store
  cannot have reached fails with `NOT_UP_TO_BOUND` rather than serving a result from behind it.
- **Restore + multi-partition** — restore from the changelog, with a `StateRestoreListener`
  asserting the store was genuinely rebuilt rather than silently reprocessed from the input topic;
  and a scan spanning multiple partitions.

Also adds the `junit-jupiter-params` test dependency for the parameterized range test.

Test-only change; no production code is touched.

Checklist
------------------
- **[N]** Contains customer facing changes? Including API/behavior changes
- **[N/A]** Is this change gated behind config(s)?
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
- **[N]** Does this change require modifying existing system tests or adding new system tests?
- **[Y]** Must this be released together with other change(s), either in this repo or another one?
    - Stacked on #4461, which must merge first.

References
----------
JIRA:
- KIP-1271 (header-aware state stores) / KIP-1356 (headers-aware IQv2 queries)
- Base PR: #4461. Follow-up: #4464 (window/session stores) is stacked on this branch.

Test & Review
------------
```
mvn -pl streams-integration-tests verify
```
28 integration tests, green locally (17 from this PR + 11 from #4461).

Review note: this PR targets `kip-1356-iqv2-base`, so only
`TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java` and the pom line are its own.

Open questions / Follow-ups
--------------------------