### PR TITLE
Add KIP-1356 IQv2 headers-aware window/session-store integration tests

### DIFF
--- a/streams-integration-tests/pom.xml
+++ b/streams-integration-tests/pom.xml
@@ -141,6 +141,11 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeadersIQv2IntegrationTestBase.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeadersIQv2IntegrationTestBase.java
@@ -39,9 +39,11 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -55,6 +57,7 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
+import org.junit.jupiter.api.AfterEach;
 
 /**
  * Shared infrastructure for the KIP-1356 headers-aware IQv2 integration tests. Holds the boilerplate
@@ -72,12 +75,41 @@ import org.apache.kafka.streams.Topology;
  */
 public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness {
 
-    /** GUID bytes the producer wrote for the key / value schema, captured on send (see below). */
-    private byte[] expectedKeyGuid;
-    private byte[] expectedValueGuid;
+    /**
+     * The schema-id GUID bytes a producer wrote into a record's {@code __key_schema_id} /
+     * {@code __value_schema_id} headers, captured on send by {@link #sendAndCapture} so a later IQv2
+     * result can be asserted byte-for-byte equal to what that record produced. Either field is
+     * {@code null} when the record carried no corresponding header (a tombstone writes no value
+     * header). Capturing per record -- rather than into a shared field -- lets a subclass that
+     * produces more than one key or value schema assert each result against its own GUID.
+     */
+    protected static final class CapturedSchemaIds {
+        private final byte[] keyGuid;
+        private final byte[] valueGuid;
+
+        private CapturedSchemaIds(byte[] keyGuid, byte[] valueGuid) {
+            this.keyGuid = keyGuid;
+            this.valueGuid = valueGuid;
+        }
+    }
+
+    /**
+     * Serdes handed to the topology. Streams does not close serdes passed via
+     * {@code Consumed.with}/{@code Produced.with}/{@code StoreBuilder}, so each would leak its
+     * {@code CachedSchemaRegistryClient} HTTP connection pool -- we close them ourselves in teardown.
+     */
+    private final List<GenericAvroSerde> createdSerdes = new ArrayList<>();
 
     protected HeadersIQv2IntegrationTestBase() {
         super(1, true);
+    }
+
+    @AfterEach
+    public void closeSerdes() {
+        for (GenericAvroSerde serde : createdSerdes) {
+            serde.close();
+        }
+        createdSerdes.clear();
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -91,7 +123,7 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
     protected void createTopicsWithPartitions(int numPartitions, String... topicNames)
         throws Exception {
         Properties adminProps = new Properties();
-        adminProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
+        adminProps.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
         try (AdminClient admin = AdminClient.create(adminProps)) {
             List<NewTopic> topics = Arrays.stream(topicNames)
                 .map(name -> new NewTopic(name, numPartitions, (short) 1))
@@ -111,6 +143,7 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
         config.put(AbstractKafkaSchemaSerDeConfig.KEY_SCHEMA_ID_SERIALIZER,
             HeaderSchemaIdSerializer.class.getName());
         serde.configure(config, true);
+        createdSerdes.add(serde);
         return serde;
     }
 
@@ -121,6 +154,7 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
         config.put(AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_SERIALIZER,
             HeaderSchemaIdSerializer.class.getName());
         serde.configure(config, false);
+        createdSerdes.add(serde);
         return serde;
     }
 
@@ -165,18 +199,30 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
     protected KafkaStreams startStreamsAndAwaitRunning(Topology topology, String appId,
         int timeoutSeconds, Integer commitIntervalMs) throws Exception {
         CountDownLatch startedLatch = new CountDownLatch(1);
+        AtomicReference<KafkaStreams.State> lastState =
+            new AtomicReference<>(KafkaStreams.State.CREATED);
         KafkaStreams streams = new KafkaStreams(topology, createStreamsProps(appId, commitIntervalMs));
-        streams.cleanUp();
-        streams.setStateListener((newState, oldState) -> {
-            if (newState == KafkaStreams.State.RUNNING) {
-                startedLatch.countDown();
-            }
-        });
-        streams.start();
         boolean running = false;
         try {
-            running = startedLatch.await(timeoutSeconds, TimeUnit.SECONDS);
-            assertTrue(running, "KafkaStreams should reach RUNNING state");
+            streams.cleanUp();
+            streams.setStateListener((newState, oldState) -> {
+                lastState.set(newState);
+                // Count down on RUNNING and on any shutdown/error state, so a startup failure fails
+                // fast with the observed state instead of waiting out the whole timeout.
+                if (newState == KafkaStreams.State.RUNNING
+                    || newState.hasStartedOrFinishedShuttingDown()) {
+                    startedLatch.countDown();
+                }
+            });
+            streams.start();
+            boolean reached = startedLatch.await(timeoutSeconds, TimeUnit.SECONDS);
+            assertTrue(reached,
+                "KafkaStreams did not reach RUNNING within " + timeoutSeconds
+                    + "s (last observed state: " + lastState.get() + ")");
+            assertEquals(KafkaStreams.State.RUNNING, lastState.get(),
+                "KafkaStreams should reach RUNNING state (last observed state: "
+                    + lastState.get() + ")");
+            running = true;
             return streams;
         } finally {
             if (!running) {
@@ -187,7 +233,8 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
 
     protected void closeStreams(KafkaStreams streams) {
         if (streams != null) {
-            streams.close(Duration.ofSeconds(10));
+            assertTrue(streams.close(Duration.ofSeconds(10)),
+                "KafkaStreams.close() timed out before shutting down cleanly");
         }
     }
 
@@ -196,43 +243,42 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
     // ---------------------------------------------------------------------------------------------
 
     /**
-     * Sends {@code record} synchronously and captures the schema-id GUID bytes the serializer wrote
-     * into the record's headers, so later IQv2 results can be asserted byte-equal to what was
-     * produced. A tombstone (null value) writes no value header and leaves the captured value GUID
-     * untouched.
+     * Sends {@code record} synchronously and returns the schema-id GUID bytes the serializer wrote
+     * into the record's headers, so the IQv2 result for this record can be asserted byte-equal to
+     * what was produced. A tombstone (null value) writes no value header, so the returned value GUID
+     * is {@code null}.
      */
-    protected void sendAndCapture(KafkaProducer<GenericRecord, GenericRecord> producer,
+    protected CapturedSchemaIds sendAndCapture(KafkaProducer<GenericRecord, GenericRecord> producer,
         ProducerRecord<GenericRecord, GenericRecord> record) throws Exception {
         producer.send(record).get();
         Header keyHeader = record.headers().lastHeader(SchemaId.KEY_SCHEMA_ID_HEADER);
-        if (keyHeader != null) {
-            expectedKeyGuid = keyHeader.value().clone();
-        }
+        byte[] keyGuid = keyHeader != null ? keyHeader.value().clone() : null;
         Header valueHeader = record.headers().lastHeader(SchemaId.VALUE_SCHEMA_ID_HEADER);
-        if (valueHeader != null) {
-            expectedValueGuid = valueHeader.value().clone();
-        }
+        byte[] valueGuid = valueHeader != null ? valueHeader.value().clone() : null;
+        return new CapturedSchemaIds(keyGuid, valueGuid);
     }
 
-    protected void produce(String topic, GenericRecord key, GenericRecord value, long timestamp)
-        throws Exception {
-        try (KafkaProducer<GenericRecord, GenericRecord> producer =
-                 new KafkaProducer<>(createProducerProps())) {
-            sendAndCapture(producer, new ProducerRecord<>(topic, null, timestamp, key, value));
-            producer.flush();
-        }
-    }
-
-    protected void produceAll(String topic, List<GenericRecord> keys, List<GenericRecord> values,
+    /** Produces a single record and returns the GUIDs its serializer wrote (see {@link #sendAndCapture}). */
+    protected CapturedSchemaIds produce(String topic, GenericRecord key, GenericRecord value,
         long timestamp) throws Exception {
         try (KafkaProducer<GenericRecord, GenericRecord> producer =
                  new KafkaProducer<>(createProducerProps())) {
-            for (int i = 0; i < keys.size(); i++) {
-                sendAndCapture(producer,
-                    new ProducerRecord<>(topic, null, timestamp, keys.get(i), values.get(i)));
-            }
-            producer.flush();
+            return sendAndCapture(producer, new ProducerRecord<>(topic, null, timestamp, key, value));
         }
+    }
+
+    /** Produces one record per key/value pair and returns the captured GUIDs in produce order. */
+    protected List<CapturedSchemaIds> produceAll(String topic, List<GenericRecord> keys,
+        List<GenericRecord> values, long timestamp) throws Exception {
+        List<CapturedSchemaIds> captured = new ArrayList<>();
+        try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                 new KafkaProducer<>(createProducerProps())) {
+            for (int i = 0; i < keys.size(); i++) {
+                captured.add(sendAndCapture(producer,
+                    new ProducerRecord<>(topic, null, timestamp, keys.get(i), values.get(i))));
+            }
+        }
+        return captured;
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -262,8 +308,8 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
                 }
             }
         }
-        assertEquals(expectedCount, results.size(),
-            "Expected " + expectedCount + " records from " + topic
+        assertTrue(results.size() >= expectedCount,
+            "Expected at least " + expectedCount + " records from " + topic
                 + " but got " + results.size() + " within 30s");
         return results;
     }
@@ -274,22 +320,26 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
 
     /**
      * Asserts the record carries a well-formed 17-byte {@code MAGIC_BYTE_V1} schema-id GUID in both
-     * the {@code __key_schema_id} and {@code __value_schema_id} headers and, once a producer has
-     * recorded the GUID it wrote (via {@link #sendAndCapture}), that the bytes are exactly those
-     * produced.
+     * the {@code __key_schema_id} and {@code __value_schema_id} headers and that the bytes are
+     * exactly the GUIDs {@code expected} captured when this record was produced (via
+     * {@link #produce}/{@link #produceAll}). A {@code null} {@code expected} or a missing captured
+     * GUID fails, rather than silently degrading to a format-only check.
      */
-    protected void assertSchemaIdHeaders(Headers headers, String context) {
+    protected void assertSchemaIdHeaders(Headers headers, CapturedSchemaIds expected,
+        String context) {
+        assertNotNull(expected,
+            context + ": no captured schema-id GUIDs -- produce the record via produce/produceAll");
         byte[] keyBytes = assertGuidHeader(headers, SchemaId.KEY_SCHEMA_ID_HEADER, "Key", context);
-        if (expectedKeyGuid != null) {
-            assertArrayEquals(expectedKeyGuid, keyBytes,
-                context + ": Key GUID header should equal the GUID the producer wrote");
-        }
+        assertNotNull(expected.keyGuid,
+            context + ": no produced key GUID captured -- produce a record before asserting");
+        assertArrayEquals(expected.keyGuid, keyBytes,
+            context + ": Key GUID header should equal the GUID the producer wrote");
         byte[] valueBytes =
             assertGuidHeader(headers, SchemaId.VALUE_SCHEMA_ID_HEADER, "Value", context);
-        if (expectedValueGuid != null) {
-            assertArrayEquals(expectedValueGuid, valueBytes,
-                context + ": Value GUID header should equal the GUID the producer wrote");
-        }
+        assertNotNull(expected.valueGuid,
+            context + ": no produced value GUID captured -- produce a record before asserting");
+        assertArrayEquals(expected.valueGuid, valueBytes,
+            context + ": Value GUID header should equal the GUID the producer wrote");
     }
 
     private static byte[] assertGuidHeader(Headers headers, String headerName, String which,

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeadersIQv2IntegrationTestBase.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeadersIQv2IntegrationTestBase.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.streams.integration;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.confluent.kafka.schemaregistry.ClusterTestHarness;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import io.confluent.kafka.serializers.schema.id.HeaderSchemaIdSerializer;
+import io.confluent.kafka.serializers.schema.id.SchemaId;
+import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+
+/**
+ * Shared infrastructure for the KIP-1356 headers-aware IQv2 integration tests. Holds the boilerplate
+ * that would otherwise be copy-pasted across every store-type-specific test: topic creation,
+ * header-mode Avro serdes, a {@link KafkaStreams} start/await/close lifecycle, an output-topic
+ * completion-barrier consumer, and the schema-id GUID header assertion.
+ *
+ * <p>Every concrete test produces records whose schema-id GUID is carried in the
+ * {@code __key_schema_id} / {@code __value_schema_id} headers (via {@link HeaderSchemaIdSerializer}).
+ * When a record is produced through {@link #sendAndCapture}, the exact GUID bytes the serializer wrote
+ * are captured, so {@link #assertSchemaIdHeaders} can assert that the bytes returned by an IQv2 query
+ * are byte-for-byte the GUID that was produced -- not merely a well-formed one.
+ *
+ * <p>Runs against a real 1-broker cluster + embedded Schema Registry ({@code super(1, true)}).
+ */
+public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness {
+
+    /** GUID bytes the producer wrote for the key / value schema, captured on send (see below). */
+    private byte[] expectedKeyGuid;
+    private byte[] expectedValueGuid;
+
+    protected HeadersIQv2IntegrationTestBase() {
+        super(1, true);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Topics
+    // ---------------------------------------------------------------------------------------------
+
+    protected void createTopics(String... topicNames) throws Exception {
+        createTopicsWithPartitions(1, topicNames);
+    }
+
+    protected void createTopicsWithPartitions(int numPartitions, String... topicNames)
+        throws Exception {
+        Properties adminProps = new Properties();
+        adminProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
+        try (AdminClient admin = AdminClient.create(adminProps)) {
+            List<NewTopic> topics = Arrays.stream(topicNames)
+                .map(name -> new NewTopic(name, numPartitions, (short) 1))
+                .collect(Collectors.toList());
+            admin.createTopics(topics).all().get(30, TimeUnit.SECONDS);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Header-mode serdes and client configs
+    // ---------------------------------------------------------------------------------------------
+
+    protected GenericAvroSerde createKeySerde() {
+        GenericAvroSerde serde = new GenericAvroSerde();
+        Map<String, Object> config = new HashMap<>();
+        config.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
+        config.put(AbstractKafkaSchemaSerDeConfig.KEY_SCHEMA_ID_SERIALIZER,
+            HeaderSchemaIdSerializer.class.getName());
+        serde.configure(config, true);
+        return serde;
+    }
+
+    protected GenericAvroSerde createValueSerde() {
+        GenericAvroSerde serde = new GenericAvroSerde();
+        Map<String, Object> config = new HashMap<>();
+        config.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
+        config.put(AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_SERIALIZER,
+            HeaderSchemaIdSerializer.class.getName());
+        serde.configure(config, false);
+        return serde;
+    }
+
+    protected Properties createProducerProps() {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaAvroSerializer.class.getName());
+        props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
+        props.put(AbstractKafkaSchemaSerDeConfig.KEY_SCHEMA_ID_SERIALIZER,
+            HeaderSchemaIdSerializer.class.getName());
+        props.put(AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_SERIALIZER,
+            HeaderSchemaIdSerializer.class.getName());
+        return props;
+    }
+
+    protected Properties createStreamsProps(String appId, Integer commitIntervalMs) {
+        Properties props = new Properties();
+        props.put(StreamsConfig.APPLICATION_ID_CONFIG, appId);
+        props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
+        props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
+        if (commitIntervalMs != null) {
+            props.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, commitIntervalMs);
+        }
+        return props;
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Streams lifecycle
+    // ---------------------------------------------------------------------------------------------
+
+    protected KafkaStreams startStreamsAndAwaitRunning(Topology topology, String appId)
+        throws Exception {
+        return startStreamsAndAwaitRunning(topology, appId, 30, null);
+    }
+
+    protected KafkaStreams startStreamsAndAwaitRunning(Topology topology, String appId,
+        int timeoutSeconds) throws Exception {
+        return startStreamsAndAwaitRunning(topology, appId, timeoutSeconds, null);
+    }
+
+    protected KafkaStreams startStreamsAndAwaitRunning(Topology topology, String appId,
+        int timeoutSeconds, Integer commitIntervalMs) throws Exception {
+        CountDownLatch startedLatch = new CountDownLatch(1);
+        KafkaStreams streams = new KafkaStreams(topology, createStreamsProps(appId, commitIntervalMs));
+        streams.cleanUp();
+        streams.setStateListener((newState, oldState) -> {
+            if (newState == KafkaStreams.State.RUNNING) {
+                startedLatch.countDown();
+            }
+        });
+        streams.start();
+        boolean running = false;
+        try {
+            running = startedLatch.await(timeoutSeconds, TimeUnit.SECONDS);
+            assertTrue(running, "KafkaStreams should reach RUNNING state");
+            return streams;
+        } finally {
+            if (!running) {
+                closeStreams(streams);
+            }
+        }
+    }
+
+    protected void closeStreams(KafkaStreams streams) {
+        if (streams != null) {
+            streams.close(Duration.ofSeconds(10));
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Producing (captures the produced schema-id GUID for byte-equality assertions)
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Sends {@code record} synchronously and captures the schema-id GUID bytes the serializer wrote
+     * into the record's headers, so later IQv2 results can be asserted byte-equal to what was
+     * produced. A tombstone (null value) writes no value header and leaves the captured value GUID
+     * untouched.
+     */
+    protected void sendAndCapture(KafkaProducer<GenericRecord, GenericRecord> producer,
+        ProducerRecord<GenericRecord, GenericRecord> record) throws Exception {
+        producer.send(record).get();
+        Header keyHeader = record.headers().lastHeader(SchemaId.KEY_SCHEMA_ID_HEADER);
+        if (keyHeader != null) {
+            expectedKeyGuid = keyHeader.value().clone();
+        }
+        Header valueHeader = record.headers().lastHeader(SchemaId.VALUE_SCHEMA_ID_HEADER);
+        if (valueHeader != null) {
+            expectedValueGuid = valueHeader.value().clone();
+        }
+    }
+
+    protected void produce(String topic, GenericRecord key, GenericRecord value, long timestamp)
+        throws Exception {
+        try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                 new KafkaProducer<>(createProducerProps())) {
+            sendAndCapture(producer, new ProducerRecord<>(topic, null, timestamp, key, value));
+            producer.flush();
+        }
+    }
+
+    protected void produceAll(String topic, List<GenericRecord> keys, List<GenericRecord> values,
+        long timestamp) throws Exception {
+        try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                 new KafkaProducer<>(createProducerProps())) {
+            for (int i = 0; i < keys.size(); i++) {
+                sendAndCapture(producer,
+                    new ProducerRecord<>(topic, null, timestamp, keys.get(i), values.get(i)));
+            }
+            producer.flush();
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Consuming (output-topic completion barrier)
+    // ---------------------------------------------------------------------------------------------
+
+    protected List<ConsumerRecord<GenericRecord, GenericRecord>> consumeRecords(
+        String topic, String groupId, int expectedCount) {
+        Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerList);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KafkaAvroDeserializer.class.getName());
+        props.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, restApp.restConnect);
+        props.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, false);
+
+        List<ConsumerRecord<GenericRecord, GenericRecord>> results = new ArrayList<>();
+        try (KafkaConsumer<GenericRecord, GenericRecord> consumer = new KafkaConsumer<>(props)) {
+            consumer.subscribe(Collections.singletonList(topic));
+            long deadline = System.currentTimeMillis() + 30_000;
+            while (results.size() < expectedCount && System.currentTimeMillis() < deadline) {
+                ConsumerRecords<GenericRecord, GenericRecord> records =
+                    consumer.poll(Duration.ofMillis(500));
+                for (ConsumerRecord<GenericRecord, GenericRecord> record : records) {
+                    results.add(record);
+                }
+            }
+        }
+        assertEquals(expectedCount, results.size(),
+            "Expected " + expectedCount + " records from " + topic
+                + " but got " + results.size() + " within 30s");
+        return results;
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Header assertions
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Asserts the record carries a well-formed 17-byte {@code MAGIC_BYTE_V1} schema-id GUID in both
+     * the {@code __key_schema_id} and {@code __value_schema_id} headers and, once a producer has
+     * recorded the GUID it wrote (via {@link #sendAndCapture}), that the bytes are exactly those
+     * produced.
+     */
+    protected void assertSchemaIdHeaders(Headers headers, String context) {
+        byte[] keyBytes = assertGuidHeader(headers, SchemaId.KEY_SCHEMA_ID_HEADER, "Key", context);
+        if (expectedKeyGuid != null) {
+            assertArrayEquals(expectedKeyGuid, keyBytes,
+                context + ": Key GUID header should equal the GUID the producer wrote");
+        }
+        byte[] valueBytes =
+            assertGuidHeader(headers, SchemaId.VALUE_SCHEMA_ID_HEADER, "Value", context);
+        if (expectedValueGuid != null) {
+            assertArrayEquals(expectedValueGuid, valueBytes,
+                context + ": Value GUID header should equal the GUID the producer wrote");
+        }
+    }
+
+    private static byte[] assertGuidHeader(Headers headers, String headerName, String which,
+        String context) {
+        Header header = headers.lastHeader(headerName);
+        assertNotNull(header, context + ": should have " + headerName + " header");
+        byte[] bytes = header.value();
+        assertEquals(17, bytes.length, context + ": " + which + " GUID header should be 17 bytes");
+        assertEquals(SchemaId.MAGIC_BYTE_V1, bytes[0],
+            context + ": " + which + " header should have V1 magic byte");
+        return bytes;
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Misc
+    // ---------------------------------------------------------------------------------------------
+
+    protected static void sleepQuietly(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeadersIQv2IntegrationTestBase.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/HeadersIQv2IntegrationTestBase.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.avro.generic.GenericRecord;
@@ -106,10 +107,23 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
 
     @AfterEach
     public void closeSerdes() {
+        RuntimeException firstError = null;
         for (GenericAvroSerde serde : createdSerdes) {
-            serde.close();
+            try {
+                serde.close();
+            } catch (RuntimeException e) {
+                // Keep closing the rest so a single failing serde can't leak the others.
+                if (firstError == null) {
+                    firstError = e;
+                } else {
+                    firstError.addSuppressed(e);
+                }
+            }
         }
         createdSerdes.clear();
+        if (firstError != null) {
+            throw firstError;
+        }
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -201,6 +215,10 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
         CountDownLatch startedLatch = new CountDownLatch(1);
         AtomicReference<KafkaStreams.State> lastState =
             new AtomicReference<>(KafkaStreams.State.CREATED);
+        // Record that RUNNING was observed, rather than re-reading lastState after the latch:
+        // RUNNING -> REBALANCING is a valid transition, so a benign follow-up rebalance could
+        // otherwise flip lastState away from RUNNING and spuriously fail the start assertion.
+        AtomicBoolean reachedRunning = new AtomicBoolean(false);
         KafkaStreams streams = new KafkaStreams(topology, createStreamsProps(appId, commitIntervalMs));
         boolean running = false;
         try {
@@ -209,8 +227,10 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
                 lastState.set(newState);
                 // Count down on RUNNING and on any shutdown/error state, so a startup failure fails
                 // fast with the observed state instead of waiting out the whole timeout.
-                if (newState == KafkaStreams.State.RUNNING
-                    || newState.hasStartedOrFinishedShuttingDown()) {
+                if (newState == KafkaStreams.State.RUNNING) {
+                    reachedRunning.set(true);
+                    startedLatch.countDown();
+                } else if (newState.hasStartedOrFinishedShuttingDown()) {
                     startedLatch.countDown();
                 }
             });
@@ -219,9 +239,9 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
             assertTrue(reached,
                 "KafkaStreams did not reach RUNNING within " + timeoutSeconds
                     + "s (last observed state: " + lastState.get() + ")");
-            assertEquals(KafkaStreams.State.RUNNING, lastState.get(),
-                "KafkaStreams should reach RUNNING state (last observed state: "
-                    + lastState.get() + ")");
+            assertTrue(reachedRunning.get(),
+                "KafkaStreams entered a shutdown state before reaching RUNNING (last observed "
+                    + "state: " + lastState.get() + ")");
             running = true;
             return streams;
         } finally {
@@ -270,6 +290,7 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
     /** Produces one record per key/value pair and returns the captured GUIDs in produce order. */
     protected List<CapturedSchemaIds> produceAll(String topic, List<GenericRecord> keys,
         List<GenericRecord> values, long timestamp) throws Exception {
+        assertEquals(keys.size(), values.size(), "produceAll requires one value per key");
         List<CapturedSchemaIds> captured = new ArrayList<>();
         try (KafkaProducer<GenericRecord, GenericRecord> producer =
                  new KafkaProducer<>(createProducerProps())) {
@@ -324,6 +345,10 @@ public abstract class HeadersIQv2IntegrationTestBase extends ClusterTestHarness 
      * exactly the GUIDs {@code expected} captured when this record was produced (via
      * {@link #produce}/{@link #produceAll}). A {@code null} {@code expected} or a missing captured
      * GUID fails, rather than silently degrading to a format-only check.
+     *
+     * <p>This asserts a value-bearing record: both a key and a value GUID must have been captured.
+     * It is not applicable to tombstones -- a null-value record captures no value GUID (see
+     * {@link CapturedSchemaIds}) and would fail the value-header assertion here.
      */
     protected void assertSchemaIdHeaders(Headers headers, CapturedSchemaIds expected,
         String context) {

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
@@ -153,8 +153,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             assertPointQuery(streams, storeName, "word-1", 10L, false);
             assertPointQuery(streams, storeName, "word-2", 20L, false);
             assertPointQuery(streams, storeName, "word-3", 30L, false);
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -174,8 +175,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         try {
             assertPointQuery(streams, storeName, "word-1", 10L, true);
             assertPointQuery(streams, storeName, "word-2", 20L, true);
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -232,8 +234,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             assertNotNull(phase, "re-put word-1: should carry the new record's phase header");
             assertEquals("after", new String(phase.value(), StandardCharsets.UTF_8),
                 "re-put word-1: query should return the re-put's headers, not the pre-tombstone ones");
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -262,8 +265,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             // covers skipCache). Asserting success first stops a failed skipCache query passing as null.
             assertPointReturnsNull(streams, storeName, "word-1",
                 "skipCache before flush (empty store)", true);
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -307,8 +311,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 queryRange(streams, storeName, query, expectedWords.size());
             assertEquals(expectedWords, wordsOf(records), "range " + label);
             assertHeadersOnEach(records, "IQv2 range " + label);
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -371,8 +376,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             assertEquals(Arrays.asList("word-2", "word-1"), wordsOf(boundedDesc),
                 "bounded descending [word-1, word-2]");
             assertHeadersOnEach(boundedDesc, "IQv2 bounded descending");
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -396,8 +402,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 TimestampedRangeWithHeadersQuery.withLowerBound(createKey("word-9")), 0);
             assertTrue(none.isEmpty(),
                 "range with a lower bound past the last key should return no records");
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -447,8 +454,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             }
             assertTrue(served.isEmpty(),
                 "range query must not serve unflushed cached entries but returned: " + served);
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -481,8 +489,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             assertThrows(IllegalStateException.class,
                 () -> range.get(0).headers().add("x", new byte[]{1}),
                 "range query should return read-only headers");
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -530,8 +539,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 streams, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 1);
             assertEquals(producedHeaders, headerEntries(range.get(0).headers()),
                 "range query should return the full produced header set");
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -554,8 +564,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             produceRecords(input, Arrays.asList("word-1", "word-2", "word-3"),
                 Arrays.asList(10L, 20L, 30L));
             consumeRecords(output, "iqv2-restore-pre", 3);
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
 
         // Restart with the same APPLICATION_ID; cleanUp() wipes the local state dir so the store must
@@ -611,8 +622,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             assertTrue(restoredCount.get() > 0,
                 "store should have been restored from the changelog (restored "
                     + restoredCount.get() + " records)");
-        } finally {
             closeStreams(restored);
+        } finally {
+            closeStreamsQuietly(restored);
         }
     }
 
@@ -670,12 +682,24 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 sleepQuietly(200);
             }
 
+            // Assert the distinct key set, not just the count: returning one key twice and dropping
+            // another would keep the size at numKeys but change the set.
+            Set<String> expectedKeys = new HashSet<>();
+            for (int i = 1; i <= numKeys; i++) {
+                expectedKeys.add("word-" + i);
+            }
+            Set<String> actualKeys = all.stream()
+                .map(r -> r.key().get("word").toString())
+                .collect(Collectors.toSet());
             assertEquals(numKeys, all.size(), "should read every key across partitions");
+            assertEquals(expectedKeys, actualKeys,
+                "should read every distinct key across partitions (none dropped or duplicated)");
             assertTrue(partitionsSeen.size() > 1,
                 "records should span more than one partition but saw: " + partitionsSeen);
             assertHeadersOnEach(all, "IQv2 multi-partition scan");
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -759,6 +783,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         TimestampedRangeWithHeadersQuery<GenericRecord, GenericRecord> query, int expected) {
         long deadline = System.currentTimeMillis() + QUERY_DEADLINE_MS;
         List<ReadOnlyRecord<GenericRecord, GenericRecord>> out = new ArrayList<>();
+        boolean sawSuccess = false;
         String lastFailure = null;
         while (System.currentTimeMillis() < deadline) {
             out.clear();
@@ -767,6 +792,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             QueryResult<ReadOnlyRecordIterator<GenericRecord, GenericRecord>> pr =
                 result.getOnlyPartitionResult();
             if (pr != null && pr.isSuccess() && pr.getResult() != null) {
+                sawSuccess = true;
                 try (ReadOnlyRecordIterator<GenericRecord, GenericRecord> it = pr.getResult()) {
                     while (it.hasNext()) {
                         out.add(it.next());
@@ -780,8 +806,11 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             }
             sleepQuietly(200);
         }
-        assertEquals(expected, out.size(), "IQv2 range query returned an unexpected count"
+        // Require at least one successful query: otherwise an expected==0 caller would pass on a query
+        // that failed on every attempt (e.g. an unsupported query type), reading as assertEquals(0, 0).
+        assertTrue(sawSuccess, "IQv2 range query never succeeded within 30s"
             + (lastFailure != null ? " (last failure: " + lastFailure + ")" : ""));
+        assertEquals(expected, out.size(), "IQv2 range query returned an unexpected count");
         return out;
     }
 
@@ -870,7 +899,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             return streams;
         } finally {
             if (!populated) {
-                closeStreams(streams);
+                closeStreamsQuietly(streams);
             }
         }
     }

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
@@ -36,8 +36,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -690,7 +688,6 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         // be rebuilt from the changelog. Attach a StateRestoreListener BEFORE start() to prove the
         // rebuild actually happened: cleanUp() clears local state but not committed offsets, so
         // without this the restart could silently reprocess the input and pass with no restore at all.
-        // (The base start helper can't set a restore listener, so this instance is started inline.)
         AtomicLong restoredCount = new AtomicLong(0);
         StateRestoreListener restoreListener = new StateRestoreListener() {
             @Override
@@ -708,27 +705,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 }
             }
         };
-        // Construct, configure and start inside the try: this instance is created here rather than
-        // through the base helper, so it is not in the base's startedStreams and teardown will not
-        // close it. If cleanUp() or start() threw outside the try, nothing would ever close it and
-        // its state-directory lock and StreamThreads would leak for the rest of the fork JVM.
-        KafkaStreams restored = null;
+        KafkaStreams restored = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, true), appId, 90, null, restoreListener);
         try {
-            restored = new KafkaStreams(
-                buildTopology(input, output, storeName, true), createStreamsProps(appId, null));
-            restored.cleanUp();
-            restored.setGlobalStateRestoreListener(restoreListener);
-            CountDownLatch restoredRunning = new CountDownLatch(1);
-            restored.setStateListener((newState, oldState) -> {
-                if (newState == KafkaStreams.State.RUNNING) {
-                    restoredRunning.countDown();
-                }
-            });
-            restored.start();
-
-            assertTrue(restoredRunning.await(90, TimeUnit.SECONDS),
-                "restored KafkaStreams should reach RUNNING");
-
             ReadOnlyRecord<GenericRecord, GenericRecord> word1 =
                 queryPointExpectPresent(restored, storeName, createKey("word-1"), false);
             assertEquals(10L, word1.value().get("count"), "restored word-1 value");

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
@@ -59,6 +59,9 @@ import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.ReadOnlyRecord;
 import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.query.FailureReason;
+import org.apache.kafka.streams.query.Position;
+import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.query.StateQueryRequest;
 import org.apache.kafka.streams.query.StateQueryResult;
@@ -123,10 +126,12 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
     private static final String SEQ_HEADER = "seq";
 
     // Per-record captures, keyed by word, so each IQv2 result is asserted against its own record's
-    // produced schema-id GUIDs (see HeadersIQv2IntegrationTestBase#assertSchemaIdHeaders) and its
-    // own produced timestamp -- not a single shared value that every record would trivially match.
+    // produced schema-id GUIDs (see HeadersIQv2IntegrationTestBase#assertSchemaIdHeaders), its own
+    // produced count and its own produced timestamp -- not a single shared value that every record
+    // would trivially match.
     private final Map<String, CapturedSchemaIds> capturedByWord = new HashMap<>();
     private final Map<String, Long> timestampByWord = new HashMap<>();
+    private final Map<String, Long> countByWord = new HashMap<>();
 
     // A fixed, explicit base timestamp so each record's timestamp is known and assertable.
     private static final long BASE_TIMESTAMP = 1_600_000_000_000L;
@@ -205,6 +210,10 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             produceTombstone(input, "word-1");
             consumeRecords(output, appId + "-post", 2);
             assertPointReturnsNull(streams, storeName, "word-1", "tombstoned key", false);
+            // The range path is pinned to drop a tombstoned key by
+            // shouldDropTombstonedKeyFromRangeScan rather than here: caching is enabled in this test,
+            // and a range header-query reads the store without consulting the record cache, so the
+            // still-unflushed delete would not be visible to a scan run at this point.
 
             // A key that was never written is likewise absent.
             assertPointReturnsNull(streams, storeName, "no-such-word", "never-written key", false);
@@ -222,6 +231,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 reput.headers().add("phase", "after".getBytes(StandardCharsets.UTF_8));
                 capturedByWord.put("word-1", sendAndCapture(producer, reput));
                 timestampByWord.put("word-1", reputTs);
+                countByWord.put("word-1", 99L);
                 producer.flush();
             }
             consumeRecords(output, appId + "-reput", 3);
@@ -271,6 +281,67 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         }
     }
 
+    /**
+     * Covers the position-bound path for both header queries. Every other test here uses the default
+     * unbounded position, so neither {@code withPositionBound(...)} nor
+     * {@link StateQueryResult#getPosition()} would otherwise be exercised at all.
+     */
+    @Test
+    public void shouldReportPositionAndRejectQueryBoundedBeyondIt() throws Exception {
+        String input = "iqv2-position-input";
+        String output = "iqv2-position-output";
+        String storeName = "iqv2-position-store";
+        String appId = "iqv2-position-test";
+
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Collections.singletonList("word-1"), Collections.singletonList(10L), false, null);
+        try {
+            // A query served under the default (unbounded) bound reports the position the store had
+            // reached when it answered.
+            StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> unbounded =
+                streams.query(StateQueryRequest.inStore(storeName)
+                    .withQuery(TimestampedKeyWithHeadersQuery
+                        .<GenericRecord, GenericRecord>withKey(createKey("word-1"))));
+            Position position = unbounded.getPosition();
+            assertNotNull(position, "unbounded query should report a position");
+            assertTrue(position.getTopics().contains(input),
+                "reported position should cover the input topic but was: " + position);
+
+            // A bound at an offset the store cannot have reached must fail the query with
+            // NOT_UP_TO_BOUND rather than quietly serving a result from behind the bound.
+            PositionBound beyond = PositionBound.at(
+                Position.emptyPosition().withComponent(input, 0, Long.MAX_VALUE));
+            assertNotUpToBound(streams.query(StateQueryRequest.inStore(storeName)
+                .withQuery(TimestampedKeyWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withKey(createKey("word-1")))
+                .withPositionBound(beyond)), "point query");
+            assertNotUpToBound(streams.query(StateQueryRequest.inStore(storeName)
+                .withQuery(TimestampedRangeWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withNoBounds())
+                .withPositionBound(beyond)), "range query");
+            closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
+        }
+    }
+
+    /**
+     * Asserts every partition result failed with {@link FailureReason#NOT_UP_TO_BOUND} -- checking
+     * the reason, not merely that the query failed, so an unrelated failure can't pass as coverage.
+     */
+    private static <R> void assertNotUpToBound(StateQueryResult<R> result, String context) {
+        Map<Integer, QueryResult<R>> partitionResults = result.getPartitionResults();
+        assertFalse(partitionResults.isEmpty(), context + " should return a partition result");
+        for (Map.Entry<Integer, QueryResult<R>> e : partitionResults.entrySet()) {
+            QueryResult<R> pr = e.getValue();
+            assertTrue(pr.isFailure(), context
+                + " bounded beyond the store's position should fail on partition " + e.getKey());
+            assertEquals(FailureReason.NOT_UP_TO_BOUND, pr.getFailureReason(),
+                context + " should fail with NOT_UP_TO_BOUND on partition " + e.getKey());
+        }
+    }
+
     // ---------------------------------------------------------------------------------------------
     // TimestampedRangeWithHeadersQuery (range / scan)
     // ---------------------------------------------------------------------------------------------
@@ -310,7 +381,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             List<ReadOnlyRecord<GenericRecord, GenericRecord>> records =
                 queryRange(streams, storeName, query, expectedWords.size());
             assertEquals(expectedWords, wordsOf(records), "range " + label);
-            assertHeadersOnEach(records, "IQv2 range " + label);
+            assertRecordsMatchProduced(records, "IQv2 range " + label);
             closeStreams(streams);
         } finally {
             closeStreamsQuietly(streams);
@@ -355,7 +426,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                     .<GenericRecord, GenericRecord>withNoBounds().withAscendingKeys(),
                 3);
             assertEquals(Arrays.asList("word-1", "word-2", "word-3"), wordsOf(asc), "ascending keys");
-            assertHeadersOnEach(asc, "IQv2 ascending");
+            assertRecordsMatchProduced(asc, "IQv2 ascending");
 
             List<ReadOnlyRecord<GenericRecord, GenericRecord>> desc = queryRange(
                 streams, storeName,
@@ -363,7 +434,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                     .<GenericRecord, GenericRecord>withNoBounds().withDescendingKeys(),
                 3);
             assertEquals(Arrays.asList("word-3", "word-2", "word-1"), wordsOf(desc), "descending keys");
-            assertHeadersOnEach(desc, "IQv2 descending");
+            assertRecordsMatchProduced(desc, "IQv2 descending");
 
             // Bounded + descending: the ordering flip must also apply to a bounded range, not just a
             // full scan -- guards against an ordering bug that only surfaces on the bounded path.
@@ -375,7 +446,53 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 2);
             assertEquals(Arrays.asList("word-2", "word-1"), wordsOf(boundedDesc),
                 "bounded descending [word-1, word-2]");
-            assertHeadersOnEach(boundedDesc, "IQv2 bounded descending");
+            assertRecordsMatchProduced(boundedDesc, "IQv2 bounded descending");
+            closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
+        }
+    }
+
+    /**
+     * Pins the range path to drop a tombstoned key, not just the point path -- every other range test
+     * here runs against a store where nothing was ever deleted.
+     *
+     * <p>Caching is disabled so the delete is store-visible. A range header-query reads the store
+     * directly and does not consult the record cache, so with caching enabled the tombstone would
+     * still be sitting unflushed in the cache and the scan would return the stale entry -- which
+     * would make this a test of cache-flush timing rather than of the store contract.
+     */
+    @Test
+    public void shouldDropTombstonedKeyFromRangeScan() throws Exception {
+        String input = "iqv2-range-tombstone-input";
+        String output = "iqv2-range-tombstone-output";
+        String storeName = "iqv2-range-tombstone-store";
+        String appId = "iqv2-range-tombstone-test";
+
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Arrays.asList("word-1", "word-2", "word-3"), Arrays.asList(10L, 20L, 30L), false, null);
+        try {
+            // Positive control: all three keys are visible to the range path before any delete, so a
+            // post-delete scan that returns fewer keys is doing so because of the tombstone.
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> before = queryRange(
+                streams, storeName, TimestampedRangeWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withNoBounds().withAscendingKeys(), 3);
+            assertEquals(Arrays.asList("word-1", "word-2", "word-3"), wordsOf(before),
+                "range scan before tombstone");
+            assertRecordsMatchProduced(before, "range before tombstone");
+
+            // The processor forwards the null-value record too, so a 4th output record marks the
+            // tombstone as applied to the store.
+            produceTombstone(input, "word-2");
+            consumeRecords(output, appId + "-post", 4);
+
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> after = queryRange(
+                streams, storeName, TimestampedRangeWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withNoBounds().withAscendingKeys(), 2);
+            assertEquals(Arrays.asList("word-1", "word-3"), wordsOf(after),
+                "range scan should drop the tombstoned key");
+            assertRecordsMatchProduced(after, "range after tombstone");
             closeStreams(streams);
         } finally {
             closeStreamsQuietly(streams);
@@ -591,18 +708,24 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 }
             }
         };
-        KafkaStreams restored = new KafkaStreams(
-            buildTopology(input, output, storeName, true), createStreamsProps(appId, null));
-        restored.cleanUp();
-        restored.setGlobalStateRestoreListener(restoreListener);
-        CountDownLatch restoredRunning = new CountDownLatch(1);
-        restored.setStateListener((newState, oldState) -> {
-            if (newState == KafkaStreams.State.RUNNING) {
-                restoredRunning.countDown();
-            }
-        });
-        restored.start();
+        // Construct, configure and start inside the try: this instance is created here rather than
+        // through the base helper, so it is not in the base's startedStreams and teardown will not
+        // close it. If cleanUp() or start() threw outside the try, nothing would ever close it and
+        // its state-directory lock and StreamThreads would leak for the rest of the fork JVM.
+        KafkaStreams restored = null;
         try {
+            restored = new KafkaStreams(
+                buildTopology(input, output, storeName, true), createStreamsProps(appId, null));
+            restored.cleanUp();
+            restored.setGlobalStateRestoreListener(restoreListener);
+            CountDownLatch restoredRunning = new CountDownLatch(1);
+            restored.setStateListener((newState, oldState) -> {
+                if (newState == KafkaStreams.State.RUNNING) {
+                    restoredRunning.countDown();
+                }
+            });
+            restored.start();
+
             assertTrue(restoredRunning.await(90, TimeUnit.SECONDS),
                 "restored KafkaStreams should reach RUNNING");
 
@@ -615,7 +738,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 restored, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 3);
             assertEquals(new HashSet<>(Arrays.asList("word-1", "word-2", "word-3")),
                 new HashSet<>(wordsOf(all)), "restored scan keys");
-            assertHeadersOnEach(all, "restored scan");
+            assertRecordsMatchProduced(all, "restored scan");
 
             // Pin that the store was genuinely rebuilt from the changelog, not repopulated by a
             // silent reprocess of the input topic.
@@ -696,7 +819,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 "should read every distinct key across partitions (none dropped or duplicated)");
             assertTrue(partitionsSeen.size() > 1,
                 "records should span more than one partition but saw: " + partitionsSeen);
-            assertHeadersOnEach(all, "IQv2 multi-partition scan");
+            assertRecordsMatchProduced(all, "IQv2 multi-partition scan");
             closeStreams(streams);
         } finally {
             closeStreamsQuietly(streams);
@@ -820,12 +943,23 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             .collect(Collectors.toList());
     }
 
-    private void assertHeadersOnEach(
+    /**
+     * Asserts every record in a range/scan result matches what was produced for its own key: value,
+     * timestamp and headers. The point-query path checks all three (see {@link #assertPointQuery}),
+     * so the range path must too -- otherwise a range that returned the right key and headers but
+     * another entry's value or timestamp would pass unnoticed.
+     */
+    private void assertRecordsMatchProduced(
         List<ReadOnlyRecord<GenericRecord, GenericRecord>> records, String context) {
         for (int i = 0; i < records.size(); i++) {
             ReadOnlyRecord<GenericRecord, GenericRecord> record = records.get(i);
             String word = record.key().get("word").toString();
-            assertRecordHeaders(record, word, context + " entry " + i);
+            String entryContext = context + " entry " + i;
+            Long expectedCount = countByWord.get(word);
+            assertNotNull(expectedCount, entryContext + ": no produced count for " + word);
+            assertEquals(expectedCount, record.value().get("count"), entryContext + " value");
+            assertEquals(timestampByWord.get(word), record.timestamp(), entryContext + " timestamp");
+            assertRecordHeaders(record, word, entryContext);
         }
     }
 
@@ -917,6 +1051,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 record.headers().add(SEQ_HEADER, word.getBytes(StandardCharsets.UTF_8));
                 capturedByWord.put(word, sendAndCapture(producer, record));
                 timestampByWord.put(word, timestamp);
+                countByWord.put(word, counts.get(i));
             }
             producer.flush();
         }

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
@@ -17,6 +17,7 @@
 package io.confluent.kafka.streams.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -102,7 +103,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
     // carries the same schema-id GUIDs. Capture them once when producing and assert that IQv2
     // results come back byte-equal to what was produced (see
     // HeadersIQv2IntegrationTestBase#assertSchemaIdHeaders).
-    private CapturedSchemaIds valueSchemaIds;
+    private CapturedSchemaIds producedSchemaIds;
 
     // ---------------------------------------------------------------------------------------------
     // TimestampedKeyWithHeadersQuery (point)
@@ -362,6 +363,31 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         }
     }
 
+    @Test
+    public void shouldReturnEmptyForRangeWithNoMatches() throws Exception {
+        String input = "iqv2-emptyrange-input";
+        String output = "iqv2-emptyrange-output";
+        String storeName = "iqv2-emptyrange-store";
+        String appId = "iqv2-emptyrange-test";
+
+        // Caching disabled: range header-queries bypass the cache and read the store directly.
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Arrays.asList("word-1", "word-2", "word-3"), Arrays.asList(10L, 20L, 30L),
+            false, null);
+        try {
+            // A lower bound past the last stored key selects nothing: the query must still succeed
+            // and return an empty iterator -- not fail, and not spuriously return the stored keys.
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> none = queryRange(
+                streams, storeName,
+                TimestampedRangeWithHeadersQuery.withLowerBound(createKey("word-9")), 0);
+            assertTrue(none.isEmpty(),
+                "range with a lower bound past the last key should return no records");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
     // ---------------------------------------------------------------------------------------------
     // Restore-from-changelog and multi-partition
     // ---------------------------------------------------------------------------------------------
@@ -393,7 +419,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             ReadOnlyRecord<GenericRecord, GenericRecord> word1 =
                 queryPointExpectPresent(restored, storeName, createKey("word-1"), false);
             assertEquals(10L, word1.value().get("count"), "restored word-1 value");
-            assertSchemaIdHeaders(word1.headers(), valueSchemaIds, "restored word-1");
+            assertSchemaIdHeaders(word1.headers(), producedSchemaIds, "restored word-1");
 
             List<ReadOnlyRecord<GenericRecord, GenericRecord>> all = queryRange(
                 restored, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 3);
@@ -480,6 +506,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             query = query.skipCache();
         }
         long deadline = System.currentTimeMillis() + 30_000;
+        String lastFailure = null;
         while (System.currentTimeMillis() < deadline) {
             StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> result =
                 streams.query(StateQueryRequest.inStore(storeName).withQuery(query));
@@ -487,9 +514,13 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             if (pr != null && pr.isSuccess() && pr.getResult() != null) {
                 return pr.getResult();
             }
+            if (pr != null && pr.isFailure()) {
+                lastFailure = pr.getFailureReason() + ": " + pr.getFailureMessage();
+            }
             sleepQuietly(200);
         }
-        throw new AssertionError("IQv2 point query never returned a result for key " + key);
+        throw new AssertionError("IQv2 point query never returned a result for key " + key
+            + (lastFailure != null ? " (last failure: " + lastFailure + ")" : ""));
     }
 
     private void assertPointQuery(KafkaStreams streams, String storeName, String word,
@@ -499,7 +530,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         assertEquals(word, record.key().get("word").toString(), "IQv2 point key " + word);
         assertEquals(expectedCount, record.value().get("count"), "IQv2 point value " + word);
         assertTrue(record.timestamp() >= 0, "IQv2 point timestamp should be non-negative: " + word);
-        assertSchemaIdHeaders(record.headers(), valueSchemaIds,
+        assertSchemaIdHeaders(record.headers(), producedSchemaIds,
             "IQv2 point " + word + (skipCache ? " (skipCache)" : ""));
     }
 
@@ -513,8 +544,11 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> result =
             streams.query(StateQueryRequest.inStore(storeName)
                 .withQuery(TimestampedKeyWithHeadersQuery.withKey(createKey(word))));
+        Map<Integer, QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>>> partitionResults =
+            result.getPartitionResults();
+        assertFalse(partitionResults.isEmpty(), context + " query should return a partition result");
         QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> pr =
-            result.getPartitionResults().values().iterator().next();
+            partitionResults.values().iterator().next();
         assertTrue(pr.isSuccess(), context + " query should succeed");
         assertNull(pr.getResult(), context + " should yield a null result");
     }
@@ -538,6 +572,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         TimestampedRangeWithHeadersQuery<GenericRecord, GenericRecord> query, int expected) {
         long deadline = System.currentTimeMillis() + 30_000;
         List<ReadOnlyRecord<GenericRecord, GenericRecord>> out = new ArrayList<>();
+        String lastFailure = null;
         while (System.currentTimeMillis() < deadline) {
             out.clear();
             StateQueryResult<ReadOnlyRecordIterator<GenericRecord, GenericRecord>> result =
@@ -553,10 +588,13 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
                 if (out.size() >= expected) {
                     return out;
                 }
+            } else if (pr != null && pr.isFailure()) {
+                lastFailure = pr.getFailureReason() + ": " + pr.getFailureMessage();
             }
             sleepQuietly(200);
         }
-        assertEquals(expected, out.size(), "IQv2 range query returned an unexpected count");
+        assertEquals(expected, out.size(), "IQv2 range query returned an unexpected count"
+            + (lastFailure != null ? " (last failure: " + lastFailure + ")" : ""));
         return out;
     }
 
@@ -569,7 +607,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
     private void assertHeadersOnEach(
         List<ReadOnlyRecord<GenericRecord, GenericRecord>> records, String context) {
         for (int i = 0; i < records.size(); i++) {
-            assertSchemaIdHeaders(records.get(i).headers(), valueSchemaIds, context + " entry " + i);
+            assertSchemaIdHeaders(records.get(i).headers(), producedSchemaIds, context + " entry " + i);
         }
     }
 
@@ -620,7 +658,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         try (KafkaProducer<GenericRecord, GenericRecord> producer =
                  new KafkaProducer<>(createProducerProps())) {
             for (int i = 0; i < words.size(); i++) {
-                valueSchemaIds = sendAndCapture(producer, new ProducerRecord<>(
+                producedSchemaIds = sendAndCapture(producer, new ProducerRecord<>(
                     topic, createKey(words.get(i)), createValue(counts.get(i), "PUT")));
             }
             producer.flush();

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -39,6 +40,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -46,6 +48,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
@@ -67,6 +70,9 @@ import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.TimestampedKeyValueStoreWithHeaders;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * KIP-1356 IQv2 integration test for the timestamped key-value store with headers.
@@ -288,16 +294,67 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         }
     }
 
+    @Test
+    public void shouldPreserveFullHeaderSetIncludingDuplicatesAndEmpty() throws Exception {
+        String input = "iqv2-headerset-input";
+        String output = "iqv2-headerset-output";
+        String storeName = "iqv2-headerset-store";
+        String appId = "iqv2-headerset-test";
+
+        createTopics(input, output);
+        // Caching disabled so both query paths read the store-served record directly.
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, false), appId, 30, null);
+        try {
+            // A header set no serde would produce on its own: an arbitrary user header, a duplicate
+            // key ("trace" twice, distinct values), and a zero-length value. The serde adds the
+            // schema-id headers during send(); snapshot the full produced set (in order) afterward so
+            // the round-trip below is asserted against exactly what was written -- count, order,
+            // duplicate key and empty value included, and nothing spurious added. An implementation
+            // that special-cased the __*_schema_id keys, collapsed the duplicate to lastHeader,
+            // dropped the empty value, or reordered would fail here.
+            List<String> producedHeaders;
+            try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                     new KafkaProducer<>(createProducerProps())) {
+                ProducerRecord<GenericRecord, GenericRecord> record = new ProducerRecord<>(
+                    input, null, BASE_TIMESTAMP, createKey("word-1"), createValue(10L));
+                record.headers().add(SEQ_HEADER, "word-1".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("trace", "A".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("trace", "B".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("empty", new byte[0]);
+                producer.send(record).get();
+                producer.flush();
+                producedHeaders = headerEntries(record.headers());
+            }
+            consumeRecords(output, appId + "-barrier", 1);
+
+            ReadOnlyRecord<GenericRecord, GenericRecord> point =
+                queryPointExpectPresent(streams, storeName, createKey("word-1"), false);
+            assertEquals(producedHeaders, headerEntries(point.headers()),
+                "point query should return the full produced header set -- order, the duplicate "
+                    + "'trace' key, the empty value and the schema-id headers -- and nothing else");
+
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> range = queryRange(
+                streams, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 1);
+            assertEquals(producedHeaders, headerEntries(range.get(0).headers()),
+                "range query should return the full produced header set");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
     // ---------------------------------------------------------------------------------------------
     // TimestampedRangeWithHeadersQuery (range / scan)
     // ---------------------------------------------------------------------------------------------
 
-    @Test
-    public void shouldQueryRangeWithBounds() throws Exception {
-        String input = "iqv2-range-input";
-        String output = "iqv2-range-output";
-        String storeName = "iqv2-range-store";
-        String appId = "iqv2-range-test";
+    @ParameterizedTest(name = "range {0}")
+    @MethodSource("rangeCases")
+    public void shouldQueryRange(String label, String lowerWord, String upperWord,
+        List<String> expectedWords) throws Exception {
+        String input = "iqv2-range-" + label + "-input";
+        String output = "iqv2-range-" + label + "-output";
+        String storeName = "iqv2-range-" + label + "-store";
+        String appId = "iqv2-range-" + label + "-test";
 
         // Caching disabled: a range header-query reads the store directly (it never consults the
         // cache), so writes must be store-served -- this makes them visible immediately.
@@ -307,18 +364,45 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             Arrays.asList(10L, 20L, 30L, 40L, 50L),
             false, null);
         try {
-            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
-                streams, storeName,
-                TimestampedRangeWithHeadersQuery
-                    .<GenericRecord, GenericRecord>withRange(createKey("word-2"), createKey("word-4"))
-                    .withAscendingKeys(),
-                3);
-            List<String> words = wordsOf(records);
-            assertEquals(Arrays.asList("word-2", "word-3", "word-4"), words, "range [word-2, word-4]");
-            assertHeadersOnEach(records, "IQv2 range");
+            TimestampedRangeWithHeadersQuery<GenericRecord, GenericRecord> query;
+            if (lowerWord == null && upperWord == null) {
+                query = TimestampedRangeWithHeadersQuery.withNoBounds();
+            } else if (lowerWord != null && upperWord != null) {
+                query = TimestampedRangeWithHeadersQuery.withRange(
+                    createKey(lowerWord), createKey(upperWord));
+            } else if (lowerWord != null) {
+                query = TimestampedRangeWithHeadersQuery.withLowerBound(createKey(lowerWord));
+            } else {
+                query = TimestampedRangeWithHeadersQuery.withUpperBound(createKey(upperWord));
+            }
+            // Pin the order so the assertion checks the contract, not the store's incidental
+            // iteration order (a bare bound is ResultOrder.ANY).
+            query = query.withAscendingKeys();
+
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records =
+                queryRange(streams, storeName, query, expectedWords.size());
+            assertEquals(expectedWords, wordsOf(records), "range " + label);
+            assertHeadersOnEach(records, "IQv2 range " + label);
         } finally {
             closeStreams(streams);
         }
+    }
+
+    /**
+     * Cases for {@link #shouldQueryRange}: {@code (label, lower-bound word or null, upper-bound word
+     * or null, expected words)}, all against the same populated set {@code word-1..word-5}. Replaces
+     * the four near-identical bounds/scan/lower/upper range tests.
+     */
+    private static Stream<Arguments> rangeCases() {
+        return Stream.of(
+            Arguments.of("bounds", "word-2", "word-4",
+                Arrays.asList("word-2", "word-3", "word-4")),
+            Arguments.of("scan-all", null, null,
+                Arrays.asList("word-1", "word-2", "word-3", "word-4", "word-5")),
+            Arguments.of("lower-only", "word-3", null,
+                Arrays.asList("word-3", "word-4", "word-5")),
+            Arguments.of("upper-only", null, "word-2",
+                Arrays.asList("word-1", "word-2")));
     }
 
     @Test
@@ -363,86 +447,6 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             assertEquals(Arrays.asList("word-2", "word-1"), wordsOf(boundedDesc),
                 "bounded descending [word-1, word-2]");
             assertHeadersOnEach(boundedDesc, "IQv2 bounded descending");
-        } finally {
-            closeStreams(streams);
-        }
-    }
-
-    @Test
-    public void shouldScanAllWithNoBounds() throws Exception {
-        String input = "iqv2-scan-input";
-        String output = "iqv2-scan-output";
-        String storeName = "iqv2-scan-store";
-        String appId = "iqv2-scan-test";
-
-        // Caching disabled: range header-queries bypass the cache and read the store directly.
-        KafkaStreams streams = startAndPopulate(
-            storeName, input, output, appId,
-            Arrays.asList("word-1", "word-2", "word-3"), Arrays.asList(10L, 20L, 30L),
-            false, null);
-        try {
-            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
-                streams, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 3);
-            // Compare as a sorted List (not a Set) so a scan that emitted a duplicate key would fail.
-            List<String> words = wordsOf(records);
-            Collections.sort(words);
-            assertEquals(Arrays.asList("word-1", "word-2", "word-3"), words,
-                "scan should return exactly the three keys, each once");
-            assertHeadersOnEach(records, "IQv2 scan");
-        } finally {
-            closeStreams(streams);
-        }
-    }
-
-    @Test
-    public void shouldQueryLowerBoundOnly() throws Exception {
-        String input = "iqv2-lower-input";
-        String output = "iqv2-lower-output";
-        String storeName = "iqv2-lower-store";
-        String appId = "iqv2-lower-test";
-
-        // Caching disabled: range header-queries bypass the cache and read the store directly.
-        KafkaStreams streams = startAndPopulate(
-            storeName, input, output, appId,
-            Arrays.asList("word-1", "word-2", "word-3", "word-4"),
-            Arrays.asList(10L, 20L, 30L, 40L),
-            false, null);
-        try {
-            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
-                streams, storeName,
-                TimestampedRangeWithHeadersQuery
-                    .<GenericRecord, GenericRecord>withLowerBound(createKey("word-3"))
-                    .withAscendingKeys(),
-                2);
-            assertEquals(Arrays.asList("word-3", "word-4"), wordsOf(records), "lower bound word-3");
-            assertHeadersOnEach(records, "IQv2 lower bound");
-        } finally {
-            closeStreams(streams);
-        }
-    }
-
-    @Test
-    public void shouldQueryUpperBoundOnly() throws Exception {
-        String input = "iqv2-upper-input";
-        String output = "iqv2-upper-output";
-        String storeName = "iqv2-upper-store";
-        String appId = "iqv2-upper-test";
-
-        // Caching disabled: range header-queries bypass the cache and read the store directly.
-        KafkaStreams streams = startAndPopulate(
-            storeName, input, output, appId,
-            Arrays.asList("word-1", "word-2", "word-3", "word-4"),
-            Arrays.asList(10L, 20L, 30L, 40L),
-            false, null);
-        try {
-            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
-                streams, storeName,
-                TimestampedRangeWithHeadersQuery
-                    .<GenericRecord, GenericRecord>withUpperBound(createKey("word-2"))
-                    .withAscendingKeys(),
-                2);
-            assertEquals(Arrays.asList("word-1", "word-2"), wordsOf(records), "upper bound word-2");
-            assertHeadersOnEach(records, "IQv2 upper bound");
         } finally {
             closeStreams(streams);
         }
@@ -725,13 +729,22 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         Map<Integer, QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>>> partitionResults =
             result.getPartitionResults();
         assertFalse(partitionResults.isEmpty(), context + " query should return a partition result");
-        QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> pr =
-            partitionResults.values().iterator().next();
-        // Assert success first: getOnlyPartitionResult() filters out FAILED results too, so a query
-        // that failed outright would otherwise masquerade as a legitimate "absent key" null.
-        assertTrue(pr.isSuccess(), context + " query should succeed but failed: "
-            + (pr.isFailure() ? pr.getFailureReason() + ": " + pr.getFailureMessage() : ""));
-        assertNull(pr.getResult(), context + " should yield a null result");
+        // The key lives in exactly one partition, but rather than hand-pick it (queryMetadataForKey
+        // returns NOT_AVAILABLE for this PAPI addStateStore store, so partitionResults.get(-1) is
+        // null), assert every returned partition result directly. Checking all of them -- not one
+        // resolved partition -- is strictly stronger: a lingering value in ANY partition fails the
+        // assertion instead of being missed.
+        for (Map.Entry<Integer, QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>>> e
+            : partitionResults.entrySet()) {
+            QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> pr = e.getValue();
+            // Assert success first: getResult() is null for a FAILED result too, so a query that
+            // failed outright would otherwise masquerade as a legitimate "absent key" null.
+            assertTrue(pr.isSuccess(), context + " query should succeed but failed on partition "
+                + e.getKey() + ": "
+                + (pr.isFailure() ? pr.getFailureReason() + ": " + pr.getFailureMessage() : ""));
+            assertNull(pr.getResult(),
+                context + " should yield a null result on partition " + e.getKey());
+        }
     }
 
     private List<ReadOnlyRecord<GenericRecord, GenericRecord>> queryRange(
@@ -798,6 +811,20 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             context + ": " + SEQ_HEADER + " header should carry this record's own key");
     }
 
+    /**
+     * Renders headers as an ordered {@code key=base64(value)} list, preserving insertion order and
+     * duplicate keys, so two header sets can be compared for exact equality -- count, order,
+     * duplicates and byte-exact values (including a zero-length value, which base64s to {@code ""}).
+     */
+    private static List<String> headerEntries(Headers headers) {
+        List<String> entries = new ArrayList<>();
+        for (Header h : headers) {
+            entries.add(h.key() + "=" + (h.value() == null
+                ? "<null>" : Base64.getEncoder().encodeToString(h.value())));
+        }
+        return entries;
+    }
+
     // ---------------------------------------------------------------------------------------------
     // Topology + populate helpers
     // ---------------------------------------------------------------------------------------------
@@ -861,11 +888,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
 
     /** Produces a tombstone (null value) for {@code word}, deleting it from the header-aware store. */
     private void produceTombstone(String topic, String word) throws Exception {
-        try (KafkaProducer<GenericRecord, GenericRecord> producer =
-                 new KafkaProducer<>(createProducerProps())) {
-            sendAndCapture(producer, new ProducerRecord<>(topic, createKey(word), (GenericRecord) null));
-            producer.flush();
-        }
+        produce(topic, createKey(word), null, BASE_TIMESTAMP);
     }
 
     /**

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
@@ -1,0 +1,695 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.streams.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.confluent.kafka.serializers.schema.id.HeaderSchemaIdSerializer;
+import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.ReadOnlyRecord;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.query.StateQueryRequest;
+import org.apache.kafka.streams.query.StateQueryResult;
+import org.apache.kafka.streams.query.TimestampedKeyWithHeadersQuery;
+import org.apache.kafka.streams.query.TimestampedRangeWithHeadersQuery;
+import org.apache.kafka.streams.state.ReadOnlyRecordIterator;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.TimestampedKeyValueStoreWithHeaders;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
+import org.junit.jupiter.api.Test;
+
+/**
+ * KIP-1356 IQv2 integration test for the timestamped key-value store with headers.
+ *
+ * <p>Verifies that the headers-aware IQv2 query types —
+ * {@link TimestampedKeyWithHeadersQuery} (point) and {@link TimestampedRangeWithHeadersQuery}
+ * (range / scan) — return the record headers persisted by a KIP-1271
+ * {@link TimestampedKeyValueStoreWithHeaders}. In particular, records are produced with the
+ * schema-id GUID carried in the {@code __key_schema_id} / {@code __value_schema_id} headers (via
+ * {@link HeaderSchemaIdSerializer}); this test asserts those 17-byte {@code MAGIC_BYTE_V1} GUID
+ * headers survive the store and come back through each IQv2 query as a
+ * {@link ReadOnlyRecord} / {@link ReadOnlyRecordIterator}.
+ *
+ * <p>Shared cluster/serde/lifecycle infrastructure lives in {@link HeadersIQv2IntegrationTestBase}.
+ */
+public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
+    extends HeadersIQv2IntegrationTestBase {
+
+    private static final String KEY_SCHEMA_JSON =
+        "{"
+            + "\"type\":\"record\","
+            + "\"name\":\"WordKey\","
+            + "\"namespace\":\"io.confluent.kafka.streams.integration\","
+            + "\"fields\":["
+            + "  {\"name\":\"word\",\"type\":\"string\"}"
+            + "]"
+            + "}";
+
+    private static final String VALUE_SCHEMA_JSON =
+        "{"
+            + "\"type\":\"record\","
+            + "\"name\":\"WordValue\","
+            + "\"namespace\":\"io.confluent.kafka.streams.integration\","
+            + "\"fields\":["
+            + "  {\"name\":\"count\",\"type\":\"long\"},"
+            + "  {\"name\":\"operation\",\"type\":\"string\",\"default\":\"PUT\"}"
+            + "]"
+            + "}";
+
+    private final Schema keySchema = new Schema.Parser().parse(KEY_SCHEMA_JSON);
+    private final Schema valueSchema = new Schema.Parser().parse(VALUE_SCHEMA_JSON);
+
+    // Every record in each test shares this one key/value schema, so every value-bearing record
+    // carries the same schema-id GUIDs. Capture them once when producing and assert that IQv2
+    // results come back byte-equal to what was produced (see
+    // HeadersIQv2IntegrationTestBase#assertSchemaIdHeaders).
+    private CapturedSchemaIds valueSchemaIds;
+
+    // ---------------------------------------------------------------------------------------------
+    // TimestampedKeyWithHeadersQuery (point)
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldQueryPointWithHeaders() throws Exception {
+        String input = "iqv2-point-input";
+        String output = "iqv2-point-output";
+        String storeName = "iqv2-point-store";
+        String appId = "iqv2-point-test";
+
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Arrays.asList("word-1", "word-2", "word-3"), Arrays.asList(10L, 20L, 30L),
+            true, null);
+        try {
+            assertPointQuery(streams, storeName, "word-1", 10L, false);
+            assertPointQuery(streams, storeName, "word-2", 20L, false);
+            assertPointQuery(streams, storeName, "word-3", 30L, false);
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    @Test
+    public void shouldQueryPointSkipCache() throws Exception {
+        String input = "iqv2-skipcache-input";
+        String output = "iqv2-skipcache-output";
+        String storeName = "iqv2-skipcache-store";
+        String appId = "iqv2-skipcache-test";
+
+        // Low commit interval so the cache flushes into the underlying store, making the
+        // skipCache (store-served) read visible.
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Arrays.asList("word-1", "word-2"), Arrays.asList(10L, 20L),
+            true, 500);
+        try {
+            assertPointQuery(streams, storeName, "word-1", 10L, true);
+            assertPointQuery(streams, storeName, "word-2", 20L, true);
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    @Test
+    public void shouldReturnNullAfterTombstoningHeaderedKey() throws Exception {
+        String input = "iqv2-tombstone-input";
+        String output = "iqv2-tombstone-output";
+        String storeName = "iqv2-tombstone-store";
+        String appId = "iqv2-tombstone-test";
+
+        createTopics(input, output);
+        // Caching enabled + default commit interval: nothing flushes during the test, so the put and
+        // the later delete are both served from the record cache (read-your-writes/read-your-deletes).
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, true), appId, 30, null);
+        try {
+            // Populate word-1 and confirm the header-aware store serves it back with its schema-id
+            // headers -- establishing that there is a genuinely headered entry to remove.
+            produceRecords(input, Collections.singletonList("word-1"), Collections.singletonList(10L));
+            consumeRecords(output, appId + "-pre", 1);
+            assertPointQuery(streams, storeName, "word-1", 10L, false);
+
+            // Tombstone word-1 (null value). The header-aware store must drop the previously-headered
+            // entry so the point query stops returning it.
+            produceTombstone(input, "word-1");
+            consumeRecords(output, appId + "-post", 2);
+            assertPointReturnsNull(streams, storeName, "word-1", "tombstoned key");
+
+            // A key that was never written is likewise absent.
+            assertPointReturnsNull(streams, storeName, "no-such-word", "never-written key");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    @Test
+    public void shouldServeCacheHitBeforeFlushWithHeaders() throws Exception {
+        String input = "iqv2-cachehit-input";
+        String output = "iqv2-cachehit-output";
+        String storeName = "iqv2-cachehit-store";
+        String appId = "iqv2-cachehit-test";
+
+        createTopics(input, output);
+        // Caching enabled + a very large commit interval so nothing is committed/flushed during the
+        // test: the record lives only in the record cache (the persistent store stays empty).
+        int tenMinutes = (int) Duration.ofMinutes(10).toMillis();
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, true), appId, 30, tenMinutes);
+        try {
+            produceRecords(input, Collections.singletonList("word-1"), Collections.singletonList(10L));
+            consumeRecords(output, appId + "-barrier", 1);
+
+            // Read-your-writes: the not-yet-flushed record is served from the cache, with headers.
+            assertPointQuery(streams, storeName, "word-1", 10L, false);
+
+            // skipCache bypasses the cache and reads the persistent store, which is still empty; a null
+            // result positively proves the read above was genuinely cache-served (and covers skipCache).
+            assertNull(queryPointOnce(streams, storeName, createKey("word-1"), true),
+                "skipCache should read the empty store and return null before any flush");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // TimestampedRangeWithHeadersQuery (range / scan)
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldQueryRangeWithBounds() throws Exception {
+        String input = "iqv2-range-input";
+        String output = "iqv2-range-output";
+        String storeName = "iqv2-range-store";
+        String appId = "iqv2-range-test";
+
+        // Caching disabled: a range header-query reads the store directly (it never consults the
+        // cache), so writes must be store-served -- this makes them visible immediately.
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Arrays.asList("word-1", "word-2", "word-3", "word-4", "word-5"),
+            Arrays.asList(10L, 20L, 30L, 40L, 50L),
+            false, null);
+        try {
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
+                streams, storeName,
+                TimestampedRangeWithHeadersQuery.withRange(createKey("word-2"), createKey("word-4")),
+                3);
+            List<String> words = wordsOf(records);
+            assertEquals(Arrays.asList("word-2", "word-3", "word-4"), words, "range [word-2, word-4]");
+            assertHeadersOnEach(records, "IQv2 range");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    @Test
+    public void shouldQueryRangeAscendingAndDescending() throws Exception {
+        String input = "iqv2-order-input";
+        String output = "iqv2-order-output";
+        String storeName = "iqv2-order-store";
+        String appId = "iqv2-order-test";
+
+        // Caching disabled: range header-queries bypass the cache and read the store directly.
+        // Produce the keys out of order so the asc/desc assertions prove the query orders results by
+        // serialized key, not by insertion order.
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Arrays.asList("word-2", "word-3", "word-1"), Arrays.asList(20L, 30L, 10L),
+            false, null);
+        try {
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> asc = queryRange(
+                streams, storeName,
+                TimestampedRangeWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withNoBounds().withAscendingKeys(),
+                3);
+            assertEquals(Arrays.asList("word-1", "word-2", "word-3"), wordsOf(asc), "ascending keys");
+            assertHeadersOnEach(asc, "IQv2 ascending");
+
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> desc = queryRange(
+                streams, storeName,
+                TimestampedRangeWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withNoBounds().withDescendingKeys(),
+                3);
+            assertEquals(Arrays.asList("word-3", "word-2", "word-1"), wordsOf(desc), "descending keys");
+            assertHeadersOnEach(desc, "IQv2 descending");
+
+            // Bounded + descending: the ordering flip must also apply to a bounded range, not just a
+            // full scan -- guards against an ordering bug that only surfaces on the bounded path.
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> boundedDesc = queryRange(
+                streams, storeName,
+                TimestampedRangeWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withRange(createKey("word-1"), createKey("word-2"))
+                    .withDescendingKeys(),
+                2);
+            assertEquals(Arrays.asList("word-2", "word-1"), wordsOf(boundedDesc),
+                "bounded descending [word-1, word-2]");
+            assertHeadersOnEach(boundedDesc, "IQv2 bounded descending");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    @Test
+    public void shouldScanAllWithNoBounds() throws Exception {
+        String input = "iqv2-scan-input";
+        String output = "iqv2-scan-output";
+        String storeName = "iqv2-scan-store";
+        String appId = "iqv2-scan-test";
+
+        // Caching disabled: range header-queries bypass the cache and read the store directly.
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Arrays.asList("word-1", "word-2", "word-3"), Arrays.asList(10L, 20L, 30L),
+            false, null);
+        try {
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
+                streams, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 3);
+            // Compare as a sorted List (not a Set) so a scan that emitted a duplicate key would fail.
+            List<String> words = wordsOf(records);
+            Collections.sort(words);
+            assertEquals(Arrays.asList("word-1", "word-2", "word-3"), words,
+                "scan should return exactly the three keys, each once");
+            assertHeadersOnEach(records, "IQv2 scan");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    @Test
+    public void shouldQueryLowerBoundOnly() throws Exception {
+        String input = "iqv2-lower-input";
+        String output = "iqv2-lower-output";
+        String storeName = "iqv2-lower-store";
+        String appId = "iqv2-lower-test";
+
+        // Caching disabled: range header-queries bypass the cache and read the store directly.
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Arrays.asList("word-1", "word-2", "word-3", "word-4"),
+            Arrays.asList(10L, 20L, 30L, 40L),
+            false, null);
+        try {
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
+                streams, storeName,
+                TimestampedRangeWithHeadersQuery.withLowerBound(createKey("word-3")), 2);
+            assertEquals(Arrays.asList("word-3", "word-4"), wordsOf(records), "lower bound word-3");
+            assertHeadersOnEach(records, "IQv2 lower bound");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    @Test
+    public void shouldQueryUpperBoundOnly() throws Exception {
+        String input = "iqv2-upper-input";
+        String output = "iqv2-upper-output";
+        String storeName = "iqv2-upper-store";
+        String appId = "iqv2-upper-test";
+
+        // Caching disabled: range header-queries bypass the cache and read the store directly.
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Arrays.asList("word-1", "word-2", "word-3", "word-4"),
+            Arrays.asList(10L, 20L, 30L, 40L),
+            false, null);
+        try {
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
+                streams, storeName,
+                TimestampedRangeWithHeadersQuery.withUpperBound(createKey("word-2")), 2);
+            assertEquals(Arrays.asList("word-1", "word-2"), wordsOf(records), "upper bound word-2");
+            assertHeadersOnEach(records, "IQv2 upper bound");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Restore-from-changelog and multi-partition
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldRestoreFromChangelogThenQueryIQv2WithHeaders() throws Exception {
+        String input = "iqv2-restore-input";
+        String output = "iqv2-restore-output";
+        String storeName = "iqv2-restore-store";
+        String appId = "iqv2-restore-test";
+
+        createTopics(input, output);
+
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, true), appId, 30, null);
+        try {
+            produceRecords(input, Arrays.asList("word-1", "word-2", "word-3"),
+                Arrays.asList(10L, 20L, 30L));
+            consumeRecords(output, "iqv2-restore-pre", 3);
+        } finally {
+            closeStreams(streams);
+        }
+
+        // Restart with the same APPLICATION_ID; cleanUp() wipes the local state dir so the store
+        // must be rebuilt from the changelog. The restored entries must still carry their headers.
+        KafkaStreams restored = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, true), appId, 90, null);
+        try {
+            ReadOnlyRecord<GenericRecord, GenericRecord> word1 =
+                queryPointExpectPresent(restored, storeName, createKey("word-1"), false);
+            assertEquals(10L, word1.value().get("count"), "restored word-1 value");
+            assertSchemaIdHeaders(word1.headers(), valueSchemaIds, "restored word-1");
+
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> all = queryRange(
+                restored, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 3);
+            assertEquals(new HashSet<>(Arrays.asList("word-1", "word-2", "word-3")),
+                new HashSet<>(wordsOf(all)), "restored scan keys");
+            assertHeadersOnEach(all, "restored scan");
+        } finally {
+            closeStreams(restored);
+        }
+    }
+
+    @Test
+    public void shouldQueryAcrossPartitionsWithHeaders() throws Exception {
+        String input = "iqv2-mp-input";
+        String output = "iqv2-mp-output";
+        String storeName = "iqv2-mp-store";
+        String appId = "iqv2-mp-test";
+        int numPartitions = 3;
+        int numKeys = 9;
+
+        createTopicsWithPartitions(numPartitions, input, output);
+
+        List<String> words = new ArrayList<>();
+        List<Long> counts = new ArrayList<>();
+        for (int i = 1; i <= numKeys; i++) {
+            words.add("word-" + i);
+            counts.add(i * 10L);
+        }
+
+        // Caching disabled: the scan reads each partition's store directly, so writes are visible
+        // immediately without waiting for a cache flush.
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, false), appId, 30, null);
+        try {
+            produceRecords(input, words, counts);
+            consumeRecords(output, "iqv2-mp-consumer", numKeys);
+
+            // Scan every locally-available partition; collect and assert headers on every record.
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> all = new ArrayList<>();
+            Set<Integer> partitionsSeen = new HashSet<>();
+            long deadline = System.currentTimeMillis() + 30_000;
+            while (System.currentTimeMillis() < deadline) {
+                all.clear();
+                partitionsSeen.clear();
+                StateQueryResult<ReadOnlyRecordIterator<GenericRecord, GenericRecord>> result =
+                    streams.query(StateQueryRequest.inStore(storeName)
+                        .withQuery(TimestampedRangeWithHeadersQuery.withNoBounds()));
+                for (Map.Entry<Integer, QueryResult<ReadOnlyRecordIterator<GenericRecord, GenericRecord>>> e :
+                    result.getPartitionResults().entrySet()) {
+                    QueryResult<ReadOnlyRecordIterator<GenericRecord, GenericRecord>> pr = e.getValue();
+                    if (pr.isSuccess() && pr.getResult() != null) {
+                        try (ReadOnlyRecordIterator<GenericRecord, GenericRecord> it = pr.getResult()) {
+                            while (it.hasNext()) {
+                                all.add(it.next());
+                                partitionsSeen.add(e.getKey());
+                            }
+                        }
+                    }
+                }
+                if (all.size() >= numKeys) {
+                    break;
+                }
+                sleepQuietly(200);
+            }
+
+            assertEquals(numKeys, all.size(), "should read every key across partitions");
+            assertTrue(partitionsSeen.size() > 1,
+                "records should span more than one partition but saw: " + partitionsSeen);
+            assertHeadersOnEach(all, "IQv2 multi-partition scan");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // IQv2 query helpers
+    // ---------------------------------------------------------------------------------------------
+
+    private ReadOnlyRecord<GenericRecord, GenericRecord> queryPointExpectPresent(
+        KafkaStreams streams, String storeName, GenericRecord key, boolean skipCache) {
+        TimestampedKeyWithHeadersQuery<GenericRecord, GenericRecord> query =
+            TimestampedKeyWithHeadersQuery.withKey(key);
+        if (skipCache) {
+            query = query.skipCache();
+        }
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (System.currentTimeMillis() < deadline) {
+            StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> result =
+                streams.query(StateQueryRequest.inStore(storeName).withQuery(query));
+            QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> pr = result.getOnlyPartitionResult();
+            if (pr != null && pr.isSuccess() && pr.getResult() != null) {
+                return pr.getResult();
+            }
+            sleepQuietly(200);
+        }
+        throw new AssertionError("IQv2 point query never returned a result for key " + key);
+    }
+
+    private void assertPointQuery(KafkaStreams streams, String storeName, String word,
+        long expectedCount, boolean skipCache) {
+        ReadOnlyRecord<GenericRecord, GenericRecord> record =
+            queryPointExpectPresent(streams, storeName, createKey(word), skipCache);
+        assertEquals(word, record.key().get("word").toString(), "IQv2 point key " + word);
+        assertEquals(expectedCount, record.value().get("count"), "IQv2 point value " + word);
+        assertTrue(record.timestamp() >= 0, "IQv2 point timestamp should be non-negative: " + word);
+        assertSchemaIdHeaders(record.headers(), valueSchemaIds,
+            "IQv2 point " + word + (skipCache ? " (skipCache)" : ""));
+    }
+
+    /**
+     * Asserts a point query for {@code word} succeeds but yields a null result. A success-with-null is
+     * filtered out of {@link StateQueryResult#getOnlyPartitionResult()} (which returns null), so this
+     * inspects the per-partition result directly to distinguish "succeeded, absent" from a failure.
+     */
+    private void assertPointReturnsNull(KafkaStreams streams, String storeName, String word,
+        String context) {
+        StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> result =
+            streams.query(StateQueryRequest.inStore(storeName)
+                .withQuery(TimestampedKeyWithHeadersQuery.withKey(createKey(word))));
+        QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> pr =
+            result.getPartitionResults().values().iterator().next();
+        assertTrue(pr.isSuccess(), context + " query should succeed");
+        assertNull(pr.getResult(), context + " should yield a null result");
+    }
+
+    /** Single point query, no retry. Returns null for an absent/tombstoned key (or empty store). */
+    private ReadOnlyRecord<GenericRecord, GenericRecord> queryPointOnce(
+        KafkaStreams streams, String storeName, GenericRecord key, boolean skipCache) {
+        TimestampedKeyWithHeadersQuery<GenericRecord, GenericRecord> query =
+            TimestampedKeyWithHeadersQuery.withKey(key);
+        if (skipCache) {
+            query = query.skipCache();
+        }
+        StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> result =
+            streams.query(StateQueryRequest.inStore(storeName).withQuery(query));
+        QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> pr = result.getOnlyPartitionResult();
+        return pr == null ? null : pr.getResult();
+    }
+
+    private List<ReadOnlyRecord<GenericRecord, GenericRecord>> queryRange(
+        KafkaStreams streams, String storeName,
+        TimestampedRangeWithHeadersQuery<GenericRecord, GenericRecord> query, int expected) {
+        long deadline = System.currentTimeMillis() + 30_000;
+        List<ReadOnlyRecord<GenericRecord, GenericRecord>> out = new ArrayList<>();
+        while (System.currentTimeMillis() < deadline) {
+            out.clear();
+            StateQueryResult<ReadOnlyRecordIterator<GenericRecord, GenericRecord>> result =
+                streams.query(StateQueryRequest.inStore(storeName).withQuery(query));
+            QueryResult<ReadOnlyRecordIterator<GenericRecord, GenericRecord>> pr =
+                result.getOnlyPartitionResult();
+            if (pr != null && pr.isSuccess() && pr.getResult() != null) {
+                try (ReadOnlyRecordIterator<GenericRecord, GenericRecord> it = pr.getResult()) {
+                    while (it.hasNext()) {
+                        out.add(it.next());
+                    }
+                }
+                if (out.size() >= expected) {
+                    return out;
+                }
+            }
+            sleepQuietly(200);
+        }
+        assertEquals(expected, out.size(), "IQv2 range query returned an unexpected count");
+        return out;
+    }
+
+    private static List<String> wordsOf(List<ReadOnlyRecord<GenericRecord, GenericRecord>> records) {
+        return records.stream()
+            .map(r -> r.key().get("word").toString())
+            .collect(Collectors.toList());
+    }
+
+    private void assertHeadersOnEach(
+        List<ReadOnlyRecord<GenericRecord, GenericRecord>> records, String context) {
+        for (int i = 0; i < records.size(); i++) {
+            assertSchemaIdHeaders(records.get(i).headers(), valueSchemaIds, context + " entry " + i);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Topology + populate helpers
+    // ---------------------------------------------------------------------------------------------
+
+    private Topology buildTopology(String input, String output, String storeName,
+        boolean cachingEnabled) {
+        GenericAvroSerde keySerde = createKeySerde();
+        GenericAvroSerde valueSerde = createValueSerde();
+        StoreBuilder<TimestampedKeyValueStoreWithHeaders<GenericRecord, GenericRecord>> storeBuilder =
+            Stores.timestampedKeyValueStoreWithHeadersBuilder(
+                Stores.persistentTimestampedKeyValueStoreWithHeaders(storeName), keySerde, valueSerde);
+        storeBuilder = cachingEnabled
+            ? storeBuilder.withCachingEnabled()
+            : storeBuilder.withCachingDisabled();
+
+        StreamsBuilder builder = new StreamsBuilder();
+        builder
+            .addStateStore(storeBuilder)
+            .stream(input, Consumed.with(keySerde, valueSerde))
+            .process(() -> new PutProcessor(storeName), storeName)
+            .to(output, Produced.with(keySerde, valueSerde));
+        return builder.build();
+    }
+
+    private KafkaStreams startAndPopulate(String storeName, String input, String output, String appId,
+        List<String> words, List<Long> counts, boolean cachingEnabled, Integer commitIntervalMs)
+        throws Exception {
+        createTopics(input, output);
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, cachingEnabled), appId, 30, commitIntervalMs);
+        boolean populated = false;
+        try {
+            produceRecords(input, words, counts);
+            consumeRecords(output, appId + "-populate-consumer", words.size());
+            populated = true;
+            return streams;
+        } finally {
+            if (!populated) {
+                closeStreams(streams);
+            }
+        }
+    }
+
+    private void produceRecords(String topic, List<String> words, List<Long> counts) throws Exception {
+        try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                 new KafkaProducer<>(createProducerProps())) {
+            for (int i = 0; i < words.size(); i++) {
+                valueSchemaIds = sendAndCapture(producer, new ProducerRecord<>(
+                    topic, createKey(words.get(i)), createValue(counts.get(i), "PUT")));
+            }
+            producer.flush();
+        }
+    }
+
+    /** Produces a tombstone (null value) for {@code word}, deleting it from the header-aware store. */
+    private void produceTombstone(String topic, String word) throws Exception {
+        try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                 new KafkaProducer<>(createProducerProps())) {
+            sendAndCapture(producer, new ProducerRecord<>(topic, createKey(word), (GenericRecord) null));
+            producer.flush();
+        }
+    }
+
+    /**
+     * Processor that stores each incoming record (value, timestamp, headers) into the header-aware
+     * store and forwards the stored record downstream, so the output topic acts as a completion
+     * barrier for the produced batch.
+     */
+    private static class PutProcessor
+        implements Processor<GenericRecord, GenericRecord, GenericRecord, GenericRecord> {
+
+        private final String storeName;
+        private ProcessorContext<GenericRecord, GenericRecord> context;
+        private TimestampedKeyValueStoreWithHeaders<GenericRecord, GenericRecord> store;
+
+        PutProcessor(String storeName) {
+            this.storeName = storeName;
+        }
+
+        @Override
+        public void init(ProcessorContext<GenericRecord, GenericRecord> context) {
+            this.context = context;
+            this.store = context.getStateStore(storeName);
+        }
+
+        @Override
+        public void process(Record<GenericRecord, GenericRecord> record) {
+            if (record.value() == null) {
+                // Tombstone the header-aware entry (mirrors the window/session writers' null handling)
+                // and forward the null-value record so the output topic still acts as a completion
+                // barrier for the batch.
+                store.put(record.key(), null);
+                context.forward(record);
+                return;
+            }
+            store.put(record.key(),
+                ValueTimestampHeaders.make(record.value(), record.timestamp(), record.headers()));
+            ValueTimestampHeaders<GenericRecord> stored = store.get(record.key());
+            context.forward(new Record<>(
+                record.key(), stored.value(), stored.timestamp(), stored.headers()));
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Avro record factories (schema-specific; the shared infrastructure lives in the base class)
+    // ---------------------------------------------------------------------------------------------
+
+    private GenericRecord createKey(String word) {
+        GenericRecord key = new GenericData.Record(keySchema);
+        key.put("word", word);
+        return key;
+    }
+
+    private GenericRecord createValue(long count, String operation) {
+        GenericRecord value = new GenericData.Record(valueSchema);
+        value.put("count", count);
+        value.put("operation", operation);
+        return value;
+    }
+}

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
@@ -279,67 +279,6 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         }
     }
 
-    /**
-     * Covers the position-bound path for both header queries. Every other test here uses the default
-     * unbounded position, so neither {@code withPositionBound(...)} nor
-     * {@link StateQueryResult#getPosition()} would otherwise be exercised at all.
-     */
-    @Test
-    public void shouldReportPositionAndRejectQueryBoundedBeyondIt() throws Exception {
-        String input = "iqv2-position-input";
-        String output = "iqv2-position-output";
-        String storeName = "iqv2-position-store";
-        String appId = "iqv2-position-test";
-
-        KafkaStreams streams = startAndPopulate(
-            storeName, input, output, appId,
-            Collections.singletonList("word-1"), Collections.singletonList(10L), false, null);
-        try {
-            // A query served under the default (unbounded) bound reports the position the store had
-            // reached when it answered.
-            StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> unbounded =
-                streams.query(StateQueryRequest.inStore(storeName)
-                    .withQuery(TimestampedKeyWithHeadersQuery
-                        .<GenericRecord, GenericRecord>withKey(createKey("word-1"))));
-            Position position = unbounded.getPosition();
-            assertNotNull(position, "unbounded query should report a position");
-            assertTrue(position.getTopics().contains(input),
-                "reported position should cover the input topic but was: " + position);
-
-            // A bound at an offset the store cannot have reached must fail the query with
-            // NOT_UP_TO_BOUND rather than quietly serving a result from behind the bound.
-            PositionBound beyond = PositionBound.at(
-                Position.emptyPosition().withComponent(input, 0, Long.MAX_VALUE));
-            assertNotUpToBound(streams.query(StateQueryRequest.inStore(storeName)
-                .withQuery(TimestampedKeyWithHeadersQuery
-                    .<GenericRecord, GenericRecord>withKey(createKey("word-1")))
-                .withPositionBound(beyond)), "point query");
-            assertNotUpToBound(streams.query(StateQueryRequest.inStore(storeName)
-                .withQuery(TimestampedRangeWithHeadersQuery
-                    .<GenericRecord, GenericRecord>withNoBounds())
-                .withPositionBound(beyond)), "range query");
-            closeStreams(streams);
-        } finally {
-            closeStreamsQuietly(streams);
-        }
-    }
-
-    /**
-     * Asserts every partition result failed with {@link FailureReason#NOT_UP_TO_BOUND} -- checking
-     * the reason, not merely that the query failed, so an unrelated failure can't pass as coverage.
-     */
-    private static <R> void assertNotUpToBound(StateQueryResult<R> result, String context) {
-        Map<Integer, QueryResult<R>> partitionResults = result.getPartitionResults();
-        assertFalse(partitionResults.isEmpty(), context + " should return a partition result");
-        for (Map.Entry<Integer, QueryResult<R>> e : partitionResults.entrySet()) {
-            QueryResult<R> pr = e.getValue();
-            assertTrue(pr.isFailure(), context
-                + " bounded beyond the store's position should fail on partition " + e.getKey());
-            assertEquals(FailureReason.NOT_UP_TO_BOUND, pr.getFailureReason(),
-                context + " should fail with NOT_UP_TO_BOUND on partition " + e.getKey());
-        }
-    }
-
     // ---------------------------------------------------------------------------------------------
     // TimestampedRangeWithHeadersQuery (range / scan)
     // ---------------------------------------------------------------------------------------------
@@ -657,6 +596,71 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             closeStreams(streams);
         } finally {
             closeStreamsQuietly(streams);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Position bounds (point + range)
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Covers the position-bound path for both header queries. Every other test here uses the default
+     * unbounded position, so neither {@code withPositionBound(...)} nor
+     * {@link StateQueryResult#getPosition()} would otherwise be exercised at all.
+     */
+    @Test
+    public void shouldReportPositionAndRejectQueryBoundedBeyondIt() throws Exception {
+        String input = "iqv2-position-input";
+        String output = "iqv2-position-output";
+        String storeName = "iqv2-position-store";
+        String appId = "iqv2-position-test";
+
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Collections.singletonList("word-1"), Collections.singletonList(10L), false, null);
+        try {
+            // A query served under the default (unbounded) bound reports the position the store had
+            // reached when it answered.
+            StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> unbounded =
+                streams.query(StateQueryRequest.inStore(storeName)
+                    .withQuery(TimestampedKeyWithHeadersQuery
+                        .<GenericRecord, GenericRecord>withKey(createKey("word-1"))));
+            Position position = unbounded.getPosition();
+            assertNotNull(position, "unbounded query should report a position");
+            assertTrue(position.getTopics().contains(input),
+                "reported position should cover the input topic but was: " + position);
+
+            // A bound at an offset the store cannot have reached must fail the query with
+            // NOT_UP_TO_BOUND rather than quietly serving a result from behind the bound.
+            PositionBound beyond = PositionBound.at(
+                Position.emptyPosition().withComponent(input, 0, Long.MAX_VALUE));
+            assertNotUpToBound(streams.query(StateQueryRequest.inStore(storeName)
+                .withQuery(TimestampedKeyWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withKey(createKey("word-1")))
+                .withPositionBound(beyond)), "point query");
+            assertNotUpToBound(streams.query(StateQueryRequest.inStore(storeName)
+                .withQuery(TimestampedRangeWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withNoBounds())
+                .withPositionBound(beyond)), "range query");
+            closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
+        }
+    }
+
+    /**
+     * Asserts every partition result failed with {@link FailureReason#NOT_UP_TO_BOUND} -- checking
+     * the reason, not merely that the query failed, so an unrelated failure can't pass as coverage.
+     */
+    private static <R> void assertNotUpToBound(StateQueryResult<R> result, String context) {
+        Map<Integer, QueryResult<R>> partitionResults = result.getPartitionResults();
+        assertFalse(partitionResults.isEmpty(), context + " should return a partition result");
+        for (Map.Entry<Integer, QueryResult<R>> e : partitionResults.entrySet()) {
+            QueryResult<R> pr = e.getValue();
+            assertTrue(pr.isFailure(), context
+                + " bounded beyond the store's position should fail on partition " + e.getKey());
+            assertEquals(FailureReason.NOT_UP_TO_BOUND, pr.getFailureReason(),
+                context + " should fail with NOT_UP_TO_BOUND on partition " + e.getKey());
         }
     }
 

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
@@ -18,30 +18,40 @@ package io.confluent.kafka.streams.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.confluent.kafka.serializers.schema.id.HeaderSchemaIdSerializer;
 import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Header;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.ReadOnlyRecord;
@@ -91,19 +101,29 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             + "\"name\":\"WordValue\","
             + "\"namespace\":\"io.confluent.kafka.streams.integration\","
             + "\"fields\":["
-            + "  {\"name\":\"count\",\"type\":\"long\"},"
-            + "  {\"name\":\"operation\",\"type\":\"string\",\"default\":\"PUT\"}"
+            + "  {\"name\":\"count\",\"type\":\"long\"}"
             + "]"
             + "}";
 
     private final Schema keySchema = new Schema.Parser().parse(KEY_SCHEMA_JSON);
     private final Schema valueSchema = new Schema.Parser().parse(VALUE_SCHEMA_JSON);
 
-    // Every record in each test shares this one key/value schema, so every value-bearing record
-    // carries the same schema-id GUIDs. Capture them once when producing and assert that IQv2
-    // results come back byte-equal to what was produced (see
-    // HeadersIQv2IntegrationTestBase#assertSchemaIdHeaders).
-    private CapturedSchemaIds producedSchemaIds;
+    /**
+     * A distinct user header attached to every produced record, carrying that record's own key
+     * ({@code seq=<word>}). Because it differs per record -- unlike the schema-id GUIDs, which are
+     * byte-identical for every record since they all share one schema -- asserting it on each IQv2
+     * result proves the store returned <em>this</em> record's headers, not another record's.
+     */
+    private static final String SEQ_HEADER = "seq";
+
+    // Per-record captures, keyed by word, so each IQv2 result is asserted against its own record's
+    // produced schema-id GUIDs (see HeadersIQv2IntegrationTestBase#assertSchemaIdHeaders) and its
+    // own produced timestamp -- not a single shared value that every record would trivially match.
+    private final Map<String, CapturedSchemaIds> capturedByWord = new HashMap<>();
+    private final Map<String, Long> timestampByWord = new HashMap<>();
+
+    // A fixed, explicit base timestamp so each record's timestamp is known and assertable.
+    private static final long BASE_TIMESTAMP = 1_600_000_000_000L;
 
     // ---------------------------------------------------------------------------------------------
     // TimestampedKeyWithHeadersQuery (point)
@@ -173,10 +193,36 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             // entry so the point query stops returning it.
             produceTombstone(input, "word-1");
             consumeRecords(output, appId + "-post", 2);
-            assertPointReturnsNull(streams, storeName, "word-1", "tombstoned key");
+            assertPointReturnsNull(streams, storeName, "word-1", "tombstoned key", false);
 
             // A key that was never written is likewise absent.
-            assertPointReturnsNull(streams, storeName, "no-such-word", "never-written key");
+            assertPointReturnsNull(streams, storeName, "no-such-word", "never-written key", false);
+
+            // Re-put word-1 after the tombstone with a NEW record carrying a distinguishing header
+            // (phase=after). The pre-tombstone record had no such header, so a store that lingered
+            // the old headers instead of taking the re-put's would fail the phase assertion below --
+            // this pins that a re-put comes back with its own headers, not the pre-tombstone ones.
+            long reputTs = BASE_TIMESTAMP + 100;
+            try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                     new KafkaProducer<>(createProducerProps())) {
+                ProducerRecord<GenericRecord, GenericRecord> reput = new ProducerRecord<>(
+                    input, null, reputTs, createKey("word-1"), createValue(99L));
+                reput.headers().add(SEQ_HEADER, "word-1".getBytes(StandardCharsets.UTF_8));
+                reput.headers().add("phase", "after".getBytes(StandardCharsets.UTF_8));
+                capturedByWord.put("word-1", sendAndCapture(producer, reput));
+                timestampByWord.put("word-1", reputTs);
+                producer.flush();
+            }
+            consumeRecords(output, appId + "-reput", 3);
+
+            ReadOnlyRecord<GenericRecord, GenericRecord> afterReput =
+                queryPointExpectPresent(streams, storeName, createKey("word-1"), false);
+            assertEquals(99L, afterReput.value().get("count"), "re-put word-1 value");
+            assertRecordHeaders(afterReput, "word-1", "re-put word-1");
+            Header phase = afterReput.headers().lastHeader("phase");
+            assertNotNull(phase, "re-put word-1: should carry the new record's phase header");
+            assertEquals("after", new String(phase.value(), StandardCharsets.UTF_8),
+                "re-put word-1: query should return the re-put's headers, not the pre-tombstone ones");
         } finally {
             closeStreams(streams);
         }
@@ -202,10 +248,41 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             // Read-your-writes: the not-yet-flushed record is served from the cache, with headers.
             assertPointQuery(streams, storeName, "word-1", 10L, false);
 
-            // skipCache bypasses the cache and reads the persistent store, which is still empty; a null
-            // result positively proves the read above was genuinely cache-served (and covers skipCache).
-            assertNull(queryPointOnce(streams, storeName, createKey("word-1"), true),
-                "skipCache should read the empty store and return null before any flush");
+            // skipCache bypasses the cache and reads the persistent store, which is still empty; a
+            // successful null result positively proves the read above was genuinely cache-served (and
+            // covers skipCache). Asserting success first stops a failed skipCache query passing as null.
+            assertPointReturnsNull(streams, storeName, "word-1",
+                "skipCache before flush (empty store)", true);
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    @Test
+    public void shouldReturnReadOnlyHeaders() throws Exception {
+        String input = "iqv2-readonly-input";
+        String output = "iqv2-readonly-output";
+        String storeName = "iqv2-readonly-store";
+        String appId = "iqv2-readonly-test";
+
+        // Caching disabled so the range query (which bypasses the cache) sees the store-served record.
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Collections.singletonList("word-1"), Collections.singletonList(10L), false, null);
+        try {
+            // The query marks the returned headers read-only on both the point and range paths, so
+            // an attempt to mutate them must throw.
+            ReadOnlyRecord<GenericRecord, GenericRecord> point =
+                queryPointExpectPresent(streams, storeName, createKey("word-1"), false);
+            assertThrows(IllegalStateException.class,
+                () -> point.headers().add("x", new byte[]{1}),
+                "point query should return read-only headers");
+
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> range = queryRange(
+                streams, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 1);
+            assertThrows(IllegalStateException.class,
+                () -> range.get(0).headers().add("x", new byte[]{1}),
+                "range query should return read-only headers");
         } finally {
             closeStreams(streams);
         }
@@ -232,7 +309,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         try {
             List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
                 streams, storeName,
-                TimestampedRangeWithHeadersQuery.withRange(createKey("word-2"), createKey("word-4")),
+                TimestampedRangeWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withRange(createKey("word-2"), createKey("word-4"))
+                    .withAscendingKeys(),
                 3);
             List<String> words = wordsOf(records);
             assertEquals(Arrays.asList("word-2", "word-3", "word-4"), words, "range [word-2, word-4]");
@@ -331,7 +410,10 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         try {
             List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
                 streams, storeName,
-                TimestampedRangeWithHeadersQuery.withLowerBound(createKey("word-3")), 2);
+                TimestampedRangeWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withLowerBound(createKey("word-3"))
+                    .withAscendingKeys(),
+                2);
             assertEquals(Arrays.asList("word-3", "word-4"), wordsOf(records), "lower bound word-3");
             assertHeadersOnEach(records, "IQv2 lower bound");
         } finally {
@@ -355,7 +437,10 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         try {
             List<ReadOnlyRecord<GenericRecord, GenericRecord>> records = queryRange(
                 streams, storeName,
-                TimestampedRangeWithHeadersQuery.withUpperBound(createKey("word-2")), 2);
+                TimestampedRangeWithHeadersQuery
+                    .<GenericRecord, GenericRecord>withUpperBound(createKey("word-2"))
+                    .withAscendingKeys(),
+                2);
             assertEquals(Arrays.asList("word-1", "word-2"), wordsOf(records), "upper bound word-2");
             assertHeadersOnEach(records, "IQv2 upper bound");
         } finally {
@@ -388,6 +473,57 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         }
     }
 
+    @Test
+    public void shouldNotServeRangeFromCacheBeforeFlush() throws Exception {
+        String input = "iqv2-rangecache-input";
+        String output = "iqv2-rangecache-output";
+        String storeName = "iqv2-rangecache-store";
+        String appId = "iqv2-rangecache-test";
+
+        createTopics(input, output);
+        // Caching enabled + a very large commit interval so nothing flushes during the test: the
+        // records live only in the record cache; the persistent store stays empty.
+        int tenMinutes = (int) Duration.ofMinutes(10).toMillis();
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, true), appId, 30, tenMinutes);
+        try {
+            produceRecords(input, Arrays.asList("word-1", "word-2", "word-3"),
+                Arrays.asList(10L, 20L, 30L));
+            consumeRecords(output, appId + "-barrier", 3);
+
+            // Positive control: a point query serves the not-yet-flushed records from the cache, so
+            // they are genuinely present -- just unflushed.
+            assertPointQuery(streams, storeName, "word-1", 10L, false);
+
+            // The range path bypasses the cache and reads the still-empty persistent store, so it
+            // must return nothing. This turns the "range never consults the cache" comment on the
+            // range tests into an asserted guarantee, catching a future change that starts consulting
+            // the cache. Emptiness is asserted from a single successful query -- there is nothing to
+            // wait for.
+            StateQueryResult<ReadOnlyRecordIterator<GenericRecord, GenericRecord>> result =
+                streams.query(StateQueryRequest.inStore(storeName)
+                    .withQuery(TimestampedRangeWithHeadersQuery.withNoBounds()));
+            QueryResult<ReadOnlyRecordIterator<GenericRecord, GenericRecord>> pr =
+                result.getOnlyPartitionResult();
+            assertNotNull(pr, "range query should return a partition result");
+            assertTrue(pr.isSuccess(), "range query should succeed but failed: "
+                + (pr.isFailure() ? pr.getFailureReason() + ": " + pr.getFailureMessage() : ""));
+            List<String> served = new ArrayList<>();
+            ReadOnlyRecordIterator<GenericRecord, GenericRecord> iter = pr.getResult();
+            if (iter != null) {
+                try (ReadOnlyRecordIterator<GenericRecord, GenericRecord> it = iter) {
+                    while (it.hasNext()) {
+                        served.add(it.next().key().get("word").toString());
+                    }
+                }
+            }
+            assertTrue(served.isEmpty(),
+                "range query must not serve unflushed cached entries but returned: " + served);
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
     // ---------------------------------------------------------------------------------------------
     // Restore-from-changelog and multi-partition
     // ---------------------------------------------------------------------------------------------
@@ -411,21 +547,59 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             closeStreams(streams);
         }
 
-        // Restart with the same APPLICATION_ID; cleanUp() wipes the local state dir so the store
-        // must be rebuilt from the changelog. The restored entries must still carry their headers.
-        KafkaStreams restored = startStreamsAndAwaitRunning(
-            buildTopology(input, output, storeName, true), appId, 90, null);
+        // Restart with the same APPLICATION_ID; cleanUp() wipes the local state dir so the store must
+        // be rebuilt from the changelog. Attach a StateRestoreListener BEFORE start() to prove the
+        // rebuild actually happened: cleanUp() clears local state but not committed offsets, so
+        // without this the restart could silently reprocess the input and pass with no restore at all.
+        // (The base start helper can't set a restore listener, so this instance is started inline.)
+        AtomicLong restoredCount = new AtomicLong(0);
+        StateRestoreListener restoreListener = new StateRestoreListener() {
+            @Override
+            public void onRestoreStart(TopicPartition tp, String store, long start, long end) {
+            }
+
+            @Override
+            public void onBatchRestored(TopicPartition tp, String store, long end, long batch) {
+            }
+
+            @Override
+            public void onRestoreEnd(TopicPartition tp, String store, long totalRestored) {
+                if (store.equals(storeName)) {
+                    restoredCount.addAndGet(totalRestored);
+                }
+            }
+        };
+        KafkaStreams restored = new KafkaStreams(
+            buildTopology(input, output, storeName, true), createStreamsProps(appId, null));
+        restored.cleanUp();
+        restored.setGlobalStateRestoreListener(restoreListener);
+        CountDownLatch restoredRunning = new CountDownLatch(1);
+        restored.setStateListener((newState, oldState) -> {
+            if (newState == KafkaStreams.State.RUNNING) {
+                restoredRunning.countDown();
+            }
+        });
+        restored.start();
         try {
+            assertTrue(restoredRunning.await(90, TimeUnit.SECONDS),
+                "restored KafkaStreams should reach RUNNING");
+
             ReadOnlyRecord<GenericRecord, GenericRecord> word1 =
                 queryPointExpectPresent(restored, storeName, createKey("word-1"), false);
             assertEquals(10L, word1.value().get("count"), "restored word-1 value");
-            assertSchemaIdHeaders(word1.headers(), producedSchemaIds, "restored word-1");
+            assertRecordHeaders(word1, "word-1", "restored word-1");
 
             List<ReadOnlyRecord<GenericRecord, GenericRecord>> all = queryRange(
                 restored, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 3);
             assertEquals(new HashSet<>(Arrays.asList("word-1", "word-2", "word-3")),
                 new HashSet<>(wordsOf(all)), "restored scan keys");
             assertHeadersOnEach(all, "restored scan");
+
+            // Pin that the store was genuinely rebuilt from the changelog, not repopulated by a
+            // silent reprocess of the input topic.
+            assertTrue(restoredCount.get() > 0,
+                "store should have been restored from the changelog (restored "
+                    + restoredCount.get() + " records)");
         } finally {
             closeStreams(restored);
         }
@@ -527,11 +701,11 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         long expectedCount, boolean skipCache) {
         ReadOnlyRecord<GenericRecord, GenericRecord> record =
             queryPointExpectPresent(streams, storeName, createKey(word), skipCache);
+        String context = "IQv2 point " + word + (skipCache ? " (skipCache)" : "");
         assertEquals(word, record.key().get("word").toString(), "IQv2 point key " + word);
         assertEquals(expectedCount, record.value().get("count"), "IQv2 point value " + word);
-        assertTrue(record.timestamp() >= 0, "IQv2 point timestamp should be non-negative: " + word);
-        assertSchemaIdHeaders(record.headers(), producedSchemaIds,
-            "IQv2 point " + word + (skipCache ? " (skipCache)" : ""));
+        assertEquals(timestampByWord.get(word), record.timestamp(), "IQv2 point timestamp " + word);
+        assertRecordHeaders(record, word, context);
     }
 
     /**
@@ -540,31 +714,24 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
      * inspects the per-partition result directly to distinguish "succeeded, absent" from a failure.
      */
     private void assertPointReturnsNull(KafkaStreams streams, String storeName, String word,
-        String context) {
-        StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> result =
-            streams.query(StateQueryRequest.inStore(storeName)
-                .withQuery(TimestampedKeyWithHeadersQuery.withKey(createKey(word))));
-        Map<Integer, QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>>> partitionResults =
-            result.getPartitionResults();
-        assertFalse(partitionResults.isEmpty(), context + " query should return a partition result");
-        QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> pr =
-            partitionResults.values().iterator().next();
-        assertTrue(pr.isSuccess(), context + " query should succeed");
-        assertNull(pr.getResult(), context + " should yield a null result");
-    }
-
-    /** Single point query, no retry. Returns null for an absent/tombstoned key (or empty store). */
-    private ReadOnlyRecord<GenericRecord, GenericRecord> queryPointOnce(
-        KafkaStreams streams, String storeName, GenericRecord key, boolean skipCache) {
+        String context, boolean skipCache) {
         TimestampedKeyWithHeadersQuery<GenericRecord, GenericRecord> query =
-            TimestampedKeyWithHeadersQuery.withKey(key);
+            TimestampedKeyWithHeadersQuery.withKey(createKey(word));
         if (skipCache) {
             query = query.skipCache();
         }
         StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> result =
             streams.query(StateQueryRequest.inStore(storeName).withQuery(query));
-        QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> pr = result.getOnlyPartitionResult();
-        return pr == null ? null : pr.getResult();
+        Map<Integer, QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>>> partitionResults =
+            result.getPartitionResults();
+        assertFalse(partitionResults.isEmpty(), context + " query should return a partition result");
+        QueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> pr =
+            partitionResults.values().iterator().next();
+        // Assert success first: getOnlyPartitionResult() filters out FAILED results too, so a query
+        // that failed outright would otherwise masquerade as a legitimate "absent key" null.
+        assertTrue(pr.isSuccess(), context + " query should succeed but failed: "
+            + (pr.isFailure() ? pr.getFailureReason() + ": " + pr.getFailureMessage() : ""));
+        assertNull(pr.getResult(), context + " should yield a null result");
     }
 
     private List<ReadOnlyRecord<GenericRecord, GenericRecord>> queryRange(
@@ -607,8 +774,28 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
     private void assertHeadersOnEach(
         List<ReadOnlyRecord<GenericRecord, GenericRecord>> records, String context) {
         for (int i = 0; i < records.size(); i++) {
-            assertSchemaIdHeaders(records.get(i).headers(), producedSchemaIds, context + " entry " + i);
+            ReadOnlyRecord<GenericRecord, GenericRecord> record = records.get(i);
+            String word = record.key().get("word").toString();
+            assertRecordHeaders(record, word, context + " entry " + i);
         }
+    }
+
+    /**
+     * Asserts the record carries the exact headers produced for {@code word}: the schema-id GUIDs
+     * byte-equal to what that record's serializer wrote, and the distinct {@code seq} header equal to
+     * the word itself. The {@code seq} check is what makes this a per-record fidelity assertion -- a
+     * store that returned another record's headers, or one shared {@code Headers} instance for every
+     * entry, would carry the wrong {@code seq} and fail here.
+     */
+    private void assertRecordHeaders(ReadOnlyRecord<GenericRecord, GenericRecord> record,
+        String word, String context) {
+        CapturedSchemaIds expected = capturedByWord.get(word);
+        assertNotNull(expected, context + ": no captured schema-id GUIDs for " + word);
+        assertSchemaIdHeaders(record.headers(), expected, context);
+        Header seq = record.headers().lastHeader(SEQ_HEADER);
+        assertNotNull(seq, context + ": missing " + SEQ_HEADER + " header");
+        assertEquals(word, new String(seq.value(), StandardCharsets.UTF_8),
+            context + ": " + SEQ_HEADER + " header should carry this record's own key");
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -658,8 +845,15 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         try (KafkaProducer<GenericRecord, GenericRecord> producer =
                  new KafkaProducer<>(createProducerProps())) {
             for (int i = 0; i < words.size(); i++) {
-                producedSchemaIds = sendAndCapture(producer, new ProducerRecord<>(
-                    topic, createKey(words.get(i)), createValue(counts.get(i), "PUT")));
+                String word = words.get(i);
+                long timestamp = BASE_TIMESTAMP + i;
+                ProducerRecord<GenericRecord, GenericRecord> record = new ProducerRecord<>(
+                    topic, null, timestamp, createKey(word), createValue(counts.get(i)));
+                // Distinct per-record user header so each IQv2 result can be checked against its own
+                // record -- see SEQ_HEADER. The serde adds the schema-id headers during send().
+                record.headers().add(SEQ_HEADER, word.getBytes(StandardCharsets.UTF_8));
+                capturedByWord.put(word, sendAndCapture(producer, record));
+                timestampByWord.put(word, timestamp);
             }
             producer.flush();
         }
@@ -724,10 +918,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         return key;
     }
 
-    private GenericRecord createValue(long count, String operation) {
+    private GenericRecord createValue(long count) {
         GenericRecord value = new GenericData.Record(valueSchema);
         value.put("count", count);
-        value.put("operation", operation);
         return value;
     }
 }

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest.java
@@ -131,6 +131,9 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
     // A fixed, explicit base timestamp so each record's timestamp is known and assertable.
     private static final long BASE_TIMESTAMP = 1_600_000_000_000L;
 
+    // How long the IQv2 query helpers poll for a result to become locally available before failing.
+    private static final long QUERY_DEADLINE_MS = 30_000;
+
     // ---------------------------------------------------------------------------------------------
     // TimestampedKeyWithHeadersQuery (point)
     // ---------------------------------------------------------------------------------------------
@@ -259,85 +262,6 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             // covers skipCache). Asserting success first stops a failed skipCache query passing as null.
             assertPointReturnsNull(streams, storeName, "word-1",
                 "skipCache before flush (empty store)", true);
-        } finally {
-            closeStreams(streams);
-        }
-    }
-
-    @Test
-    public void shouldReturnReadOnlyHeaders() throws Exception {
-        String input = "iqv2-readonly-input";
-        String output = "iqv2-readonly-output";
-        String storeName = "iqv2-readonly-store";
-        String appId = "iqv2-readonly-test";
-
-        // Caching disabled so the range query (which bypasses the cache) sees the store-served record.
-        KafkaStreams streams = startAndPopulate(
-            storeName, input, output, appId,
-            Collections.singletonList("word-1"), Collections.singletonList(10L), false, null);
-        try {
-            // The query marks the returned headers read-only on both the point and range paths, so
-            // an attempt to mutate them must throw.
-            ReadOnlyRecord<GenericRecord, GenericRecord> point =
-                queryPointExpectPresent(streams, storeName, createKey("word-1"), false);
-            assertThrows(IllegalStateException.class,
-                () -> point.headers().add("x", new byte[]{1}),
-                "point query should return read-only headers");
-
-            List<ReadOnlyRecord<GenericRecord, GenericRecord>> range = queryRange(
-                streams, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 1);
-            assertThrows(IllegalStateException.class,
-                () -> range.get(0).headers().add("x", new byte[]{1}),
-                "range query should return read-only headers");
-        } finally {
-            closeStreams(streams);
-        }
-    }
-
-    @Test
-    public void shouldPreserveFullHeaderSetIncludingDuplicatesAndEmpty() throws Exception {
-        String input = "iqv2-headerset-input";
-        String output = "iqv2-headerset-output";
-        String storeName = "iqv2-headerset-store";
-        String appId = "iqv2-headerset-test";
-
-        createTopics(input, output);
-        // Caching disabled so both query paths read the store-served record directly.
-        KafkaStreams streams = startStreamsAndAwaitRunning(
-            buildTopology(input, output, storeName, false), appId, 30, null);
-        try {
-            // A header set no serde would produce on its own: an arbitrary user header, a duplicate
-            // key ("trace" twice, distinct values), and a zero-length value. The serde adds the
-            // schema-id headers during send(); snapshot the full produced set (in order) afterward so
-            // the round-trip below is asserted against exactly what was written -- count, order,
-            // duplicate key and empty value included, and nothing spurious added. An implementation
-            // that special-cased the __*_schema_id keys, collapsed the duplicate to lastHeader,
-            // dropped the empty value, or reordered would fail here.
-            List<String> producedHeaders;
-            try (KafkaProducer<GenericRecord, GenericRecord> producer =
-                     new KafkaProducer<>(createProducerProps())) {
-                ProducerRecord<GenericRecord, GenericRecord> record = new ProducerRecord<>(
-                    input, null, BASE_TIMESTAMP, createKey("word-1"), createValue(10L));
-                record.headers().add(SEQ_HEADER, "word-1".getBytes(StandardCharsets.UTF_8));
-                record.headers().add("trace", "A".getBytes(StandardCharsets.UTF_8));
-                record.headers().add("trace", "B".getBytes(StandardCharsets.UTF_8));
-                record.headers().add("empty", new byte[0]);
-                producer.send(record).get();
-                producer.flush();
-                producedHeaders = headerEntries(record.headers());
-            }
-            consumeRecords(output, appId + "-barrier", 1);
-
-            ReadOnlyRecord<GenericRecord, GenericRecord> point =
-                queryPointExpectPresent(streams, storeName, createKey("word-1"), false);
-            assertEquals(producedHeaders, headerEntries(point.headers()),
-                "point query should return the full produced header set -- order, the duplicate "
-                    + "'trace' key, the empty value and the schema-id headers -- and nothing else");
-
-            List<ReadOnlyRecord<GenericRecord, GenericRecord>> range = queryRange(
-                streams, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 1);
-            assertEquals(producedHeaders, headerEntries(range.get(0).headers()),
-                "range query should return the full produced header set");
         } finally {
             closeStreams(streams);
         }
@@ -529,6 +453,89 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
     }
 
     // ---------------------------------------------------------------------------------------------
+    // Header contract (point + range)
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldReturnReadOnlyHeaders() throws Exception {
+        String input = "iqv2-readonly-input";
+        String output = "iqv2-readonly-output";
+        String storeName = "iqv2-readonly-store";
+        String appId = "iqv2-readonly-test";
+
+        // Caching disabled so the range query (which bypasses the cache) sees the store-served record.
+        KafkaStreams streams = startAndPopulate(
+            storeName, input, output, appId,
+            Collections.singletonList("word-1"), Collections.singletonList(10L), false, null);
+        try {
+            // The query marks the returned headers read-only on both the point and range paths, so
+            // an attempt to mutate them must throw.
+            ReadOnlyRecord<GenericRecord, GenericRecord> point =
+                queryPointExpectPresent(streams, storeName, createKey("word-1"), false);
+            assertThrows(IllegalStateException.class,
+                () -> point.headers().add("x", new byte[]{1}),
+                "point query should return read-only headers");
+
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> range = queryRange(
+                streams, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 1);
+            assertThrows(IllegalStateException.class,
+                () -> range.get(0).headers().add("x", new byte[]{1}),
+                "range query should return read-only headers");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    @Test
+    public void shouldPreserveFullHeaderSetIncludingDuplicatesAndEmpty() throws Exception {
+        String input = "iqv2-headerset-input";
+        String output = "iqv2-headerset-output";
+        String storeName = "iqv2-headerset-store";
+        String appId = "iqv2-headerset-test";
+
+        createTopics(input, output);
+        // Caching disabled so both query paths read the store-served record directly.
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildTopology(input, output, storeName, false), appId, 30, null);
+        try {
+            // A header set no serde would produce on its own: an arbitrary user header, a duplicate
+            // key ("trace" twice, distinct values), and a zero-length value. The serde adds the
+            // schema-id headers during send(); snapshot the full produced set (in order) afterward so
+            // the round-trip below is asserted against exactly what was written -- count, order,
+            // duplicate key and empty value included, and nothing spurious added. An implementation
+            // that special-cased the __*_schema_id keys, collapsed the duplicate to lastHeader,
+            // dropped the empty value, or reordered would fail here.
+            List<String> producedHeaders;
+            try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                     new KafkaProducer<>(createProducerProps())) {
+                ProducerRecord<GenericRecord, GenericRecord> record = new ProducerRecord<>(
+                    input, null, BASE_TIMESTAMP, createKey("word-1"), createValue(10L));
+                record.headers().add(SEQ_HEADER, "word-1".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("trace", "A".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("trace", "B".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("empty", new byte[0]);
+                producer.send(record).get();
+                producer.flush();
+                producedHeaders = headerEntries(record.headers());
+            }
+            consumeRecords(output, appId + "-barrier", 1);
+
+            ReadOnlyRecord<GenericRecord, GenericRecord> point =
+                queryPointExpectPresent(streams, storeName, createKey("word-1"), false);
+            assertEquals(producedHeaders, headerEntries(point.headers()),
+                "point query should return the full produced header set -- order, the duplicate "
+                    + "'trace' key, the empty value and the schema-id headers -- and nothing else");
+
+            List<ReadOnlyRecord<GenericRecord, GenericRecord>> range = queryRange(
+                streams, storeName, TimestampedRangeWithHeadersQuery.withNoBounds(), 1);
+            assertEquals(producedHeaders, headerEntries(range.get(0).headers()),
+                "range query should return the full produced header set");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
     // Restore-from-changelog and multi-partition
     // ---------------------------------------------------------------------------------------------
 
@@ -638,7 +645,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
             // Scan every locally-available partition; collect and assert headers on every record.
             List<ReadOnlyRecord<GenericRecord, GenericRecord>> all = new ArrayList<>();
             Set<Integer> partitionsSeen = new HashSet<>();
-            long deadline = System.currentTimeMillis() + 30_000;
+            long deadline = System.currentTimeMillis() + QUERY_DEADLINE_MS;
             while (System.currentTimeMillis() < deadline) {
                 all.clear();
                 partitionsSeen.clear();
@@ -683,7 +690,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
         if (skipCache) {
             query = query.skipCache();
         }
-        long deadline = System.currentTimeMillis() + 30_000;
+        long deadline = System.currentTimeMillis() + QUERY_DEADLINE_MS;
         String lastFailure = null;
         while (System.currentTimeMillis() < deadline) {
             StateQueryResult<ReadOnlyRecord<GenericRecord, GenericRecord>> result =
@@ -750,7 +757,7 @@ public class TimestampedKeyValueStoreWithHeadersIQv2IntegrationTest
     private List<ReadOnlyRecord<GenericRecord, GenericRecord>> queryRange(
         KafkaStreams streams, String storeName,
         TimestampedRangeWithHeadersQuery<GenericRecord, GenericRecord> query, int expected) {
-        long deadline = System.currentTimeMillis() + 30_000;
+        long deadline = System.currentTimeMillis() + QUERY_DEADLINE_MS;
         List<ReadOnlyRecord<GenericRecord, GenericRecord>> out = new ArrayList<>();
         String lastFailure = null;
         while (System.currentTimeMillis() < deadline) {

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/WindowAndSessionStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/WindowAndSessionStoreWithHeadersIQv2IntegrationTest.java
@@ -18,6 +18,7 @@ package io.confluent.kafka.streams.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.confluent.kafka.serializers.schema.id.HeaderSchemaIdSerializer;
@@ -28,6 +29,7 @@ import java.time.Instant;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -45,6 +47,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -607,6 +610,210 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
     }
 
     // ---------------------------------------------------------------------------------------------
+    // Cache visibility, legacy-supplier controls, retain-duplicates, null-value, header-set,
+    // read-only
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldNotServeWindowFromCacheBeforeFlush() throws Exception {
+        String input = "iqv2-wincache-input";
+        String output = "iqv2-wincache-output";
+        String storeName = "iqv2-wincache-store";
+        String appId = "iqv2-wincache-test";
+
+        createTopics(input, output);
+        long base = baseTimestamp();
+        // Caching enabled + a very large commit interval so nothing flushes during the test: the record
+        // lives only in the record cache. The headers-aware CachingWindowStore does not override IQv2
+        // query(), so the query reads the still-empty persistent store and must return nothing. The
+        // barrier proves the processor genuinely put the record -- it is present, just unflushed.
+        int tenMinutes = (int) Duration.ofMinutes(10).toMillis();
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildWindowTopology(input, output, storeName, true, false), appId, 30, tenMinutes);
+        try {
+            produceOne(input, base, "sensor-1", createValue(1), "s1-cache");
+            consumeRecords(output, appId + "-barrier", 1);
+
+            assertTrue(queryWindowed(streams, storeName,
+                    TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
+                        createKey("sensor-1"), Instant.ofEpochMilli(base), Instant.ofEpochMilli(base)), 0)
+                    .isEmpty(),
+                "cached-but-unflushed window write must be invisible to the IQv2 query");
+
+            closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
+        }
+    }
+
+    @Test
+    public void shouldNotServeSessionFromCacheBeforeFlush() throws Exception {
+        String input = "iqv2-sesscache-input";
+        String output = "iqv2-sesscache-output";
+        String storeName = "iqv2-sesscache-store";
+        String appId = "iqv2-sesscache-test";
+
+        createTopics(input, output);
+        long base = baseTimestamp();
+        // Same as the window case: CachingSessionStore does not override IQv2 query(), so a
+        // cached-but-unflushed session write is invisible to the session query.
+        int tenMinutes = (int) Duration.ofMinutes(10).toMillis();
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildSessionTopology(input, output, storeName, true), appId, 30, tenMinutes);
+        try {
+            produceOne(input, base, "sensor-1", createValue(1), "s1-cache");
+            consumeRecords(output, appId + "-barrier", 1);
+
+            assertTrue(queryWindowed(streams, storeName,
+                    TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-1")), 0).isEmpty(),
+                "cached-but-unflushed session write must be invisible to the IQv2 query");
+
+            closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
+        }
+    }
+
+    @Test
+    public void shouldRetainDuplicateWindowsWithHeaders() throws Exception {
+        String input = "iqv2-windup-input";
+        String output = "iqv2-windup-output";
+        String storeName = "iqv2-windup-store";
+        String appId = "iqv2-windup-test";
+
+        createTopics(input, output);
+        long base = baseTimestamp();
+        // retainDuplicates=true: two puts to the same key+window coexist (seqnum-suffixed) instead of
+        // overwriting, and a null-value put is a no-op rather than a tombstone. (The builder also
+        // disables caching under retained duplicates.)
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildWindowTopology(input, output, storeName, false, true), appId);
+        try {
+            try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                     new KafkaProducer<>(createProducerProps())) {
+                send(producer, input, base, "sensor-1", createValue(1), "s1-dup-1");
+                send(producer, input, base, "sensor-1", createValue(2), "s1-dup-2");
+                // A null value would tombstone a normal store, but is a no-op under retained duplicates.
+                send(producer, input, base, "sensor-1", null, "s1-dup-tomb");
+                producer.flush();
+            }
+            consumeRecords(output, appId + "-barrier", 3);
+
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> records = queryWindowed(
+                streams, storeName,
+                TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
+                    createKey("sensor-1"), Instant.ofEpochMilli(base), Instant.ofEpochMilli(base)), 2);
+            assertEquals(2, records.size(), "both duplicate windows are retained (null put was a no-op)");
+            // Sort by reading so the assertion is independent of duplicate iteration order.
+            records.sort(Comparator.comparingLong(
+                (ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord> r) ->
+                    (Long) r.value().get("reading")));
+            assertWindowedRecord(records.get(0), "sensor-1", base, 1L, "s1-dup-1", "windup first");
+            assertWindowedRecord(records.get(1), "sensor-1", base, 2L, "s1-dup-2", "windup second");
+
+            closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
+        }
+    }
+
+    @Test
+    public void shouldReturnReadOnlyHeaders() throws Exception {
+        long base = baseTimestamp();
+
+        // Window path.
+        String winInput = "iqv2-rowin-input";
+        String winOutput = "iqv2-rowin-output";
+        String winStore = "iqv2-rowin-store";
+        String winAppId = "iqv2-rowin-test";
+        createTopics(winInput, winOutput);
+        KafkaStreams winStreams = startStreamsAndAwaitRunning(
+            buildWindowTopology(winInput, winOutput, winStore), winAppId);
+        try {
+            produceOne(winInput, base, "sensor-1", createValue(1), "s1-ro-win");
+            consumeRecords(winOutput, winAppId + "-barrier", 1);
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> winRecords = queryWindowed(
+                winStreams, winStore,
+                TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
+                    createKey("sensor-1"), Instant.ofEpochMilli(base), Instant.ofEpochMilli(base)), 1);
+            Headers winHeaders = winRecords.get(0).headers();
+            assertThrows(IllegalStateException.class, () -> winHeaders.add("x", new byte[]{1}),
+                "window query should return read-only headers");
+            closeStreams(winStreams);
+        } finally {
+            closeStreamsQuietly(winStreams);
+        }
+
+        // Session path.
+        String sessInput = "iqv2-rosess-input";
+        String sessOutput = "iqv2-rosess-output";
+        String sessStore = "iqv2-rosess-store";
+        String sessAppId = "iqv2-rosess-test";
+        createTopics(sessInput, sessOutput);
+        KafkaStreams sessStreams = startStreamsAndAwaitRunning(
+            buildSessionTopology(sessInput, sessOutput, sessStore), sessAppId);
+        try {
+            produceOne(sessInput, base, "sensor-1", createValue(1), "s1-ro-sess");
+            consumeRecords(sessOutput, sessAppId + "-barrier", 1);
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> sessRecords = queryWindowed(
+                sessStreams, sessStore,
+                TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-1")), 1);
+            Headers sessHeaders = sessRecords.get(0).headers();
+            assertThrows(IllegalStateException.class, () -> sessHeaders.add("x", new byte[]{1}),
+                "session query should return read-only headers");
+            closeStreams(sessStreams);
+        } finally {
+            closeStreamsQuietly(sessStreams);
+        }
+    }
+
+    @Test
+    public void shouldPreserveFullHeaderSetIncludingDuplicatesAndEmpty() throws Exception {
+        String input = "iqv2-winheaderset-input";
+        String output = "iqv2-winheaderset-output";
+        String storeName = "iqv2-winheaderset-store";
+        String appId = "iqv2-winheaderset-test";
+
+        createTopics(input, output);
+        long base = baseTimestamp();
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildWindowTopology(input, output, storeName), appId);
+        try {
+            // A header set no serde would produce on its own: an arbitrary user header, a duplicate key
+            // ("trace" twice, distinct values) and a zero-length value. The serde adds the schema-id
+            // headers during send(); snapshot the full produced set (in order) afterward so the
+            // round-trip is asserted against exactly what was written -- count, order, duplicate key
+            // and empty value included, and nothing spurious added or dropped.
+            List<String> producedHeaders;
+            try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                     new KafkaProducer<>(createProducerProps())) {
+                ProducerRecord<GenericRecord, GenericRecord> record = new ProducerRecord<>(
+                    input, null, base, createKey("sensor-1"), createValue(1));
+                record.headers().add(SEQ_HEADER, "s1-full".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("trace", "A".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("trace", "B".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("empty", new byte[0]);
+                producer.send(record).get();
+                producer.flush();
+                producedHeaders = headerEntries(record.headers());
+            }
+            consumeRecords(output, appId + "-barrier", 1);
+
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> records = queryWindowed(
+                streams, storeName,
+                TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
+                    createKey("sensor-1"), Instant.ofEpochMilli(base), Instant.ofEpochMilli(base)), 1);
+            assertEquals(producedHeaders, headerEntries(records.get(0).headers()),
+                "window query should return the full produced header set -- order, the duplicate "
+                    + "'trace' key, the empty value and the schema-id headers -- and nothing else");
+
+            closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
     // IQv2 query helpers
     // ---------------------------------------------------------------------------------------------
 
@@ -656,6 +863,7 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
     private Map.Entry<Integer, ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>>
         querySessionByKeyWithPartition(KafkaStreams streams, String storeName, GenericRecord key) {
         long deadline = System.currentTimeMillis() + 30_000;
+        String lastFailure = null;
         while (System.currentTimeMillis() < deadline) {
             StateQueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> result =
                 streams.query(StateQueryRequest.inStore(storeName)
@@ -675,6 +883,8 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
                             found = new AbstractMap.SimpleEntry<>(entry.getKey(), it.next());
                         }
                     }
+                } else if (pr.isFailure()) {
+                    lastFailure = pr.getFailureReason() + ": " + pr.getFailureMessage();
                 }
             }
             if (found != null) {
@@ -682,7 +892,10 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             }
             sleepQuietly(200);
         }
-        throw new AssertionError("session withKey query never returned a result for " + key);
+        // Surface the IQ failure reason rather than dropping it, so a query that failed on every
+        // attempt reports why instead of a bare "never returned a result".
+        throw new AssertionError("session withKey query never returned a result for " + key
+            + (lastFailure != null ? " (last failure: " + lastFailure + ")" : ""));
     }
 
     private void assertWindowedRecord(ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord> record,
@@ -730,6 +943,20 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             .sorted(Comparator.comparingLong(
                 (ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord> r) -> r.key().window().start()))
             .collect(Collectors.toList());
+    }
+
+    /**
+     * Renders headers as an ordered {@code key=base64(value)} list, preserving insertion order and
+     * duplicate keys, so two header sets can be compared for exact equality -- count, order,
+     * duplicates and byte-exact values (a zero-length value base64s to {@code ""}).
+     */
+    private static List<String> headerEntries(Headers headers) {
+        List<String> entries = new ArrayList<>();
+        for (Header h : headers) {
+            entries.add(h.key() + "=" + (h.value() == null
+                ? "<null>" : Base64.getEncoder().encodeToString(h.value())));
+        }
+        return entries;
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -817,14 +1044,21 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
     // ---------------------------------------------------------------------------------------------
 
     private Topology buildWindowTopology(String input, String output, String storeName) {
+        return buildWindowTopology(input, output, storeName, false, false);
+    }
+
+    private Topology buildWindowTopology(String input, String output, String storeName,
+        boolean cachingEnabled, boolean retainDuplicates) {
         GenericAvroSerde keySerde = createKeySerde();
         GenericAvroSerde valueSerde = createValueSerde();
         StoreBuilder<TimestampedWindowStoreWithHeaders<GenericRecord, GenericRecord>> storeBuilder =
             Stores.timestampedWindowStoreWithHeadersBuilder(
                 Stores.persistentTimestampedWindowStoreWithHeaders(
-                    storeName, RETENTION_PERIOD, WINDOW_SIZE, false),
-                keySerde, valueSerde)
-                .withCachingDisabled();
+                    storeName, RETENTION_PERIOD, WINDOW_SIZE, retainDuplicates),
+                keySerde, valueSerde);
+        storeBuilder = cachingEnabled
+            ? storeBuilder.withCachingEnabled()
+            : storeBuilder.withCachingDisabled();
 
         StreamsBuilder builder = new StreamsBuilder();
         builder
@@ -836,13 +1070,20 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
     }
 
     private Topology buildSessionTopology(String input, String output, String storeName) {
+        return buildSessionTopology(input, output, storeName, false);
+    }
+
+    private Topology buildSessionTopology(String input, String output, String storeName,
+        boolean cachingEnabled) {
         GenericAvroSerde keySerde = createKeySerde();
         GenericAvroSerde valueSerde = createValueSerde();
         StoreBuilder<SessionStoreWithHeaders<GenericRecord, GenericRecord>> storeBuilder =
             Stores.sessionStoreWithHeadersBuilder(
                 Stores.persistentSessionStoreWithHeaders(storeName, SESSION_RETENTION),
-                keySerde, valueSerde)
-                .withCachingDisabled();
+                keySerde, valueSerde);
+        storeBuilder = cachingEnabled
+            ? storeBuilder.withCachingEnabled()
+            : storeBuilder.withCachingDisabled();
 
         StreamsBuilder builder = new StreamsBuilder();
         builder

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/WindowAndSessionStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/WindowAndSessionStoreWithHeadersIQv2IntegrationTest.java
@@ -17,26 +17,34 @@
 package io.confluent.kafka.streams.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.confluent.kafka.serializers.schema.id.HeaderSchemaIdSerializer;
 import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Header;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -45,6 +53,7 @@ import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.processor.StateRestoreListener;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.ReadOnlyRecord;
@@ -81,7 +90,10 @@ import org.junit.jupiter.api.Test;
  * Records are produced with the schema-id GUID carried in the {@code __key_schema_id} /
  * {@code __value_schema_id} headers (via {@link HeaderSchemaIdSerializer}); each query result is a
  * {@link ReadOnlyRecordIterator} of {@link ReadOnlyRecord} whose headers must be the 17-byte
- * {@code MAGIC_BYTE_V1} GUID.
+ * {@code MAGIC_BYTE_V1} GUID. Because every record shares one Avro key/value schema, the schema-id
+ * GUIDs are byte-identical across records and cannot on their own prove a result carries <em>this</em>
+ * record's headers; every produced record therefore also carries a distinct {@link #SEQ_HEADER}
+ * ({@code seq}) header whose per-record value pins that fidelity.
  *
  * <p>Shared cluster/serde/lifecycle infrastructure lives in {@link HeadersIQv2IntegrationTestBase}.
  */
@@ -109,11 +121,18 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             + "\"namespace\":\"io.confluent.kafka.streams.integration\","
             + "\"fields\":[{\"name\":\"reading\",\"type\":\"long\"}]}");
 
-    // Every record in each test shares this one key/value schema, so every value-bearing record
-    // carries the same schema-id GUIDs. Capture them once when producing and assert that IQv2
-    // results come back byte-equal to what was produced (see
-    // HeadersIQv2IntegrationTestBase#assertSchemaIdHeaders).
-    private CapturedSchemaIds valueSchemaIds;
+    /**
+     * A distinct user header attached to every produced record, carrying that record's own id
+     * ({@code seq=<id>}). Because it differs per record -- unlike the schema-id GUIDs, which are
+     * byte-identical for every record since they all share one Avro schema -- asserting it on each
+     * IQv2 result proves the store returned <em>this</em> record's headers, not another record's.
+     */
+    private static final String SEQ_HEADER = "seq";
+
+    // Per-record captures, keyed by the record's seq id, so each IQv2 result is asserted against its
+    // own produced schema-id GUIDs (see HeadersIQv2IntegrationTestBase#assertSchemaIdHeaders) -- not
+    // a single shared value that every record would trivially match.
+    private final Map<String, CapturedSchemaIds> capturedBySeq = new HashMap<>();
 
     // ---------------------------------------------------------------------------------------------
     // TimestampedWindowKeyWithHeadersQuery (window store: single key across window-start range)
@@ -127,7 +146,7 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
         String appId = "iqv2-winkey-test";
 
         createTopics(input, output);
-        long base = alignedBase(WINDOW_SIZE.toMillis());
+        long base = baseTimestamp();
         long w0 = base;
         long w1 = base + 100;
         long w2 = base + 200;
@@ -140,17 +159,17 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             try (KafkaProducer<GenericRecord, GenericRecord> producer =
                      new KafkaProducer<>(createProducerProps())) {
                 // Queried key sensor-1 across four windows: live, live, tombstoned, live.
-                valueSchemaIds = sendAndCapture(producer, new ProducerRecord<>(input, null, w0, createKey("sensor-1"), createValue(0)));
-                sendAndCapture(producer, new ProducerRecord<>(input, null, w1, createKey("sensor-1"), createValue(1)));
-                sendAndCapture(producer, new ProducerRecord<>(input, null, w2, createKey("sensor-1"), createValue(2)));
-                sendAndCapture(producer, new ProducerRecord<>(input, null, w2, createKey("sensor-1"), (GenericRecord) null));
-                sendAndCapture(producer, new ProducerRecord<>(input, null, w3, createKey("sensor-1"), createValue(3)));
+                send(producer, input, w0, "sensor-1", createValue(0), "s1-w0");
+                send(producer, input, w1, "sensor-1", createValue(1), "s1-w1");
+                send(producer, input, w2, "sensor-1", createValue(2), "s1-w2");
+                send(producer, input, w2, "sensor-1", null, "s1-w2-tomb");
+                send(producer, input, w3, "sensor-1", createValue(3), "s1-w3");
                 // Noise key sensor-2 must not leak into sensor-1's results; its w0 tombstone is key-scoped
                 // and must not drop sensor-1's own w0.
-                sendAndCapture(producer, new ProducerRecord<>(input, null, w0, createKey("sensor-2"), createValue(10)));
-                sendAndCapture(producer, new ProducerRecord<>(input, null, w0, createKey("sensor-2"), (GenericRecord) null));
-                sendAndCapture(producer, new ProducerRecord<>(input, null, w1, createKey("sensor-2"), createValue(11)));
-                sendAndCapture(producer, new ProducerRecord<>(input, null, w4, createKey("sensor-2"), createValue(14)));
+                send(producer, input, w0, "sensor-2", createValue(10), "s2-w0");
+                send(producer, input, w0, "sensor-2", null, "s2-w0-tomb");
+                send(producer, input, w1, "sensor-2", createValue(11), "s2-w1");
+                send(producer, input, w4, "sensor-2", createValue(14), "s2-w4");
                 producer.flush();
             }
             consumeRecords(output, appId + "-barrier", 9);
@@ -164,9 +183,9 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             assertEquals(Arrays.asList(w0, w1, w3),
                 records.stream().map(r -> r.key().window().start()).collect(Collectors.toList()),
                 "sensor-1 window starts (w2 tombstoned, sensor-2 excluded)");
-            assertWindowedRecord(records.get(0), "sensor-1", w0, 0L, "winkey sensor-1 w0");
-            assertWindowedRecord(records.get(1), "sensor-1", w1, 1L, "winkey sensor-1 w1");
-            assertWindowedRecord(records.get(2), "sensor-1", w3, 3L, "winkey sensor-1 w3");
+            assertWindowedRecord(records.get(0), "sensor-1", w0, 0L, "s1-w0", "winkey sensor-1 w0");
+            assertWindowedRecord(records.get(1), "sensor-1", w1, 1L, "s1-w1", "winkey sensor-1 w1");
+            assertWindowedRecord(records.get(2), "sensor-1", w3, 3L, "s1-w3", "winkey sensor-1 w3");
 
             // Sub-range [w1, w2]: only w1 (w0 below lower bound, w2 tombstoned, w3 above upper bound).
             List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> subRange = queryWindowed(
@@ -175,7 +194,7 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
                     createKey("sensor-1"), Instant.ofEpochMilli(w1), Instant.ofEpochMilli(w2)),
                 1);
             assertEquals(1, subRange.size(), "sub-range returns only w1");
-            assertWindowedRecord(subRange.get(0), "sensor-1", w1, 1L, "winkey sub-range w1");
+            assertWindowedRecord(subRange.get(0), "sensor-1", w1, 1L, "s1-w1", "winkey sub-range w1");
 
             // A never-written key -> empty.
             assertTrue(queryWindowed(streams, storeName,
@@ -199,10 +218,30 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             assertEquals(Arrays.asList(w1, w4),
                 key2.stream().map(r -> r.key().window().start()).collect(Collectors.toList()),
                 "sensor-2 window starts (w0 tombstoned)");
-            assertWindowedRecord(key2.get(0), "sensor-2", w1, 11L, "winkey sensor-2 w1");
-            assertWindowedRecord(key2.get(1), "sensor-2", w4, 14L, "winkey sensor-2 w4");
-        } finally {
+            assertWindowedRecord(key2.get(0), "sensor-2", w1, 11L, "s2-w1", "winkey sensor-2 w1");
+            assertWindowedRecord(key2.get(1), "sensor-2", w4, 14L, "s2-w4", "winkey sensor-2 w4");
+
+            // Revival: re-put sensor-1's tombstoned w2 with a NEW record carrying a distinct seq. The
+            // store must serve the re-put's headers, not the stale pre-tombstone w2 headers -- this is
+            // where lingering headers would surface, so it proves a tombstoned entry revives with its
+            // own headers.
+            try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                     new KafkaProducer<>(createProducerProps())) {
+                send(producer, input, w2, "sensor-1", createValue(22), "s1-w2-revived");
+                producer.flush();
+            }
+            consumeRecords(output, appId + "-revive", 10);
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> revived = queryWindowed(
+                streams, storeName,
+                TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
+                    createKey("sensor-1"), Instant.ofEpochMilli(w2), Instant.ofEpochMilli(w2)),
+                1);
+            assertEquals(1, revived.size(), "revived w2 returns exactly one record");
+            assertWindowedRecord(revived.get(0), "sensor-1", w2, 22L, "s1-w2-revived", "winkey revived w2");
+
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -218,7 +257,7 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
         String appId = "iqv2-winrange-test";
 
         createTopics(input, output);
-        long base = alignedBase(WINDOW_SIZE.toMillis());
+        long base = baseTimestamp();
         long w0 = base;
         long w1 = base + 100;
         long w2 = base + 200;
@@ -229,13 +268,13 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             try (KafkaProducer<GenericRecord, GenericRecord> producer =
                      new KafkaProducer<>(createProducerProps())) {
                 // sensor-1 across two windows, both live and in range.
-                valueSchemaIds = sendAndCapture(producer, new ProducerRecord<>(input, null, w0, createKey("sensor-1"), createValue(0)));
-                sendAndCapture(producer, new ProducerRecord<>(input, null, w1, createKey("sensor-1"), createValue(1)));
+                send(producer, input, w0, "sensor-1", createValue(0), "s1-w0");
+                send(producer, input, w1, "sensor-1", createValue(1), "s1-w1");
                 // sensor-2: live in-range at w0, tombstoned in-range at w1, live out-of-range at w2.
-                sendAndCapture(producer, new ProducerRecord<>(input, null, w0, createKey("sensor-2"), createValue(10)));
-                sendAndCapture(producer, new ProducerRecord<>(input, null, w1, createKey("sensor-2"), createValue(11)));
-                sendAndCapture(producer, new ProducerRecord<>(input, null, w1, createKey("sensor-2"), (GenericRecord) null));
-                sendAndCapture(producer, new ProducerRecord<>(input, null, w2, createKey("sensor-2"), createValue(12)));
+                send(producer, input, w0, "sensor-2", createValue(10), "s2-w0");
+                send(producer, input, w1, "sensor-2", createValue(11), "s2-w1");
+                send(producer, input, w1, "sensor-2", null, "s2-w1-tomb");
+                send(producer, input, w2, "sensor-2", createValue(12), "s2-w2");
                 producer.flush();
             }
             consumeRecords(output, appId + "-barrier", 6);
@@ -246,6 +285,10 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
                 TimestampedWindowRangeWithHeadersQuery.withWindowStartRange(
                     Instant.ofEpochMilli(w0), Instant.ofEpochMilli(w1)),
                 3);
+            // Exactly the three expected windows come back: a spurious extra key would otherwise be
+            // silently ignored by the per-sensor filters below.
+            assertEquals(3, records.size(),
+                "range returns exactly sensor-1 w0/w1 and sensor-2 w0");
 
             // sensor-1: both windows are in range.
             List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> sensor1 =
@@ -253,8 +296,8 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             assertEquals(Arrays.asList(w0, w1),
                 sensor1.stream().map(r -> r.key().window().start()).collect(Collectors.toList()),
                 "sensor-1 windows in range");
-            assertWindowedRecord(sensor1.get(0), "sensor-1", w0, 0L, "winrange sensor-1 w0");
-            assertWindowedRecord(sensor1.get(1), "sensor-1", w1, 1L, "winrange sensor-1 w1");
+            assertWindowedRecord(sensor1.get(0), "sensor-1", w0, 0L, "s1-w0", "winrange sensor-1 w0");
+            assertWindowedRecord(sensor1.get(1), "sensor-1", w1, 1L, "s1-w1", "winrange sensor-1 w1");
 
             // sensor-2: w0 survives; w1 is tombstoned; w2 is excluded by the range upper bound.
             List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> sensor2 =
@@ -262,9 +305,11 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             assertEquals(Arrays.asList(w0),
                 sensor2.stream().map(r -> r.key().window().start()).collect(Collectors.toList()),
                 "sensor-2 windows in range (w1 tombstoned, w2 out of range)");
-            assertWindowedRecord(sensor2.get(0), "sensor-2", w0, 10L, "winrange sensor-2 w0");
-        } finally {
+            assertWindowedRecord(sensor2.get(0), "sensor-2", w0, 10L, "s2-w0", "winrange sensor-2 w0");
+
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -280,7 +325,7 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
         String appId = "iqv2-session-test";
 
         createTopics(input, output);
-        long base = alignedBase(WINDOW_SIZE.toMillis());
+        long base = baseTimestamp();
 
         KafkaStreams streams = startStreamsAndAwaitRunning(
             buildSessionMergingTopology(input, output, storeName), appId);
@@ -288,30 +333,34 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             try (KafkaProducer<GenericRecord, GenericRecord> producer =
                      new KafkaProducer<>(createProducerProps())) {
                 // sensor-1: three records within the merge gap collapse into one variable-length session
-                // [base, base+55] whose reading is the sum (1+2+3=6) and whose headers come from the last
-                // record folded in.
-                valueSchemaIds = sendAndCapture(producer, new ProducerRecord<>(input, null, base, createKey("sensor-1"), createValue(1)));
-                sendAndCapture(producer, new ProducerRecord<>(input, null, base + 30, createKey("sensor-1"), createValue(2)));
-                sendAndCapture(producer, new ProducerRecord<>(input, null, base + 55, createKey("sensor-1"), createValue(3)));
+                // [base, base+55] whose reading is the sum (1+2+3=6) and whose headers are the LAST
+                // folded record's -- asserted via its distinct seq (s1-merge-3) below.
+                send(producer, input, base, "sensor-1", createValue(1), "s1-merge-1");
+                send(producer, input, base + 30, "sensor-1", createValue(2), "s1-merge-2");
+                send(producer, input, base + 55, "sensor-1", createValue(3), "s1-merge-3");
                 // A distant record (> gap away) forms a separate, zero-length session [base+500, base+500].
-                sendAndCapture(producer, new ProducerRecord<>(input, null, base + 500, createKey("sensor-1"), createValue(4)));
+                send(producer, input, base + 500, "sensor-1", createValue(4), "s1-distant");
                 // Noise key sensor-2: a session written then tombstoned -- must not survive or leak.
-                sendAndCapture(producer, new ProducerRecord<>(input, null, base, createKey("sensor-2"), createValue(20)));
-                sendAndCapture(producer, new ProducerRecord<>(input, null, base, createKey("sensor-2"), (GenericRecord) null));
+                send(producer, input, base, "sensor-2", createValue(20), "s2-sess");
+                send(producer, input, base, "sensor-2", null, "s2-tomb");
                 producer.flush();
             }
             consumeRecords(output, appId + "-barrier", 6);
 
-            // sensor-1 has two variable-length sessions, returned in window-start order.
+            // sensor-1 has two variable-length sessions. The withKey session query documents no
+            // iteration order, so sort locally (recordsForSensor) to assert the set order-independently.
             List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> records = recordsForSensor(
                 queryWindowed(streams, storeName,
                     TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-1")), 2),
                 "sensor-1");
             assertEquals(2, records.size(), "sensor-1 should have two sessions");
-            // Merged, variable-length session [base, base+55], summed reading, last writer's headers.
-            assertSessionRecord(records.get(0), "sensor-1", base, base + 55, 6L, "session merged");
+            // Merged, variable-length session [base, base+55], summed reading, last folded record's
+            // headers (seq s1-merge-3).
+            assertSessionRecord(records.get(0), "sensor-1", base, base + 55, 6L, "s1-merge-3",
+                "session merged");
             // A separate zero-length session -- proves the end round-trips from the stored value.
-            assertSessionRecord(records.get(1), "sensor-1", base + 500, base + 500, 4L, "session zero-length");
+            assertSessionRecord(records.get(1), "sensor-1", base + 500, base + 500, 4L, "s1-distant",
+                "session zero-length");
 
             // sensor-2's only session was tombstoned -> empty; a never-written key is likewise empty.
             assertTrue(queryWindowed(streams, storeName,
@@ -320,8 +369,10 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             assertTrue(queryWindowed(streams, storeName,
                     TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-999")), 0).isEmpty(),
                 "never-written key returns no sessions");
-        } finally {
+
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -337,30 +388,42 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
         String appId = "iqv2-winrestore-test";
 
         createTopics(input, output);
-        long base = alignedBase(WINDOW_SIZE.toMillis());
+        long base = baseTimestamp();
 
         KafkaStreams streams = startStreamsAndAwaitRunning(
             buildWindowTopology(input, output, storeName), appId);
         try {
-            valueSchemaIds = produce(input, createKey("sensor-1"), createValue(1), base);
+            produceOne(input, base, "sensor-1", createValue(1), "s1-restore");
             consumeRecords(output, appId + "-pre", 1);
-        } finally {
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
 
         // Restart with the same APPLICATION_ID; cleanUp() wipes the local state dir so the window
-        // store must be rebuilt from the changelog. The restored entry must still carry its headers.
-        KafkaStreams restored = startStreamsAndAwaitRunning(
-            buildWindowTopology(input, output, storeName), appId, 90);
+        // store must be rebuilt from the changelog. The restore listener proves the rebuild actually
+        // happened -- cleanUp() clears local state but not committed offsets, so without it the
+        // restart could silently reprocess the input and pass with no restore at all.
+        AtomicLong restoredCount = new AtomicLong(0);
+        KafkaStreams restored = startRestoredAndAwaitRunning(
+            buildWindowTopology(input, output, storeName), appId, storeName, restoredCount);
         try {
             List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> records = queryWindowed(
                 restored, storeName,
                 TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
                     createKey("sensor-1"), Instant.ofEpochMilli(base), Instant.ofEpochMilli(base)),
                 1);
-            assertWindowedRecord(records.get(0), "sensor-1", base, 1L, "restored window sensor-1");
-        } finally {
+            assertEquals(1, records.size(), "exactly one restored window entry");
+            assertWindowedRecord(records.get(0), "sensor-1", base, 1L, "s1-restore",
+                "restored window sensor-1");
+            // Pin that the store was genuinely rebuilt from the changelog, not repopulated by a
+            // silent reprocess of the input topic.
+            assertTrue(restoredCount.get() > 0,
+                "window store should have been restored from the changelog (restored "
+                    + restoredCount.get() + " records)");
             closeStreams(restored);
+        } finally {
+            closeStreamsQuietly(restored);
         }
     }
 
@@ -372,31 +435,48 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
         String appId = "iqv2-sessrestore-test";
 
         createTopics(input, output);
-        long base = alignedBase(WINDOW_SIZE.toMillis());
-        long sessionEnd = base + SESSION_DURATION_MS;
+        long base = baseTimestamp();
 
+        // Use the merging writer so a multi-record (merged) AggregationWithHeaders -- not just a
+        // single fixed-length session -- goes through the changelog and back.
         KafkaStreams streams = startStreamsAndAwaitRunning(
-            buildSessionTopology(input, output, storeName), appId);
+            buildSessionMergingTopology(input, output, storeName), appId);
         try {
-            valueSchemaIds = produce(input, createKey("sensor-1"), createValue(42), base);
-            consumeRecords(output, appId + "-pre", 1);
-        } finally {
+            try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                     new KafkaProducer<>(createProducerProps())) {
+                // Three records within the merge gap -> one merged session [base, base+55], reading 6,
+                // carrying the last folded record's headers (seq s1-sr-3).
+                send(producer, input, base, "sensor-1", createValue(1), "s1-sr-1");
+                send(producer, input, base + 30, "sensor-1", createValue(2), "s1-sr-2");
+                send(producer, input, base + 55, "sensor-1", createValue(3), "s1-sr-3");
+                producer.flush();
+            }
+            consumeRecords(output, appId + "-pre", 3);
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
 
         // Restart with the same APPLICATION_ID; the session store (backed by AggregationWithHeaders)
-        // must be rebuilt from the changelog, and the restored session must still carry its headers.
-        KafkaStreams restored = startStreamsAndAwaitRunning(
-            buildSessionTopology(input, output, storeName), appId, 90);
+        // must be rebuilt from the changelog, and the restored merged session must still carry its
+        // headers. The restore listener proves the rebuild happened rather than a silent reprocess.
+        AtomicLong restoredCount = new AtomicLong(0);
+        KafkaStreams restored = startRestoredAndAwaitRunning(
+            buildSessionMergingTopology(input, output, storeName), appId, storeName, restoredCount);
         try {
-            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> records = queryWindowed(
-                restored, storeName,
-                TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-1")),
-                1);
-            assertSessionRecord(
-                records.get(0), "sensor-1", base, sessionEnd, 42L, "restored session sensor-1");
-        } finally {
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> records = recordsForSensor(
+                queryWindowed(restored, storeName,
+                    TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-1")), 1),
+                "sensor-1");
+            assertEquals(1, records.size(), "exactly one restored (merged) session");
+            assertSessionRecord(records.get(0), "sensor-1", base, base + 55, 6L, "s1-sr-3",
+                "restored merged session sensor-1");
+            assertTrue(restoredCount.get() > 0,
+                "session store should have been restored from the changelog (restored "
+                    + restoredCount.get() + " records)");
             closeStreams(restored);
+        } finally {
+            closeStreamsQuietly(restored);
         }
     }
 
@@ -410,19 +490,19 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
         int numKeys = 9;
 
         createTopicsWithPartitions(numPartitions, input, output);
-        long base = alignedBase(WINDOW_SIZE.toMillis());
-
-        List<GenericRecord> keys = new ArrayList<>();
-        List<GenericRecord> values = new ArrayList<>();
-        for (int i = 1; i <= numKeys; i++) {
-            keys.add(createKey("sensor-" + i));
-            values.add(createValue(i));
-        }
+        long base = baseTimestamp();
 
         KafkaStreams streams = startStreamsAndAwaitRunning(
             buildWindowTopology(input, output, storeName), appId);
         try {
-            valueSchemaIds = produceAll(input, keys, values, base).get(0);
+            try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                     new KafkaProducer<>(createProducerProps())) {
+                for (int i = 1; i <= numKeys; i++) {
+                    String sensorId = "sensor-" + i;
+                    send(producer, input, base, sensorId, createValue(i), sensorId);
+                }
+                producer.flush();
+            }
             consumeRecords(output, appId + "-barrier", numKeys);
 
             // withWindowStartRange fans across partitions; aggregate every partition's result.
@@ -453,16 +533,30 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
                 sleepQuietly(200);
             }
 
+            // Assert the distinct key set, not just the count: returning one key twice and dropping
+            // another would keep the size at numKeys but change the set.
+            Set<String> expectedKeys = new HashSet<>();
+            for (int i = 1; i <= numKeys; i++) {
+                expectedKeys.add("sensor-" + i);
+            }
+            Set<String> actualKeys = all.stream()
+                .map(r -> r.key().key().get("sensorId").toString())
+                .collect(Collectors.toSet());
             assertEquals(numKeys, all.size(), "should read every key across partitions");
+            assertEquals(expectedKeys, actualKeys,
+                "should read every distinct key across partitions (none dropped or duplicated)");
             assertTrue(partitionsSeen.size() > 1,
                 "window records should span more than one partition but saw: " + partitionsSeen);
             for (ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord> r : all) {
                 String sensorId = r.key().key().get("sensorId").toString();
                 long reading = Long.parseLong(sensorId.substring("sensor-".length()));
-                assertWindowedRecord(r, sensorId, base, reading, "window multi-partition " + sensorId);
+                assertWindowedRecord(r, sensorId, base, reading, sensorId,
+                    "window multi-partition " + sensorId);
             }
-        } finally {
+
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -476,20 +570,20 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
         int numKeys = 9;
 
         createTopicsWithPartitions(numPartitions, input, output);
-        long base = alignedBase(WINDOW_SIZE.toMillis());
+        long base = baseTimestamp();
         long sessionEnd = base + SESSION_DURATION_MS;
-
-        List<GenericRecord> keys = new ArrayList<>();
-        List<GenericRecord> values = new ArrayList<>();
-        for (int i = 1; i <= numKeys; i++) {
-            keys.add(createKey("sensor-" + i));
-            values.add(createValue(i));
-        }
 
         KafkaStreams streams = startStreamsAndAwaitRunning(
             buildSessionTopology(input, output, storeName), appId);
         try {
-            valueSchemaIds = produceAll(input, keys, values, base).get(0);
+            try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                     new KafkaProducer<>(createProducerProps())) {
+                for (int i = 1; i <= numKeys; i++) {
+                    String sensorId = "sensor-" + i;
+                    send(producer, input, base, sensorId, createValue(i), sensorId);
+                }
+                producer.flush();
+            }
             consumeRecords(output, appId + "-barrier", numKeys);
 
             // A session withKey query routes to the key's partition, so query each key and record the
@@ -499,14 +593,16 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
                 String sensorId = "sensor-" + i;
                 Map.Entry<Integer, ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> served =
                     querySessionByKeyWithPartition(streams, storeName, createKey(sensorId));
-                assertSessionRecord(served.getValue(), sensorId, base, sessionEnd, i,
+                assertSessionRecord(served.getValue(), sensorId, base, sessionEnd, i, sensorId,
                     "session multi-partition " + sensorId);
                 partitionsSeen.add(served.getKey());
             }
             assertTrue(partitionsSeen.size() > 1,
                 "session keys should resolve across more than one partition but saw: " + partitionsSeen);
-        } finally {
+
             closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
         }
     }
 
@@ -519,6 +615,8 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
         Query<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> query, int expected) {
         long deadline = System.currentTimeMillis() + 30_000;
         List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> out = new ArrayList<>();
+        boolean sawSuccess = false;
+        String lastFailure = null;
         while (System.currentTimeMillis() < deadline) {
             out.clear();
             StateQueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> result =
@@ -526,6 +624,7 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             QueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> pr =
                 result.getOnlyPartitionResult();
             if (pr != null && pr.isSuccess() && pr.getResult() != null) {
+                sawSuccess = true;
                 try (ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord> it = pr.getResult()) {
                     while (it.hasNext()) {
                         out.add(it.next());
@@ -534,16 +633,25 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
                 if (out.size() >= expected) {
                     return out;
                 }
+            } else if (pr != null && pr.isFailure()) {
+                lastFailure = pr.getFailureReason() + ": " + pr.getFailureMessage();
             }
             sleepQuietly(200);
         }
+        // Require at least one successful query: otherwise an expected==0 caller would pass on a query
+        // that failed on every attempt (e.g. an unsupported query type), reading as assertEquals(0, 0).
+        assertTrue(sawSuccess, "IQv2 windowed query never succeeded within 30s"
+            + (lastFailure != null ? " (last failure: " + lastFailure + ")" : ""));
         assertEquals(expected, out.size(), "IQv2 windowed query returned an unexpected count");
         return out;
     }
 
     /**
      * Runs a session {@code withKey} query (which routes to the key's partition) and returns the
-     * partition id that served it together with the single session record.
+     * partition id that served it together with the single session record. {@code streams.query}
+     * opens an iterator for every local partition result eagerly, so this drains and closes every
+     * partition's iterator each attempt -- returning early from inside the loop would leak the
+     * iterators of the partitions not yet visited.
      */
     private Map.Entry<Integer, ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>>
         querySessionByKeyWithPartition(KafkaStreams streams, String storeName, GenericRecord key) {
@@ -552,16 +660,25 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             StateQueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> result =
                 streams.query(StateQueryRequest.inStore(storeName)
                     .withQuery(TimestampedWindowRangeWithHeadersQuery.withKey(key)));
-            for (Integer partition : result.getPartitionResults().keySet()) {
+            Map.Entry<Integer, ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> found = null;
+            for (Map.Entry<Integer,
+                    QueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>>> entry
+                    : result.getPartitionResults().entrySet()) {
                 QueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> pr =
-                    result.getPartitionResults().get(partition);
+                    entry.getValue();
                 if (pr.isSuccess() && pr.getResult() != null) {
-                    try (ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord> it = pr.getResult()) {
-                        if (it.hasNext()) {
-                            return new AbstractMap.SimpleEntry<>(partition, it.next());
+                    try (ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord> it =
+                             pr.getResult()) {
+                        // Take the first match, but keep draining/closing the remaining partitions'
+                        // iterators before returning.
+                        if (found == null && it.hasNext()) {
+                            found = new AbstractMap.SimpleEntry<>(entry.getKey(), it.next());
                         }
                     }
                 }
+            }
+            if (found != null) {
+                return found;
             }
             sleepQuietly(200);
         }
@@ -569,23 +686,41 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
     }
 
     private void assertWindowedRecord(ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord> record,
-        String sensorId, long windowStart, long reading, String context) {
+        String sensorId, long windowStart, long reading, String seq, String context) {
         assertEquals(sensorId, record.key().key().get("sensorId").toString(), context + " key");
         assertEquals(windowStart, record.key().window().start(), context + " window start");
         assertEquals(windowStart + EVENT_TIME_OFFSET_MS, record.timestamp(), context + " event-time");
         assertEquals(reading, record.value().get("reading"), context + " value");
-        assertSchemaIdHeaders(record.headers(), valueSchemaIds, context);
+        assertRecordHeaders(record, seq, context);
     }
 
     private void assertSessionRecord(ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord> record,
-        String sensorId, long start, long end, long reading, String context) {
+        String sensorId, long start, long end, long reading, String seq, String context) {
         assertEquals(sensorId, record.key().key().get("sensorId").toString(), context + " key");
         assertEquals(start, record.key().window().start(), context + " session start");
         assertEquals(end, record.key().window().end(), context + " session end");
         // A session carries no per-record event-time; timestamp() is the session window's end.
         assertEquals(end, record.timestamp(), context + " timestamp == session end");
         assertEquals(reading, record.value().get("reading"), context + " value");
-        assertSchemaIdHeaders(record.headers(), valueSchemaIds, context);
+        assertRecordHeaders(record, seq, context);
+    }
+
+    /**
+     * Asserts the record carries the exact headers produced for {@code seq}: the schema-id GUIDs
+     * byte-equal to what that record's serializer wrote, and the distinct {@code seq} header equal to
+     * the id passed here. The {@code seq} check is what makes this a per-record fidelity assertion --
+     * every record shares one Avro schema, so the schema-id GUIDs alone are byte-identical across
+     * records and could not distinguish one record's headers from another's.
+     */
+    private void assertRecordHeaders(ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord> record,
+        String seq, String context) {
+        CapturedSchemaIds expected = capturedBySeq.get(seq);
+        assertNotNull(expected, context + ": no captured schema-id GUIDs for seq " + seq);
+        assertSchemaIdHeaders(record.headers(), expected, context);
+        Header seqHeader = record.headers().lastHeader(SEQ_HEADER);
+        assertNotNull(seqHeader, context + ": missing " + SEQ_HEADER + " header");
+        assertEquals(seq, new String(seqHeader.value(), StandardCharsets.UTF_8),
+            context + ": " + SEQ_HEADER + " header should carry this record's own id");
     }
 
     private List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> recordsForSensor(
@@ -595,6 +730,86 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             .sorted(Comparator.comparingLong(
                 (ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord> r) -> r.key().window().start()))
             .collect(Collectors.toList());
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Producing (attaches a distinct per-record seq header and captures the produced GUIDs)
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Sends one record carrying a distinct {@link #SEQ_HEADER} ({@code seq}) so each IQv2 result can
+     * be asserted against its own produced record -- not a single shared value every record would
+     * trivially match -- and captures the schema-id GUIDs the serializer wrote, keyed by {@code seq}.
+     * A null {@code value} produces a tombstone (no value GUID captured); its seq is never asserted.
+     */
+    private void send(KafkaProducer<GenericRecord, GenericRecord> producer, String topic,
+        long timestamp, String sensorId, GenericRecord value, String seq) throws Exception {
+        ProducerRecord<GenericRecord, GenericRecord> record =
+            new ProducerRecord<>(topic, null, timestamp, createKey(sensorId), value);
+        record.headers().add(SEQ_HEADER, seq.getBytes(StandardCharsets.UTF_8));
+        capturedBySeq.put(seq, sendAndCapture(producer, record));
+    }
+
+    /** Produces a single record (with its own producer) via {@link #send}. */
+    private void produceOne(String topic, long timestamp, String sensorId, GenericRecord value,
+        String seq) throws Exception {
+        try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                 new KafkaProducer<>(createProducerProps())) {
+            send(producer, topic, timestamp, sensorId, value, seq);
+            producer.flush();
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Streams lifecycle helpers specific to this test
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Starts a KafkaStreams that must rebuild its store from the changelog and returns it once
+     * RUNNING, wiring a {@link StateRestoreListener} that sums the records restored for
+     * {@code storeName} into {@code restoredCount} -- so a test can prove the store was genuinely
+     * restored, not silently reprocessed from the input topic. The base start helper cannot set a
+     * restore listener, so the instance is started inline here.
+     */
+    private KafkaStreams startRestoredAndAwaitRunning(Topology topology, String appId,
+        String storeName, AtomicLong restoredCount) throws Exception {
+        StateRestoreListener restoreListener = new StateRestoreListener() {
+            @Override
+            public void onRestoreStart(TopicPartition tp, String store, long start, long end) {
+            }
+
+            @Override
+            public void onBatchRestored(TopicPartition tp, String store, long end, long batch) {
+            }
+
+            @Override
+            public void onRestoreEnd(TopicPartition tp, String store, long totalRestored) {
+                if (store.equals(storeName)) {
+                    restoredCount.addAndGet(totalRestored);
+                }
+            }
+        };
+        KafkaStreams restored = new KafkaStreams(topology, createStreamsProps(appId, null));
+        boolean running = false;
+        try {
+            restored.cleanUp();
+            restored.setGlobalStateRestoreListener(restoreListener);
+            CountDownLatch runningLatch = new CountDownLatch(1);
+            restored.setStateListener((newState, oldState) -> {
+                if (newState == KafkaStreams.State.RUNNING) {
+                    runningLatch.countDown();
+                }
+            });
+            restored.start();
+            assertTrue(runningLatch.await(90, TimeUnit.SECONDS),
+                "restored KafkaStreams should reach RUNNING within 90s");
+            running = true;
+            return restored;
+        } finally {
+            if (!running) {
+                closeStreamsQuietly(restored);
+            }
+        }
     }
 
     // ---------------------------------------------------------------------------------------------
@@ -794,8 +1009,15 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
     // Avro record factories (schema-specific; the shared infrastructure lives in the base class)
     // ---------------------------------------------------------------------------------------------
 
-    private static long alignedBase(long windowMs) {
-        return (System.currentTimeMillis() / windowMs) * windowMs;
+    /**
+     * A recent base event-time for the produced records. It must be recent -- within the stores'
+     * retention ({@link #RETENTION_PERIOD} / {@link #SESSION_RETENTION}) -- so no entry expires
+     * before it is queried. It is deliberately not aligned to the window size: every processor
+     * derives its window/session bounds from {@code record.timestamp()} directly, so aligning the
+     * base to a window boundary would have no effect on where the windows fall.
+     */
+    private static long baseTimestamp() {
+        return System.currentTimeMillis();
     }
 
     private GenericRecord createKey(String sensorId) {

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/WindowAndSessionStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/WindowAndSessionStoreWithHeadersIQv2IntegrationTest.java
@@ -56,6 +56,7 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.errors.InvalidStateStoreException;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.Windowed;
@@ -531,13 +532,14 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
                     streams.query(StateQueryRequest.inStore(storeName)
                         .withQuery(TimestampedWindowRangeWithHeadersQuery.withWindowStartRange(
                             Instant.ofEpochMilli(base), Instant.ofEpochMilli(base))));
-                String failure = drainPartitions(result, (partition, record) -> {
+                // Overwrite rather than accumulate: the assertions below read `all` and
+                // `partitionsSeen`, which hold this attempt's result only, so a failure carried over
+                // from an earlier attempt would append a stale reason to an assertion that failed for
+                // an unrelated one.
+                lastFailure = drainPartitions(result, (partition, record) -> {
                     all.add(record);
                     partitionsSeen.add(partition);
                 });
-                if (failure != null) {
-                    lastFailure = failure;
-                }
                 if (all.size() >= numKeys) {
                     break;
                 }
@@ -601,8 +603,9 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             }
             consumeRecords(output, appId + "-barrier", numKeys);
 
-            // A session withKey query routes to the key's partition, so query each key and record the
-            // partition that served it; collectively the keys must resolve across >1 partition.
+            // A session withKey query runs on every local partition; only the partition owning the key
+            // has a session for it, so query each key and record the partition that returned it.
+            // Collectively the keys must resolve across >1 partition.
             Set<Integer> partitionsSeen = new HashSet<>();
             for (int i = 1; i <= numKeys; i++) {
                 String sensorId = "sensor-" + i;
@@ -855,6 +858,9 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
                 result.getOnlyPartitionResult();
             if (pr != null && pr.isSuccess() && pr.getResult() != null) {
                 sawSuccess = true;
+                // Drop any carried-over reason: this attempt succeeded, so it -- not an older failed
+                // attempt -- produced the `out` the assertions below report on.
+                lastFailure = null;
                 try (ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord> it = pr.getResult()) {
                     while (it.hasNext()) {
                         out.add(it.next());
@@ -868,19 +874,25 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             }
             sleepQuietly(200);
         }
+        String failureSuffix = lastFailure != null ? " (last failure: " + lastFailure + ")" : "";
         // Require at least one successful query: otherwise an expected==0 caller would pass on a query
         // that failed on every attempt (e.g. an unsupported query type), reading as assertEquals(0, 0).
-        assertTrue(sawSuccess, "IQv2 windowed query never succeeded within " + QUERY_DEADLINE_MS + "ms"
-            + (lastFailure != null ? " (last failure: " + lastFailure + ")" : ""));
-        assertEquals(expected, out.size(), "IQv2 windowed query returned an unexpected count");
+        assertTrue(sawSuccess,
+            "IQv2 windowed query never succeeded within " + QUERY_DEADLINE_MS + "ms" + failureSuffix);
+        // `out` holds the last attempt's result, so surface that attempt's failure here too: a run
+        // whose final attempt failed would otherwise read as a bare "expected: <3> but was: <0>".
+        assertEquals(expected, out.size(),
+            "IQv2 windowed query returned an unexpected count" + failureSuffix);
         return out;
     }
 
     /**
-     * Runs a session {@code withKey} query (which routes to the key's partition) and returns the
-     * partition id that served it together with the single session record, retrying until a result
-     * appears. Every partition's iterator is drained and closed on each attempt -- see
-     * {@link #drainPartitions}.
+     * Runs a session {@code withKey} query and returns the partition id that served it together with
+     * the single session record, retrying until a result appears. A {@link StateQueryRequest} without
+     * {@code withPartitions} targets every local partition, so the query runs on all of them and only
+     * the partition owning the key returns a session -- which is what makes the "exactly one result"
+     * assertion below meaningful. Every partition's iterator is drained and closed on each attempt --
+     * see {@link #drainPartitions}.
      */
     private Map.Entry<Integer, ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>>
         querySessionByKeyWithPartition(KafkaStreams streams, String storeName, GenericRecord key) {
@@ -1018,6 +1030,27 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
     // ---------------------------------------------------------------------------------------------
 
     /**
+     * Resolves an IQv1 store handle, retrying until the store is queryable. {@link KafkaStreams#store}
+     * throws {@link InvalidStateStoreException} whenever the store is not currently available (a
+     * rebalance, a thread not yet RUNNING), so a single call can flake even after the output-topic
+     * barrier -- the same reason every IQv2 read in this file retries.
+     */
+    private static <T> T awaitStore(KafkaStreams streams, StoreQueryParameters<T> parameters) {
+        long deadline = System.currentTimeMillis() + QUERY_DEADLINE_MS;
+        InvalidStateStoreException lastFailure = null;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                return streams.store(parameters);
+            } catch (InvalidStateStoreException e) {
+                lastFailure = e;
+                sleepQuietly(200);
+            }
+        }
+        throw new AssertionError("store " + parameters.storeName() + " did not become queryable within "
+            + QUERY_DEADLINE_MS + "ms", lastFailure);
+    }
+
+    /**
      * Positive control for {@link #shouldNotServeWindowFromCacheBeforeFlush}: reads the entry back
      * through IQv1 {@link ReadOnlyWindowStore#fetch}, which merges the record cache with the
      * persistent store, so a cached-but-unflushed write is visible here even though the IQv2 query
@@ -1026,7 +1059,7 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
     private void assertWindowServedFromCache(KafkaStreams streams, String storeName, String sensorId,
         long windowStart, long reading, String seq, String context) {
         ReadOnlyWindowStore<GenericRecord, ValueTimestampHeaders<GenericRecord>> store =
-            streams.store(StoreQueryParameters.fromNameAndType(
+            awaitStore(streams, StoreQueryParameters.fromNameAndType(
                 storeName, QueryableStoreTypes.timestampedWindowStoreWithHeaders()));
         List<ValueTimestampHeaders<GenericRecord>> served = new ArrayList<>();
         try (WindowStoreIterator<ValueTimestampHeaders<GenericRecord>> it = store.fetch(
@@ -1047,7 +1080,7 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
     private void assertSessionServedFromCache(KafkaStreams streams, String storeName, String sensorId,
         long start, long end, long reading, String seq, String context) {
         ReadOnlySessionStore<GenericRecord, AggregationWithHeaders<GenericRecord>> store =
-            streams.store(StoreQueryParameters.fromNameAndType(
+            awaitStore(streams, StoreQueryParameters.fromNameAndType(
                 storeName, QueryableStoreTypes.sessionStoreWithHeaders()));
         List<KeyValue<Windowed<GenericRecord>, AggregationWithHeaders<GenericRecord>>> served =
             new ArrayList<>();

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/WindowAndSessionStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/WindowAndSessionStoreWithHeadersIQv2IntegrationTest.java
@@ -30,15 +30,18 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -50,6 +53,7 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StoreQueryParameters;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.kstream.Consumed;
@@ -69,12 +73,16 @@ import org.apache.kafka.streams.query.TimestampedWindowKeyWithHeadersQuery;
 import org.apache.kafka.streams.query.TimestampedWindowRangeWithHeadersQuery;
 import org.apache.kafka.streams.state.AggregationWithHeaders;
 import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
 import org.apache.kafka.streams.state.ReadOnlyRecordIterator;
+import org.apache.kafka.streams.state.ReadOnlySessionStore;
+import org.apache.kafka.streams.state.ReadOnlyWindowStore;
 import org.apache.kafka.streams.state.SessionStoreWithHeaders;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.TimestampedWindowStoreWithHeaders;
 import org.apache.kafka.streams.state.ValueTimestampHeaders;
+import org.apache.kafka.streams.state.WindowStoreIterator;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -102,6 +110,9 @@ import org.junit.jupiter.api.Test;
  */
 public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
     extends HeadersIQv2IntegrationTestBase {
+
+    // How long an IQv2 query helper keeps retrying before failing (matches the sibling KV IQv2 test).
+    private static final long QUERY_DEADLINE_MS = 30_000;
 
     private static final Duration WINDOW_SIZE = Duration.ofMinutes(10);
     private static final Duration RETENTION_PERIOD = Duration.ofHours(1);
@@ -511,7 +522,8 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             // withWindowStartRange fans across partitions; aggregate every partition's result.
             List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> all = new ArrayList<>();
             Set<Integer> partitionsSeen = new HashSet<>();
-            long deadline = System.currentTimeMillis() + 30_000;
+            String lastFailure = null;
+            long deadline = System.currentTimeMillis() + QUERY_DEADLINE_MS;
             while (System.currentTimeMillis() < deadline) {
                 all.clear();
                 partitionsSeen.clear();
@@ -519,22 +531,22 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
                     streams.query(StateQueryRequest.inStore(storeName)
                         .withQuery(TimestampedWindowRangeWithHeadersQuery.withWindowStartRange(
                             Instant.ofEpochMilli(base), Instant.ofEpochMilli(base))));
-                result.getPartitionResults().forEach((partition, pr) -> {
-                    if (pr.isSuccess() && pr.getResult() != null) {
-                        try (ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord> it =
-                                 pr.getResult()) {
-                            while (it.hasNext()) {
-                                all.add(it.next());
-                                partitionsSeen.add(partition);
-                            }
-                        }
-                    }
+                String failure = drainPartitions(result, (partition, record) -> {
+                    all.add(record);
+                    partitionsSeen.add(partition);
                 });
+                if (failure != null) {
+                    lastFailure = failure;
+                }
                 if (all.size() >= numKeys) {
                     break;
                 }
                 sleepQuietly(200);
             }
+            // Append the IQ failure reason to the assertions below: a query that failed on every
+            // partition would otherwise read as a bare "expected: <9> but was: <0>".
+            String failureSuffix =
+                lastFailure != null ? " (last partition failure: " + lastFailure + ")" : "";
 
             // Assert the distinct key set, not just the count: returning one key twice and dropping
             // another would keep the size at numKeys but change the set.
@@ -545,11 +557,11 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             Set<String> actualKeys = all.stream()
                 .map(r -> r.key().key().get("sensorId").toString())
                 .collect(Collectors.toSet());
-            assertEquals(numKeys, all.size(), "should read every key across partitions");
+            assertEquals(numKeys, all.size(), "should read every key across partitions" + failureSuffix);
             assertEquals(expectedKeys, actualKeys,
-                "should read every distinct key across partitions (none dropped or duplicated)");
+                "should read every distinct key across partitions (none dropped or duplicated)" + failureSuffix);
             assertTrue(partitionsSeen.size() > 1,
-                "window records should span more than one partition but saw: " + partitionsSeen);
+                "window records should span more than one partition but saw: " + partitionsSeen + failureSuffix);
             for (ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord> r : all) {
                 String sensorId = r.key().key().get("sensorId").toString();
                 long reading = Long.parseLong(sensorId.substring("sensor-".length()));
@@ -610,8 +622,7 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
     }
 
     // ---------------------------------------------------------------------------------------------
-    // Cache visibility, legacy-supplier controls, retain-duplicates, null-value, header-set,
-    // read-only
+    // Cache visibility, retain-duplicates (incl. the null-value no-op), header-set, read-only
     // ---------------------------------------------------------------------------------------------
 
     @Test
@@ -625,14 +636,21 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
         long base = baseTimestamp();
         // Caching enabled + a very large commit interval so nothing flushes during the test: the record
         // lives only in the record cache. The headers-aware CachingWindowStore does not override IQv2
-        // query(), so the query reads the still-empty persistent store and must return nothing. The
-        // barrier proves the processor genuinely put the record -- it is present, just unflushed.
+        // query(), so the query reads the still-empty persistent store and must return nothing.
         int tenMinutes = (int) Duration.ofMinutes(10).toMillis();
         KafkaStreams streams = startStreamsAndAwaitRunning(
             buildWindowTopology(input, output, storeName, true, false), appId, 30, tenMinutes);
         try {
             produceOne(input, base, "sensor-1", createValue(1), "s1-cache");
             consumeRecords(output, appId + "-barrier", 1);
+
+            // Positive control first: IQv1 fetch merges the record cache, so it serves the entry with
+            // its headers intact. Without it this test would assert only an absence -- a write the
+            // caching store silently dropped and a write that is merely unflushed both leave the IQv2
+            // query empty. The barrier alone cannot tell them apart: the processor forwards
+            // unconditionally after the put.
+            assertWindowServedFromCache(streams, storeName, "sensor-1", base, 1L, "s1-cache",
+                "wincache IQv1 control");
 
             assertTrue(queryWindowed(streams, storeName,
                     TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
@@ -663,6 +681,11 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
         try {
             produceOne(input, base, "sensor-1", createValue(1), "s1-cache");
             consumeRecords(output, appId + "-barrier", 1);
+
+            // Positive control (see shouldNotServeWindowFromCacheBeforeFlush): IQv1 fetch merges the
+            // record cache, proving the session is genuinely there with its headers -- just unflushed.
+            assertSessionServedFromCache(streams, storeName, "sensor-1", base,
+                base + SESSION_DURATION_MS, 1L, "s1-cache", "sesscache IQv1 control");
 
             assertTrue(queryWindowed(streams, storeName,
                     TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-1")), 0).isEmpty(),
@@ -820,7 +843,7 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
     private List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> queryWindowed(
         KafkaStreams streams, String storeName,
         Query<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> query, int expected) {
-        long deadline = System.currentTimeMillis() + 30_000;
+        long deadline = System.currentTimeMillis() + QUERY_DEADLINE_MS;
         List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> out = new ArrayList<>();
         boolean sawSuccess = false;
         String lastFailure = null;
@@ -847,7 +870,7 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
         }
         // Require at least one successful query: otherwise an expected==0 caller would pass on a query
         // that failed on every attempt (e.g. an unsupported query type), reading as assertEquals(0, 0).
-        assertTrue(sawSuccess, "IQv2 windowed query never succeeded within 30s"
+        assertTrue(sawSuccess, "IQv2 windowed query never succeeded within " + QUERY_DEADLINE_MS + "ms"
             + (lastFailure != null ? " (last failure: " + lastFailure + ")" : ""));
         assertEquals(expected, out.size(), "IQv2 windowed query returned an unexpected count");
         return out;
@@ -855,40 +878,31 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
 
     /**
      * Runs a session {@code withKey} query (which routes to the key's partition) and returns the
-     * partition id that served it together with the single session record. {@code streams.query}
-     * opens an iterator for every local partition result eagerly, so this drains and closes every
-     * partition's iterator each attempt -- returning early from inside the loop would leak the
-     * iterators of the partitions not yet visited.
+     * partition id that served it together with the single session record, retrying until a result
+     * appears. Every partition's iterator is drained and closed on each attempt -- see
+     * {@link #drainPartitions}.
      */
     private Map.Entry<Integer, ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>>
         querySessionByKeyWithPartition(KafkaStreams streams, String storeName, GenericRecord key) {
-        long deadline = System.currentTimeMillis() + 30_000;
+        long deadline = System.currentTimeMillis() + QUERY_DEADLINE_MS;
         String lastFailure = null;
         while (System.currentTimeMillis() < deadline) {
             StateQueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> result =
                 streams.query(StateQueryRequest.inStore(storeName)
                     .withQuery(TimestampedWindowRangeWithHeadersQuery.withKey(key)));
-            Map.Entry<Integer, ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> found = null;
-            for (Map.Entry<Integer,
-                    QueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>>> entry
-                    : result.getPartitionResults().entrySet()) {
-                QueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> pr =
-                    entry.getValue();
-                if (pr.isSuccess() && pr.getResult() != null) {
-                    try (ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord> it =
-                             pr.getResult()) {
-                        // Take the first match, but keep draining/closing the remaining partitions'
-                        // iterators before returning.
-                        if (found == null && it.hasNext()) {
-                            found = new AbstractMap.SimpleEntry<>(entry.getKey(), it.next());
-                        }
-                    }
-                } else if (pr.isFailure()) {
-                    lastFailure = pr.getFailureReason() + ": " + pr.getFailureMessage();
-                }
+            List<Map.Entry<Integer, ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>>> served =
+                new ArrayList<>();
+            String failure = drainPartitions(result,
+                (partition, record) -> served.add(new AbstractMap.SimpleEntry<>(partition, record)));
+            if (failure != null) {
+                lastFailure = failure;
             }
-            if (found != null) {
-                return found;
+            if (!served.isEmpty()) {
+                // Draining every partition rather than stopping at the first hit also pins that the
+                // key resolves to exactly one session on exactly one partition.
+                assertEquals(1, served.size(),
+                    "session withKey query should return exactly one session for " + key);
+                return served.get(0);
             }
             sleepQuietly(200);
         }
@@ -898,13 +912,77 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             + (lastFailure != null ? " (last failure: " + lastFailure + ")" : ""));
     }
 
+    /**
+     * Drains every successful partition result into {@code sink} (partition id, record) and closes
+     * every partition's iterator, even when one of them throws mid-iteration.
+     *
+     * <p>{@code streams.query} opens an iterator for every local partition eagerly, so a per-partition
+     * try-with-resources is not enough on its own: an exception escaping it -- or an early return --
+     * leaves the iterators of the partitions not yet visited open, leaking their store iterators and
+     * pinning the {@code num-open-iterators} metric for the rest of the fork JVM. Iterating a
+     * headers-aware result can genuinely throw: the query contract documents a
+     * {@link org.apache.kafka.streams.errors.StreamsException} for an entry that carries no
+     * event-time, and {@code next()} also deserializes through the Schema Registry client.
+     *
+     * @return the last partition failure rendered as {@code reason: message}, or {@code null} if no
+     *     partition failed
+     */
+    private static String drainPartitions(
+        StateQueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> result,
+        BiConsumer<Integer, ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> sink) {
+        Map<Integer, ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> iterators =
+            new LinkedHashMap<>();
+        String lastFailure = null;
+        for (Map.Entry<Integer,
+                QueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>>> entry
+                : result.getPartitionResults().entrySet()) {
+            QueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> pr =
+                entry.getValue();
+            if (pr.isSuccess() && pr.getResult() != null) {
+                iterators.put(entry.getKey(), pr.getResult());
+            } else if (pr.isFailure()) {
+                lastFailure = pr.getFailureReason() + ": " + pr.getFailureMessage();
+            }
+        }
+        try {
+            iterators.forEach((partition, it) -> {
+                while (it.hasNext()) {
+                    sink.accept(partition, it.next());
+                }
+            });
+        } finally {
+            closeAllQuietly(iterators.values());
+        }
+        return lastFailure;
+    }
+
+    /**
+     * Closes every iterator best-effort. Close failures are swallowed: this runs from a
+     * {@code finally}, where throwing would replace the error that actually failed the test, and
+     * nothing is actionable if a store iterator refuses to close (mirrors {@code closeStreamsQuietly}).
+     */
+    private static void closeAllQuietly(
+        Collection<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> iterators) {
+        for (ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord> it : iterators) {
+            try {
+                it.close();
+            } catch (RuntimeException e) {
+                // Best-effort cleanup; the caller's own failure is the one worth reporting.
+            }
+        }
+    }
+
     private void assertWindowedRecord(ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord> record,
         String sensorId, long windowStart, long reading, String seq, String context) {
         assertEquals(sensorId, record.key().key().get("sensorId").toString(), context + " key");
         assertEquals(windowStart, record.key().window().start(), context + " window start");
+        // The query derives the window from the store's configured size; pin it so a wrong duration
+        // (retention instead of window size, say) cannot pass unnoticed.
+        assertEquals(windowStart + WINDOW_SIZE.toMillis(), record.key().window().end(),
+            context + " window end");
         assertEquals(windowStart + EVENT_TIME_OFFSET_MS, record.timestamp(), context + " event-time");
         assertEquals(reading, record.value().get("reading"), context + " value");
-        assertRecordHeaders(record, seq, context);
+        assertRecordHeaders(record.headers(), seq, context);
     }
 
     private void assertSessionRecord(ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord> record,
@@ -915,25 +993,75 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
         // A session carries no per-record event-time; timestamp() is the session window's end.
         assertEquals(end, record.timestamp(), context + " timestamp == session end");
         assertEquals(reading, record.value().get("reading"), context + " value");
-        assertRecordHeaders(record, seq, context);
+        assertRecordHeaders(record.headers(), seq, context);
     }
 
     /**
-     * Asserts the record carries the exact headers produced for {@code seq}: the schema-id GUIDs
+     * Asserts {@code headers} are the exact headers produced for {@code seq}: the schema-id GUIDs
      * byte-equal to what that record's serializer wrote, and the distinct {@code seq} header equal to
      * the id passed here. The {@code seq} check is what makes this a per-record fidelity assertion --
      * every record shares one Avro schema, so the schema-id GUIDs alone are byte-identical across
      * records and could not distinguish one record's headers from another's.
      */
-    private void assertRecordHeaders(ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord> record,
-        String seq, String context) {
+    private void assertRecordHeaders(Headers headers, String seq, String context) {
         CapturedSchemaIds expected = capturedBySeq.get(seq);
         assertNotNull(expected, context + ": no captured schema-id GUIDs for seq " + seq);
-        assertSchemaIdHeaders(record.headers(), expected, context);
-        Header seqHeader = record.headers().lastHeader(SEQ_HEADER);
+        assertSchemaIdHeaders(headers, expected, context);
+        Header seqHeader = headers.lastHeader(SEQ_HEADER);
         assertNotNull(seqHeader, context + ": missing " + SEQ_HEADER + " header");
         assertEquals(seq, new String(seqHeader.value(), StandardCharsets.UTF_8),
             context + ": " + SEQ_HEADER + " header should carry this record's own id");
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // IQv1 cache-hit controls (the cache tests' positive half -- IQv1 merges the record cache)
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * Positive control for {@link #shouldNotServeWindowFromCacheBeforeFlush}: reads the entry back
+     * through IQv1 {@link ReadOnlyWindowStore#fetch}, which merges the record cache with the
+     * persistent store, so a cached-but-unflushed write is visible here even though the IQv2 query
+     * (which reads straight past the cache) sees nothing.
+     */
+    private void assertWindowServedFromCache(KafkaStreams streams, String storeName, String sensorId,
+        long windowStart, long reading, String seq, String context) {
+        ReadOnlyWindowStore<GenericRecord, ValueTimestampHeaders<GenericRecord>> store =
+            streams.store(StoreQueryParameters.fromNameAndType(
+                storeName, QueryableStoreTypes.timestampedWindowStoreWithHeaders()));
+        List<ValueTimestampHeaders<GenericRecord>> served = new ArrayList<>();
+        try (WindowStoreIterator<ValueTimestampHeaders<GenericRecord>> it = store.fetch(
+                 createKey(sensorId), Instant.ofEpochMilli(windowStart),
+                 Instant.ofEpochMilli(windowStart))) {
+            while (it.hasNext()) {
+                served.add(it.next().value);
+            }
+        }
+        assertEquals(1, served.size(), context + ": IQv1 fetch should serve the cached window entry");
+        assertEquals(reading, served.get(0).value().get("reading"), context + " value");
+        assertEquals(windowStart + EVENT_TIME_OFFSET_MS, served.get(0).timestamp(),
+            context + " event-time");
+        assertRecordHeaders(served.get(0).headers(), seq, context);
+    }
+
+    /** Session counterpart of {@link #assertWindowServedFromCache}. */
+    private void assertSessionServedFromCache(KafkaStreams streams, String storeName, String sensorId,
+        long start, long end, long reading, String seq, String context) {
+        ReadOnlySessionStore<GenericRecord, AggregationWithHeaders<GenericRecord>> store =
+            streams.store(StoreQueryParameters.fromNameAndType(
+                storeName, QueryableStoreTypes.sessionStoreWithHeaders()));
+        List<KeyValue<Windowed<GenericRecord>, AggregationWithHeaders<GenericRecord>>> served =
+            new ArrayList<>();
+        try (KeyValueIterator<Windowed<GenericRecord>, AggregationWithHeaders<GenericRecord>> it =
+                 store.fetch(createKey(sensorId))) {
+            while (it.hasNext()) {
+                served.add(it.next());
+            }
+        }
+        assertEquals(1, served.size(), context + ": IQv1 fetch should serve the cached session");
+        assertEquals(start, served.get(0).key.window().start(), context + " session start");
+        assertEquals(end, served.get(0).key.window().end(), context + " session end");
+        assertEquals(reading, served.get(0).value.aggregation().get("reading"), context + " value");
+        assertRecordHeaders(served.get(0).value.headers(), seq, context);
     }
 
     private List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> recordsForSensor(

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/WindowAndSessionStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/WindowAndSessionStoreWithHeadersIQv2IntegrationTest.java
@@ -944,6 +944,43 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
     }
 
     /**
+     * Session counterpart to {@link #shouldServeWindowWithHeadersAfterCacheFlush}. Not a duplicate of
+     * it: the session store flushes through {@code CachingSessionStore} and encodes its headers with
+     * {@code AggregationWithHeadersSerializer} / {@code HeadersSerializer}, both different from the
+     * window store's {@code CachingWindowStore} and {@code ValueTimestampHeadersSerde}, so the
+     * cache-to-RocksDB path carrying headers is a separate one and needs its own coverage.
+     */
+    @Test
+    public void shouldServeSessionWithHeadersAfterCacheFlush() throws Exception {
+        String input = "iqv2-sessflush-input";
+        String output = "iqv2-sessflush-output";
+        String storeName = "iqv2-sessflush-store";
+        String appId = "iqv2-sessflush-test";
+
+        createTopics(input, output);
+        long base = baseTimestamp();
+        // Caching enabled with a 1s commit interval so the record cache is flushed into the store
+        // during the test -- the mirror of shouldNotServeSessionFromCacheBeforeFlush, which uses a
+        // ten-minute interval so nothing ever flushes.
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildSessionTopology(input, output, storeName, true), appId, 30, 1000);
+        try {
+            produceOne(input, base, "sensor-1", createValue(7), "s1-flush");
+            consumeRecords(output, appId + "-barrier", 1);
+
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> records = queryWindowed(
+                streams, storeName,
+                TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-1")), 1);
+            assertSessionRecord(records.get(0), "sensor-1", base, base + SESSION_DURATION_MS, 7L,
+                "s1-flush", "session after cache flush");
+
+            closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
+        }
+    }
+
+    /**
      * Negative control on query dispatch: each headers-aware query form is bound to one store type,
      * and sending the other form must fail with {@link FailureReason#UNKNOWN_QUERY_TYPE} rather than
      * being silently answered. Needs no data -- the store type alone decides.

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/WindowAndSessionStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/WindowAndSessionStoreWithHeadersIQv2IntegrationTest.java
@@ -1,0 +1,816 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.streams.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.confluent.kafka.serializers.schema.id.HeaderSchemaIdSerializer;
+import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.kstream.internals.SessionWindow;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.ReadOnlyRecord;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.query.Query;
+import org.apache.kafka.streams.query.QueryResult;
+import org.apache.kafka.streams.query.StateQueryRequest;
+import org.apache.kafka.streams.query.StateQueryResult;
+import org.apache.kafka.streams.query.TimestampedWindowKeyWithHeadersQuery;
+import org.apache.kafka.streams.query.TimestampedWindowRangeWithHeadersQuery;
+import org.apache.kafka.streams.state.AggregationWithHeaders;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.ReadOnlyRecordIterator;
+import org.apache.kafka.streams.state.SessionStoreWithHeaders;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.TimestampedWindowStoreWithHeaders;
+import org.apache.kafka.streams.state.ValueTimestampHeaders;
+import org.junit.jupiter.api.Test;
+
+/**
+ * KIP-1356 IQv2 integration test for the headers-aware window and session stores.
+ *
+ * <p>Verifies that the headers-aware IQv2 query types return the record headers persisted by the
+ * KIP-1271 {@link TimestampedWindowStoreWithHeaders} and {@link SessionStoreWithHeaders}:
+ * <ul>
+ *   <li>{@link TimestampedWindowKeyWithHeadersQuery} — single key across a window-start range
+ *       (window store);</li>
+ *   <li>{@link TimestampedWindowRangeWithHeadersQuery#withWindowStartRange} — all keys across a
+ *       window-start range (window store);</li>
+ *   <li>{@link TimestampedWindowRangeWithHeadersQuery#withKey} — all sessions for a key (session
+ *       store), where {@link ReadOnlyRecord#timestamp()} is the session window's end.</li>
+ * </ul>
+ * Records are produced with the schema-id GUID carried in the {@code __key_schema_id} /
+ * {@code __value_schema_id} headers (via {@link HeaderSchemaIdSerializer}); each query result is a
+ * {@link ReadOnlyRecordIterator} of {@link ReadOnlyRecord} whose headers must be the 17-byte
+ * {@code MAGIC_BYTE_V1} GUID.
+ *
+ * <p>Shared cluster/serde/lifecycle infrastructure lives in {@link HeadersIQv2IntegrationTestBase}.
+ */
+public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
+    extends HeadersIQv2IntegrationTestBase {
+
+    private static final Duration WINDOW_SIZE = Duration.ofMinutes(10);
+    private static final Duration RETENTION_PERIOD = Duration.ofHours(1);
+    // Retention period for the session store (long enough that no session under test expires).
+    private static final Duration SESSION_RETENTION = Duration.ofMinutes(30);
+    private static final long SESSION_DURATION_MS = Duration.ofSeconds(5).toMillis();
+    // The window-store writer stores each value's event-time this far into its window, so that
+    // ReadOnlyRecord.timestamp() (the stored event-time) is distinguishable from the window start.
+    private static final long EVENT_TIME_OFFSET_MS = 3;
+    // Records for the same key within this gap are merged into one (variable-length) session by the
+    // merging session writer; records farther apart start a new session.
+    private static final long SESSION_MERGE_GAP_MS = 100;
+
+    private static final Schema KEY_SCHEMA = new Schema.Parser().parse(
+        "{\"type\":\"record\",\"name\":\"SensorKey\","
+            + "\"namespace\":\"io.confluent.kafka.streams.integration\","
+            + "\"fields\":[{\"name\":\"sensorId\",\"type\":\"string\"}]}");
+    private static final Schema VALUE_SCHEMA = new Schema.Parser().parse(
+        "{\"type\":\"record\",\"name\":\"SensorValue\","
+            + "\"namespace\":\"io.confluent.kafka.streams.integration\","
+            + "\"fields\":[{\"name\":\"reading\",\"type\":\"long\"}]}");
+
+    // Every record in each test shares this one key/value schema, so every value-bearing record
+    // carries the same schema-id GUIDs. Capture them once when producing and assert that IQv2
+    // results come back byte-equal to what was produced (see
+    // HeadersIQv2IntegrationTestBase#assertSchemaIdHeaders).
+    private CapturedSchemaIds valueSchemaIds;
+
+    // ---------------------------------------------------------------------------------------------
+    // TimestampedWindowKeyWithHeadersQuery (window store: single key across window-start range)
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldQueryWindowKeyWithHeaders() throws Exception {
+        String input = "iqv2-winkey-input";
+        String output = "iqv2-winkey-output";
+        String storeName = "iqv2-winkey-store";
+        String appId = "iqv2-winkey-test";
+
+        createTopics(input, output);
+        long base = alignedBase(WINDOW_SIZE.toMillis());
+        long w0 = base;
+        long w1 = base + 100;
+        long w2 = base + 200;
+        long w3 = base + 300;
+        long w4 = base + 400;
+
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildWindowTopology(input, output, storeName), appId);
+        try {
+            try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                     new KafkaProducer<>(createProducerProps())) {
+                // Queried key sensor-1 across four windows: live, live, tombstoned, live.
+                valueSchemaIds = sendAndCapture(producer, new ProducerRecord<>(input, null, w0, createKey("sensor-1"), createValue(0)));
+                sendAndCapture(producer, new ProducerRecord<>(input, null, w1, createKey("sensor-1"), createValue(1)));
+                sendAndCapture(producer, new ProducerRecord<>(input, null, w2, createKey("sensor-1"), createValue(2)));
+                sendAndCapture(producer, new ProducerRecord<>(input, null, w2, createKey("sensor-1"), (GenericRecord) null));
+                sendAndCapture(producer, new ProducerRecord<>(input, null, w3, createKey("sensor-1"), createValue(3)));
+                // Noise key sensor-2 must not leak into sensor-1's results; its w0 tombstone is key-scoped
+                // and must not drop sensor-1's own w0.
+                sendAndCapture(producer, new ProducerRecord<>(input, null, w0, createKey("sensor-2"), createValue(10)));
+                sendAndCapture(producer, new ProducerRecord<>(input, null, w0, createKey("sensor-2"), (GenericRecord) null));
+                sendAndCapture(producer, new ProducerRecord<>(input, null, w1, createKey("sensor-2"), createValue(11)));
+                sendAndCapture(producer, new ProducerRecord<>(input, null, w4, createKey("sensor-2"), createValue(14)));
+                producer.flush();
+            }
+            consumeRecords(output, appId + "-barrier", 9);
+
+            // Full range over sensor-1: w0, w1, w3 in window-start order (w2 tombstoned, sensor-2 excluded).
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> records = queryWindowed(
+                streams, storeName,
+                TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
+                    createKey("sensor-1"), Instant.ofEpochMilli(w0), Instant.ofEpochMilli(w4)),
+                3);
+            assertEquals(Arrays.asList(w0, w1, w3),
+                records.stream().map(r -> r.key().window().start()).collect(Collectors.toList()),
+                "sensor-1 window starts (w2 tombstoned, sensor-2 excluded)");
+            assertWindowedRecord(records.get(0), "sensor-1", w0, 0L, "winkey sensor-1 w0");
+            assertWindowedRecord(records.get(1), "sensor-1", w1, 1L, "winkey sensor-1 w1");
+            assertWindowedRecord(records.get(2), "sensor-1", w3, 3L, "winkey sensor-1 w3");
+
+            // Sub-range [w1, w2]: only w1 (w0 below lower bound, w2 tombstoned, w3 above upper bound).
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> subRange = queryWindowed(
+                streams, storeName,
+                TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
+                    createKey("sensor-1"), Instant.ofEpochMilli(w1), Instant.ofEpochMilli(w2)),
+                1);
+            assertEquals(1, subRange.size(), "sub-range returns only w1");
+            assertWindowedRecord(subRange.get(0), "sensor-1", w1, 1L, "winkey sub-range w1");
+
+            // A never-written key -> empty.
+            assertTrue(queryWindowed(streams, storeName,
+                    TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
+                        createKey("sensor-999"), Instant.ofEpochMilli(w0), Instant.ofEpochMilli(w4)), 0)
+                    .isEmpty(),
+                "never-written key returns no records");
+            // A window-start range after sensor-1's last window -> empty.
+            assertTrue(queryWindowed(streams, storeName,
+                    TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
+                        createKey("sensor-1"), Instant.ofEpochMilli(w4), Instant.ofEpochMilli(w4 + 100)), 0)
+                    .isEmpty(),
+                "window-start range excluding all of sensor-1's windows returns no records");
+
+            // Bidirectional isolation: sensor-2 returns only its live windows (w1, w4; w0 tombstoned).
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> key2 = queryWindowed(
+                streams, storeName,
+                TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
+                    createKey("sensor-2"), Instant.ofEpochMilli(w0), Instant.ofEpochMilli(w4)),
+                2);
+            assertEquals(Arrays.asList(w1, w4),
+                key2.stream().map(r -> r.key().window().start()).collect(Collectors.toList()),
+                "sensor-2 window starts (w0 tombstoned)");
+            assertWindowedRecord(key2.get(0), "sensor-2", w1, 11L, "winkey sensor-2 w1");
+            assertWindowedRecord(key2.get(1), "sensor-2", w4, 14L, "winkey sensor-2 w4");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // TimestampedWindowRangeWithHeadersQuery.withWindowStartRange (window store: all keys)
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldQueryWindowRangeWithHeaders() throws Exception {
+        String input = "iqv2-winrange-input";
+        String output = "iqv2-winrange-output";
+        String storeName = "iqv2-winrange-store";
+        String appId = "iqv2-winrange-test";
+
+        createTopics(input, output);
+        long base = alignedBase(WINDOW_SIZE.toMillis());
+        long w0 = base;
+        long w1 = base + 100;
+        long w2 = base + 200;
+
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildWindowTopology(input, output, storeName), appId);
+        try {
+            try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                     new KafkaProducer<>(createProducerProps())) {
+                // sensor-1 across two windows, both live and in range.
+                valueSchemaIds = sendAndCapture(producer, new ProducerRecord<>(input, null, w0, createKey("sensor-1"), createValue(0)));
+                sendAndCapture(producer, new ProducerRecord<>(input, null, w1, createKey("sensor-1"), createValue(1)));
+                // sensor-2: live in-range at w0, tombstoned in-range at w1, live out-of-range at w2.
+                sendAndCapture(producer, new ProducerRecord<>(input, null, w0, createKey("sensor-2"), createValue(10)));
+                sendAndCapture(producer, new ProducerRecord<>(input, null, w1, createKey("sensor-2"), createValue(11)));
+                sendAndCapture(producer, new ProducerRecord<>(input, null, w1, createKey("sensor-2"), (GenericRecord) null));
+                sendAndCapture(producer, new ProducerRecord<>(input, null, w2, createKey("sensor-2"), createValue(12)));
+                producer.flush();
+            }
+            consumeRecords(output, appId + "-barrier", 6);
+
+            // Range [w0, w1]: every key's windows whose start falls in the range.
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> records = queryWindowed(
+                streams, storeName,
+                TimestampedWindowRangeWithHeadersQuery.withWindowStartRange(
+                    Instant.ofEpochMilli(w0), Instant.ofEpochMilli(w1)),
+                3);
+
+            // sensor-1: both windows are in range.
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> sensor1 =
+                recordsForSensor(records, "sensor-1");
+            assertEquals(Arrays.asList(w0, w1),
+                sensor1.stream().map(r -> r.key().window().start()).collect(Collectors.toList()),
+                "sensor-1 windows in range");
+            assertWindowedRecord(sensor1.get(0), "sensor-1", w0, 0L, "winrange sensor-1 w0");
+            assertWindowedRecord(sensor1.get(1), "sensor-1", w1, 1L, "winrange sensor-1 w1");
+
+            // sensor-2: w0 survives; w1 is tombstoned; w2 is excluded by the range upper bound.
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> sensor2 =
+                recordsForSensor(records, "sensor-2");
+            assertEquals(Arrays.asList(w0),
+                sensor2.stream().map(r -> r.key().window().start()).collect(Collectors.toList()),
+                "sensor-2 windows in range (w1 tombstoned, w2 out of range)");
+            assertWindowedRecord(sensor2.get(0), "sensor-2", w0, 10L, "winrange sensor-2 w0");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // TimestampedWindowRangeWithHeadersQuery.withKey (session store: all sessions for a key)
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldQuerySessionByKeyWithHeaders() throws Exception {
+        String input = "iqv2-session-input";
+        String output = "iqv2-session-output";
+        String storeName = "iqv2-session-store";
+        String appId = "iqv2-session-test";
+
+        createTopics(input, output);
+        long base = alignedBase(WINDOW_SIZE.toMillis());
+
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildSessionMergingTopology(input, output, storeName), appId);
+        try {
+            try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                     new KafkaProducer<>(createProducerProps())) {
+                // sensor-1: three records within the merge gap collapse into one variable-length session
+                // [base, base+55] whose reading is the sum (1+2+3=6) and whose headers come from the last
+                // record folded in.
+                valueSchemaIds = sendAndCapture(producer, new ProducerRecord<>(input, null, base, createKey("sensor-1"), createValue(1)));
+                sendAndCapture(producer, new ProducerRecord<>(input, null, base + 30, createKey("sensor-1"), createValue(2)));
+                sendAndCapture(producer, new ProducerRecord<>(input, null, base + 55, createKey("sensor-1"), createValue(3)));
+                // A distant record (> gap away) forms a separate, zero-length session [base+500, base+500].
+                sendAndCapture(producer, new ProducerRecord<>(input, null, base + 500, createKey("sensor-1"), createValue(4)));
+                // Noise key sensor-2: a session written then tombstoned -- must not survive or leak.
+                sendAndCapture(producer, new ProducerRecord<>(input, null, base, createKey("sensor-2"), createValue(20)));
+                sendAndCapture(producer, new ProducerRecord<>(input, null, base, createKey("sensor-2"), (GenericRecord) null));
+                producer.flush();
+            }
+            consumeRecords(output, appId + "-barrier", 6);
+
+            // sensor-1 has two variable-length sessions, returned in window-start order.
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> records = recordsForSensor(
+                queryWindowed(streams, storeName,
+                    TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-1")), 2),
+                "sensor-1");
+            assertEquals(2, records.size(), "sensor-1 should have two sessions");
+            // Merged, variable-length session [base, base+55], summed reading, last writer's headers.
+            assertSessionRecord(records.get(0), "sensor-1", base, base + 55, 6L, "session merged");
+            // A separate zero-length session -- proves the end round-trips from the stored value.
+            assertSessionRecord(records.get(1), "sensor-1", base + 500, base + 500, 4L, "session zero-length");
+
+            // sensor-2's only session was tombstoned -> empty; a never-written key is likewise empty.
+            assertTrue(queryWindowed(streams, storeName,
+                    TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-2")), 0).isEmpty(),
+                "sensor-2's tombstoned session should be excluded");
+            assertTrue(queryWindowed(streams, storeName,
+                    TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-999")), 0).isEmpty(),
+                "never-written key returns no sessions");
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Restore-from-changelog and multi-partition
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldRestoreWindowStoreFromChangelogPreservingHeaders() throws Exception {
+        String input = "iqv2-winrestore-input";
+        String output = "iqv2-winrestore-output";
+        String storeName = "iqv2-winrestore-store";
+        String appId = "iqv2-winrestore-test";
+
+        createTopics(input, output);
+        long base = alignedBase(WINDOW_SIZE.toMillis());
+
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildWindowTopology(input, output, storeName), appId);
+        try {
+            valueSchemaIds = produce(input, createKey("sensor-1"), createValue(1), base);
+            consumeRecords(output, appId + "-pre", 1);
+        } finally {
+            closeStreams(streams);
+        }
+
+        // Restart with the same APPLICATION_ID; cleanUp() wipes the local state dir so the window
+        // store must be rebuilt from the changelog. The restored entry must still carry its headers.
+        KafkaStreams restored = startStreamsAndAwaitRunning(
+            buildWindowTopology(input, output, storeName), appId, 90);
+        try {
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> records = queryWindowed(
+                restored, storeName,
+                TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
+                    createKey("sensor-1"), Instant.ofEpochMilli(base), Instant.ofEpochMilli(base)),
+                1);
+            assertWindowedRecord(records.get(0), "sensor-1", base, 1L, "restored window sensor-1");
+        } finally {
+            closeStreams(restored);
+        }
+    }
+
+    @Test
+    public void shouldRestoreSessionStoreFromChangelogPreservingHeaders() throws Exception {
+        String input = "iqv2-sessrestore-input";
+        String output = "iqv2-sessrestore-output";
+        String storeName = "iqv2-sessrestore-store";
+        String appId = "iqv2-sessrestore-test";
+
+        createTopics(input, output);
+        long base = alignedBase(WINDOW_SIZE.toMillis());
+        long sessionEnd = base + SESSION_DURATION_MS;
+
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildSessionTopology(input, output, storeName), appId);
+        try {
+            valueSchemaIds = produce(input, createKey("sensor-1"), createValue(42), base);
+            consumeRecords(output, appId + "-pre", 1);
+        } finally {
+            closeStreams(streams);
+        }
+
+        // Restart with the same APPLICATION_ID; the session store (backed by AggregationWithHeaders)
+        // must be rebuilt from the changelog, and the restored session must still carry its headers.
+        KafkaStreams restored = startStreamsAndAwaitRunning(
+            buildSessionTopology(input, output, storeName), appId, 90);
+        try {
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> records = queryWindowed(
+                restored, storeName,
+                TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-1")),
+                1);
+            assertSessionRecord(
+                records.get(0), "sensor-1", base, sessionEnd, 42L, "restored session sensor-1");
+        } finally {
+            closeStreams(restored);
+        }
+    }
+
+    @Test
+    public void shouldQueryWindowAcrossPartitionsWithHeaders() throws Exception {
+        String input = "iqv2-winmp-input";
+        String output = "iqv2-winmp-output";
+        String storeName = "iqv2-winmp-store";
+        String appId = "iqv2-winmp-test";
+        int numPartitions = 3;
+        int numKeys = 9;
+
+        createTopicsWithPartitions(numPartitions, input, output);
+        long base = alignedBase(WINDOW_SIZE.toMillis());
+
+        List<GenericRecord> keys = new ArrayList<>();
+        List<GenericRecord> values = new ArrayList<>();
+        for (int i = 1; i <= numKeys; i++) {
+            keys.add(createKey("sensor-" + i));
+            values.add(createValue(i));
+        }
+
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildWindowTopology(input, output, storeName), appId);
+        try {
+            valueSchemaIds = produceAll(input, keys, values, base).get(0);
+            consumeRecords(output, appId + "-barrier", numKeys);
+
+            // withWindowStartRange fans across partitions; aggregate every partition's result.
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> all = new ArrayList<>();
+            Set<Integer> partitionsSeen = new HashSet<>();
+            long deadline = System.currentTimeMillis() + 30_000;
+            while (System.currentTimeMillis() < deadline) {
+                all.clear();
+                partitionsSeen.clear();
+                StateQueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> result =
+                    streams.query(StateQueryRequest.inStore(storeName)
+                        .withQuery(TimestampedWindowRangeWithHeadersQuery.withWindowStartRange(
+                            Instant.ofEpochMilli(base), Instant.ofEpochMilli(base))));
+                result.getPartitionResults().forEach((partition, pr) -> {
+                    if (pr.isSuccess() && pr.getResult() != null) {
+                        try (ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord> it =
+                                 pr.getResult()) {
+                            while (it.hasNext()) {
+                                all.add(it.next());
+                                partitionsSeen.add(partition);
+                            }
+                        }
+                    }
+                });
+                if (all.size() >= numKeys) {
+                    break;
+                }
+                sleepQuietly(200);
+            }
+
+            assertEquals(numKeys, all.size(), "should read every key across partitions");
+            assertTrue(partitionsSeen.size() > 1,
+                "window records should span more than one partition but saw: " + partitionsSeen);
+            for (ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord> r : all) {
+                String sensorId = r.key().key().get("sensorId").toString();
+                long reading = Long.parseLong(sensorId.substring("sensor-".length()));
+                assertWindowedRecord(r, sensorId, base, reading, "window multi-partition " + sensorId);
+            }
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    @Test
+    public void shouldQuerySessionAcrossPartitionsWithHeaders() throws Exception {
+        String input = "iqv2-sessmp-input";
+        String output = "iqv2-sessmp-output";
+        String storeName = "iqv2-sessmp-store";
+        String appId = "iqv2-sessmp-test";
+        int numPartitions = 3;
+        int numKeys = 9;
+
+        createTopicsWithPartitions(numPartitions, input, output);
+        long base = alignedBase(WINDOW_SIZE.toMillis());
+        long sessionEnd = base + SESSION_DURATION_MS;
+
+        List<GenericRecord> keys = new ArrayList<>();
+        List<GenericRecord> values = new ArrayList<>();
+        for (int i = 1; i <= numKeys; i++) {
+            keys.add(createKey("sensor-" + i));
+            values.add(createValue(i));
+        }
+
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildSessionTopology(input, output, storeName), appId);
+        try {
+            valueSchemaIds = produceAll(input, keys, values, base).get(0);
+            consumeRecords(output, appId + "-barrier", numKeys);
+
+            // A session withKey query routes to the key's partition, so query each key and record the
+            // partition that served it; collectively the keys must resolve across >1 partition.
+            Set<Integer> partitionsSeen = new HashSet<>();
+            for (int i = 1; i <= numKeys; i++) {
+                String sensorId = "sensor-" + i;
+                Map.Entry<Integer, ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> served =
+                    querySessionByKeyWithPartition(streams, storeName, createKey(sensorId));
+                assertSessionRecord(served.getValue(), sensorId, base, sessionEnd, i,
+                    "session multi-partition " + sensorId);
+                partitionsSeen.add(served.getKey());
+            }
+            assertTrue(partitionsSeen.size() > 1,
+                "session keys should resolve across more than one partition but saw: " + partitionsSeen);
+        } finally {
+            closeStreams(streams);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // IQv2 query helpers
+    // ---------------------------------------------------------------------------------------------
+
+    private List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> queryWindowed(
+        KafkaStreams streams, String storeName,
+        Query<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> query, int expected) {
+        long deadline = System.currentTimeMillis() + 30_000;
+        List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> out = new ArrayList<>();
+        while (System.currentTimeMillis() < deadline) {
+            out.clear();
+            StateQueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> result =
+                streams.query(StateQueryRequest.inStore(storeName).withQuery(query));
+            QueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> pr =
+                result.getOnlyPartitionResult();
+            if (pr != null && pr.isSuccess() && pr.getResult() != null) {
+                try (ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord> it = pr.getResult()) {
+                    while (it.hasNext()) {
+                        out.add(it.next());
+                    }
+                }
+                if (out.size() >= expected) {
+                    return out;
+                }
+            }
+            sleepQuietly(200);
+        }
+        assertEquals(expected, out.size(), "IQv2 windowed query returned an unexpected count");
+        return out;
+    }
+
+    /**
+     * Runs a session {@code withKey} query (which routes to the key's partition) and returns the
+     * partition id that served it together with the single session record.
+     */
+    private Map.Entry<Integer, ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>>
+        querySessionByKeyWithPartition(KafkaStreams streams, String storeName, GenericRecord key) {
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (System.currentTimeMillis() < deadline) {
+            StateQueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> result =
+                streams.query(StateQueryRequest.inStore(storeName)
+                    .withQuery(TimestampedWindowRangeWithHeadersQuery.withKey(key)));
+            for (Integer partition : result.getPartitionResults().keySet()) {
+                QueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> pr =
+                    result.getPartitionResults().get(partition);
+                if (pr.isSuccess() && pr.getResult() != null) {
+                    try (ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord> it = pr.getResult()) {
+                        if (it.hasNext()) {
+                            return new AbstractMap.SimpleEntry<>(partition, it.next());
+                        }
+                    }
+                }
+            }
+            sleepQuietly(200);
+        }
+        throw new AssertionError("session withKey query never returned a result for " + key);
+    }
+
+    private void assertWindowedRecord(ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord> record,
+        String sensorId, long windowStart, long reading, String context) {
+        assertEquals(sensorId, record.key().key().get("sensorId").toString(), context + " key");
+        assertEquals(windowStart, record.key().window().start(), context + " window start");
+        assertEquals(windowStart + EVENT_TIME_OFFSET_MS, record.timestamp(), context + " event-time");
+        assertEquals(reading, record.value().get("reading"), context + " value");
+        assertSchemaIdHeaders(record.headers(), valueSchemaIds, context);
+    }
+
+    private void assertSessionRecord(ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord> record,
+        String sensorId, long start, long end, long reading, String context) {
+        assertEquals(sensorId, record.key().key().get("sensorId").toString(), context + " key");
+        assertEquals(start, record.key().window().start(), context + " session start");
+        assertEquals(end, record.key().window().end(), context + " session end");
+        // A session carries no per-record event-time; timestamp() is the session window's end.
+        assertEquals(end, record.timestamp(), context + " timestamp == session end");
+        assertEquals(reading, record.value().get("reading"), context + " value");
+        assertSchemaIdHeaders(record.headers(), valueSchemaIds, context);
+    }
+
+    private List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> recordsForSensor(
+        List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> records, String sensorId) {
+        return records.stream()
+            .filter(r -> sensorId.equals(r.key().key().get("sensorId").toString()))
+            .sorted(Comparator.comparingLong(
+                (ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord> r) -> r.key().window().start()))
+            .collect(Collectors.toList());
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Topologies + processors
+    // ---------------------------------------------------------------------------------------------
+
+    private Topology buildWindowTopology(String input, String output, String storeName) {
+        GenericAvroSerde keySerde = createKeySerde();
+        GenericAvroSerde valueSerde = createValueSerde();
+        StoreBuilder<TimestampedWindowStoreWithHeaders<GenericRecord, GenericRecord>> storeBuilder =
+            Stores.timestampedWindowStoreWithHeadersBuilder(
+                Stores.persistentTimestampedWindowStoreWithHeaders(
+                    storeName, RETENTION_PERIOD, WINDOW_SIZE, false),
+                keySerde, valueSerde)
+                .withCachingDisabled();
+
+        StreamsBuilder builder = new StreamsBuilder();
+        builder
+            .addStateStore(storeBuilder)
+            .stream(input, Consumed.with(keySerde, valueSerde))
+            .process(() -> new WindowPutProcessor(storeName), storeName)
+            .to(output, Produced.with(keySerde, valueSerde));
+        return builder.build();
+    }
+
+    private Topology buildSessionTopology(String input, String output, String storeName) {
+        GenericAvroSerde keySerde = createKeySerde();
+        GenericAvroSerde valueSerde = createValueSerde();
+        StoreBuilder<SessionStoreWithHeaders<GenericRecord, GenericRecord>> storeBuilder =
+            Stores.sessionStoreWithHeadersBuilder(
+                Stores.persistentSessionStoreWithHeaders(storeName, SESSION_RETENTION),
+                keySerde, valueSerde)
+                .withCachingDisabled();
+
+        StreamsBuilder builder = new StreamsBuilder();
+        builder
+            .addStateStore(storeBuilder)
+            .stream(input, Consumed.with(keySerde, valueSerde))
+            .process(() -> new SessionPutProcessor(storeName), storeName)
+            .to(output, Produced.with(keySerde, valueSerde));
+        return builder.build();
+    }
+
+    private Topology buildSessionMergingTopology(String input, String output, String storeName) {
+        GenericAvroSerde keySerde = createKeySerde();
+        GenericAvroSerde valueSerde = createValueSerde();
+        StoreBuilder<SessionStoreWithHeaders<GenericRecord, GenericRecord>> storeBuilder =
+            Stores.sessionStoreWithHeadersBuilder(
+                Stores.persistentSessionStoreWithHeaders(storeName, SESSION_RETENTION),
+                keySerde, valueSerde)
+                .withCachingDisabled();
+
+        StreamsBuilder builder = new StreamsBuilder();
+        builder
+            .addStateStore(storeBuilder)
+            .stream(input, Consumed.with(keySerde, valueSerde))
+            .process(() -> new SessionMergingPutProcessor(storeName), storeName)
+            .to(output, Produced.with(keySerde, valueSerde));
+        return builder.build();
+    }
+
+    /**
+     * Stores each incoming record into the window store at the window start derived from its
+     * event-time, preserving the record's headers, then forwards it as a completion barrier.
+     */
+    private static class WindowPutProcessor
+        implements Processor<GenericRecord, GenericRecord, GenericRecord, GenericRecord> {
+
+        private final String storeName;
+        private ProcessorContext<GenericRecord, GenericRecord> context;
+        private TimestampedWindowStoreWithHeaders<GenericRecord, GenericRecord> store;
+
+        WindowPutProcessor(String storeName) {
+            this.storeName = storeName;
+        }
+
+        @Override
+        public void init(ProcessorContext<GenericRecord, GenericRecord> context) {
+            this.context = context;
+            this.store = context.getStateStore(storeName);
+        }
+
+        @Override
+        public void process(Record<GenericRecord, GenericRecord> record) {
+            // The record timestamp is the window start; a null value tombstones that window. The stored
+            // event-time is a few ms into the window so timestamp() is distinguishable from the start.
+            long windowStart = record.timestamp();
+            if (record.value() == null) {
+                store.put(record.key(), null, windowStart);
+            } else {
+                store.put(record.key(),
+                    ValueTimestampHeaders.make(
+                        record.value(), windowStart + EVENT_TIME_OFFSET_MS, record.headers()),
+                    windowStart);
+            }
+            context.forward(record);
+        }
+    }
+
+    /**
+     * Stores each incoming record as a fixed-length session (start == event-time,
+     * end == event-time + {@link #SESSION_DURATION_MS}), preserving the record's headers, then
+     * forwards it as a completion barrier.
+     */
+    private static class SessionPutProcessor
+        implements Processor<GenericRecord, GenericRecord, GenericRecord, GenericRecord> {
+
+        private final String storeName;
+        private ProcessorContext<GenericRecord, GenericRecord> context;
+        private SessionStoreWithHeaders<GenericRecord, GenericRecord> store;
+
+        SessionPutProcessor(String storeName) {
+            this.storeName = storeName;
+        }
+
+        @Override
+        public void init(ProcessorContext<GenericRecord, GenericRecord> context) {
+            this.context = context;
+            this.store = context.getStateStore(storeName);
+        }
+
+        @Override
+        public void process(Record<GenericRecord, GenericRecord> record) {
+            long start = record.timestamp();
+            long end = start + SESSION_DURATION_MS;
+            store.put(new Windowed<>(record.key(), new SessionWindow(start, end)),
+                AggregationWithHeaders.make(record.value(), record.headers()));
+            context.forward(record);
+        }
+    }
+
+    /**
+     * Real session-windowing writer: merges records for the same key within {@link #SESSION_MERGE_GAP_MS}
+     * into a single variable-length session (summing the reading, taking the last folded record's
+     * headers), and tombstones every overlapping session on a null value. Used to exercise the session
+     * form of {@link TimestampedWindowRangeWithHeadersQuery}.
+     */
+    private static class SessionMergingPutProcessor
+        implements Processor<GenericRecord, GenericRecord, GenericRecord, GenericRecord> {
+
+        private final String storeName;
+        private ProcessorContext<GenericRecord, GenericRecord> context;
+        private SessionStoreWithHeaders<GenericRecord, GenericRecord> store;
+
+        SessionMergingPutProcessor(String storeName) {
+            this.storeName = storeName;
+        }
+
+        @Override
+        public void init(ProcessorContext<GenericRecord, GenericRecord> context) {
+            this.context = context;
+            this.store = context.getStateStore(storeName);
+        }
+
+        @Override
+        public void process(Record<GenericRecord, GenericRecord> record) {
+            long ts = record.timestamp();
+            List<KeyValue<Windowed<GenericRecord>, AggregationWithHeaders<GenericRecord>>> overlapping =
+                new ArrayList<>();
+            try (KeyValueIterator<Windowed<GenericRecord>, AggregationWithHeaders<GenericRecord>> sessions =
+                     store.findSessions(record.key(), ts - SESSION_MERGE_GAP_MS, ts + SESSION_MERGE_GAP_MS)) {
+                while (sessions.hasNext()) {
+                    overlapping.add(sessions.next());
+                }
+            }
+
+            if (record.value() == null) {
+                // Tombstone every overlapping session via put(..., null) (not remove()) so the store's
+                // IQv2 Position still advances.
+                for (KeyValue<Windowed<GenericRecord>, AggregationWithHeaders<GenericRecord>> existing
+                         : overlapping) {
+                    store.put(existing.key, null);
+                }
+                context.forward(record);
+                return;
+            }
+
+            long mergedStart = ts;
+            long mergedEnd = ts;
+            long mergedReading = 0L;
+            for (KeyValue<Windowed<GenericRecord>, AggregationWithHeaders<GenericRecord>> existing
+                     : overlapping) {
+                mergedStart = Math.min(mergedStart, existing.key.window().start());
+                mergedEnd = Math.max(mergedEnd, existing.key.window().end());
+                mergedReading += (Long) existing.value.aggregation().get("reading");
+                store.remove(existing.key); // superseded by the merged window written below
+            }
+            mergedReading += (Long) record.value().get("reading");
+            store.put(
+                new Windowed<>(record.key(), new SessionWindow(mergedStart, mergedEnd)),
+                AggregationWithHeaders.make(newValue(mergedReading), record.headers()));
+            context.forward(record);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Avro record factories (schema-specific; the shared infrastructure lives in the base class)
+    // ---------------------------------------------------------------------------------------------
+
+    private static long alignedBase(long windowMs) {
+        return (System.currentTimeMillis() / windowMs) * windowMs;
+    }
+
+    private GenericRecord createKey(String sensorId) {
+        GenericRecord key = new GenericData.Record(KEY_SCHEMA);
+        key.put("sensorId", sensorId);
+        return key;
+    }
+
+    private GenericRecord createValue(long reading) {
+        return newValue(reading);
+    }
+
+    private static GenericRecord newValue(long reading) {
+        GenericRecord value = new GenericData.Record(VALUE_SCHEMA);
+        value.put("reading", reading);
+        return value;
+    }
+}

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/WindowAndSessionStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/WindowAndSessionStoreWithHeadersIQv2IntegrationTest.java
@@ -17,6 +17,7 @@
 package io.confluent.kafka.streams.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -38,8 +39,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -66,6 +65,7 @@ import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.ReadOnlyRecord;
 import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.query.FailureReason;
 import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.query.StateQueryRequest;
@@ -114,6 +114,11 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
 
     // How long an IQv2 query helper keeps retrying before failing (matches the sibling KV IQv2 test).
     private static final long QUERY_DEADLINE_MS = 30_000;
+
+    // How long an "expected to stay empty" assertion keeps re-querying. An absence needs a settle
+    // window, not a single lucky attempt: a record that has merely not landed yet looks identical to
+    // one that is genuinely absent. See assertQueryStaysEmpty.
+    private static final long EMPTY_SETTLE_MS = 2_000;
 
     private static final Duration WINDOW_SIZE = Duration.ofMinutes(10);
     private static final Duration RETENTION_PERIOD = Duration.ofHours(1);
@@ -355,12 +360,30 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
                 send(producer, input, base + 55, "sensor-1", createValue(3), "s1-merge-3");
                 // A distant record (> gap away) forms a separate, zero-length session [base+500, base+500].
                 send(producer, input, base + 500, "sensor-1", createValue(4), "s1-distant");
-                // Noise key sensor-2: a session written then tombstoned -- must not survive or leak.
+                // Noise key sensor-2: a session written, then tombstoned below -- must not survive
+                // or leak.
                 send(producer, input, base, "sensor-2", createValue(20), "s2-sess");
+                producer.flush();
+            }
+            consumeRecords(output, appId + "-barrier", 5);
+
+            // Prove sensor-2's session was genuinely written before removing it. Without this, a put
+            // that silently no-oped would leave nothing for the tombstone to remove and the
+            // post-tombstone emptiness assertion below would pass for the wrong reason.
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> sensor2 = queryWindowed(
+                streams, storeName,
+                TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-2")), 1);
+            assertEquals(1, sensor2.size(), "sensor-2 should have exactly one session before the "
+                + "tombstone");
+            assertSessionRecord(sensor2.get(0), "sensor-2", base, base, 20L, "s2-sess",
+                "sensor-2 session before tombstone");
+
+            try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                     new KafkaProducer<>(createProducerProps())) {
                 send(producer, input, base, "sensor-2", null, "s2-tomb");
                 producer.flush();
             }
-            consumeRecords(output, appId + "-barrier", 6);
+            consumeRecords(output, appId + "-tombstone-barrier", 6);
 
             // sensor-1 has two variable-length sessions. The withKey session query documents no
             // iteration order, so sort locally (recordsForSensor) to assert the set order-independently.
@@ -378,11 +401,11 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
                 "session zero-length");
 
             // sensor-2's only session was tombstoned -> empty; a never-written key is likewise empty.
-            assertTrue(queryWindowed(streams, storeName,
-                    TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-2")), 0).isEmpty(),
+            assertQueryStaysEmpty(streams, storeName,
+                TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-2")),
                 "sensor-2's tombstoned session should be excluded");
-            assertTrue(queryWindowed(streams, storeName,
-                    TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-999")), 0).isEmpty(),
+            assertQueryStaysEmpty(streams, storeName,
+                TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-999")),
                 "never-written key returns no sessions");
 
             closeStreams(streams);
@@ -655,10 +678,9 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             assertWindowServedFromCache(streams, storeName, "sensor-1", base, 1L, "s1-cache",
                 "wincache IQv1 control");
 
-            assertTrue(queryWindowed(streams, storeName,
-                    TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
-                        createKey("sensor-1"), Instant.ofEpochMilli(base), Instant.ofEpochMilli(base)), 0)
-                    .isEmpty(),
+            assertQueryStaysEmpty(streams, storeName,
+                TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
+                    createKey("sensor-1"), Instant.ofEpochMilli(base), Instant.ofEpochMilli(base)),
                 "cached-but-unflushed window write must be invisible to the IQv2 query");
 
             closeStreams(streams);
@@ -690,8 +712,8 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             assertSessionServedFromCache(streams, storeName, "sensor-1", base,
                 base + SESSION_DURATION_MS, 1L, "s1-cache", "sesscache IQv1 control");
 
-            assertTrue(queryWindowed(streams, storeName,
-                    TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-1")), 0).isEmpty(),
+            assertQueryStaysEmpty(streams, storeName,
+                TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-1")),
                 "cached-but-unflushed session write must be invisible to the IQv2 query");
 
             closeStreams(streams);
@@ -839,6 +861,156 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
         }
     }
 
+    /**
+     * Session counterpart to {@link #shouldPreserveFullHeaderSetIncludingDuplicatesAndEmpty}: the
+     * session store encodes headers through {@code AggregationWithHeadersSerializer} /
+     * {@code HeadersSerializer}, a different path from the window store's
+     * {@code ValueTimestampHeadersSerde}, so the duplicate key and empty value need pinning there too.
+     */
+    @Test
+    public void shouldPreserveFullHeaderSetIncludingDuplicatesAndEmptyForSession() throws Exception {
+        String input = "iqv2-sessheaderset-input";
+        String output = "iqv2-sessheaderset-output";
+        String storeName = "iqv2-sessheaderset-store";
+        String appId = "iqv2-sessheaderset-test";
+
+        createTopics(input, output);
+        long base = baseTimestamp();
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildSessionTopology(input, output, storeName), appId);
+        try {
+            List<String> producedHeaders;
+            try (KafkaProducer<GenericRecord, GenericRecord> producer =
+                     new KafkaProducer<>(createProducerProps())) {
+                ProducerRecord<GenericRecord, GenericRecord> record = new ProducerRecord<>(
+                    input, null, base, createKey("sensor-1"), createValue(1));
+                record.headers().add(SEQ_HEADER, "s1-full".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("trace", "A".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("trace", "B".getBytes(StandardCharsets.UTF_8));
+                record.headers().add("empty", new byte[0]);
+                producer.send(record).get();
+                producer.flush();
+                producedHeaders = headerEntries(record.headers());
+            }
+            consumeRecords(output, appId + "-barrier", 1);
+
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> records = queryWindowed(
+                streams, storeName,
+                TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-1")), 1);
+            assertEquals(producedHeaders, headerEntries(records.get(0).headers()),
+                "session query should return the full produced header set -- order, the duplicate "
+                    + "'trace' key, the empty value and the schema-id headers -- and nothing else");
+
+            closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
+        }
+    }
+
+    /**
+     * The cache tests above pin that an unflushed write is invisible; this pins the other half of
+     * that pair -- that a header-bearing record written through {@code CachingWindowStore} reaches
+     * RocksDB with its headers intact once the cache is flushed. A short commit interval drives the
+     * flush, and the query helper polls until it lands.
+     */
+    @Test
+    public void shouldServeWindowWithHeadersAfterCacheFlush() throws Exception {
+        String input = "iqv2-winflush-input";
+        String output = "iqv2-winflush-output";
+        String storeName = "iqv2-winflush-store";
+        String appId = "iqv2-winflush-test";
+
+        createTopics(input, output);
+        long base = baseTimestamp();
+        // Caching enabled, but a 1s commit interval so the record cache is flushed into the store
+        // during the test rather than sitting there for the whole run.
+        KafkaStreams streams = startStreamsAndAwaitRunning(
+            buildWindowTopology(input, output, storeName, true, false), appId, 30, 1000);
+        try {
+            produceOne(input, base, "sensor-1", createValue(7), "s1-flush");
+            consumeRecords(output, appId + "-barrier", 1);
+
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> records = queryWindowed(
+                streams, storeName,
+                TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
+                    createKey("sensor-1"), Instant.ofEpochMilli(base), Instant.ofEpochMilli(base)), 1);
+            assertWindowedRecord(records.get(0), "sensor-1", base, 7L, "s1-flush",
+                "window after cache flush");
+
+            closeStreams(streams);
+        } finally {
+            closeStreamsQuietly(streams);
+        }
+    }
+
+    /**
+     * Negative control on query dispatch: each headers-aware query form is bound to one store type,
+     * and sending the other form must fail with {@link FailureReason#UNKNOWN_QUERY_TYPE} rather than
+     * being silently answered. Needs no data -- the store type alone decides.
+     */
+    @Test
+    public void shouldRejectMismatchedQueryTypeWithUnknownQueryType() throws Exception {
+        String windowInput = "iqv2-mismatch-win-input";
+        String windowOutput = "iqv2-mismatch-win-output";
+        String windowStore = "iqv2-mismatch-win-store";
+        String sessionInput = "iqv2-mismatch-sess-input";
+        String sessionOutput = "iqv2-mismatch-sess-output";
+        String sessionStore = "iqv2-mismatch-sess-store";
+        long base = baseTimestamp();
+
+        createTopics(windowInput, windowOutput);
+        KafkaStreams windowStreams = startStreamsAndAwaitRunning(
+            buildWindowTopology(windowInput, windowOutput, windowStore), "iqv2-mismatch-win-test");
+        try {
+            // A session query (withKey) sent to a window store.
+            assertUnknownQueryType(windowStreams, windowStore,
+                TimestampedWindowRangeWithHeadersQuery.withKey(createKey("sensor-1")),
+                "session withKey query against a window store");
+            closeStreams(windowStreams);
+        } finally {
+            closeStreamsQuietly(windowStreams);
+        }
+
+        createTopics(sessionInput, sessionOutput);
+        KafkaStreams sessionStreams = startStreamsAndAwaitRunning(
+            buildSessionTopology(sessionInput, sessionOutput, sessionStore),
+            "iqv2-mismatch-sess-test");
+        try {
+            // A window query (withKeyAndWindowStartRange) sent to a session store.
+            assertUnknownQueryType(sessionStreams, sessionStore,
+                TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
+                    createKey("sensor-1"), Instant.ofEpochMilli(base), Instant.ofEpochMilli(base)),
+                "window start-range query against a session store");
+            closeStreams(sessionStreams);
+        } finally {
+            closeStreamsQuietly(sessionStreams);
+        }
+    }
+
+    /**
+     * Asserts every partition result failed with {@link FailureReason#UNKNOWN_QUERY_TYPE} -- the
+     * reason, not merely that it failed, so an unrelated failure cannot pass as coverage.
+     */
+    private static void assertUnknownQueryType(KafkaStreams streams, String storeName,
+        Query<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> query, String context) {
+        StateQueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> result =
+            streams.query(StateQueryRequest.inStore(storeName).withQuery(query));
+        Map<Integer, QueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>>>
+            partitionResults = result.getPartitionResults();
+        assertFalse(partitionResults.isEmpty(), context + " should return a partition result");
+        for (Map.Entry<Integer,
+                QueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>>> e
+                : partitionResults.entrySet()) {
+            QueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> pr =
+                e.getValue();
+            assertTrue(pr.isFailure(),
+                context + " should fail on partition " + e.getKey() + " but succeeded");
+            assertEquals(FailureReason.UNKNOWN_QUERY_TYPE, pr.getFailureReason(),
+                context + " should fail with UNKNOWN_QUERY_TYPE on partition " + e.getKey()
+                    + " but got: " + pr.getFailureReason() + ": " + pr.getFailureMessage());
+        }
+    }
+
     // ---------------------------------------------------------------------------------------------
     // IQv2 query helpers
     // ---------------------------------------------------------------------------------------------
@@ -884,6 +1056,40 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
         assertEquals(expected, out.size(),
             "IQv2 windowed query returned an unexpected count" + failureSuffix);
         return out;
+    }
+
+    /**
+     * Asserts {@code query} keeps returning nothing for a settle window, failing on the first
+     * non-empty attempt.
+     *
+     * <p>{@link #queryWindowed} is the wrong tool for an empty expectation: its {@code out.size() >=
+     * expected} check is trivially true for {@code expected == 0}, so it returns on the very first
+     * successful attempt and gives an emptiness claim no margin at all -- a record that had simply
+     * not landed yet would read as a confirmed absence. Polling across a window instead means the
+     * assertion has to hold repeatedly, and requiring at least one success keeps a query that failed
+     * on every attempt (an unsupported query type, say) from passing as "empty".
+     */
+    private void assertQueryStaysEmpty(KafkaStreams streams, String storeName,
+        Query<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> query, String context) {
+        long deadline = System.currentTimeMillis() + EMPTY_SETTLE_MS;
+        boolean sawSuccess = false;
+        String lastFailure = null;
+        while (System.currentTimeMillis() < deadline) {
+            StateQueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> result =
+                streams.query(StateQueryRequest.inStore(storeName).withQuery(query));
+            List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> served = new ArrayList<>();
+            String failure = drainPartitions(result, (partition, record) -> served.add(record));
+            if (failure != null) {
+                lastFailure = failure;
+            } else {
+                sawSuccess = true;
+            }
+            assertTrue(served.isEmpty(), context + " but got " + served.size() + " record(s)");
+            sleepQuietly(200);
+        }
+        assertTrue(sawSuccess, context + ": query never succeeded within " + EMPTY_SETTLE_MS
+            + "ms, so its emptiness proves nothing"
+            + (lastFailure != null ? " (last failure: " + lastFailure + ")" : ""));
     }
 
     /**
@@ -1156,8 +1362,10 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
      * Starts a KafkaStreams that must rebuild its store from the changelog and returns it once
      * RUNNING, wiring a {@link StateRestoreListener} that sums the records restored for
      * {@code storeName} into {@code restoredCount} -- so a test can prove the store was genuinely
-     * restored, not silently reprocessed from the input topic. The base start helper cannot set a
-     * restore listener, so the instance is started inline here.
+     * restored, not silently reprocessed from the input topic. Starting through the base helper --
+     * rather than hand-rolling the start here -- keeps its count-down on a terminal state (so a
+     * failed restore fails fast with the observed state instead of blocking for the full 90s) and
+     * keeps the instance tracked for teardown.
      */
     private KafkaStreams startRestoredAndAwaitRunning(Topology topology, String appId,
         String storeName, AtomicLong restoredCount) throws Exception {
@@ -1177,27 +1385,7 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
                 }
             }
         };
-        KafkaStreams restored = new KafkaStreams(topology, createStreamsProps(appId, null));
-        boolean running = false;
-        try {
-            restored.cleanUp();
-            restored.setGlobalStateRestoreListener(restoreListener);
-            CountDownLatch runningLatch = new CountDownLatch(1);
-            restored.setStateListener((newState, oldState) -> {
-                if (newState == KafkaStreams.State.RUNNING) {
-                    runningLatch.countDown();
-                }
-            });
-            restored.start();
-            assertTrue(runningLatch.await(90, TimeUnit.SECONDS),
-                "restored KafkaStreams should reach RUNNING within 90s");
-            running = true;
-            return restored;
-        } finally {
-            if (!running) {
-                closeStreamsQuietly(restored);
-            }
-        }
+        return startStreamsAndAwaitRunning(topology, appId, 90, null, restoreListener);
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/WindowAndSessionStoreWithHeadersIQv2IntegrationTest.java
+++ b/streams-integration-tests/src/test/java/io/confluent/kafka/streams/integration/WindowAndSessionStoreWithHeadersIQv2IntegrationTest.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -217,16 +218,14 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
             assertWindowedRecord(subRange.get(0), "sensor-1", w1, 1L, "s1-w1", "winkey sub-range w1");
 
             // A never-written key -> empty.
-            assertTrue(queryWindowed(streams, storeName,
-                    TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
-                        createKey("sensor-999"), Instant.ofEpochMilli(w0), Instant.ofEpochMilli(w4)), 0)
-                    .isEmpty(),
+            assertQueryStaysEmpty(streams, storeName,
+                TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
+                    createKey("sensor-999"), Instant.ofEpochMilli(w0), Instant.ofEpochMilli(w4)),
                 "never-written key returns no records");
             // A window-start range after sensor-1's last window -> empty.
-            assertTrue(queryWindowed(streams, storeName,
-                    TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
-                        createKey("sensor-1"), Instant.ofEpochMilli(w4), Instant.ofEpochMilli(w4 + 100)), 0)
-                    .isEmpty(),
+            assertQueryStaysEmpty(streams, storeName,
+                TimestampedWindowKeyWithHeadersQuery.withKeyAndWindowStartRange(
+                    createKey("sensor-1"), Instant.ofEpochMilli(w4), Instant.ofEpochMilli(w4 + 100)),
                 "window-start range excluding all of sensor-1's windows returns no records");
 
             // Bidirectional isolation: sensor-2 returns only its live windows (w1, w4; w0 tombstoned).
@@ -1030,11 +1029,22 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
      */
     private static void assertUnknownQueryType(KafkaStreams streams, String storeName,
         Query<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> query, String context) {
-        StateQueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> result =
-            streams.query(StateQueryRequest.inStore(storeName).withQuery(query));
+        // Retry like every other query helper here. This one's callers produce no data and wait on no
+        // output-topic barrier, so RUNNING is their only synchronisation: a rebalance that leaves the
+        // partition results momentarily empty would otherwise fail the assertion below outright.
+        long deadline = System.currentTimeMillis() + QUERY_DEADLINE_MS;
         Map<Integer, QueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>>>
-            partitionResults = result.getPartitionResults();
-        assertFalse(partitionResults.isEmpty(), context + " should return a partition result");
+            partitionResults = Collections.emptyMap();
+        while (System.currentTimeMillis() < deadline) {
+            partitionResults = streams.query(StateQueryRequest.inStore(storeName).withQuery(query))
+                .getPartitionResults();
+            if (!partitionResults.isEmpty()) {
+                break;
+            }
+            sleepQuietly(200);
+        }
+        assertFalse(partitionResults.isEmpty(), context + " should return a partition result but "
+            + "none was served within " + QUERY_DEADLINE_MS + "ms");
         for (Map.Entry<Integer,
                 QueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>>> e
                 : partitionResults.entrySet()) {
@@ -1114,12 +1124,18 @@ public class WindowAndSessionStoreWithHeadersIQv2IntegrationTest
         while (System.currentTimeMillis() < deadline) {
             StateQueryResult<ReadOnlyRecordIterator<Windowed<GenericRecord>, GenericRecord>> result =
                 streams.query(StateQueryRequest.inStore(storeName).withQuery(query));
+            // Take success from the partition results themselves, the way queryWindowed does.
+            // drainPartitions returning null means "no partition failed", which is NOT the same as
+            // "some partition succeeded": an empty partition-result map -- nobody served the query at
+            // all -- also reports no failure, and counting that as a success would put the emptiness
+            // claim below right back to proving nothing.
+            if (result.getPartitionResults().values().stream().anyMatch(QueryResult::isSuccess)) {
+                sawSuccess = true;
+            }
             List<ReadOnlyRecord<Windowed<GenericRecord>, GenericRecord>> served = new ArrayList<>();
             String failure = drainPartitions(result, (partition, record) -> served.add(record));
             if (failure != null) {
                 lastFailure = failure;
-            } else {
-                sawSuccess = true;
             }
             assertTrue(served.isEmpty(), context + " but got " + served.size() + " record(s)");
             sleepQuietly(200);


### PR DESCRIPTION
What
----
Adds `WindowAndSessionStoreWithHeadersIQv2IntegrationTest` (16 tests): IQv2 coverage for the
headers-aware window and session stores — `TimestampedWindowKeyWithHeadersQuery`,
`TimestampedWindowRangeWithHeadersQuery` — against real KIP-1271
`TimestampedWindowStoreWithHeaders` / `SessionStoreWithHeaders` instances.

Window and session are covered as separate paths throughout, because they are: a session encodes
its headers through `AggregationWithHeadersSerializer` / `HeadersSerializer` and flushes through
`CachingSessionStore`, where a window uses `ValueTimestampHeadersSerde` and `CachingWindowStore`.

- **Queries** — window by key and window-start range; session by key, covering a merged
  variable-length session (headers are the last folded record's) and a zero-length session, with
  `timestamp()` asserted to be the session end.
- **Cache, as a before/after pair per store type** — a cached-but-unflushed write is invisible to
  the IQv2 query (with an IQv1 fetch as the positive control, proving the record is genuinely
  there and merely unflushed), and after a commit-driven flush the record is served from the store
  with its headers intact.
- **Header contract** — returned headers are read-only; the full produced header set round-trips
  exactly (duplicate key, zero-length value, ordering) for the window store *and* the session
  store.
- **Query-type dispatch** — a session `withKey` query sent to a window store, and a window
  start-range query sent to a session store, both fail with `UNKNOWN_QUERY_TYPE` rather than being
  silently answered.
- **Retained duplicates, restore, multi-partition** — duplicate windows under
  `retainDuplicates`; restore from the changelog for both store types, with a
  `StateRestoreListener` proving a real rebuild; and multi-partition scans for both.

Test-only change; no production code is touched.

Checklist
------------------
- **[N]** Contains customer facing changes? Including API/behavior changes
- **[N/A]** Is this change gated behind config(s)?
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
- **[N]** Does this change require modifying existing system tests or adding new system tests?
- **[Y]** Must this be released together with other change(s), either in this repo or another one?
    - Stacked on #4462, which is stacked on #4461; both must merge first.

References
----------
JIRA:
- KIP-1271 (header-aware state stores) / KIP-1356 (headers-aware IQv2 queries)
- Base PRs: #4461 (shared test base), #4462 (KV store).

Test & Review
------------
```
mvn -pl streams-integration-tests verify
```
44 integration tests, green locally (16 from this PR + 28 from #4461/#4462).

Review note: this PR targets `kip-1356-iqv2-kv-tests`, so
`WindowAndSessionStoreWithHeadersIQv2IntegrationTest.java` is its only file.

Open questions / Follow-ups
--------------------------