### PR TITLE
Pin transitive Jackson to 3.2.1 to fix CVEs in 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
         <google.auth.version>1.24.1</google.auth.version>
         <guice.version>5.1.0</guice.version>
         <jsonata-version>2.6.4</jsonata-version>
+        <jackson3.version>3.2.1</jackson3.version>
         <json-schema.version>1.14.6</json-schema.version>
         <json-skema.version>0.30.0</json-skema.version>
         <kcache.version>5.2.3</kcache.version>
@@ -268,6 +269,18 @@
                 <groupId>com.fasterxml.jackson.module</groupId>
                 <artifactId>jackson-module-parameter-names</artifactId>
                 <version>${jackson.version}</version>
+            </dependency>
+            <!-- Jackson 3 (tools.jackson.*) arrives transitively via JSONata4Java; pin it here
+                 since the parent only manages the Jackson 2 (com.fasterxml.jackson.*) groupIds. -->
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>tools.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson3.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.hubspot.jackson</groupId>


### PR DESCRIPTION

<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
JSONata4Java declares both Jacksons 2 & 3 as dependencies, but only the Jackson 2 groupIds are managed by rest-utils-parent, so the Jackson 3 coordinates were resolving unconstrained at 3.2.0, which is affected by CVE-2026-59889 (fixed in 3.2.1).

Manage tools.jackson.core:jackson-databind and jackson-core at 3.2.1.

The Jackson 3 BOM is deliberately not imported: it also manages com.fasterxml.jackson.core:jackson-annotations at 2.22, which would override the inherited Jackson 2 annotations version repo-wide.


Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[ ]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[ ]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[ ]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[ ]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[ ]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
