### PR TITLE
MINOR: Fix build for kafka-clients NetworkClient and MiniKdc API changes

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -193,6 +193,20 @@
             </exclusions>
         </dependency>
         <dependency>
+            <!-- provides MiniKdc and JaasTestUtils, moved here from the Scala core test jar -->
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-server</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test-fixtures</classifier>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.confluent.networking</groupId>
+                    <artifactId>cc-custom-dns-resolver-java18</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
             <classifier>test</classifier>

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/KafkaGroupLeaderElector.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/KafkaGroupLeaderElector.java
@@ -24,6 +24,7 @@ import io.confluent.kafka.schemaregistry.storage.LeaderElector;
 import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
 import io.confluent.kafka.schemaregistry.storage.SchemaRegistryIdentity;
 import org.apache.kafka.clients.ApiVersions;
+import org.apache.kafka.clients.BootstrapConfiguration;
 import org.apache.kafka.clients.ClientUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.Metadata;
@@ -154,6 +155,8 @@ public class KafkaGroupLeaderElector implements LeaderElector, SchemaRegistryReb
           new ApiVersions(),
           logContext,
           MetadataRecoveryStrategy.NONE,
+          // bootstrap addresses are resolved eagerly above via metadata.bootstrap()
+          BootstrapConfiguration.DISABLED,
           false);
 
       this.client = new ConsumerNetworkClient(

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/SASLClusterTestHarness.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/SASLClusterTestHarness.java
@@ -15,13 +15,13 @@
 
 package io.confluent.kafka.schemaregistry;
 
-import kafka.security.minikdc.MiniKdc;
 import kafka.server.KafkaConfig;
-import kafka.security.JaasTestUtils;
 import kafka.utils.TestUtils;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.apache.kafka.common.security.authenticator.LoginManager;
+import org.apache.kafka.security.JaasTestUtils;
+import org.apache.kafka.security.minikdc.MiniKdc;
 import org.junit.jupiter.api.AfterEach;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
Two breakages from the latest AK kafka-clients (8.4.0-422-ccs):

1. The NetworkClient constructor gained a BootstrapConfiguration parameter before the trailing metadataClusterCheckEnable flag. Pass BootstrapConfiguration.DISABLED, which preserves current behavior: KafkaGroupLeaderElector already resolves the bootstrap addresses eagerly via metadata.bootstrap(), and NetworkClient short-circuits its own bootstrap resolution when the configuration is DISABLED.

2. MiniKdc and JaasTestUtils were ported from Scala core to Java and moved to the kafka-server test-fixtures artifact (kafka.security.minikdc.MiniKdc -> org.apache.kafka.security.minikdc.MiniKdc, kafka.security.JaasTestUtils -> org.apache.kafka.security.JaasTestUtils). Add that test dependency and update the imports in SASLClusterTestHarness; the method signatures are unchanged, so no call sites needed edits.

Verified with a full `mvn install -DskipTests` and by running KafkaStoreSASLTest (3/3 pass), which exercises the relocated MiniKdc.