### PR TITLE
Init 5113 backup restore error handling

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
@@ -164,10 +164,10 @@ public class AvroConverter implements Converter {
   private byte[] restoreFromWrapper(
       String topic, Headers headers, Schema wrapperSchema, Struct wrapper) {
     try {
-      if (wrapperSchema.field(BackupWrapper.FIELD_DATA) == null) {
-        throw new DataException("Malformed backup wrapper: missing '"
-            + BackupWrapper.FIELD_DATA + "' field");
-      }
+      BackupWrapper.requireFields(wrapperSchema,
+          BackupWrapper.FIELD_DATA,
+          BackupWrapper.FIELD_SCHEMA_TYPE,
+          BackupWrapper.FIELD_RAW_SCHEMA);
       String schemaType = wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE);
       if (!SchemaBackupConfig.TYPE_AVRO.equals(schemaType)) {
         throw new DataException(

--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
@@ -19,6 +19,7 @@ package io.confluent.connect.avro;
 import io.confluent.connect.schema.backup.api.BackupWrapper;
 import io.confluent.connect.schema.backup.api.SchemaBackupConfig;
 import io.confluent.connect.schema.backup.core.BackupConverterHelper;
+import io.confluent.connect.schema.backup.core.BackupExceptionMapper;
 import io.confluent.connect.schema.backup.core.BackupReferenceResolver;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.ParsedSchemaAndValue;
@@ -197,11 +198,9 @@ public class AvroConverter implements Converter {
       }
 
       return serializer.serialize(topic, isKey, headers, avroValue, serializeSchema);
-    } catch (DataException e) {
-      throw e;
     } catch (Exception e) {
-      throw new DataException(
-          String.format("Failed to restore Avro data for topic %s", topic), e);
+      throw BackupExceptionMapper.classify(
+          "restore Avro backup for topic " + topic, e);
     }
   }
 
@@ -273,8 +272,8 @@ public class AvroConverter implements Converter {
           SchemaBackupConfig.TYPE_AVRO, isKey,
           AVRO_SCHEMA_FACTORY, serializer::computeSubjectName);
     } catch (Exception e) {
-      throw new DataException(
-          String.format("Failed to wrap backup metadata for topic %s", topic), e);
+      throw BackupExceptionMapper.classify(
+          "wrap Avro backup for topic " + topic, e);
     }
   }
 

--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroConverter.java
@@ -177,6 +177,11 @@ public class AvroConverter implements Converter {
       Object actualData = wrapper.get(BackupWrapper.FIELD_DATA);
       Schema actualConnectSchema = wrapperSchema.field(BackupWrapper.FIELD_DATA).schema();
       String rawSchema = wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA);
+      if (rawSchema == null) {
+        throw new DataException(
+            "Malformed backup wrapper: missing '" + BackupWrapper.FIELD_RAW_SCHEMA
+            + "' for topic " + topic + ". Cannot guarantee pristine restore.");
+      }
 
       BackupReferenceResolver.ResolutionResult resolved =
           backupHelper.getReferenceResolver().resolveFromWrapper(
@@ -187,15 +192,10 @@ public class AvroConverter implements Converter {
       Object avroValue = restoreAvroData.fromConnectData(
           actualConnectSchema, avroSchema, actualData);
 
-      AvroSchema serializeSchema;
-      if (rawSchema != null) {
-        serializeSchema = resolved.hasReferences()
-            ? new AvroSchema(rawSchema, resolved.getTargetRefs(),
-                resolved.getResolvedSchemas(), null)
-            : new AvroSchema(rawSchema);
-      } else {
-        serializeSchema = new AvroSchema(avroSchema);
-      }
+      AvroSchema serializeSchema = resolved.hasReferences()
+          ? new AvroSchema(rawSchema, resolved.getTargetRefs(),
+              resolved.getResolvedSchemas(), null)
+          : new AvroSchema(rawSchema);
 
       return serializer.serialize(topic, isKey, headers, avroValue, serializeSchema);
     } catch (Exception e) {

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroConverterBackupTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroConverterBackupTest.java
@@ -25,15 +25,35 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import io.confluent.connect.schema.backup.api.BackupWrapper;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import io.confluent.kafka.serializers.schema.id.HeaderSchemaIdSerializer;
+import io.confluent.kafka.serializers.schema.id.SchemaId;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.DataException;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,113 +61,951 @@ import org.junit.Test;
 public class AvroConverterBackupTest {
 
   private static final String TOPIC = "test-topic";
-  private static final String FIELD_NAME = "name";
-  private static final String FIELD_COUNT = "count";
   private static final String SCHEMA_TYPE = "AVRO";
+  private static final String SR_URL_KEY = "schema.registry.url";
+  private static final String FAKE_SR_URL = "http://fake-url";
+  private static final String BACKUP_ENABLED_KEY = "schema.backup.enabled";
 
+  private static final String FIELD_NAME = "name";
+  private static final String FIELD_ID = "id";
+  private static final String FIELD_COUNT = "count";
+
+  // Source-cluster SR + converters (default for all tests).
   private final SchemaRegistryClient schemaRegistry;
   private final AvroConverter converter;
   private final AvroConverter plainConverter;
+  private KafkaAvroSerializer rawAvroSerializer;
+  private KafkaAvroDeserializer rawAvroDeserializer;
+
+  private final SchemaRegistryClient targetSchemaRegistry;
+  private final AvroConverter targetConverter;
+  private KafkaAvroDeserializer targetAvroDeserializer;
+
+  private int topicCounter = 0;
 
   public AvroConverterBackupTest() {
     schemaRegistry = new MockSchemaRegistryClient();
     converter = new AvroConverter(schemaRegistry);
     plainConverter = new AvroConverter(schemaRegistry);
+    targetSchemaRegistry = new MockSchemaRegistryClient();
+    targetConverter = new AvroConverter(targetSchemaRegistry);
   }
 
   @Before
   public void setUp() {
     Map<String, Object> backupConfig = new HashMap<>();
-    backupConfig.put("schema.registry.url", "http://fake-url");
-    backupConfig.put("schema.backup.enabled", "true");
+    backupConfig.put(SR_URL_KEY, FAKE_SR_URL);
+    backupConfig.put(BACKUP_ENABLED_KEY, "true");
     converter.configure(backupConfig, false);
+    targetConverter.configure(backupConfig, false);
 
-    plainConverter.configure(
-        Collections.singletonMap("schema.registry.url", "http://fake-url"),
-        false);
+    Map<String, Object> plainConfig = Collections.singletonMap(SR_URL_KEY, FAKE_SR_URL);
+    plainConverter.configure(plainConfig, false);
+
+    rawAvroSerializer = new KafkaAvroSerializer(schemaRegistry);
+    rawAvroSerializer.configure(plainConfig, false);
+    rawAvroDeserializer = new KafkaAvroDeserializer(schemaRegistry);
+    rawAvroDeserializer.configure(plainConfig, false);
+
+    targetAvroDeserializer = new KafkaAvroDeserializer(targetSchemaRegistry);
+    targetAvroDeserializer.configure(plainConfig, false);
   }
 
+  private static KafkaAvroSerializer newReferenceAwareAvroSerializer(
+      SchemaRegistryClient sr) {
+    Map<String, Object> cfg = new HashMap<>();
+    cfg.put(SR_URL_KEY, FAKE_SR_URL);
+    cfg.put("auto.register.schemas", "false");
+    cfg.put("use.latest.version", "true");
+    KafkaAvroSerializer s = new KafkaAvroSerializer(sr);
+    s.configure(cfg, false);
+    return s;
+  }
+
+  private String nextTopic() {
+    return TOPIC + "-" + (topicCounter++);
+  }
+
+  private static void assertWrapperShape(SchemaAndValue wrapped, String expectedType) {
+    assertNotNull("wrapped result", wrapped);
+    assertNotNull("wrapped schema", wrapped.schema());
+    assertEquals("wrapper schema name", BackupWrapper.NAME, wrapped.schema().name());
+    Struct w = (Struct) wrapped.value();
+    assertEquals("schema type", expectedType, w.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
+    assertNotNull("schema subject", w.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT));
+    assertNotNull("raw schema", w.getString(BackupWrapper.FIELD_RAW_SCHEMA));
+    assertNotNull("data field", w.get(BackupWrapper.FIELD_DATA));
+    assertNotNull("schema ID", w.getInt32(BackupWrapper.FIELD_SCHEMA_ID));
+    assertTrue("schema ID > 0", w.getInt32(BackupWrapper.FIELD_SCHEMA_ID) > 0);
+    assertNotNull("schema version", w.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION));
+  }
+
+  private static void assertBytesExact(byte[] original, byte[] restored) {
+    assertNotNull("original bytes", original);
+    assertNotNull("restored bytes", restored);
+    assertArrayEquals("byte-exact roundtrip", original, restored);
+  }
+
+  private static void assertWireSchemaIdPreserved(byte[] original, byte[] restored) {
+    assertTrue("original wire-format long enough", original.length >= 5);
+    assertTrue("restored wire-format long enough", restored.length >= 5);
+    assertEquals("original magic byte", (byte) 0x00, original[0]);
+    assertEquals("restored magic byte", (byte) 0x00, restored[0]);
+    int origId = ByteBuffer.wrap(original, 1, 4).getInt();
+    int restoredId = ByteBuffer.wrap(restored, 1, 4).getInt();
+    assertEquals("wire-format schema ID preserved", origId, restoredId);
+  }
+
+  private static void assertValueEqual(Object originalDeser, Object restoredDeser) {
+    assertEquals("deserialized value equality", originalDeser, restoredDeser);
+  }
+
+  private static void assertWrapperSchemaIdMatchesSource(
+      SchemaAndValue wrapped, byte[] sourceBytes) {
+    int sourceWireId = ByteBuffer.wrap(sourceBytes, 1, 4).getInt();
+    Integer wrapperId = ((Struct) wrapped.value()).getInt32(BackupWrapper.FIELD_SCHEMA_ID);
+    assertNotNull("wrapper schema ID populated", wrapperId);
+    assertEquals("wrapper.schemaId matches source wire ID at bytes[1..4]",
+        sourceWireId, wrapperId.intValue());
+  }
+
+  private void assertRawSchemaMatchesSourceRegistered(
+      SchemaAndValue wrapped, byte[] sourceBytes) throws Exception {
+    int sourceWireId = ByteBuffer.wrap(sourceBytes, 1, 4).getInt();
+    ParsedSchema sourceRegistered = schemaRegistry.getSchemaById(sourceWireId);
+    String wrapperRaw = ((Struct) wrapped.value()).getString(BackupWrapper.FIELD_RAW_SCHEMA);
+    assertNotNull("wrapper rawSchema populated", wrapperRaw);
+    AvroSchema wrapperParsed = new AvroSchema(wrapperRaw);
+    assertEquals("wrapper rawSchema canonically equals source-registered schema",
+        sourceRegistered.canonicalString(), wrapperParsed.canonicalString());
+  }
+
+  private static void assertPayloadBytesEqual(byte[] source, byte[] restored) {
+    assertTrue("source has 5-byte header + payload", source.length >= 5);
+    assertTrue("restored has 5-byte header + payload", restored.length >= 5);
+    byte[] sourcePayload = Arrays.copyOfRange(source, 5, source.length);
+    byte[] restoredPayload = Arrays.copyOfRange(restored, 5, restored.length);
+    assertArrayEquals("payload bytes (bytes[5..end]) equal", sourcePayload, restoredPayload);
+  }
+
+  private static void assertCrossClusterBytesEquivalent(byte[] sourceBytes,
+      byte[] restoredBytes) {
+    assertTrue("source has 5-byte header + payload", sourceBytes.length >= 5);
+    assertTrue("restored has 5-byte header + payload", restoredBytes.length >= 5);
+    assertEquals("source magic byte", (byte) 0x00, sourceBytes[0]);
+    assertEquals("restored magic byte", (byte) 0x00, restoredBytes[0]);
+    int sourceId = ByteBuffer.wrap(sourceBytes, 1, 4).getInt();
+    int restoredId = ByteBuffer.wrap(restoredBytes, 1, 4).getInt();
+    assertTrue("source wire ID positive", sourceId > 0);
+    assertTrue("restored wire ID positive", restoredId > 0);
+    // Payload byte-exactness is the semantic-equivalence guarantee.
+    assertPayloadBytesEqual(sourceBytes, restoredBytes);
+  }
+
+  private void assertFullFidelityRoundTrip(String topic, Schema connectSchema, Struct value) {
+    byte[] originalBytes = plainConverter.fromConnectData(topic, connectSchema, value);
+    assertNotNull("plain serialization produced bytes", originalBytes);
+
+    SchemaAndValue wrapped = converter.toConnectData(topic, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    assertWrapperShape(wrapped, SCHEMA_TYPE);
+    assertBytesExact(originalBytes, restoredBytes);
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
+    String raw = ((Struct) wrapped.value()).getString(BackupWrapper.FIELD_RAW_SCHEMA);
+    assertNotNull("raw schema captured", raw);
+    AvroSchema restoredParsed = new AvroSchema(raw);
+    assertNotNull("raw schema parses", restoredParsed.canonicalString());
+    SchemaAndValue originalDeser = plainConverter.toConnectData(topic, originalBytes);
+    SchemaAndValue restoredDeser = plainConverter.toConnectData(topic, restoredBytes);
+    assertValueEqual(originalDeser.value(), restoredDeser.value());
+  }
+
+  private Map<String, Object> backupConfigWith(String key, String value) {
+    Map<String, Object> cfg = new HashMap<>();
+    cfg.put(SR_URL_KEY, FAKE_SR_URL);
+    cfg.put(BACKUP_ENABLED_KEY, "true");
+    cfg.put(key, value);
+    return cfg;
+  }
+
+  // ================ Default-behavior gates ================
+
   @Test
-  public void testBackupToConnectDataWrapsMetadata() {
+  public void testDefaultWrapperShape() {
     Schema schema = SchemaBuilder.struct()
+        .name("TestRecord")
         .field(FIELD_NAME, Schema.STRING_SCHEMA)
         .field("age", Schema.INT32_SCHEMA)
         .build();
-    Struct value = new Struct(schema)
-        .put(FIELD_NAME, "Alice")
-        .put("age", 30);
+    Struct value = new Struct(schema).put(FIELD_NAME, "Alice").put("age", 30);
 
     byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
-    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, serialized);
 
-    assertNotNull(result);
-    assertNotNull(result.schema());
-    assertEquals(BackupWrapper.NAME, result.schema().name());
-
-    Struct wrapper = (Struct) result.value();
-    assertNotNull(wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_ID));
-    assertEquals(SCHEMA_TYPE, wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
-    assertNotNull(wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA));
-    assertNotNull(wrapper.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT));
-    assertNotNull(wrapper.get(BackupWrapper.FIELD_DATA));
+    assertWrapperShape(wrapped, SCHEMA_TYPE);
+    Struct w = (Struct) wrapped.value();
+    assertTrue("subject contains topic",
+        w.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT).contains(TOPIC));
   }
 
   @Test
-  public void testBackupFromConnectDataRestores() {
+  public void testDefaultBytesExactForStruct() {
     Schema schema = SchemaBuilder.struct()
-        .field(FIELD_NAME, Schema.STRING_SCHEMA)
-        .build();
-    Struct value = new Struct(schema).put(FIELD_NAME, "Bob");
-
-    // Serialize to get valid wire-format bytes
-    byte[] original = plainConverter.fromConnectData(TOPIC, schema, value);
-    assertNotNull(original);
-    assertTrue(original.length >= 5);
-
-    // Wrap via backup toConnectData
-    SchemaAndValue wrapped = converter.toConnectData(TOPIC, original);
-    assertEquals(BackupWrapper.NAME, wrapped.schema().name());
-
-    // Restore via backup fromConnectData
-    byte[] restored = converter.fromConnectData(
-        TOPIC, wrapped.schema(), wrapped.value());
-
-    assertNotNull(restored);
-    // Wire format: magic byte 0x00 followed by 4-byte schema ID
-    assertEquals(0x00, restored[0]);
-  }
-
-  @Test
-  public void testBackupRoundTrip() {
-    Schema schema = SchemaBuilder.struct()
-        .field("id", Schema.STRING_SCHEMA)
+        .name("Exact")
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
         .field(FIELD_COUNT, Schema.INT32_SCHEMA)
         .build();
-    Struct original = new Struct(schema)
-        .put("id", "order-1")
-        .put(FIELD_COUNT, 42);
+    Struct value = new Struct(schema).put(FIELD_ID, "order-1").put(FIELD_COUNT, 42);
 
-    // Serialize with plain converter
-    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, original);
-
-    // Backup path: toConnectData wraps, fromConnectData restores
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
     SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
-    byte[] restoredBytes = converter.fromConnectData(
-        TOPIC, wrapped.schema(), wrapped.value());
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
 
-    // Deserialize restored bytes and compare values
-    SchemaAndValue restoredData = plainConverter.toConnectData(TOPIC, restoredBytes);
-    Struct restored = (Struct) restoredData.value();
-    assertEquals("order-1", restored.getString("id"));
-    assertEquals(Integer.valueOf(42), restored.getInt32(FIELD_COUNT));
+    assertBytesExact(originalBytes, restoredBytes);
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
   }
 
   @Test
-  public void testBackupDisabledNoWrapping() {
+  public void testDefaultWireSchemaIdPreserved() {
+    Schema schema = SchemaBuilder.struct()
+        .name("IdCheck")
+        .field(FIELD_ID, Schema.INT32_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, 42);
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
+  }
+
+  @Test
+  public void testDefaultRawSchemaSemanticallyEqual() {
+    Schema schema = SchemaBuilder.struct()
+        .name("io.confluent.test.RawCheck")
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
+        .field("value", Schema.INT32_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_NAME, "raw-check").put("value", 42);
+
+    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, serialized);
+
+    String raw = ((Struct) wrapped.value()).getString(BackupWrapper.FIELD_RAW_SCHEMA);
+    assertNotNull("raw schema captured", raw);
+    AvroSchema restored = new AvroSchema(raw);
+    // Round-trip through AvroSchema canonicalString must be stable.
+    AvroSchema roundtripped = new AvroSchema(restored.canonicalString());
+    assertEquals("raw schema canonical stable",
+        restored.canonicalString(), roundtripped.canonicalString());
+  }
+
+  @Test
+  public void testDefaultSingletonUnionFlattenedOptionalString() {
+    Schema schema = SchemaBuilder.struct()
+        .name("Nullable")
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
+        .field("nickname", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Struct with = new Struct(schema).put(FIELD_NAME, "Alice").put("nickname", "Al");
+    Struct without = new Struct(schema).put(FIELD_NAME, "Bob"); // nickname null
+
+    assertFullFidelityRoundTrip(TOPIC, schema, with);
+    assertFullFidelityRoundTrip(TOPIC, schema, without);
+  }
+
+  @Test
+  public void testDefaultComplexRealisticSchemaAllAxesPass() {
+    Schema addressSchema = SchemaBuilder.struct()
+        .name("io.confluent.test.Address")
+        .field("street", Schema.STRING_SCHEMA)
+        .field("city", Schema.STRING_SCHEMA)
+        .field("country", Schema.STRING_SCHEMA)
+        .build();
+
+    Schema contactSchema = SchemaBuilder.struct()
+        .name("io.confluent.test.Contact")
+        .field("name", Schema.STRING_SCHEMA)
+        .field("email", Schema.OPTIONAL_STRING_SCHEMA)
+        .field("address", addressSchema)
+        .build();
+
+    Schema profileSchema = SchemaBuilder.struct()
+        .name("io.confluent.test.Profile")
+        .field("id", Schema.STRING_SCHEMA)
+        .field("primary", addressSchema)
+        .field("secondary", addressSchema)  // shared named type
+        .field("contacts", SchemaBuilder.array(contactSchema).build())
+        .field("attributes", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).build())
+        .field("created", Timestamp.SCHEMA)          // logical type: timestamp-millis
+        .field("balance", Decimal.schema(2))         // logical type: decimal(scale=2)
+        .field("optional_note", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+
+    Struct hqAddr = new Struct(addressSchema)
+        .put("street", "1 HQ Plaza")
+        .put("city", "San Francisco")
+        .put("country", "US");
+    Struct branchAddr = new Struct(addressSchema)
+        .put("street", "2 Branch Ln")
+        .put("city", "Austin")
+        .put("country", "US");
+    Struct contactAddr = new Struct(addressSchema)
+        .put("street", "3 Friend Rd")
+        .put("city", "Boston")
+        .put("country", "US");
+    Struct contact = new Struct(contactSchema)
+        .put("name", "Bob")
+        .put("email", "bob@test.com")
+        .put("address", contactAddr);
+
+    Map<String, String> attrs = new HashMap<>();
+    attrs.put("env", "prod");
+    attrs.put("region", "us-west");
+
+    Struct profile = new Struct(profileSchema)
+        .put("id", "profile-1")
+        .put("primary", hqAddr)
+        .put("secondary", branchAddr)
+        .put("contacts", Collections.singletonList(contact))
+        .put("attributes", attrs)
+        .put("created", new Date(1700000000000L))
+        .put("balance", new BigDecimal("1234.56"))
+        .put("optional_note", null);
+
+    String topic = nextTopic();
+    byte[] originalBytes = plainConverter.fromConnectData(topic, profileSchema, profile);
+    SchemaAndValue wrapped = converter.toConnectData(topic, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    assertWrapperShape(wrapped, SCHEMA_TYPE);
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
+    String raw = ((Struct) wrapped.value()).getString(BackupWrapper.FIELD_RAW_SCHEMA);
+    assertNotNull("raw Avro schema captured", raw);
+    AvroSchema restoredSchema = new AvroSchema(raw);
+    assertNotNull("raw schema parses cleanly", restoredSchema.canonicalString());
+    SchemaAndValue originalDeser = plainConverter.toConnectData(topic, originalBytes);
+    SchemaAndValue restoredDeser = plainConverter.toConnectData(topic, restoredBytes);
+    assertValueEqual(originalDeser.value(), restoredDeser.value());
+  }
+
+  @Test
+  public void testIdempotencyKitchenSinkStableAcrossCycles() {
+    Schema schema = SchemaBuilder.struct()
+        .name("IdempotencyTarget")
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .field(FIELD_COUNT, Schema.INT32_SCHEMA)
+        .field(FIELD_NAME, Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema)
+        .put(FIELD_ID, "idem-1")
+        .put(FIELD_COUNT, 42)
+        .put(FIELD_NAME, "stable");
+
+    byte[] wire0 = plainConverter.fromConnectData(TOPIC, schema, value);
+    int id0 = ByteBuffer.wrap(wire0, 1, 4).getInt();
+
+    SchemaAndValue wrapped1 = converter.toConnectData(TOPIC, wire0);
+    byte[] restored1 = converter.fromConnectData(TOPIC, wrapped1.schema(), wrapped1.value());
+    int id1 = ByteBuffer.wrap(restored1, 1, 4).getInt();
+
+    SchemaAndValue wrapped2 = converter.toConnectData(TOPIC, restored1);
+    byte[] restored2 = converter.fromConnectData(TOPIC, wrapped2.schema(), wrapped2.value());
+    int id2 = ByteBuffer.wrap(restored2, 1, 4).getInt();
+
+    assertEquals("schema ID stable across cycle 1", id0, id1);
+    assertEquals("schema ID stable across cycle 2", id1, id2);
+    assertArrayEquals("wire bytes stable across cycles", restored1, restored2);
+
+    Struct w1 = (Struct) wrapped1.value();
+    Struct w2 = (Struct) wrapped2.value();
+    assertEquals("wrapper raw schema stable",
+        w1.getString(BackupWrapper.FIELD_RAW_SCHEMA),
+        w2.getString(BackupWrapper.FIELD_RAW_SCHEMA));
+    assertEquals("wrapper schema ID stable",
+        w1.getInt32(BackupWrapper.FIELD_SCHEMA_ID),
+        w2.getInt32(BackupWrapper.FIELD_SCHEMA_ID));
+  }
+
+  @Test
+  public void testDefaultSharedNamedTypeAtMultipleFieldsSurvives() {
+    Schema addressSchema = SchemaBuilder.struct()
+        .name("Address")
+        .field("street", Schema.STRING_SCHEMA)
+        .field("city", Schema.STRING_SCHEMA)
+        .parameter("connect.custom", "shared-address")
+        .build();
+    Schema personSchema = SchemaBuilder.struct()
+        .name("Person")
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
+        .field("homeAddress", addressSchema)
+        .field("workAddress", addressSchema)
+        .build();
+    Struct value = new Struct(personSchema)
+        .put(FIELD_NAME, "Alice")
+        .put("homeAddress", new Struct(addressSchema)
+            .put("street", "1 Home Ln").put("city", "Hometown"))
+        .put("workAddress", new Struct(addressSchema)
+            .put("street", "2 Work Ave").put("city", "Workville"));
+
+    assertFullFidelityRoundTrip(TOPIC, personSchema, value);
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, personSchema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    String raw = ((Struct) wrapped.value()).getString(BackupWrapper.FIELD_RAW_SCHEMA);
+    assertNotNull("raw Avro schema captured", raw);
+    assertTrue("shared-type params captured in raw schema",
+        raw.contains("shared-address"));
+  }
+
+  @Test
+  public void testDefaultLogicalTypesPreserved() {
+    Schema schema = SchemaBuilder.struct()
+        .name("LogicalTypes")
+        .field("price", Decimal.builder(2).build())
+        .field("createdOn", org.apache.kafka.connect.data.Date.builder().build())
+        .field("updatedAt", Timestamp.builder().build())
+        .build();
+    Struct value = new Struct(schema)
+        .put("price", new BigDecimal("19.99"))
+        .put("createdOn", new java.util.Date(0))
+        .put("updatedAt", new java.util.Date(1_700_000_000_000L));
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    assertBytesExact(originalBytes, restoredBytes);
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
+    SchemaAndValue restoredData = plainConverter.toConnectData(TOPIC, restoredBytes);
+    Struct restored = (Struct) restoredData.value();
+    assertEquals("decimal preserved", new BigDecimal("19.99"), restored.get("price"));
+    assertEquals("date preserved", new java.util.Date(0), restored.get("createdOn"));
+    assertEquals("timestamp preserved",
+        new java.util.Date(1_700_000_000_000L), restored.get("updatedAt"));
+  }
+
+  @Test
+  public void testDefaultBytesFieldPreserved() {
+    Schema schema = SchemaBuilder.struct()
+        .name("BytesHolder")
+        .field("payload", Schema.BYTES_SCHEMA)
+        .build();
+    byte[] rawBytes = new byte[]{0x00, 0x01, 0x7F, (byte) 0x80, (byte) 0xFF, 0x42};
+    Struct value = new Struct(schema).put("payload", ByteBuffer.wrap(rawBytes));
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    assertBytesExact(originalBytes, restoredBytes);
+    SchemaAndValue restoredData = plainConverter.toConnectData(TOPIC, restoredBytes);
+    ByteBuffer restoredPayload = (ByteBuffer) ((Struct) restoredData.value()).get("payload");
+    assertArrayEquals("byte payload preserved",
+        rawBytes, Arrays.copyOfRange(restoredPayload.array(),
+            restoredPayload.arrayOffset(), restoredPayload.arrayOffset() + rawBytes.length));
+  }
+
+  @Test
+  public void testDefaultEmptyCollectionsPreserved() {
+    Schema schema = SchemaBuilder.struct()
+        .name("EmptyCollections")
+        .field("tags", SchemaBuilder.array(Schema.STRING_SCHEMA).build())
+        .field("attrs", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).build())
+        .build();
+    Struct value = new Struct(schema)
+        .put("tags", Collections.emptyList())
+        .put("attrs", Collections.emptyMap());
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    assertBytesExact(originalBytes, restoredBytes);
+    SchemaAndValue restoredData = plainConverter.toConnectData(TOPIC, restoredBytes);
+    Struct restored = (Struct) restoredData.value();
+    assertTrue("empty tags array preserved",
+        ((java.util.List<?>) restored.get("tags")).isEmpty());
+    assertTrue("empty attrs map preserved",
+        ((java.util.Map<?, ?>) restored.get("attrs")).isEmpty());
+  }
+
+  @Test
+  public void testDefaultPristineRestoreWithRawAvroProducer() throws Exception {
+    String topic = nextTopic();
+    org.apache.avro.Schema rawAvroSchema = org.apache.avro.SchemaBuilder
+        .record("PristineEvent").namespace("io.confluent.test").fields()
+        .requiredString("id")
+        .requiredInt("count")
+        .optionalString("note")
+        .endRecord();
+    org.apache.avro.generic.GenericRecord record =
+        new org.apache.avro.generic.GenericRecordBuilder(rawAvroSchema)
+            .set("id", "pristine-1")
+            .set("count", 42)
+            .set("note", "e2e")
+            .build();
+
+    byte[] sourceBytes = rawAvroSerializer.serialize(topic, record);
+    SchemaAndValue wrapped = converter.toConnectData(topic, sourceBytes);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    assertWrapperShape(wrapped, SCHEMA_TYPE);
+    assertWrapperSchemaIdMatchesSource(wrapped, sourceBytes);
+    assertRawSchemaMatchesSourceRegistered(wrapped, sourceBytes);
+    assertWireSchemaIdPreserved(sourceBytes, restoredBytes);
+    assertPayloadBytesEqual(sourceBytes, restoredBytes);
+    assertBytesExact(sourceBytes, restoredBytes);
+    Object originalDeser = rawAvroDeserializer.deserialize(topic, sourceBytes);
+    Object restoredDeser = rawAvroDeserializer.deserialize(topic, restoredBytes);
+    assertValueEqual(originalDeser, restoredDeser);
+  }
+
+  @Test
+  public void testDefaultPristineRestoreMegaKitchenSinkAllTypesAndReferences() throws Exception {
+    converter.configure(
+        backupConfigWith("enhanced.avro.schema.support", "true"), false);
+
+    String topic = nextTopic();
+
+    String addressSubject = "shared.Address";
+    org.apache.avro.Schema addressAvro = org.apache.avro.SchemaBuilder
+        .record("Address").namespace("io.confluent.test.shared").fields()
+        .requiredString("street")
+        .requiredString("city")
+        .requiredString("country")
+        .endRecord();
+    schemaRegistry.register(addressSubject, new AvroSchema(addressAvro));
+
+    org.apache.avro.Schema priorityAvro = org.apache.avro.SchemaBuilder
+        .enumeration("Priority").namespace("io.confluent.test")
+        .symbols("LOW", "MEDIUM", "HIGH");
+    org.apache.avro.Schema uuidAvro = org.apache.avro.SchemaBuilder
+        .fixed("Uuid16").namespace("io.confluent.test").size(16);
+    org.apache.avro.Schema timestampMillisAvro = org.apache.avro.LogicalTypes.timestampMillis()
+        .addToSchema(org.apache.avro.SchemaBuilder.builder().longType());
+    org.apache.avro.Schema dateAvro = org.apache.avro.LogicalTypes.date()
+        .addToSchema(org.apache.avro.SchemaBuilder.builder().intType());
+    org.apache.avro.Schema decimalAvro = org.apache.avro.LogicalTypes.decimal(10, 2)
+        .addToSchema(org.apache.avro.SchemaBuilder.builder().bytesType());
+
+    org.apache.avro.Schema personAvro = org.apache.avro.SchemaBuilder
+        .record("MegaPerson").namespace("io.confluent.test").fields()
+        // Primitives
+        .requiredString("id")
+        .requiredInt("age")
+        .requiredLong("balanceCents")
+        .requiredDouble("rating")
+        .requiredBoolean("active")
+        .name("payload").type().bytesType().noDefault()
+        // Logical types
+        .name("createdAtMs").type(timestampMillisAvro).noDefault()
+        .name("birthDate").type(dateAvro).noDefault()
+        .name("priceUsd").type(decimalAvro).noDefault()
+        // Enum + Fixed
+        .name("priority").type(priorityAvro).noDefault()
+        .name("guid").type(uuidAvro).noDefault()
+        // Cross-subject reference used at TWO fields (shared named type)
+        .name("homeAddress").type(addressAvro).noDefault()
+        .name("workAddress").type(addressAvro).noDefault()
+        // Array + Map + Nullable
+        .name("tags").type().array().items().stringType().noDefault()
+        .name("attrs").type().map().values().stringType().noDefault()
+        .name("bio").type().nullable().stringType().stringDefault("")
+        .endRecord();
+
+    SchemaReference addressRef = new SchemaReference(
+        "io.confluent.test.shared.Address", addressSubject, 1);
+    Map<String, String> resolvedRefs = new HashMap<>();
+    resolvedRefs.put("io.confluent.test.shared.Address", addressAvro.toString());
+    AvroSchema personSchema = new AvroSchema(
+        personAvro.toString(),
+        Collections.singletonList(addressRef),
+        resolvedRefs,
+        null);
+    schemaRegistry.register(topic + "-value", personSchema);
+
+    org.apache.avro.generic.GenericRecord homeAddrRec =
+        new org.apache.avro.generic.GenericRecordBuilder(addressAvro)
+            .set("street", "1 Home Ln").set("city", "Hometown").set("country", "US")
+            .build();
+    org.apache.avro.generic.GenericRecord workAddrRec =
+        new org.apache.avro.generic.GenericRecordBuilder(addressAvro)
+            .set("street", "2 Work Ave").set("city", "Workville").set("country", "US")
+            .build();
+    org.apache.avro.Conversions.DecimalConversion decConv =
+        new org.apache.avro.Conversions.DecimalConversion();
+    ByteBuffer priceBytes = decConv.toBytes(
+        new BigDecimal("123.45"), decimalAvro, org.apache.avro.LogicalTypes.decimal(10, 2));
+    byte[] guidRaw = new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+    org.apache.avro.generic.GenericData.Fixed guidFixed =
+        new org.apache.avro.generic.GenericData.Fixed(uuidAvro, guidRaw);
+    org.apache.avro.generic.GenericData.EnumSymbol prioritySymbol =
+        new org.apache.avro.generic.GenericData.EnumSymbol(priorityAvro, "HIGH");
+
+    org.apache.avro.generic.GenericRecord person =
+        new org.apache.avro.generic.GenericRecordBuilder(personAvro)
+            .set("id", "person-1")
+            .set("age", 30)
+            .set("balanceCents", 100_000L)
+            .set("rating", 4.5)
+            .set("active", true)
+            .set("payload", ByteBuffer.wrap(new byte[]{0x00, 0x7F, (byte) 0x80, (byte) 0xFF}))
+            .set("createdAtMs", 1_700_000_000_000L)
+            .set("birthDate", 15_000)
+            .set("priceUsd", priceBytes)
+            .set("priority", prioritySymbol)
+            .set("guid", guidFixed)
+            .set("homeAddress", homeAddrRec)
+            .set("workAddress", workAddrRec)
+            .set("tags", Arrays.asList("premium", "verified"))
+            .set("attrs", Collections.singletonMap("env", "prod"))
+            .set("bio", "test bio")
+            .build();
+
+    byte[] sourceBytes = rawAvroSerializer.serialize(topic, person);
+
+    SchemaAndValue wrapped = converter.toConnectData(topic, sourceBytes);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    assertWrapperShape(wrapped, SCHEMA_TYPE);
+    assertWrapperSchemaIdMatchesSource(wrapped, sourceBytes);
+    assertRawSchemaMatchesSourceRegistered(wrapped, sourceBytes);
+    assertWireSchemaIdPreserved(sourceBytes, restoredBytes);
+    assertPayloadBytesEqual(sourceBytes, restoredBytes);
+    assertBytesExact(sourceBytes, restoredBytes);
+
+    // Semantic equivalence via re-deserialization through the raw Avro path.
+    Object originalDeser = rawAvroDeserializer.deserialize(topic, sourceBytes);
+    Object restoredDeser = rawAvroDeserializer.deserialize(topic, restoredBytes);
+    assertValueEqual(originalDeser, restoredDeser);
+  }
+
+  private static final String ADDRESS_SCHEMA_JSON =
+      "{\"type\":\"record\",\"name\":\"Address\","
+          + "\"namespace\":\"io.confluent.test.shared\","
+          + "\"fields\":["
+          + "{\"name\":\"street\",\"type\":\"string\"},"
+          + "{\"name\":\"city\",\"type\":\"string\"},"
+          + "{\"name\":\"country\",\"type\":\"string\"}]}";
+  private static final String ADDRESS_FQCN = "io.confluent.test.shared.Address";
+  private static final String ADDRESS_SUBJECT = "shared.Address";
+
+  private static final String PERSON_WITH_REF_SCHEMA_JSON =
+      "{\"type\":\"record\",\"name\":\"PersonRef\","
+          + "\"namespace\":\"io.confluent.test\","
+          + "\"fields\":["
+          + "{\"name\":\"name\",\"type\":\"string\"},"
+          + "{\"name\":\"homeAddress\",\"type\":"
+          + "{\"type\":\"record\",\"name\":\"Address\","
+          + "\"namespace\":\"io.confluent.test.shared\","
+          + "\"fields\":["
+          + "{\"name\":\"street\",\"type\":\"string\"},"
+          + "{\"name\":\"city\",\"type\":\"string\"},"
+          + "{\"name\":\"country\",\"type\":\"string\"}]}},"
+          + "{\"name\":\"workAddress\",\"type\":\"io.confluent.test.shared.Address\"}]}";
+
+  private RefTestFixture registerAndProducePersonWithAddressRef() throws Exception {
+    String topic = nextTopic();
+    schemaRegistry.register(ADDRESS_SUBJECT, new AvroSchema(ADDRESS_SCHEMA_JSON));
+    SchemaReference addressRef = new SchemaReference(ADDRESS_FQCN, ADDRESS_SUBJECT, 1);
+    Map<String, String> resolved = new HashMap<>();
+    resolved.put(ADDRESS_FQCN, ADDRESS_SCHEMA_JSON);
+    AvroSchema personSchema = new AvroSchema(
+        PERSON_WITH_REF_SCHEMA_JSON, Collections.singletonList(addressRef), resolved, null);
+    schemaRegistry.register(topic + "-value", personSchema);
+
+    org.apache.avro.Schema personAvroSchema = personSchema.rawSchema();
+    org.apache.avro.Schema addressAvroSchema =
+        personAvroSchema.getField("homeAddress").schema();
+    org.apache.avro.generic.GenericRecord addr =
+        new org.apache.avro.generic.GenericRecordBuilder(addressAvroSchema)
+            .set("street", "1 Main St").set("city", "Springfield").set("country", "US")
+            .build();
+    org.apache.avro.generic.GenericRecord person =
+        new org.apache.avro.generic.GenericRecordBuilder(personAvroSchema)
+            .set("name", "Alice")
+            .set("homeAddress", addr)
+            .set("workAddress", addr)
+            .build();
+    KafkaAvroSerializer refSerializer = newReferenceAwareAvroSerializer(schemaRegistry);
+    byte[] sourceBytes = refSerializer.serialize(topic, person);
+    return new RefTestFixture(topic, sourceBytes);
+  }
+
+  private static final class RefTestFixture {
+    final String topic;
+    final byte[] sourceBytes;
+    RefTestFixture(String topic, byte[] sourceBytes) {
+      this.topic = topic;
+      this.sourceBytes = sourceBytes;
+    }
+  }
+
+  @Test
+  public void testDefaultPristineRestoreCrossClusterWithCrossSubjectReferences()
+      throws Exception {
+    RefTestFixture fx = registerAndProducePersonWithAddressRef();
+    int sourceWireId = ByteBuffer.wrap(fx.sourceBytes, 1, 4).getInt();
+    String sourcePersonCanonical =
+        schemaRegistry.getSchemaById(sourceWireId).canonicalString();
+
+    SchemaAndValue wrapped = converter.toConnectData(fx.topic, fx.sourceBytes);
+
+    assertWrapperShape(wrapped, SCHEMA_TYPE);
+    assertWrapperSchemaIdMatchesSource(wrapped, fx.sourceBytes);
+    Struct wrapperStruct = (Struct) wrapped.value();
+    assertEquals("wrapper rawSchema equals source-registered canonical form",
+        sourcePersonCanonical,
+        wrapperStruct.getString(BackupWrapper.FIELD_RAW_SCHEMA));
+    String refTree = wrapperStruct.getString(BackupWrapper.FIELD_REFERENCE_TREE);
+    String directRefs = wrapperStruct.getString(BackupWrapper.FIELD_DIRECT_REFS);
+    assertNotNull("reference tree captured", refTree);
+    assertNotNull("direct refs captured", directRefs);
+    assertTrue("reference tree mentions Address FQCN: " + refTree,
+        refTree.contains(ADDRESS_FQCN));
+    assertTrue("direct refs mention Address subject: " + directRefs,
+        directRefs.contains(ADDRESS_SUBJECT));
+
+    // Target SR is empty; restore must re-register Address and Person there.
+    assertTrue("target SR is empty before restore",
+        targetSchemaRegistry.getAllSubjects().isEmpty());
+    byte[] restoredBytes = targetConverter.fromConnectData(
+        fx.topic, wrapped.schema(), wrapped.value());
+
+    assertTrue("target SR has Address subject",
+        targetSchemaRegistry.getAllSubjects().contains(ADDRESS_SUBJECT));
+    assertTrue("target SR has Person subject",
+        targetSchemaRegistry.getAllSubjects().contains(fx.topic + "-value"));
+
+    // Wire IDs differ across clusters; payload bytes MUST be byte-exact.
+    assertCrossClusterBytesEquivalent(fx.sourceBytes, restoredBytes);
+
+    int targetWireId = ByteBuffer.wrap(restoredBytes, 1, 4).getInt();
+    ParsedSchema targetPersonSchema = targetSchemaRegistry.getSchemaById(targetWireId);
+    assertNotNull("target SR resolves the restored wire ID", targetPersonSchema);
+    assertEquals("target Person canonical == source Person canonical",
+        sourcePersonCanonical, targetPersonSchema.canonicalString());
+    List<SchemaReference> targetRefs = targetPersonSchema.references();
+    assertEquals("target Person has one direct reference (Address)", 1, targetRefs.size());
+    assertEquals("target ref FQCN matches source",
+        ADDRESS_FQCN, targetRefs.get(0).getName());
+    assertEquals("target ref subject matches source", ADDRESS_SUBJECT,
+        targetRefs.get(0).getSubject());
+    assertTrue("target ref version is a positive integer",
+        targetRefs.get(0).getVersion() > 0);
+
+    Object sourceValue = rawAvroDeserializer.deserialize(fx.topic, fx.sourceBytes);
+    Object targetValue = targetAvroDeserializer.deserialize(fx.topic, restoredBytes);
+    assertNotNull("source deserialized non-null", sourceValue);
+    assertNotNull("target deserialized non-null", targetValue);
+    assertEquals("Avro-JSON textual form of restored record equals source's",
+        sourceValue.toString(), targetValue.toString());
+  }
+
+  // ================ Cross-subject reference negatives ================
+
+  @Test
+  public void testEdgeReferenceTreeMissingEntryThrows() throws Exception {
+    RefTestFixture fx = registerAndProducePersonWithAddressRef();
+    SchemaAndValue wrapped = converter.toConnectData(fx.topic, fx.sourceBytes);
+
+    // Rebuild wrapper with EMPTY reference tree while directRefs still lists Address.
+    Struct original = (Struct) wrapped.value();
+    Schema wrapperSchema = wrapped.schema();
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_ID),
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION),
+        original.getString(BackupWrapper.FIELD_SCHEMA_TYPE),
+        original.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT),
+        original.getString(BackupWrapper.FIELD_RAW_SCHEMA),
+        "{}",  // reference tree emptied
+        original.getString(BackupWrapper.FIELD_DIRECT_REFS));
+    Struct badWrapper = BackupWrapper.buildWrapper(
+        wrapperSchema, original.get(BackupWrapper.FIELD_DATA), fields);
+
+    try {
+      converter.fromConnectData(fx.topic, wrapperSchema, badWrapper);
+      fail("Expected DataException for empty reference tree with populated direct refs");
+    } catch (DataException e) {
+      assertEquals("Corrupt backup wrapper: partial reference metadata "
+          + "(treeEmpty=true, directRefsEmpty=false)", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testEdgeCorruptReferenceTreeJsonThrows() throws Exception {
+    RefTestFixture fx = registerAndProducePersonWithAddressRef();
+    SchemaAndValue wrapped = converter.toConnectData(fx.topic, fx.sourceBytes);
+
+    Struct original = (Struct) wrapped.value();
+    Schema wrapperSchema = wrapped.schema();
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_ID),
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION),
+        original.getString(BackupWrapper.FIELD_SCHEMA_TYPE),
+        original.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT),
+        original.getString(BackupWrapper.FIELD_RAW_SCHEMA),
+        "{ not valid json",  // corrupt JSON
+        original.getString(BackupWrapper.FIELD_DIRECT_REFS));
+    Struct badWrapper = BackupWrapper.buildWrapper(
+        wrapperSchema, original.get(BackupWrapper.FIELD_DATA), fields);
+
+    try {
+      converter.fromConnectData(fx.topic, wrapperSchema, badWrapper);
+      fail("Expected DataException on corrupt reference tree JSON");
+    } catch (DataException e) {
+      assertEquals("Cannot parse reference tree JSON for restore. "
+          + "Backup metadata may be corrupt.", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testEdgeDirectRefsWithoutReferenceTreeThrows() throws Exception {
+    RefTestFixture fx = registerAndProducePersonWithAddressRef();
+    SchemaAndValue wrapped = converter.toConnectData(fx.topic, fx.sourceBytes);
+
+    Struct original = (Struct) wrapped.value();
+    Schema wrapperSchema = wrapped.schema();
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_ID),
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION),
+        original.getString(BackupWrapper.FIELD_SCHEMA_TYPE),
+        original.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT),
+        original.getString(BackupWrapper.FIELD_RAW_SCHEMA),
+        null,  // reference tree cleared
+        original.getString(BackupWrapper.FIELD_DIRECT_REFS));
+    Struct badWrapper = BackupWrapper.buildWrapper(
+        wrapperSchema, original.get(BackupWrapper.FIELD_DATA), fields);
+
+    try {
+      converter.fromConnectData(fx.topic, wrapperSchema, badWrapper);
+      fail("Expected DataException on directRefs-without-reference-tree corruption");
+    } catch (DataException e) {
+      assertEquals("Corrupt backup wrapper: partial reference metadata "
+          + "(treeEmpty=true, directRefsEmpty=false)", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testDefaultUnicodeInPayloadPreserved() {
+    Schema schema = SchemaBuilder.struct()
+        .name("UnicodePayload")
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
+        .build();
+    String unicode = "Hello 世界 🚀 café";
+    Struct value = new Struct(schema).put(FIELD_NAME, unicode);
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    assertBytesExact(originalBytes, restoredBytes);
+    SchemaAndValue restoredData = plainConverter.toConnectData(TOPIC, restoredBytes);
+    assertEquals("unicode string preserved",
+        unicode, ((Struct) restoredData.value()).getString(FIELD_NAME));
+  }
+
+  // ================ Config-lossiness pairs (same config on/off) ================
+
+  @Test
+  public void testEnhancedAvroSupportOnPreservesPackageInSchemaName() {
+    converter.configure(backupConfigWith("enhanced.avro.schema.support", "true"), false);
+
+    Schema schema = SchemaBuilder.struct()
+        .name("io.confluent.test.Namespaced")
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, "n-1");
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    assertBytesExact(originalBytes, restoredBytes);
+    // Raw Avro schema retains the fully qualified name.
+    String raw = ((Struct) wrapped.value()).getString(BackupWrapper.FIELD_RAW_SCHEMA);
+    assertTrue("raw schema retains namespace io.confluent.test",
+        raw.contains("io.confluent.test"));
+  }
+
+  @Test
+  public void testEnhancedAvroSupportOffBackupStillPreservesRawSchema() {
+    // Default config (enhanced.avro.schema.support defaults to false).
+    Schema schema = SchemaBuilder.struct()
+        .name("io.confluent.test.Namespaced")
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, "n-1");
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    // Wire bytes still preserved because raw Avro schema is source-of-truth for restore.
+    assertBytesExact(originalBytes, restoredBytes);
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
+  }
+
+  @Test
+  public void testConnectMetaDataOnEmbedsConnectParamsInAvroSchema() {
+    // Default config (connect.meta.data defaults to true).
+    Schema schema = SchemaBuilder.struct()
+        .name("MetaCheck")
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .parameter("custom.param", "custom-value")
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, "m-1");
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+
+    // The Avro schema captured in the wrapper includes connect.parameters when meta.data is on.
+    String raw = ((Struct) wrapped.value()).getString(BackupWrapper.FIELD_RAW_SCHEMA);
+    assertTrue("raw schema contains connect.parameters when meta.data on",
+        raw.contains("connect.parameters"));
+  }
+
+  @Test
+  public void testConnectMetaDataOffDropsConnectParamsFromAvroSchema() {
+    converter.configure(backupConfigWith("connect.meta.data", "false"), false);
+    plainConverter.configure(
+        backupConfigWith("connect.meta.data", "false"), false);
+
+    Schema schema = SchemaBuilder.struct()
+        .name("MetaCheck")
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .parameter("custom.param", "custom-value")
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, "m-1");
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+
+    String raw = ((Struct) wrapped.value()).getString(BackupWrapper.FIELD_RAW_SCHEMA);
+    // Wire bytes still roundtrip fine because backup uses raw schema as source-of-truth.
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+    assertBytesExact(originalBytes, restoredBytes);
+    // But Connect-side parameters are NOT embedded in the Avro schema.
+    assertFalse("raw schema drops connect.parameters when meta.data off",
+        raw.contains("custom.param"));
+  }
+
+  // ================ Edge cases and error handling ================
+
+  @Test
+  public void testEdgeNullValue() {
+    SchemaAndValue result = converter.toConnectData(TOPIC, null);
+    assertNull(result.schema());
+    assertNull(result.value());
+  }
+
+  @Test
+  public void testEdgeBackupDisabledNoWrapping() {
     Schema schema = Schema.STRING_SCHEMA;
     byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, "hello");
-
-    // Use plainConverter (backup disabled)
     SchemaAndValue result = plainConverter.toConnectData(TOPIC, serialized);
 
     assertNotNull(result.schema());
@@ -155,62 +1013,13 @@ public class AvroConverterBackupTest {
   }
 
   @Test
-  public void testBackupNullValue() {
-    SchemaAndValue result = converter.toConnectData(TOPIC, null);
-    assertNull(result.schema());
-    assertNull(result.value());
-  }
-
-  @Test
-  public void testBackupPrimitiveType() {
-    byte[] serialized = plainConverter.fromConnectData(
-        TOPIC, Schema.STRING_SCHEMA, "test-value");
-
-    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
-
-    assertEquals(BackupWrapper.NAME, result.schema().name());
-    Struct wrapper = (Struct) result.value();
-    assertEquals(SCHEMA_TYPE, wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
-  }
-
-  @Test
-  public void testBackupWrapperFields() {
+  public void testEdgeNonWrapperSchemaSerializesNormally() {
     Schema schema = SchemaBuilder.struct()
-        .field("x", Schema.INT32_SCHEMA)
-        .build();
-    Struct value = new Struct(schema).put("x", 1);
-
-    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
-    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
-
-    Struct wrapper = (Struct) result.value();
-    assertEquals(SCHEMA_TYPE, wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
-    // Subject should follow TopicNameStrategy: topic-value
-    assertTrue(wrapper.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT)
-        .contains(TOPIC));
-  }
-
-  @Test
-  public void testBackupSchemaIdExtracted() {
-    byte[] serialized = plainConverter.fromConnectData(
-        TOPIC, Schema.INT32_SCHEMA, 42);
-
-    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
-    Struct wrapper = (Struct) result.value();
-
-    int wrappedId = wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_ID);
-    // Schema ID extracted from wire format should match what SR assigned
-    assertTrue(wrappedId > 0);
-  }
-
-  @Test
-  public void testBackupNonWrapperSchemaNormalSerialization() {
-    Schema schema = SchemaBuilder.struct()
+        .name("Direct")
         .field(FIELD_NAME, Schema.STRING_SCHEMA)
         .build();
     Struct value = new Struct(schema).put(FIELD_NAME, "direct");
 
-    // Even in backup mode, non-wrapper schemas serialize normally
     byte[] result = converter.fromConnectData(TOPIC, schema, value);
     assertNotNull(result);
     assertTrue(result.length > 5);
@@ -218,8 +1027,7 @@ public class AvroConverterBackupTest {
   }
 
   @Test
-  public void testBackupRestoreMissingDataField() {
-    // Build a struct with wrapper name but missing FIELD_DATA
+  public void testEdgeMissingDataFieldThrows() {
     Schema badSchema = SchemaBuilder.struct()
         .name(BackupWrapper.NAME)
         .field(BackupWrapper.FIELD_SCHEMA_ID, Schema.INT32_SCHEMA)
@@ -228,52 +1036,17 @@ public class AvroConverterBackupTest {
 
     try {
       converter.fromConnectData(TOPIC, badSchema, badWrapper);
-      fail("Expected DataException");
+      fail("Expected DataException for wrapper missing 'data' field");
     } catch (DataException e) {
-      assertTrue(e.getMessage().contains("data")
-          || e.getMessage().contains("restore")
-          || e.getMessage().contains("Failed"));
+      assertEquals("Malformed backup wrapper: missing '" + BackupWrapper.FIELD_DATA + "' field",
+          e.getMessage());
     }
   }
 
   @Test
-  public void testBackupRoundTripBytesExact() {
+  public void testEdgeNullRawSchemaThrows() {
     Schema schema = SchemaBuilder.struct()
-        .field("id", Schema.STRING_SCHEMA)
-        .field(FIELD_COUNT, Schema.INT32_SCHEMA)
-        .build();
-    Struct original = new Struct(schema)
-        .put("id", "exact-match")
-        .put(FIELD_COUNT, 100);
-
-    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, original);
-
-    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
-    byte[] restoredBytes = converter.fromConnectData(
-        TOPIC, wrapped.schema(), wrapped.value());
-
-    // Restored bytes should produce identical data
-    assertArrayEquals(originalBytes, restoredBytes);
-  }
-
-  @Test
-  public void testBackupSchemaVersionPresent() {
-    Schema schema = SchemaBuilder.struct()
-        .field("x", Schema.INT32_SCHEMA)
-        .build();
-    Struct value = new Struct(schema).put("x", 42);
-
-    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
-    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
-
-    Struct wrapper = (Struct) result.value();
-    // Schema version should be populated for registered schemas
-    assertNotNull(wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION));
-  }
-
-  @Test
-  public void testBackupRestoreNullRawSchemaThrows() {
-    Schema schema = SchemaBuilder.struct()
+        .name("Fallback")
         .field(FIELD_NAME, Schema.STRING_SCHEMA)
         .build();
     Struct value = new Struct(schema).put(FIELD_NAME, "fallback");
@@ -296,10 +1069,314 @@ public class AvroConverterBackupTest {
       converter.fromConnectData(TOPIC, wrapperSchema, modifiedWrapper);
       fail("Expected DataException for null rawSchema");
     } catch (DataException e) {
-      assertTrue(e.getMessage(),
+      assertTrue("message references rawSchema field: " + e.getMessage(),
           e.getMessage().contains(BackupWrapper.FIELD_RAW_SCHEMA));
-      assertTrue(e.getMessage(),
+      assertTrue("message mentions pristine restore: " + e.getMessage(),
           e.getMessage().contains("pristine restore"));
+    }
+  }
+
+  @Test
+  public void testEdgeBasicRoundtripDeserializes() {
+    Schema schema = SchemaBuilder.struct()
+        .name("Basic")
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .field(FIELD_COUNT, Schema.INT32_SCHEMA)
+        .build();
+    Struct original = new Struct(schema).put(FIELD_ID, "b-1").put(FIELD_COUNT, 7);
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, original);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    SchemaAndValue restoredData = plainConverter.toConnectData(TOPIC, restoredBytes);
+    Struct restored = (Struct) restoredData.value();
+    assertEquals("b-1", restored.getString(FIELD_ID));
+    assertEquals(Integer.valueOf(7), restored.getInt32(FIELD_COUNT));
+  }
+
+  @Test
+  public void testEdgePrimitiveSchemaWrapping() {
+    byte[] serialized = plainConverter.fromConnectData(
+        TOPIC, Schema.STRING_SCHEMA, "test-value");
+
+    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
+
+    assertEquals(BackupWrapper.NAME, result.schema().name());
+    Struct wrapper = (Struct) result.value();
+    assertEquals(SCHEMA_TYPE, wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
+  }
+
+  @Test
+  public void testEdgeSchemaTypeMismatchThrows() {
+    Schema schema = SchemaBuilder.struct()
+        .name("Mismatch")
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, "type-mismatch");
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+
+    // Rebuild wrapper with schema type deliberately set to PROTOBUF (wrong for Avro converter).
+    Struct original = (Struct) wrapped.value();
+    Schema wrapperSchema = wrapped.schema();
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_ID),
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION),
+        "PROTOBUF",
+        original.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT),
+        original.getString(BackupWrapper.FIELD_RAW_SCHEMA),
+        null, null);
+    Struct badWrapper = BackupWrapper.buildWrapper(
+        wrapperSchema, original.get(BackupWrapper.FIELD_DATA), fields);
+
+    try {
+      converter.fromConnectData(TOPIC, wrapperSchema, badWrapper);
+      fail("Expected DataException on schema type mismatch");
+    } catch (DataException e) {
+      assertEquals("AvroConverter received wrapper with schemaType='PROTOBUF', "
+          + "expected 'AVRO'", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testEdgeCorruptedWireIdRejected() {
+    Schema schema = SchemaBuilder.struct()
+        .name("Corrupt")
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, "corrupt");
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    byte[] corrupted = originalBytes.clone();
+    // Overwrite the 4-byte schema ID header with an unlikely-to-exist ID.
+    ByteBuffer.wrap(corrupted, 1, 4).putInt(Integer.MAX_VALUE - 1);
+
+    try {
+      converter.toConnectData(TOPIC, corrupted);
+      fail("Expected DataException for corrupted wire schema ID");
+    } catch (DataException e) {
+      assertEquals("Failed to deserialize data for topic " + TOPIC + " to Avro:",
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testEdgeEmptyPayloadHandled() {
+    byte[] empty = new byte[0];
+    try {
+      converter.toConnectData(TOPIC, empty);
+      fail("Expected DataException for zero-length payload");
+    } catch (DataException e) {
+      assertEquals("Failed to deserialize data for topic " + TOPIC + " to Avro:",
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testEdgeSinkWrapErrorClassifiedAsBackupException() throws Exception {
+    // A SR client that fetches individual schemas normally (so deserialize succeeds)
+    // but throws on getAllVersionsById, which only the wrap path uses.
+    SchemaRegistryClient wrapFailingSr = new MockSchemaRegistryClient() {
+      @Override
+      public Collection<SubjectVersion> getAllVersionsById(int id) {
+        throw new SerializationException("simulated SR unavailable during wrap");
+      }
+    };
+    AvroConverter wrapFailingConverter = new AvroConverter(wrapFailingSr);
+    Map<String, Object> cfg = new HashMap<>();
+    cfg.put(SR_URL_KEY, FAKE_SR_URL);
+    cfg.put(BACKUP_ENABLED_KEY, "true");
+    wrapFailingConverter.configure(cfg, false);
+
+    String topic = nextTopic();
+    org.apache.avro.Schema rawAvroSchema = org.apache.avro.SchemaBuilder
+        .record("WrapFail").namespace("io.confluent.test").fields()
+        .requiredString("id")
+        .endRecord();
+    wrapFailingSr.register(topic + "-value", new AvroSchema(rawAvroSchema));
+    org.apache.avro.generic.GenericRecord record =
+        new org.apache.avro.generic.GenericRecordBuilder(rawAvroSchema)
+            .set("id", "wrap-fail").build();
+    KafkaAvroSerializer refSerializer = newReferenceAwareAvroSerializer(wrapFailingSr);
+    byte[] bytes = refSerializer.serialize(topic, record);
+
+    try {
+      wrapFailingConverter.toConnectData(topic, bytes);
+      fail("Expected DataException when wrap-path SR call fails");
+    } catch (DataException e) {
+      assertEquals("Failed to wrap Avro backup for topic " + topic, e.getMessage());
+      assertTrue("cause is the simulated SerializationException",
+          e.getCause() instanceof SerializationException);
+    }
+  }
+
+  @Test
+  public void testHeaderSchemaIdSerializerBackupCapturesSchemaId() {
+    SchemaRegistryClient sr = new MockSchemaRegistryClient();
+    AvroConverter headerBackupConverter = new AvroConverter(sr);
+    AvroConverter headerPlainConverter = new AvroConverter(sr);
+    Map<String, Object> backupCfg = new HashMap<>();
+    backupCfg.put(SR_URL_KEY, FAKE_SR_URL);
+    backupCfg.put(BACKUP_ENABLED_KEY, "true");
+    backupCfg.put(AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_SERIALIZER,
+        HeaderSchemaIdSerializer.class.getName());
+    backupCfg.put(AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_DESERIALIZER,
+        "io.confluent.kafka.serializers.schema.id.DualSchemaIdDeserializer");
+    headerBackupConverter.configure(backupCfg, false);
+    Map<String, Object> plainCfg = new HashMap<>(backupCfg);
+    plainCfg.remove(BACKUP_ENABLED_KEY);
+    headerPlainConverter.configure(plainCfg, false);
+
+    Schema schema = SchemaBuilder.struct()
+        .name("HeaderIdRecord")
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, "h-1").put(FIELD_NAME, "header-test");
+
+    Headers headers = new RecordHeaders();
+    byte[] serialized = headerPlainConverter.fromConnectData(TOPIC, headers, schema, value);
+    assertNotNull("value schema ID header present",
+        headers.lastHeader(SchemaId.VALUE_SCHEMA_ID_HEADER));
+
+    SchemaAndValue wrapped = headerBackupConverter.toConnectData(TOPIC, headers, serialized);
+
+    assertNotNull("wrapper produced", wrapped);
+    assertEquals("wrapper schema name", BackupWrapper.NAME, wrapped.schema().name());
+    Struct w = (Struct) wrapped.value();
+    assertEquals("schema type", SCHEMA_TYPE, w.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
+    assertNotNull("raw schema captured", w.getString(BackupWrapper.FIELD_RAW_SCHEMA));
+    assertNotNull("wrapper populates schemaGuid from header",
+        w.getString(BackupWrapper.FIELD_SCHEMA_GUID));
+
+    Headers restoredHeaders = new RecordHeaders();
+    byte[] restoredBytes = headerBackupConverter.fromConnectData(
+        TOPIC, restoredHeaders, wrapped.schema(), wrapped.value());
+    assertNotNull("restored value schema ID header present",
+        restoredHeaders.lastHeader(SchemaId.VALUE_SCHEMA_ID_HEADER));
+
+    SchemaAndValue restoredDeser = headerPlainConverter.toConnectData(
+        TOPIC, restoredHeaders, restoredBytes);
+    Struct restored = (Struct) restoredDeser.value();
+    assertEquals("id preserved", "h-1", restored.getString(FIELD_ID));
+    assertEquals("name preserved", "header-test", restored.getString(FIELD_NAME));
+  }
+
+  // ================ Config-mismatch scenarios (backup with X, restore with X flipped) ================
+
+  @Test
+  public void testConfigMismatchEnhancedAvroSchemaSupportOnRestoreOffDocumentedLoss() {
+    // Backup side: enhanced.avro.schema.support=true
+    converter.configure(backupConfigWith("enhanced.avro.schema.support", "true"), false);
+    plainConverter.configure(
+        backupConfigWith("enhanced.avro.schema.support", "true"), false);
+
+    Schema schema = SchemaBuilder.struct()
+        .name("io.confluent.test.Mismatch")
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, "m-1");
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+
+    // Restore side: flip to false. Wrapper's rawSchema drives restore, so bytes match.
+    converter.configure(backupConfigWith("enhanced.avro.schema.support", "false"), false);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    assertBytesExact(originalBytes, restoredBytes);
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
+  }
+
+  @Test
+  public void testConfigMismatchEnhancedAvroSupportOffWithEnumSchemaDocumentsLoss() {
+    // Producer side: enhanced.avro.schema.support=true so the enum-parameterized Connect
+    // schema is turned into a proper Avro ENUM on serialize.
+    plainConverter.configure(
+        backupConfigWith("enhanced.avro.schema.support", "true"), false);
+
+    Schema enumField = SchemaBuilder.string()
+        .name("Priority")
+        .parameter("io.confluent.connect.avro.Enum", "Priority")
+        .parameter("io.confluent.connect.avro.Enum.LOW", "0")
+        .parameter("io.confluent.connect.avro.Enum.MEDIUM", "1")
+        .parameter("io.confluent.connect.avro.Enum.HIGH", "2")
+        .build();
+    Schema schema = SchemaBuilder.struct()
+        .name("EnumEvent")
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .field("priority", enumField)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, "e-1").put("priority", "HIGH");
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+
+    // Backup side: enhanced=false. Wrapper still preserves the raw Avro schema (with enum)
+    // because rawSchema comes from the SR-registered schema, not from AvroData conversion.
+    converter.configure(
+        backupConfigWith("enhanced.avro.schema.support", "false"), false);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    String raw = ((Struct) wrapped.value()).getString(BackupWrapper.FIELD_RAW_SCHEMA);
+    assertTrue("wrapper raw schema declares an enum type: " + raw,
+        raw.contains("\"type\":\"enum\""));
+    assertTrue("wrapper raw schema names the Priority enum: " + raw,
+        raw.contains("\"name\":\"Priority\""));
+    assertTrue("wrapper raw schema lists enum symbols LOW,MEDIUM,HIGH: " + raw,
+        raw.contains("\"LOW\"") && raw.contains("\"MEDIUM\"") && raw.contains("\"HIGH\""));
+
+    // AvroData drops the enum reconstruction when enhanced=false; serialize then
+    // fails because the raw schema still declares an ENUM.
+    try {
+      converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+      fail("Expected DataException restore MUST fail when enhanced.avro.schema.support "
+          + "is off and the source schema has an enum");
+    } catch (DataException e) {
+      assertEquals("Failed to restore Avro backup for topic " + TOPIC, e.getMessage());
+      Throwable rootCause = null;
+      Throwable c = e.getCause();
+      while (c != null) {
+        if (c instanceof org.apache.avro.AvroTypeException) {
+          rootCause = c;
+          break;
+        }
+        c = c.getCause();
+      }
+      assertNotNull("cause chain contains AvroTypeException", rootCause);
+      assertTrue("AvroTypeException identifies string-not-enum: " + rootCause.getMessage(),
+          rootCause.getMessage().contains("java.lang.String")
+              && rootCause.getMessage().contains("Priority"));
+    }
+  }
+
+  @Test
+  public void testConfigMismatchConnectMetaDataOnRestoreOffDocumentedLoss() {
+    // Backup side: connect.meta.data=true (default)
+    Schema schema = SchemaBuilder.struct()
+        .name("MetaMismatch")
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .parameter("custom.param", "custom-value")
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, "meta-1");
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    String rawBackup = ((Struct) wrapped.value()).getString(BackupWrapper.FIELD_RAW_SCHEMA);
+    assertTrue("raw schema captured with connect.parameters",
+        rawBackup.contains("connect.parameters"));
+
+    // Restore side: flip to false. Bytes still match because rawSchema is what re-registers.
+    converter.configure(backupConfigWith("connect.meta.data", "false"), false);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    assertBytesExact(originalBytes, restoredBytes);
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
+  }
+
+  // Helper: assertFalse for the config-off tests above.
+  private static void assertFalse(String message, boolean condition) {
+    if (condition) {
+      throw new AssertionError(message);
     }
   }
 }

--- a/avro-converter/src/test/java/io/confluent/connect/avro/AvroConverterBackupTest.java
+++ b/avro-converter/src/test/java/io/confluent/connect/avro/AvroConverterBackupTest.java
@@ -272,7 +272,7 @@ public class AvroConverterBackupTest {
   }
 
   @Test
-  public void testBackupRestoreNullRawSchemaFallback() {
+  public void testBackupRestoreNullRawSchemaThrows() {
     Schema schema = SchemaBuilder.struct()
         .field(FIELD_NAME, Schema.STRING_SCHEMA)
         .build();
@@ -281,7 +281,6 @@ public class AvroConverterBackupTest {
     byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
     SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
 
-    // Rebuild wrapper with null rawSchema to exercise fallback branch
     Struct original = (Struct) wrapped.value();
     Schema wrapperSchema = wrapped.schema();
     BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
@@ -293,8 +292,14 @@ public class AvroConverterBackupTest {
     Struct modifiedWrapper = BackupWrapper.buildWrapper(
         wrapperSchema, original.get(BackupWrapper.FIELD_DATA), fields);
 
-    byte[] restored = converter.fromConnectData(TOPIC, wrapperSchema, modifiedWrapper);
-    assertNotNull(restored);
-    assertEquals(0x00, restored[0]);
+    try {
+      converter.fromConnectData(TOPIC, wrapperSchema, modifiedWrapper);
+      fail("Expected DataException for null rawSchema");
+    } catch (DataException e) {
+      assertTrue(e.getMessage(),
+          e.getMessage().contains(BackupWrapper.FIELD_RAW_SCHEMA));
+      assertTrue(e.getMessage(),
+          e.getMessage().contains("pristine restore"));
+    }
   }
 }

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverter.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverter.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.confluent.connect.schema.backup.api.BackupWrapper;
 import io.confluent.connect.schema.backup.api.SchemaBackupConfig;
 import io.confluent.connect.schema.backup.core.BackupConverterHelper;
+import io.confluent.connect.schema.backup.core.BackupExceptionMapper;
 import io.confluent.connect.schema.backup.core.BackupReferenceResolver;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.ParsedSchemaAndValue;
@@ -189,11 +190,9 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
       }
       JsonNode jsonValue = jsonSchemaData.fromConnectData(actualConnectSchema, actualData);
       return serializer.serialize(topic, headers, isKey, jsonValue, jsonSchema);
-    } catch (DataException e) {
-      throw e;
     } catch (Exception e) {
-      throw new DataException(
-          String.format("Failed to restore JSON Schema data for topic %s", topic), e);
+      throw BackupExceptionMapper.classify(
+          "restore JSON Schema backup for topic " + topic, e);
     }
   }
 
@@ -262,8 +261,8 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
           SchemaBackupConfig.TYPE_JSON_SCHEMA, isKey,
           JSON_SCHEMA_FACTORY, serializer::computeSubjectName);
     } catch (Exception e) {
-      throw new DataException(
-          String.format("Failed to wrap backup metadata for topic %s", topic), e);
+      throw BackupExceptionMapper.classify(
+          "wrap JSON Schema backup for topic " + topic, e);
     }
   }
 

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverter.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverter.java
@@ -161,10 +161,10 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
   private byte[] restoreFromWrapper(
       String topic, Headers headers, Schema wrapperSchema, Struct wrapper) {
     try {
-      if (wrapperSchema.field(BackupWrapper.FIELD_DATA) == null) {
-        throw new DataException("Malformed backup wrapper: missing '"
-            + BackupWrapper.FIELD_DATA + "' field");
-      }
+      BackupWrapper.requireFields(wrapperSchema,
+          BackupWrapper.FIELD_DATA,
+          BackupWrapper.FIELD_SCHEMA_TYPE,
+          BackupWrapper.FIELD_RAW_SCHEMA);
       String schemaType = wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE);
       if (!SchemaBackupConfig.TYPE_JSON_SCHEMA.equals(schemaType)) {
         throw new DataException(

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverter.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaConverter.java
@@ -174,20 +174,20 @@ public class JsonSchemaConverter extends AbstractKafkaSchemaSerDe implements Con
       Object actualData = wrapper.get(BackupWrapper.FIELD_DATA);
       Schema actualConnectSchema = wrapperSchema.field(BackupWrapper.FIELD_DATA).schema();
       String rawSchema = wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA);
+      if (rawSchema == null) {
+        throw new DataException(
+            "Malformed backup wrapper: missing '" + BackupWrapper.FIELD_RAW_SCHEMA
+            + "' for topic " + topic + ". Cannot guarantee pristine restore.");
+      }
 
       BackupReferenceResolver.ResolutionResult resolved =
           backupHelper.getReferenceResolver().resolveFromWrapper(
               wrapperSchema, wrapper, JSON_SCHEMA_FACTORY);
 
-      JsonSchema jsonSchema;
-      if (rawSchema != null) {
-        jsonSchema = resolved.hasReferences()
-            ? new JsonSchema(rawSchema, resolved.getTargetRefs(),
-                resolved.getResolvedSchemas(), null)
-            : new JsonSchema(rawSchema);
-      } else {
-        jsonSchema = jsonSchemaData.fromConnectSchema(actualConnectSchema);
-      }
+      JsonSchema jsonSchema = resolved.hasReferences()
+          ? new JsonSchema(rawSchema, resolved.getTargetRefs(),
+              resolved.getResolvedSchemas(), null)
+          : new JsonSchema(rawSchema);
       JsonNode jsonValue = jsonSchemaData.fromConnectData(actualConnectSchema, actualData);
       return serializer.serialize(topic, headers, isKey, jsonValue, jsonSchema);
     } catch (Exception e) {

--- a/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaConverterBackupTest.java
+++ b/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaConverterBackupTest.java
@@ -23,13 +23,33 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.confluent.connect.schema.backup.api.BackupWrapper;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
 import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
+import io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer;
+import io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer;
+import io.confluent.kafka.serializers.schema.id.HeaderSchemaIdSerializer;
+import io.confluent.kafka.serializers.schema.id.SchemaId;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -42,102 +62,984 @@ public class JsonSchemaConverterBackupTest {
 
   private static final String TOPIC = "test-topic";
   private static final String SCHEMA_TYPE = "JSON_SCHEMA";
+  private static final String SR_URL_KEY = "schema.registry.url";
+  private static final String FAKE_SR_URL = "http://fake-url";
+  private static final String BACKUP_ENABLED_KEY = "schema.backup.enabled";
+
+  private static final String FIELD_NAME = "name";
+  private static final String FIELD_ID = "id";
   private static final String FIELD_COUNT = "count";
+
+  private static final ObjectMapper JSON = new ObjectMapper();
 
   private final SchemaRegistryClient schemaRegistry;
   private final JsonSchemaConverter converter;
   private final JsonSchemaConverter plainConverter;
+  private KafkaJsonSchemaSerializer<Object> rawJsonSerializer;
+  private KafkaJsonSchemaDeserializer<Object> rawJsonDeserializer;
+
+  private final SchemaRegistryClient targetSchemaRegistry;
+  private final JsonSchemaConverter targetConverter;
+  private KafkaJsonSchemaDeserializer<Object> targetJsonDeserializer;
+
+  private int topicCounter = 0;
 
   public JsonSchemaConverterBackupTest() {
     schemaRegistry = new MockSchemaRegistryClient(
         ImmutableList.of(new JsonSchemaProvider()));
     converter = new JsonSchemaConverter(schemaRegistry);
     plainConverter = new JsonSchemaConverter(schemaRegistry);
+    targetSchemaRegistry = new MockSchemaRegistryClient(
+        ImmutableList.of(new JsonSchemaProvider()));
+    targetConverter = new JsonSchemaConverter(targetSchemaRegistry);
   }
 
   @Before
   public void setUp() {
     Map<String, Object> backupConfig = new HashMap<>();
-    backupConfig.put("schema.registry.url", "http://fake-url");
-    backupConfig.put("schema.backup.enabled", "true");
+    backupConfig.put(SR_URL_KEY, FAKE_SR_URL);
+    backupConfig.put(BACKUP_ENABLED_KEY, "true");
     converter.configure(backupConfig, false);
+    targetConverter.configure(backupConfig, false);
 
-    Map<String, String> plainConfig = new HashMap<>();
-    plainConfig.put("schema.registry.url", "http://fake-url");
+    Map<String, Object> plainConfig = Collections.singletonMap(SR_URL_KEY, FAKE_SR_URL);
     plainConverter.configure(plainConfig, false);
+
+    rawJsonSerializer = new KafkaJsonSchemaSerializer<>(schemaRegistry);
+    rawJsonSerializer.configure(plainConfig, false);
+    rawJsonDeserializer = new KafkaJsonSchemaDeserializer<>(schemaRegistry);
+    rawJsonDeserializer.configure(plainConfig, false);
+
+    targetJsonDeserializer = new KafkaJsonSchemaDeserializer<>(targetSchemaRegistry);
+    targetJsonDeserializer.configure(plainConfig, false);
   }
 
+  private static KafkaJsonSchemaSerializer<Object> newReferenceAwareJsonSchemaSerializer(
+      SchemaRegistryClient sr) {
+    Map<String, Object> cfg = new HashMap<>();
+    cfg.put(SR_URL_KEY, FAKE_SR_URL);
+    cfg.put("auto.register.schemas", "false");
+    cfg.put("use.latest.version", "true");
+    cfg.put("latest.compatibility.strict", "false");
+    KafkaJsonSchemaSerializer<Object> s = new KafkaJsonSchemaSerializer<>(sr);
+    s.configure(cfg, false);
+    return s;
+  }
+
+  private String nextTopic() {
+    return TOPIC + "-" + (topicCounter++);
+  }
+
+  private static void assertWrapperShape(SchemaAndValue wrapped, String expectedType) {
+    assertNotNull("wrapped result", wrapped);
+    assertNotNull("wrapped schema", wrapped.schema());
+    assertEquals("wrapper schema name", BackupWrapper.NAME, wrapped.schema().name());
+    Struct w = (Struct) wrapped.value();
+    assertEquals("schema type", expectedType, w.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
+    assertNotNull("schema subject", w.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT));
+    assertNotNull("raw schema", w.getString(BackupWrapper.FIELD_RAW_SCHEMA));
+    assertNotNull("data field", w.get(BackupWrapper.FIELD_DATA));
+    assertNotNull("schema ID", w.getInt32(BackupWrapper.FIELD_SCHEMA_ID));
+    assertTrue("schema ID > 0", w.getInt32(BackupWrapper.FIELD_SCHEMA_ID) > 0);
+  }
+
+  private static void assertBytesExact(byte[] original, byte[] restored) {
+    assertNotNull("original bytes", original);
+    assertNotNull("restored bytes", restored);
+    assertArrayEquals("byte-exact roundtrip", original, restored);
+  }
+
+  private static void assertWireSchemaIdPreserved(byte[] original, byte[] restored) {
+    assertTrue("original wire-format long enough", original.length >= 5);
+    assertTrue("restored wire-format long enough", restored.length >= 5);
+    assertEquals("original magic byte", (byte) 0x00, original[0]);
+    assertEquals("restored magic byte", (byte) 0x00, restored[0]);
+    int origId = ByteBuffer.wrap(original, 1, 4).getInt();
+    int restoredId = ByteBuffer.wrap(restored, 1, 4).getInt();
+    assertEquals("wire-format schema ID preserved", origId, restoredId);
+  }
+
+  private static void assertValueEqual(Object originalDeser, Object restoredDeser) {
+    assertEquals("deserialized value equality", originalDeser, restoredDeser);
+  }
+
+  private static void assertWrapperSchemaIdMatchesSource(
+      SchemaAndValue wrapped, byte[] sourceBytes) {
+    int sourceWireId = ByteBuffer.wrap(sourceBytes, 1, 4).getInt();
+    Integer wrapperId = ((Struct) wrapped.value()).getInt32(BackupWrapper.FIELD_SCHEMA_ID);
+    assertNotNull("wrapper schema ID populated", wrapperId);
+    assertEquals("wrapper.schemaId matches source wire ID at bytes[1..4]",
+        sourceWireId, wrapperId.intValue());
+  }
+
+  private void assertRawSchemaMatchesSourceRegistered(
+      SchemaAndValue wrapped, byte[] sourceBytes) throws Exception {
+    int sourceWireId = ByteBuffer.wrap(sourceBytes, 1, 4).getInt();
+    ParsedSchema sourceRegistered = schemaRegistry.getSchemaById(sourceWireId);
+    String wrapperRaw = ((Struct) wrapped.value()).getString(BackupWrapper.FIELD_RAW_SCHEMA);
+    assertNotNull("wrapper rawSchema populated", wrapperRaw);
+    JsonSchema wrapperParsed = new JsonSchema(wrapperRaw);
+    assertEquals("wrapper rawSchema canonically equals source-registered schema",
+        sourceRegistered.canonicalString(), wrapperParsed.canonicalString());
+  }
+
+  private static void assertPayloadBytesEqual(byte[] source, byte[] restored) {
+    assertTrue("source has 5-byte header + payload", source.length >= 5);
+    assertTrue("restored has 5-byte header + payload", restored.length >= 5);
+    byte[] sourcePayload = Arrays.copyOfRange(source, 5, source.length);
+    byte[] restoredPayload = Arrays.copyOfRange(restored, 5, restored.length);
+    assertArrayEquals("payload bytes (bytes[5..end]) equal", sourcePayload, restoredPayload);
+  }
+
+  private static void assertCrossClusterBytesEquivalent(byte[] sourceBytes,
+      byte[] restoredBytes) {
+    assertTrue("source has 5-byte header + payload", sourceBytes.length >= 5);
+    assertTrue("restored has 5-byte header + payload", restoredBytes.length >= 5);
+    assertEquals("source magic byte", (byte) 0x00, sourceBytes[0]);
+    assertEquals("restored magic byte", (byte) 0x00, restoredBytes[0]);
+    int sourceId = ByteBuffer.wrap(sourceBytes, 1, 4).getInt();
+    int restoredId = ByteBuffer.wrap(restoredBytes, 1, 4).getInt();
+    assertTrue("source wire ID positive", sourceId > 0);
+    assertTrue("restored wire ID positive", restoredId > 0);
+  }
+
+  private static void assertJsonPayloadSemanticallyEqual(byte[] source, byte[] restored)
+      throws Exception {
+    assertTrue("source has 5-byte header + payload", source.length >= 5);
+    assertTrue("restored has 5-byte header + payload", restored.length >= 5);
+    byte[] sourcePayload = Arrays.copyOfRange(source, 5, source.length);
+    byte[] restoredPayload = Arrays.copyOfRange(restored, 5, restored.length);
+    JsonNode sourceJson = JSON.readTree(sourcePayload);
+    JsonNode restoredJson = JSON.readTree(restoredPayload);
+    // Source keys must appear in restored with equal values. Restored may add null-fills
+    // for schema-optional fields omitted on wire.
+    sourceJson.fields().forEachRemaining(entry -> {
+      JsonNode restoredValue = restoredJson.get(entry.getKey());
+      assertNotNull("restored missing key " + entry.getKey(), restoredValue);
+      assertEquals("value differs for key " + entry.getKey(),
+          entry.getValue(), restoredValue);
+    });
+  }
+
+  private Map<String, Object> backupConfigWith(String key, String value) {
+    Map<String, Object> cfg = new HashMap<>();
+    cfg.put(SR_URL_KEY, FAKE_SR_URL);
+    cfg.put(BACKUP_ENABLED_KEY, "true");
+    cfg.put(key, value);
+    return cfg;
+  }
+
+  // ================ Default-behavior gates ================
+
   @Test
-  public void testBackupToConnectDataWrapsMetadata() {
+  public void testDefaultWrapperShape() {
     Schema schema = SchemaBuilder.struct()
-        .field("name", Schema.STRING_SCHEMA)
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
         .field("age", Schema.INT32_SCHEMA)
         .build();
-    Struct value = new Struct(schema)
-        .put("name", "Alice")
-        .put("age", 30);
+    Struct value = new Struct(schema).put(FIELD_NAME, "Alice").put("age", 30);
 
     byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
-    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, serialized);
 
-    assertNotNull(result);
-    assertNotNull(result.schema());
-    assertEquals(BackupWrapper.NAME, result.schema().name());
-
-    Struct wrapper = (Struct) result.value();
-    assertNotNull(wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_ID));
-    assertEquals(SCHEMA_TYPE,
-        wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
-    assertNotNull(wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA));
-    assertNotNull(wrapper.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT));
-    assertNotNull(wrapper.get(BackupWrapper.FIELD_DATA));
+    assertWrapperShape(wrapped, SCHEMA_TYPE);
+    Struct w = (Struct) wrapped.value();
+    assertTrue("subject contains topic",
+        w.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT).contains(TOPIC));
   }
 
   @Test
-  public void testBackupFromConnectDataRestores() {
+  public void testDefaultBytesExactForStructWithPrimitives() {
     Schema schema = SchemaBuilder.struct()
-        .field("text", Schema.STRING_SCHEMA)
-        .build();
-    Struct value = new Struct(schema).put("text", "hello");
-
-    byte[] original = plainConverter.fromConnectData(TOPIC, schema, value);
-    assertNotNull(original);
-
-    SchemaAndValue wrapped = converter.toConnectData(TOPIC, original);
-    assertEquals(BackupWrapper.NAME, wrapped.schema().name());
-
-    byte[] restored = converter.fromConnectData(
-        TOPIC, wrapped.schema(), wrapped.value());
-
-    assertNotNull(restored);
-    assertEquals(0x00, restored[0]);
-  }
-
-  @Test
-  public void testBackupRoundTrip() {
-    Schema schema = SchemaBuilder.struct()
-        .field("id", Schema.STRING_SCHEMA)
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
         .field(FIELD_COUNT, Schema.INT32_SCHEMA)
         .build();
-    Struct original = new Struct(schema)
-        .put("id", "item-1")
-        .put(FIELD_COUNT, 5);
+    Struct value = new Struct(schema).put(FIELD_ID, "item-1").put(FIELD_COUNT, 5);
 
-    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, original);
-
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
     SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
-    byte[] restoredBytes = converter.fromConnectData(
-        TOPIC, wrapped.schema(), wrapped.value());
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
 
-    SchemaAndValue restoredData = plainConverter.toConnectData(
-        TOPIC, restoredBytes);
-    Struct restored = (Struct) restoredData.value();
-    assertEquals("item-1", restored.getString("id"));
-    assertEquals(Integer.valueOf(5), restored.getInt32(FIELD_COUNT));
+    assertBytesExact(originalBytes, restoredBytes);
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
   }
 
   @Test
-  public void testBackupDisabledNoWrapping() {
+  public void testDefaultWireSchemaIdPreserved() {
+    Schema schema = SchemaBuilder.struct()
+        .field(FIELD_ID, Schema.INT32_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, 42);
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
+  }
+
+  @Test
+  public void testDefaultRawSchemaSemanticallyEqual() {
+    Schema schema = SchemaBuilder.struct()
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
+        .field("value", Schema.INT32_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_NAME, "raw-check").put("value", 42);
+
+    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, serialized);
+
+    String raw = ((Struct) wrapped.value()).getString(BackupWrapper.FIELD_RAW_SCHEMA);
+    assertNotNull("raw schema captured", raw);
+    JsonSchema restored = new JsonSchema(raw);
+    JsonSchema roundtripped = new JsonSchema(restored.canonicalString());
+    assertEquals("raw schema canonical stable",
+        restored.canonicalString(), roundtripped.canonicalString());
+  }
+
+  @Test
+  public void testDefaultComplexRealisticSchemaAllAxesPass() {
+    Schema addressSchema = SchemaBuilder.struct()
+        .field("street", Schema.STRING_SCHEMA)
+        .field("city", Schema.STRING_SCHEMA)
+        .build();
+
+    Schema contactSchema = SchemaBuilder.struct()
+        .field("name", Schema.STRING_SCHEMA)
+        .field("email", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+
+    Schema profileSchema = SchemaBuilder.struct()
+        .field("id", Schema.STRING_SCHEMA)
+        .field("address", addressSchema)
+        .field("contacts", SchemaBuilder.array(contactSchema).build())
+        .field("optional_note", Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+
+    Struct addr = new Struct(addressSchema)
+        .put("street", "1 Main St")
+        .put("city", "Springfield");
+    Struct contact1 = new Struct(contactSchema)
+        .put("name", "Alice")
+        .put("email", "alice@test.com");
+    Struct contact2 = new Struct(contactSchema)
+        .put("name", "Bob")
+        .put("email", null);
+
+    Struct profile = new Struct(profileSchema)
+        .put("id", "p-1")
+        .put("address", addr)
+        .put("contacts", Arrays.asList(contact1, contact2))
+        .put("optional_note", null);
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, profileSchema, profile);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    assertWrapperShape(wrapped, SCHEMA_TYPE);
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
+    SchemaAndValue originalDeser = plainConverter.toConnectData(TOPIC, originalBytes);
+    SchemaAndValue restoredDeser = plainConverter.toConnectData(TOPIC, restoredBytes);
+    assertValueEqual(originalDeser.value(), restoredDeser.value());
+  }
+
+  @Test
+  public void testIdempotencyKitchenSinkStableAcrossCycles() {
+    Schema schema = SchemaBuilder.struct()
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .field(FIELD_COUNT, Schema.INT32_SCHEMA)
+        .field(FIELD_NAME, Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema)
+        .put(FIELD_ID, "idem-1")
+        .put(FIELD_COUNT, 42)
+        .put(FIELD_NAME, "stable");
+
+    byte[] wire0 = plainConverter.fromConnectData(TOPIC, schema, value);
+    int id0 = ByteBuffer.wrap(wire0, 1, 4).getInt();
+
+    SchemaAndValue wrapped1 = converter.toConnectData(TOPIC, wire0);
+    byte[] restored1 = converter.fromConnectData(TOPIC, wrapped1.schema(), wrapped1.value());
+    int id1 = ByteBuffer.wrap(restored1, 1, 4).getInt();
+
+    SchemaAndValue wrapped2 = converter.toConnectData(TOPIC, restored1);
+    byte[] restored2 = converter.fromConnectData(TOPIC, wrapped2.schema(), wrapped2.value());
+    int id2 = ByteBuffer.wrap(restored2, 1, 4).getInt();
+
+    assertEquals("schema ID stable across cycle 1", id0, id1);
+    assertEquals("schema ID stable across cycle 2", id1, id2);
+    assertArrayEquals("wire bytes stable across cycles", restored1, restored2);
+
+    Struct w1 = (Struct) wrapped1.value();
+    Struct w2 = (Struct) wrapped2.value();
+    assertEquals("wrapper raw schema stable",
+        w1.getString(BackupWrapper.FIELD_RAW_SCHEMA),
+        w2.getString(BackupWrapper.FIELD_RAW_SCHEMA));
+    assertEquals("wrapper schema ID stable",
+        w1.getInt32(BackupWrapper.FIELD_SCHEMA_ID),
+        w2.getInt32(BackupWrapper.FIELD_SCHEMA_ID));
+  }
+
+  @Test
+  public void testDefaultSharedStructTypeAtMultipleFieldsSurvives() {
+    Schema addressSchema = SchemaBuilder.struct()
+        .name("Address")
+        .field("street", Schema.STRING_SCHEMA)
+        .field("city", Schema.STRING_SCHEMA)
+        .build();
+    Schema personSchema = SchemaBuilder.struct()
+        .name("Person")
+        .field("name", Schema.STRING_SCHEMA)
+        .field("home", addressSchema)
+        .field("work", addressSchema)
+        .build();
+
+    Struct home = new Struct(addressSchema).put("street", "1 Home").put("city", "Springfield");
+    Struct work = new Struct(addressSchema).put("street", "2 Work").put("city", "Springfield");
+    Struct person = new Struct(personSchema)
+        .put("name", "Alice")
+        .put("home", home)
+        .put("work", work);
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, personSchema, person);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    assertBytesExact(originalBytes, restoredBytes);
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
+    SchemaAndValue restoredDeser = plainConverter.toConnectData(TOPIC, restoredBytes);
+    Struct restored = (Struct) restoredDeser.value();
+    assertEquals("Alice", restored.getString("name"));
+    assertEquals("1 Home", ((Struct) restored.get("home")).getString("street"));
+    assertEquals("2 Work", ((Struct) restored.get("work")).getString("street"));
+  }
+
+  @Test
+  public void testDefaultBytesFieldPreserved() {
+    Schema schema = SchemaBuilder.struct()
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .field("payload", Schema.BYTES_SCHEMA)
+        .build();
+    byte[] payload = new byte[]{0x00, 0x7F, (byte) 0x80, (byte) 0xFF};
+    Struct value = new Struct(schema).put(FIELD_ID, "b-1").put("payload", payload);
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    assertBytesExact(originalBytes, restoredBytes);
+    SchemaAndValue restoredDeser = plainConverter.toConnectData(TOPIC, restoredBytes);
+    assertArrayEquals("bytes field preserved",
+        payload, (byte[]) ((Struct) restoredDeser.value()).get("payload"));
+  }
+
+  @Test
+  public void testDefaultEmptyCollectionsPreserved() {
+    Schema schema = SchemaBuilder.struct()
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .field("tags", SchemaBuilder.array(Schema.STRING_SCHEMA).build())
+        .build();
+    Struct value = new Struct(schema)
+        .put(FIELD_ID, "e-1")
+        .put("tags", Collections.emptyList());
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    SchemaAndValue restoredDeser = plainConverter.toConnectData(TOPIC, restoredBytes);
+    Struct restored = (Struct) restoredDeser.value();
+    assertEquals("empty array preserved",
+        Collections.emptyList(), restored.get("tags"));
+    assertEquals(FIELD_ID + " preserved", "e-1", restored.getString(FIELD_ID));
+  }
+
+  @Test
+  public void testDefaultUnicodeInPayloadPreserved() {
+    Schema schema = SchemaBuilder.struct()
+        .name("UnicodePayload")
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
+        .build();
+    String unicode = "Hello 世界 🚀 café";
+    Struct value = new Struct(schema).put(FIELD_NAME, unicode);
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    assertBytesExact(originalBytes, restoredBytes);
+    SchemaAndValue restoredData = plainConverter.toConnectData(TOPIC, restoredBytes);
+    assertEquals("unicode string preserved",
+        unicode, ((Struct) restoredData.value()).getString(FIELD_NAME));
+  }
+
+  @Test
+  public void testDefaultPristineRestoreWithRawJsonSchemaProducer() throws Exception {
+    String topic = nextTopic();
+    String schemaJson = "{"
+        + "\"type\":\"object\","
+        + "\"title\":\"PristineEvent\","
+        + "\"properties\":{"
+        + "\"id\":{\"type\":\"string\"},"
+        + "\"count\":{\"type\":\"integer\"},"
+        + "\"note\":{\"type\":\"string\"}},"
+        + "\"required\":[\"id\",\"count\",\"note\"],"
+        + "\"additionalProperties\":false}";
+    JsonSchema jsonSchema = new JsonSchema(schemaJson);
+    schemaRegistry.register(topic + "-value", jsonSchema);
+
+    JsonNode record = JSON.readTree("{\"id\":\"pristine-1\",\"count\":42,\"note\":\"e2e\"}");
+    KafkaJsonSchemaSerializer<Object> refSerializer =
+        newReferenceAwareJsonSchemaSerializer(schemaRegistry);
+    byte[] sourceBytes = refSerializer.serialize(topic, record);
+
+    SchemaAndValue wrapped = converter.toConnectData(topic, sourceBytes);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    assertWrapperShape(wrapped, SCHEMA_TYPE);
+    assertWrapperSchemaIdMatchesSource(wrapped, sourceBytes);
+    assertRawSchemaMatchesSourceRegistered(wrapped, sourceBytes);
+    assertWireSchemaIdPreserved(sourceBytes, restoredBytes);
+    assertJsonPayloadSemanticallyEqual(sourceBytes, restoredBytes);
+    Object originalDeser = rawJsonDeserializer.deserialize(topic, sourceBytes);
+    Object restoredDeser = rawJsonDeserializer.deserialize(topic, restoredBytes);
+    assertValueEqual(originalDeser, restoredDeser);
+  }
+
+  @Test
+  public void testDefaultPristineRestoreMegaKitchenSinkAllTypesAndReferences() throws Exception {
+    // use.optional.for.nonrequired=true is required for the mega record because 'nickname'
+    // is declared as nullable via ["string","null"] and treated as optional at Connect level.
+    converter.configure(backupConfigWith("use.optional.for.nonrequired", "true"), false);
+
+    String topic = nextTopic();
+
+    JsonSchema addressSchema = new JsonSchema(ADDRESS_SCHEMA_JSON);
+    schemaRegistry.register(ADDRESS_SUBJECT, addressSchema);
+
+    SchemaReference addressRef =
+        new SchemaReference(ADDRESS_REFNAME, ADDRESS_SUBJECT, 1);
+    Map<String, String> resolvedRefs = ImmutableMap.of(
+        ADDRESS_REFNAME, addressSchema.canonicalString());
+    JsonSchema personSchema = new JsonSchema(
+        MEGA_PERSON_SCHEMA_JSON,
+        Collections.singletonList(addressRef),
+        resolvedRefs,
+        null);
+    schemaRegistry.register(topic + "-value", personSchema);
+
+    JsonNode record = JSON.readTree(
+        "{"
+            + "\"id\":\"person-1\","
+            + "\"age\":30,"
+            + "\"balanceCents\":100000,"
+            + "\"rating\":4.5,"
+            + "\"active\":true,"
+            + "\"payload\":\"AH+A/w==\","
+            + "\"createdAtMs\":1700000000000,"
+            + "\"birthDate\":\"1990-01-15\","
+            + "\"priceUsd\":123.45,"
+            + "\"priority\":\"HIGH\","
+            + "\"guid\":\"11111111-1111-4111-8111-111111111111\","
+            + "\"homeAddress\":{\"street\":\"1 Home Ln\",\"city\":\"Hometown\","
+            + "\"country\":\"US\"},"
+            + "\"workAddress\":{\"street\":\"2 Work Ave\",\"city\":\"Workville\","
+            + "\"country\":\"US\"},"
+            + "\"tags\":[\"premium\",\"verified\"],"
+            + "\"attrs\":{\"env\":\"prod\"},"
+            + "\"contact\":\"person@x.com\","
+            + "\"nickname\":\"nick1\","
+            + "\"nested\":{\"label\":\"n1\",\"kind\":\"B\"}"
+            + "}");
+    KafkaJsonSchemaSerializer<Object> refSerializer =
+        newReferenceAwareJsonSchemaSerializer(schemaRegistry);
+    byte[] sourceBytes = refSerializer.serialize(topic, record);
+
+    SchemaAndValue wrapped = converter.toConnectData(topic, sourceBytes);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    assertWrapperShape(wrapped, SCHEMA_TYPE);
+    assertWrapperSchemaIdMatchesSource(wrapped, sourceBytes);
+    assertRawSchemaMatchesSourceRegistered(wrapped, sourceBytes);
+    assertWireSchemaIdPreserved(sourceBytes, restoredBytes);
+    assertJsonPayloadSemanticallyEqual(sourceBytes, restoredBytes);
+
+    // Cross-subject reference metadata explicitly captured on the wrapper.
+    Struct wrapperStruct = (Struct) wrapped.value();
+    String refTree = wrapperStruct.getString(BackupWrapper.FIELD_REFERENCE_TREE);
+    String directRefs = wrapperStruct.getString(BackupWrapper.FIELD_DIRECT_REFS);
+    assertNotNull("mega wrapper captures reference tree", refTree);
+    assertNotNull("mega wrapper captures direct refs", directRefs);
+    assertTrue("reference tree mentions Address refName: " + refTree,
+        refTree.contains(ADDRESS_REFNAME));
+    assertTrue("direct refs mention Address subject: " + directRefs,
+        directRefs.contains(ADDRESS_SUBJECT));
+
+    // Source SR still resolves both Person (with its Address reference) and Address.
+    ParsedSchema registeredPerson = schemaRegistry.getSchemaBySubjectAndId(
+        topic + "-value",
+        schemaRegistry.getLatestSchemaMetadata(topic + "-value").getId());
+    assertNotNull("Person schema resolvable from source SR after backup", registeredPerson);
+    List<SchemaReference> personRefs = registeredPerson.references();
+    assertEquals("Person has one direct reference (Address)", 1, personRefs.size());
+    assertEquals("Person reference refName matches Address",
+        ADDRESS_REFNAME, personRefs.get(0).getName());
+    assertEquals("Person reference subject matches Address",
+        ADDRESS_SUBJECT, personRefs.get(0).getSubject());
+    assertNotNull("Address schema resolvable from source SR by subject",
+        schemaRegistry.getLatestSchemaMetadata(ADDRESS_SUBJECT));
+
+    // Semantic equivalence via re-deserialization through the raw JSON Schema path.
+    Object originalDeser = rawJsonDeserializer.deserialize(topic, sourceBytes);
+    Object restoredDeser = rawJsonDeserializer.deserialize(topic, restoredBytes);
+    assertValueEqual(originalDeser, restoredDeser);
+  }
+
+  // attrs carries connect.type=map to activate the Connect map branch; without the hint
+  // JsonSchemaData drops entries.
+  private static final String MEGA_PERSON_SCHEMA_JSON =
+      "{\"type\":\"object\",\"title\":\"MegaPerson\","
+          + "\"properties\":{"
+          + "\"id\":{\"type\":\"string\"},"
+          + "\"age\":{\"type\":\"integer\"},"
+          + "\"balanceCents\":{\"type\":\"integer\"},"
+          + "\"rating\":{\"type\":\"number\"},"
+          + "\"active\":{\"type\":\"boolean\"},"
+          + "\"payload\":{\"type\":\"string\",\"format\":\"binary\"},"
+          + "\"createdAtMs\":{\"type\":\"integer\"},"
+          + "\"birthDate\":{\"type\":\"string\",\"format\":\"date\"},"
+          + "\"priceUsd\":{\"type\":\"number\"},"
+          + "\"priority\":{\"type\":\"string\",\"enum\":[\"LOW\",\"MEDIUM\",\"HIGH\"]},"
+          + "\"guid\":{\"type\":\"string\",\"format\":\"uuid\"},"
+          + "\"homeAddress\":{\"$ref\":\"shared/address.json\"},"
+          + "\"workAddress\":{\"$ref\":\"shared/address.json\"},"
+          + "\"tags\":{\"type\":\"array\",\"items\":{\"type\":\"string\"}},"
+          + "\"attrs\":{\"type\":\"object\","
+          + "\"additionalProperties\":{\"type\":\"string\"},"
+          + "\"connect.type\":\"map\"},"
+          + "\"contact\":{\"oneOf\":[{\"type\":\"string\"},{\"type\":\"integer\"}]},"
+          + "\"nickname\":{\"type\":[\"string\",\"null\"]},"
+          + "\"nested\":{\"type\":\"object\","
+          + "\"properties\":{\"label\":{\"type\":\"string\"},"
+          + "\"kind\":{\"type\":\"string\",\"enum\":[\"A\",\"B\",\"C\"]}},"
+          + "\"required\":[\"label\",\"kind\"]}"
+          + "},"
+          + "\"required\":[\"id\",\"age\",\"balanceCents\",\"rating\",\"active\","
+          + "\"payload\",\"createdAtMs\",\"birthDate\",\"priceUsd\",\"priority\",\"guid\","
+          + "\"homeAddress\",\"workAddress\",\"tags\",\"attrs\",\"contact\",\"nested\"]}";
+
+  @Test
+  public void testDefaultPristineRestoreCrossClusterWithCrossSubjectReferences()
+      throws Exception {
+    RefTestFixture fx = registerAndProducePersonWithAddressRef();
+    int sourceWireId = ByteBuffer.wrap(fx.sourceBytes, 1, 4).getInt();
+    String sourcePersonCanonical =
+        schemaRegistry.getSchemaById(sourceWireId).canonicalString();
+
+    SchemaAndValue wrapped = converter.toConnectData(fx.topic, fx.sourceBytes);
+
+    assertWrapperShape(wrapped, SCHEMA_TYPE);
+    assertWrapperSchemaIdMatchesSource(wrapped, fx.sourceBytes);
+    Struct wrapperStruct = (Struct) wrapped.value();
+    assertEquals("wrapper rawSchema equals source-registered canonical form",
+        sourcePersonCanonical,
+        wrapperStruct.getString(BackupWrapper.FIELD_RAW_SCHEMA));
+    String refTree = wrapperStruct.getString(BackupWrapper.FIELD_REFERENCE_TREE);
+    String directRefs = wrapperStruct.getString(BackupWrapper.FIELD_DIRECT_REFS);
+    assertNotNull("reference tree captured", refTree);
+    assertNotNull("direct refs captured", directRefs);
+    assertTrue("reference tree mentions Address refName: " + refTree,
+        refTree.contains(ADDRESS_REFNAME));
+    assertTrue("direct refs mention Address subject: " + directRefs,
+        directRefs.contains(ADDRESS_SUBJECT));
+
+    assertTrue("target SR is empty before restore",
+        targetSchemaRegistry.getAllSubjects().isEmpty());
+    byte[] restoredBytes = targetConverter.fromConnectData(
+        fx.topic, wrapped.schema(), wrapped.value());
+
+    assertTrue("target SR has Address subject",
+        targetSchemaRegistry.getAllSubjects().contains(ADDRESS_SUBJECT));
+    assertTrue("target SR has Person subject",
+        targetSchemaRegistry.getAllSubjects().contains(fx.topic + "-value"));
+
+    assertCrossClusterBytesEquivalent(fx.sourceBytes, restoredBytes);
+    assertJsonPayloadSemanticallyEqual(fx.sourceBytes, restoredBytes);
+
+    int targetWireId = ByteBuffer.wrap(restoredBytes, 1, 4).getInt();
+    ParsedSchema targetPersonSchema = targetSchemaRegistry.getSchemaById(targetWireId);
+    assertNotNull("target SR resolves the restored wire ID", targetPersonSchema);
+    assertEquals("target Person canonical == source Person canonical",
+        sourcePersonCanonical, targetPersonSchema.canonicalString());
+    List<SchemaReference> targetRefs = targetPersonSchema.references();
+    assertEquals("target Person has one direct reference (Address)", 1, targetRefs.size());
+    assertEquals("target ref name matches source",
+        ADDRESS_REFNAME, targetRefs.get(0).getName());
+    assertEquals("target ref subject matches source", ADDRESS_SUBJECT,
+        targetRefs.get(0).getSubject());
+    assertTrue("target ref version is a positive integer",
+        targetRefs.get(0).getVersion() > 0);
+
+    Object sourceValue = rawJsonDeserializer.deserialize(fx.topic, fx.sourceBytes);
+    Object targetValue = targetJsonDeserializer.deserialize(fx.topic, restoredBytes);
+    assertNotNull("source deserialized non-null", sourceValue);
+    assertNotNull("target deserialized non-null", targetValue);
+    assertEquals("restored record equals source semantically", sourceValue, targetValue);
+  }
+
+  // ================ Cross-subject reference negatives ================
+
+  private static final String ADDRESS_REFNAME = "shared/address.json";
+  private static final String ADDRESS_SUBJECT = "shared/address.json";
+  private static final String ADDRESS_SCHEMA_JSON =
+      "{\"type\":\"object\",\"title\":\"Address\","
+          + "\"properties\":{"
+          + "\"street\":{\"type\":\"string\"},"
+          + "\"city\":{\"type\":\"string\"},"
+          + "\"country\":{\"type\":\"string\"}},"
+          + "\"required\":[\"street\",\"city\",\"country\"],"
+          + "\"additionalProperties\":false}";
+  private static final String PERSON_WITH_REF_SCHEMA_JSON =
+      "{\"type\":\"object\",\"title\":\"PersonRef\","
+          + "\"properties\":{"
+          + "\"name\":{\"type\":\"string\"},"
+          + "\"homeAddress\":{\"$ref\":\"shared/address.json\"},"
+          + "\"workAddress\":{\"$ref\":\"shared/address.json\"}},"
+          + "\"required\":[\"name\",\"homeAddress\",\"workAddress\"],"
+          + "\"additionalProperties\":false}";
+
+  private RefTestFixture registerAndProducePersonWithAddressRef() throws Exception {
+    String topic = nextTopic();
+    JsonSchema addressSchema = new JsonSchema(ADDRESS_SCHEMA_JSON);
+    schemaRegistry.register(ADDRESS_SUBJECT, addressSchema);
+    SchemaReference addressRef =
+        new SchemaReference(ADDRESS_REFNAME, ADDRESS_SUBJECT, 1);
+    Map<String, String> resolved = ImmutableMap.of(
+        ADDRESS_REFNAME, addressSchema.canonicalString());
+    JsonSchema personSchema = new JsonSchema(
+        PERSON_WITH_REF_SCHEMA_JSON,
+        Collections.singletonList(addressRef),
+        resolved,
+        null);
+    schemaRegistry.register(topic + "-value", personSchema);
+
+    JsonNode record = JSON.readTree(
+        "{\"name\":\"Alice\","
+            + "\"homeAddress\":{\"street\":\"1 Main St\",\"city\":\"Springfield\","
+            + "\"country\":\"US\"},"
+            + "\"workAddress\":{\"street\":\"1 Main St\",\"city\":\"Springfield\","
+            + "\"country\":\"US\"}}");
+    KafkaJsonSchemaSerializer<Object> refSerializer =
+        newReferenceAwareJsonSchemaSerializer(schemaRegistry);
+    byte[] sourceBytes = refSerializer.serialize(topic, record);
+    return new RefTestFixture(topic, sourceBytes);
+  }
+
+  private static final class RefTestFixture {
+    final String topic;
+    final byte[] sourceBytes;
+    RefTestFixture(String topic, byte[] sourceBytes) {
+      this.topic = topic;
+      this.sourceBytes = sourceBytes;
+    }
+  }
+
+  @Test
+  public void testEdgeReferenceTreeMissingEntryThrows() throws Exception {
+    RefTestFixture fx = registerAndProducePersonWithAddressRef();
+    SchemaAndValue wrapped = converter.toConnectData(fx.topic, fx.sourceBytes);
+
+    Struct original = (Struct) wrapped.value();
+    Schema wrapperSchema = wrapped.schema();
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_ID),
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION),
+        original.getString(BackupWrapper.FIELD_SCHEMA_TYPE),
+        original.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT),
+        original.getString(BackupWrapper.FIELD_RAW_SCHEMA),
+        "{}",
+        original.getString(BackupWrapper.FIELD_DIRECT_REFS));
+    Struct badWrapper = BackupWrapper.buildWrapper(
+        wrapperSchema, original.get(BackupWrapper.FIELD_DATA), fields);
+
+    try {
+      converter.fromConnectData(fx.topic, wrapperSchema, badWrapper);
+      fail("Expected DataException for empty reference tree with populated direct refs");
+    } catch (DataException e) {
+      assertEquals("Corrupt backup wrapper: partial reference metadata "
+          + "(treeEmpty=true, directRefsEmpty=false)", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testEdgeCorruptReferenceTreeJsonThrows() throws Exception {
+    RefTestFixture fx = registerAndProducePersonWithAddressRef();
+    SchemaAndValue wrapped = converter.toConnectData(fx.topic, fx.sourceBytes);
+
+    Struct original = (Struct) wrapped.value();
+    Schema wrapperSchema = wrapped.schema();
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_ID),
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION),
+        original.getString(BackupWrapper.FIELD_SCHEMA_TYPE),
+        original.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT),
+        original.getString(BackupWrapper.FIELD_RAW_SCHEMA),
+        "{ not valid json",
+        original.getString(BackupWrapper.FIELD_DIRECT_REFS));
+    Struct badWrapper = BackupWrapper.buildWrapper(
+        wrapperSchema, original.get(BackupWrapper.FIELD_DATA), fields);
+
+    try {
+      converter.fromConnectData(fx.topic, wrapperSchema, badWrapper);
+      fail("Expected DataException on corrupt reference tree JSON");
+    } catch (DataException e) {
+      assertEquals("Cannot parse reference tree JSON for restore. "
+          + "Backup metadata may be corrupt.", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testEdgeDirectRefsWithoutReferenceTreeThrows() throws Exception {
+    RefTestFixture fx = registerAndProducePersonWithAddressRef();
+    SchemaAndValue wrapped = converter.toConnectData(fx.topic, fx.sourceBytes);
+
+    Struct original = (Struct) wrapped.value();
+    Schema wrapperSchema = wrapped.schema();
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_ID),
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION),
+        original.getString(BackupWrapper.FIELD_SCHEMA_TYPE),
+        original.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT),
+        original.getString(BackupWrapper.FIELD_RAW_SCHEMA),
+        null,
+        original.getString(BackupWrapper.FIELD_DIRECT_REFS));
+    Struct badWrapper = BackupWrapper.buildWrapper(
+        wrapperSchema, original.get(BackupWrapper.FIELD_DATA), fields);
+
+    try {
+      converter.fromConnectData(fx.topic, wrapperSchema, badWrapper);
+      fail("Expected DataException on directRefs-without-reference-tree corruption");
+    } catch (DataException e) {
+      assertEquals("Corrupt backup wrapper: partial reference metadata "
+          + "(treeEmpty=true, directRefsEmpty=false)", e.getMessage());
+    }
+  }
+
+  // ================ Config-lossiness pairs (same config on/off) ================
+
+  @Test
+  public void testUseOptionalForNonRequiredOnPreservesRoundTripWithOmittedFields() throws Exception {
+    converter.configure(backupConfigWith("use.optional.for.nonrequired", "true"), false);
+
+    String topic = nextTopic();
+    String schemaJson = "{"
+        + "\"type\":\"object\","
+        + "\"title\":\"OptionalFields\","
+        + "\"properties\":{"
+        + "\"id\":{\"type\":\"string\"},"
+        + "\"nickname\":{\"type\":\"string\"}},"
+        + "\"required\":[\"id\"],"
+        + "\"additionalProperties\":false}";
+    JsonSchema jsonSchema = new JsonSchema(schemaJson);
+    schemaRegistry.register(topic + "-value", jsonSchema);
+
+    JsonNode record = JSON.readTree("{\"id\":\"only-required\"}");
+    KafkaJsonSchemaSerializer<Object> refSerializer =
+        newReferenceAwareJsonSchemaSerializer(schemaRegistry);
+    byte[] sourceBytes = refSerializer.serialize(topic, record);
+
+    SchemaAndValue wrapped = converter.toConnectData(topic, sourceBytes);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    assertWrapperShape(wrapped, SCHEMA_TYPE);
+    assertWireSchemaIdPreserved(sourceBytes, restoredBytes);
+    assertJsonPayloadSemanticallyEqual(sourceBytes, restoredBytes);
+  }
+
+  @Test
+  public void testUseOptionalForNonRequiredOffFailsOnOmittedNonRequiredField() throws Exception {
+    String topic = nextTopic();
+    String schemaJson = "{"
+        + "\"type\":\"object\","
+        + "\"title\":\"OptionalFieldsOff\","
+        + "\"properties\":{"
+        + "\"id\":{\"type\":\"string\"},"
+        + "\"nickname\":{\"type\":\"string\"}},"
+        + "\"required\":[\"id\"],"
+        + "\"additionalProperties\":false}";
+    JsonSchema jsonSchema = new JsonSchema(schemaJson);
+    schemaRegistry.register(topic + "-value", jsonSchema);
+
+    JsonNode record = JSON.readTree("{\"id\":\"only-required\"}");
+    KafkaJsonSchemaSerializer<Object> refSerializer =
+        newReferenceAwareJsonSchemaSerializer(schemaRegistry);
+    byte[] sourceBytes = refSerializer.serialize(topic, record);
+
+    try {
+      converter.toConnectData(topic, sourceBytes);
+      fail("Expected DataException when use.optional.for.nonrequired is default false "
+          + "and record omits a non-required property");
+    } catch (DataException e) {
+      assertTrue("message identifies null-for-required-field problem: " + e.getMessage(),
+          e.getMessage().contains("Invalid value: null used for required field")
+              || e.getMessage().contains("Invalid null value for required"));
+    }
+  }
+
+  @Test
+  public void testAdditionalPropertiesTypedMapWithoutConnectTypeHintLosesContents() throws Exception {
+    converter.configure(backupConfigWith("use.optional.for.nonrequired", "true"), false);
+
+    String topic = nextTopic();
+    String schemaJson = "{"
+        + "\"type\":\"object\","
+        + "\"title\":\"WithScores\","
+        + "\"properties\":{"
+        + "\"id\":{\"type\":\"string\"},"
+        + "\"scores\":{\"type\":\"object\",\"additionalProperties\":{\"type\":\"integer\"}}},"
+        + "\"required\":[\"id\"]}";
+    JsonSchema jsonSchema = new JsonSchema(schemaJson);
+    schemaRegistry.register(topic + "-value", jsonSchema);
+
+    JsonNode record = JSON.readTree("{\"id\":\"map-1\",\"scores\":{\"a\":1,\"b\":2}}");
+    KafkaJsonSchemaSerializer<Object> refSerializer =
+        newReferenceAwareJsonSchemaSerializer(schemaRegistry);
+    byte[] sourceBytes = refSerializer.serialize(topic, record);
+
+    SchemaAndValue wrapped = converter.toConnectData(topic, sourceBytes);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    Object restoredDeser = rawJsonDeserializer.deserialize(topic, restoredBytes);
+    String restoredJson = restoredDeser.toString();
+    assertTrue("id preserved on restored record: " + restoredJson,
+        restoredJson.contains("map-1"));
+    assertTrue("scores.a entry dropped without connect.type:map hint: " + restoredJson,
+        !restoredJson.contains("\"a\"") && !restoredJson.contains("=1"));
+    assertTrue("scores.b entry dropped without connect.type:map hint: " + restoredJson,
+        !restoredJson.contains("\"b\"") && !restoredJson.contains("=2"));
+  }
+
+  @Test
+  public void testAdditionalPropertiesTrueObjectLosesArbitraryExtras() throws Exception {
+    converter.configure(backupConfigWith("use.optional.for.nonrequired", "true"), false);
+
+    String topic = nextTopic();
+    String schemaJson = "{"
+        + "\"type\":\"object\","
+        + "\"title\":\"WithExtras\","
+        + "\"properties\":{"
+        + "\"id\":{\"type\":\"string\"},"
+        + "\"extras\":{\"type\":\"object\",\"additionalProperties\":true}},"
+        + "\"required\":[\"id\"]}";
+    JsonSchema jsonSchema = new JsonSchema(schemaJson);
+    schemaRegistry.register(topic + "-value", jsonSchema);
+
+    JsonNode record = JSON.readTree(
+        "{\"id\":\"extras-1\",\"extras\":{\"foo\":\"bar\",\"n\":9}}");
+    KafkaJsonSchemaSerializer<Object> refSerializer =
+        newReferenceAwareJsonSchemaSerializer(schemaRegistry);
+    byte[] sourceBytes = refSerializer.serialize(topic, record);
+
+    SchemaAndValue wrapped = converter.toConnectData(topic, sourceBytes);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    Object restoredDeser = rawJsonDeserializer.deserialize(topic, restoredBytes);
+    String restoredJson = restoredDeser.toString();
+    assertTrue("id preserved on restored record: " + restoredJson,
+        restoredJson.contains("extras-1"));
+    assertTrue("extras.foo dropped without connect.type:map hint: " + restoredJson,
+        !restoredJson.contains("\"foo\"") && !restoredJson.contains("bar"));
+    assertTrue("extras.n dropped without connect.type:map hint: " + restoredJson,
+        !restoredJson.contains("\"n\"") && !restoredJson.contains("=9"));
+  }
+
+  @Test
+  public void testObjectAdditionalPropertiesFalseSchemaExplicitlyRestricts() {
+    converter.configure(backupConfigWith("object.additional.properties", "false"), false);
+    plainConverter.configure(
+        backupConfigWith("object.additional.properties", "false"), false);
+
+    Schema schema = SchemaBuilder.struct()
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, "a-1");
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    assertBytesExact(originalBytes, restoredBytes);
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
+    String raw = ((Struct) wrapped.value()).getString(BackupWrapper.FIELD_RAW_SCHEMA);
+    assertTrue("raw schema restricts additional properties: " + raw,
+        raw.contains("\"additionalProperties\":false"));
+  }
+
+  @Test
+  public void testDecimalFormatBase64DefaultPreservesRoundTrip() throws Exception {
+    String topic = nextTopic();
+    String schemaJson = "{"
+        + "\"type\":\"object\","
+        + "\"title\":\"WithNumber\","
+        + "\"properties\":{"
+        + "\"id\":{\"type\":\"string\"},"
+        + "\"amount\":{\"type\":\"number\"}},"
+        + "\"required\":[\"id\",\"amount\"],"
+        + "\"additionalProperties\":false}";
+    JsonSchema jsonSchema = new JsonSchema(schemaJson);
+    schemaRegistry.register(topic + "-value", jsonSchema);
+
+    JsonNode record = JSON.readTree("{\"id\":\"dec-1\",\"amount\":123.45}");
+    KafkaJsonSchemaSerializer<Object> refSerializer =
+        newReferenceAwareJsonSchemaSerializer(schemaRegistry);
+    byte[] sourceBytes = refSerializer.serialize(topic, record);
+
+    SchemaAndValue wrapped = converter.toConnectData(topic, sourceBytes);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    assertWireSchemaIdPreserved(sourceBytes, restoredBytes);
+    assertJsonPayloadSemanticallyEqual(sourceBytes, restoredBytes);
+  }
+
+  @Test
+  public void testDecimalFormatNumericSymmetricPreservesRoundTrip() throws Exception {
+    converter.configure(backupConfigWith("decimal.format", "NUMERIC"), false);
+
+    String topic = nextTopic();
+    String schemaJson = "{"
+        + "\"type\":\"object\","
+        + "\"title\":\"WithNumberNumeric\","
+        + "\"properties\":{"
+        + "\"id\":{\"type\":\"string\"},"
+        + "\"amount\":{\"type\":\"number\"}},"
+        + "\"required\":[\"id\",\"amount\"],"
+        + "\"additionalProperties\":false}";
+    JsonSchema jsonSchema = new JsonSchema(schemaJson);
+    schemaRegistry.register(topic + "-value", jsonSchema);
+
+    JsonNode record = JSON.readTree("{\"id\":\"dec-2\",\"amount\":99.99}");
+    KafkaJsonSchemaSerializer<Object> refSerializer =
+        newReferenceAwareJsonSchemaSerializer(schemaRegistry);
+    byte[] sourceBytes = refSerializer.serialize(topic, record);
+
+    SchemaAndValue wrapped = converter.toConnectData(topic, sourceBytes);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    assertWireSchemaIdPreserved(sourceBytes, restoredBytes);
+    assertJsonPayloadSemanticallyEqual(sourceBytes, restoredBytes);
+  }
+
+  // ================ Edge cases and error handling ================
+
+  @Test
+  public void testEdgeNullValue() {
+    SchemaAndValue result = converter.toConnectData(TOPIC, null);
+    assertNull(result.schema());
+    assertNull(result.value());
+  }
+
+  @Test
+  public void testEdgeBackupDisabledNoWrapping() {
     Schema schema = SchemaBuilder.struct()
         .field("x", Schema.INT32_SCHEMA)
         .build();
@@ -151,63 +1053,9 @@ public class JsonSchemaConverterBackupTest {
   }
 
   @Test
-  public void testBackupNullValue() {
-    SchemaAndValue result = converter.toConnectData(TOPIC, null);
-    assertNull(result.schema());
-    assertNull(result.value());
-  }
-
-  @Test
-  public void testBackupPrimitiveType() {
+  public void testEdgeNonWrapperSchemaSerializesNormally() {
     Schema schema = SchemaBuilder.struct()
-        .field("val", Schema.STRING_SCHEMA)
-        .build();
-    Struct value = new Struct(schema).put("val", "test");
-
-    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
-    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
-
-    assertEquals(BackupWrapper.NAME, result.schema().name());
-    Struct wrapper = (Struct) result.value();
-    assertEquals(SCHEMA_TYPE,
-        wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
-  }
-
-  @Test
-  public void testBackupWrapperFields() {
-    Schema schema = SchemaBuilder.struct()
-        .field("data", Schema.STRING_SCHEMA)
-        .build();
-    Struct value = new Struct(schema).put("data", "check");
-
-    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
-    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
-
-    Struct wrapper = (Struct) result.value();
-    assertEquals(SCHEMA_TYPE,
-        wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
-    assertTrue(wrapper.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT)
-        .contains(TOPIC));
-  }
-
-  @Test
-  public void testBackupSchemaIdExtracted() {
-    Schema schema = SchemaBuilder.struct()
-        .field("n", Schema.INT32_SCHEMA)
-        .build();
-    Struct value = new Struct(schema).put("n", 7);
-
-    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
-    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
-
-    Struct wrapper = (Struct) result.value();
-    int wrappedId = wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_ID);
-    assertTrue(wrappedId > 0);
-  }
-
-  @Test
-  public void testBackupNonWrapperSchemaNormalSerialization() {
-    Schema schema = SchemaBuilder.struct()
+        .name("Direct")
         .field("text", Schema.STRING_SCHEMA)
         .build();
     Struct value = new Struct(schema).put("text", "direct");
@@ -219,64 +1067,29 @@ public class JsonSchemaConverterBackupTest {
   }
 
   @Test
-  public void testBackupRestoreMissingDataField() {
+  public void testEdgeMissingDataFieldThrows() {
     Schema badSchema = SchemaBuilder.struct()
         .name(BackupWrapper.NAME)
         .field(BackupWrapper.FIELD_SCHEMA_ID, Schema.INT32_SCHEMA)
         .build();
-    Struct badWrapper = new Struct(badSchema)
-        .put(BackupWrapper.FIELD_SCHEMA_ID, 1);
+    Struct badWrapper = new Struct(badSchema).put(BackupWrapper.FIELD_SCHEMA_ID, 1);
 
     try {
       converter.fromConnectData(TOPIC, badSchema, badWrapper);
-      fail("Expected DataException");
+      fail("Expected DataException for wrapper missing 'data' field");
     } catch (DataException e) {
-      assertTrue(e.getMessage().contains("data")
-          || e.getMessage().contains("restore")
-          || e.getMessage().contains("Failed"));
+      assertEquals("Malformed backup wrapper: missing '" + BackupWrapper.FIELD_DATA + "' field",
+          e.getMessage());
     }
   }
 
   @Test
-  public void testBackupRoundTripBytesExact() {
+  public void testEdgeNullRawSchemaThrows() {
     Schema schema = SchemaBuilder.struct()
-        .field("id", Schema.STRING_SCHEMA)
-        .field(FIELD_COUNT, Schema.INT32_SCHEMA)
+        .name("Fallback")
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
         .build();
-    Struct original = new Struct(schema)
-        .put("id", "exact")
-        .put(FIELD_COUNT, 77);
-
-    byte[] originalBytes = plainConverter.fromConnectData(
-        TOPIC, schema, original);
-
-    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
-    byte[] restoredBytes = converter.fromConnectData(
-        TOPIC, wrapped.schema(), wrapped.value());
-
-    assertArrayEquals(originalBytes, restoredBytes);
-  }
-
-  @Test
-  public void testBackupSchemaVersionPresent() {
-    Schema schema = SchemaBuilder.struct()
-        .field("x", Schema.INT32_SCHEMA)
-        .build();
-    Struct value = new Struct(schema).put("x", 42);
-
-    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
-    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
-
-    Struct wrapper = (Struct) result.value();
-    assertNotNull(wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION));
-  }
-
-  @Test
-  public void testBackupRestoreNullRawSchemaThrows() {
-    Schema schema = SchemaBuilder.struct()
-        .field("fallback", Schema.STRING_SCHEMA)
-        .build();
-    Struct value = new Struct(schema).put("fallback", "test");
+    Struct value = new Struct(schema).put(FIELD_NAME, "fallback");
 
     byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
     SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
@@ -296,10 +1109,251 @@ public class JsonSchemaConverterBackupTest {
       converter.fromConnectData(TOPIC, wrapperSchema, modifiedWrapper);
       fail("Expected DataException for null rawSchema");
     } catch (DataException e) {
-      assertTrue(e.getMessage(),
-          e.getMessage().contains(BackupWrapper.FIELD_RAW_SCHEMA));
-      assertTrue(e.getMessage(),
-          e.getMessage().contains("pristine restore"));
+      assertEquals("Malformed backup wrapper: missing '" + BackupWrapper.FIELD_RAW_SCHEMA
+          + "' for topic " + TOPIC + ". Cannot guarantee pristine restore.", e.getMessage());
     }
+  }
+
+  @Test
+  public void testEdgeBasicRoundtripDeserializes() {
+    Schema schema = SchemaBuilder.struct()
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .field(FIELD_COUNT, Schema.INT32_SCHEMA)
+        .build();
+    Struct original = new Struct(schema).put(FIELD_ID, "b-1").put(FIELD_COUNT, 7);
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, original);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    SchemaAndValue restoredData = plainConverter.toConnectData(TOPIC, restoredBytes);
+    Struct restored = (Struct) restoredData.value();
+    assertEquals("b-1", restored.getString(FIELD_ID));
+    assertEquals(Integer.valueOf(7), restored.getInt32(FIELD_COUNT));
+  }
+
+  @Test
+  public void testEdgeSchemaTypeMismatchThrows() {
+    Schema schema = SchemaBuilder.struct()
+        .name("Mismatch")
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, "type-mismatch");
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+
+    Struct original = (Struct) wrapped.value();
+    Schema wrapperSchema = wrapped.schema();
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_ID),
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION),
+        "AVRO",
+        original.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT),
+        original.getString(BackupWrapper.FIELD_RAW_SCHEMA),
+        null, null);
+    Struct badWrapper = BackupWrapper.buildWrapper(
+        wrapperSchema, original.get(BackupWrapper.FIELD_DATA), fields);
+
+    try {
+      converter.fromConnectData(TOPIC, wrapperSchema, badWrapper);
+      fail("Expected DataException on schema type mismatch");
+    } catch (DataException e) {
+      assertEquals("JsonSchemaConverter received wrapper with schemaType='AVRO', "
+          + "expected 'JSON_SCHEMA'", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testEdgeCorruptedWireIdRejected() {
+    Schema schema = SchemaBuilder.struct()
+        .name("Corrupt")
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, "corrupt");
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    byte[] corrupted = originalBytes.clone();
+    ByteBuffer.wrap(corrupted, 1, 4).putInt(Integer.MAX_VALUE - 1);
+
+    try {
+      converter.toConnectData(TOPIC, corrupted);
+      fail("Expected DataException for corrupted wire schema ID");
+    } catch (DataException e) {
+      assertEquals("Converting byte[] to Kafka Connect data failed due to "
+          + "serialization error of topic " + TOPIC + ": ", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testEdgeSinkWrapErrorClassifiedAsBackupException() throws Exception {
+    // A SR client that fetches individual schemas normally (so deserialize succeeds)
+    // but throws on getAllVersionsById, which only the wrap path uses.
+    SchemaRegistryClient wrapFailingSr = new MockSchemaRegistryClient(
+        ImmutableList.of(new JsonSchemaProvider())) {
+      @Override
+      public Collection<SubjectVersion> getAllVersionsById(int id) {
+        throw new SerializationException("simulated SR unavailable during wrap");
+      }
+    };
+    JsonSchemaConverter wrapFailingConverter = new JsonSchemaConverter(wrapFailingSr);
+    Map<String, Object> cfg = new HashMap<>();
+    cfg.put(SR_URL_KEY, FAKE_SR_URL);
+    cfg.put(BACKUP_ENABLED_KEY, "true");
+    wrapFailingConverter.configure(cfg, false);
+
+    String topic = nextTopic();
+    String schemaJson = "{\"type\":\"object\","
+        + "\"properties\":{\"id\":{\"type\":\"string\"}},"
+        + "\"required\":[\"id\"],\"additionalProperties\":false}";
+    JsonSchema jsonSchema = new JsonSchema(schemaJson);
+    wrapFailingSr.register(topic + "-value", jsonSchema);
+    JsonNode record = JSON.readTree("{\"id\":\"wrap-fail\"}");
+    KafkaJsonSchemaSerializer<Object> refSerializer =
+        newReferenceAwareJsonSchemaSerializer(wrapFailingSr);
+    byte[] bytes = refSerializer.serialize(topic, record);
+
+    try {
+      wrapFailingConverter.toConnectData(topic, bytes);
+      fail("Expected DataException when wrap-path SR call fails");
+    } catch (DataException e) {
+      assertEquals("Failed to wrap JSON Schema backup for topic " + topic, e.getMessage());
+      assertTrue("cause is the simulated SerializationException",
+          e.getCause() instanceof SerializationException);
+    }
+  }
+
+  @Test
+  public void testHeaderSchemaIdSerializerBackupCapturesSchemaId() {
+    SchemaRegistryClient sr = new MockSchemaRegistryClient(
+        ImmutableList.of(new JsonSchemaProvider()));
+    JsonSchemaConverter headerBackupConverter = new JsonSchemaConverter(sr);
+    JsonSchemaConverter headerPlainConverter = new JsonSchemaConverter(sr);
+    Map<String, Object> backupCfg = new HashMap<>();
+    backupCfg.put(SR_URL_KEY, FAKE_SR_URL);
+    backupCfg.put(BACKUP_ENABLED_KEY, "true");
+    backupCfg.put(AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_SERIALIZER,
+        HeaderSchemaIdSerializer.class.getName());
+    backupCfg.put(AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_DESERIALIZER,
+        "io.confluent.kafka.serializers.schema.id.DualSchemaIdDeserializer");
+    headerBackupConverter.configure(backupCfg, false);
+    Map<String, Object> plainCfg = new HashMap<>(backupCfg);
+    plainCfg.remove(BACKUP_ENABLED_KEY);
+    headerPlainConverter.configure(plainCfg, false);
+
+    Schema schema = SchemaBuilder.struct()
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, "h-1").put(FIELD_NAME, "header-test");
+
+    Headers headers = new RecordHeaders();
+    byte[] serialized = headerPlainConverter.fromConnectData(TOPIC, headers, schema, value);
+
+    assertNotNull("value schema ID header present", headers.lastHeader(SchemaId.VALUE_SCHEMA_ID_HEADER));
+
+    SchemaAndValue wrapped = headerBackupConverter.toConnectData(TOPIC, headers, serialized);
+
+    assertNotNull("wrapper produced", wrapped);
+    assertEquals("wrapper schema name", BackupWrapper.NAME, wrapped.schema().name());
+    Struct w = (Struct) wrapped.value();
+    assertEquals("schema type", SCHEMA_TYPE, w.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
+    assertNotNull("raw schema captured", w.getString(BackupWrapper.FIELD_RAW_SCHEMA));
+    // Header-path populates schemaGuid; schemaId may be inferred by SR client depending on
+    // the deserializer implementation. At minimum, guid must be present.
+    assertNotNull("wrapper populates schemaGuid from header",
+        w.getString(BackupWrapper.FIELD_SCHEMA_GUID));
+
+    Headers restoredHeaders = new RecordHeaders();
+    byte[] restoredBytes = headerBackupConverter.fromConnectData(
+        TOPIC, restoredHeaders, wrapped.schema(), wrapped.value());
+    assertNotNull("restored value schema ID header present",
+        restoredHeaders.lastHeader(SchemaId.VALUE_SCHEMA_ID_HEADER));
+
+    SchemaAndValue restoredDeser = headerPlainConverter.toConnectData(
+        TOPIC, restoredHeaders, restoredBytes);
+    Struct restored = (Struct) restoredDeser.value();
+    assertEquals("id preserved", "h-1", restored.getString(FIELD_ID));
+    assertEquals("name preserved", "header-test", restored.getString(FIELD_NAME));
+  }
+
+  // ================ Config-mismatch scenarios (backup with X, restore with X flipped) ================
+
+  @Test
+  public void testConfigMismatchUseOptionalForNonRequiredSinkOnSourceOffStillWorks()
+      throws Exception {
+    converter.configure(backupConfigWith("use.optional.for.nonrequired", "true"), false);
+
+    String topic = nextTopic();
+    String schemaJson = "{"
+        + "\"type\":\"object\","
+        + "\"title\":\"MismatchOptional\","
+        + "\"properties\":{"
+        + "\"id\":{\"type\":\"string\"},"
+        + "\"nickname\":{\"type\":\"string\"}},"
+        + "\"required\":[\"id\"],"
+        + "\"additionalProperties\":false}";
+    JsonSchema jsonSchema = new JsonSchema(schemaJson);
+    schemaRegistry.register(topic + "-value", jsonSchema);
+
+    JsonNode record = JSON.readTree("{\"id\":\"only-req\"}");
+    KafkaJsonSchemaSerializer<Object> refSerializer =
+        newReferenceAwareJsonSchemaSerializer(schemaRegistry);
+    byte[] sourceBytes = refSerializer.serialize(topic, record);
+    SchemaAndValue wrapped = converter.toConnectData(topic, sourceBytes);
+
+    converter.configure(backupConfigWith("use.optional.for.nonrequired", "false"), false);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    assertWireSchemaIdPreserved(sourceBytes, restoredBytes);
+    assertJsonPayloadSemanticallyEqual(sourceBytes, restoredBytes);
+  }
+
+  @Test
+  public void testConfigMismatchDecimalFormatBase64OnSinkNumericOnSourceStillWorks()
+      throws Exception {
+    String topic = nextTopic();
+    String schemaJson = "{"
+        + "\"type\":\"object\","
+        + "\"title\":\"MismatchDecimal\","
+        + "\"properties\":{"
+        + "\"id\":{\"type\":\"string\"},"
+        + "\"amount\":{\"type\":\"number\"}},"
+        + "\"required\":[\"id\",\"amount\"],"
+        + "\"additionalProperties\":false}";
+    JsonSchema jsonSchema = new JsonSchema(schemaJson);
+    schemaRegistry.register(topic + "-value", jsonSchema);
+
+    JsonNode record = JSON.readTree("{\"id\":\"dec-mm\",\"amount\":50.5}");
+    KafkaJsonSchemaSerializer<Object> refSerializer =
+        newReferenceAwareJsonSchemaSerializer(schemaRegistry);
+    byte[] sourceBytes = refSerializer.serialize(topic, record);
+    SchemaAndValue wrapped = converter.toConnectData(topic, sourceBytes);
+
+    converter.configure(backupConfigWith("decimal.format", "NUMERIC"), false);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    assertWireSchemaIdPreserved(sourceBytes, restoredBytes);
+    assertJsonPayloadSemanticallyEqual(sourceBytes, restoredBytes);
+  }
+
+  @Test
+  public void testConfigMismatchObjectAdditionalPropertiesSinkFalseSourceDefaultStillWorks() {
+    converter.configure(backupConfigWith("object.additional.properties", "false"), false);
+    plainConverter.configure(
+        backupConfigWith("object.additional.properties", "false"), false);
+
+    Schema schema = SchemaBuilder.struct()
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, "asymm-1");
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+
+    converter.configure(backupConfigWith("object.additional.properties", "true"), false);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    assertBytesExact(originalBytes, restoredBytes);
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
   }
 }

--- a/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaConverterBackupTest.java
+++ b/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaConverterBackupTest.java
@@ -272,7 +272,7 @@ public class JsonSchemaConverterBackupTest {
   }
 
   @Test
-  public void testBackupRestoreNullRawSchemaFallback() {
+  public void testBackupRestoreNullRawSchemaThrows() {
     Schema schema = SchemaBuilder.struct()
         .field("fallback", Schema.STRING_SCHEMA)
         .build();
@@ -292,8 +292,14 @@ public class JsonSchemaConverterBackupTest {
     Struct modifiedWrapper = BackupWrapper.buildWrapper(
         wrapperSchema, original.get(BackupWrapper.FIELD_DATA), fields);
 
-    byte[] restored = converter.fromConnectData(TOPIC, wrapperSchema, modifiedWrapper);
-    assertNotNull(restored);
-    assertEquals(0x00, restored[0]);
+    try {
+      converter.fromConnectData(TOPIC, wrapperSchema, modifiedWrapper);
+      fail("Expected DataException for null rawSchema");
+    } catch (DataException e) {
+      assertTrue(e.getMessage(),
+          e.getMessage().contains(BackupWrapper.FIELD_RAW_SCHEMA));
+      assertTrue(e.getMessage(),
+          e.getMessage().contains("pristine restore"));
+    }
   }
 }

--- a/kafka-connect-schema-backup-api/src/main/java/io/confluent/connect/schema/backup/api/BackupWrapper.java
+++ b/kafka-connect-schema-backup-api/src/main/java/io/confluent/connect/schema/backup/api/BackupWrapper.java
@@ -22,6 +22,10 @@ import org.apache.kafka.connect.data.Struct;
 
 /**
  * Backup Wrapper struct for carrying schema metadata between converters and the envelope layer.
+ * Only SR-aware converters (AvroConverter, ProtobufConverter, JsonSchemaConverter) emit this
+ * wrapper when {@code schema.backup.enabled=true}. Non-SR converters such as ByteArrayConverter,
+ * JsonConverter, and StringConverter bypass this path because they carry no Schema Registry
+ * metadata to preserve.
  */
 public final class BackupWrapper {
 

--- a/kafka-connect-schema-backup-api/src/main/java/io/confluent/connect/schema/backup/api/BackupWrapper.java
+++ b/kafka-connect-schema-backup-api/src/main/java/io/confluent/connect/schema/backup/api/BackupWrapper.java
@@ -19,6 +19,7 @@ package io.confluent.connect.schema.backup.api;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
 
 /**
  * Backup Wrapper struct for carrying schema metadata between converters and the envelope layer.
@@ -145,6 +146,14 @@ public final class BackupWrapper {
 
   public static boolean isWrapper(Schema schema) {
     return schema != null && NAME.equals(schema.name());
+  }
+
+  public static void requireFields(Schema wrapperSchema, String... fields) {
+    for (String field : fields) {
+      if (wrapperSchema.field(field) == null) {
+        throw new DataException("Malformed backup wrapper: missing '" + field + "' field");
+      }
+    }
   }
 
 }

--- a/kafka-connect-schema-backup-api/src/test/java/io/confluent/connect/schema/backup/api/BackupWrapperTest.java
+++ b/kafka-connect-schema-backup-api/src/test/java/io/confluent/connect/schema/backup/api/BackupWrapperTest.java
@@ -19,6 +19,7 @@ package io.confluent.connect.schema.backup.api;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -26,6 +27,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class BackupWrapperTest {
 
@@ -144,6 +146,32 @@ public class BackupWrapperTest {
     Struct wrapper = BackupWrapper.buildWrapper(wrapperSchema, "hello", fields);
     assertEquals(Integer.valueOf(7), wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_ID));
     assertNull(wrapper.getString(BackupWrapper.FIELD_SCHEMA_GUID));
+  }
+
+  @Test
+  public void testRequireFieldsPassesWhenAllPresent() {
+    Schema wrapperSchema = BackupWrapper.buildSchema(Schema.STRING_SCHEMA);
+    BackupWrapper.requireFields(wrapperSchema,
+        BackupWrapper.FIELD_DATA,
+        BackupWrapper.FIELD_SCHEMA_TYPE,
+        BackupWrapper.FIELD_RAW_SCHEMA);
+  }
+
+  @Test
+  public void testRequireFieldsThrowsWithNameWhenFieldMissing() {
+    Schema stripped = SchemaBuilder.struct()
+        .name(BackupWrapper.NAME)
+        .field(BackupWrapper.FIELD_DATA, Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    try {
+      BackupWrapper.requireFields(stripped,
+          BackupWrapper.FIELD_DATA,
+          BackupWrapper.FIELD_SCHEMA_TYPE);
+      fail("Expected DataException naming the missing field");
+    } catch (DataException e) {
+      assertEquals("Malformed backup wrapper: missing '"
+          + BackupWrapper.FIELD_SCHEMA_TYPE + "' field", e.getMessage());
+    }
   }
 
   @Test

--- a/kafka-connect-schema-backup-core/src/main/java/io/confluent/connect/schema/backup/core/BackupExceptionMapper.java
+++ b/kafka-connect-schema-backup-core/src/main/java/io/confluent/connect/schema/backup/core/BackupExceptionMapper.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.schema.backup.core;
+
+import io.confluent.kafka.schemaregistry.client.rest.RestService;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.schemaregistry.utils.ExceptionUtils;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.errors.InvalidConfigurationException;
+import org.apache.kafka.common.errors.NetworkException;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.errors.RetriableException;
+
+import java.io.IOException;
+
+/**
+ * Classifies backup and restore exceptions into the correct Connect type
+ * so transient failures are retried and permanent ones fail fast.
+ */
+public final class BackupExceptionMapper {
+
+  private BackupExceptionMapper() {
+  }
+
+  public static KafkaException classify(String op, Throwable cause) {
+    String msg = String.format("Failed to %s", op);
+
+    if (cause instanceof RetriableException) {
+      return (RetriableException) cause;
+    }
+    if (cause instanceof DataException) {
+      return (DataException) cause;
+    }
+
+    if (cause instanceof TimeoutException) {
+      return new RetriableException(msg, cause);
+    }
+    if (cause instanceof SerializationException) {
+      if (ExceptionUtils.isNetworkConnectionException(cause.getCause())) {
+        return new NetworkException(networkMsg(op, cause.getCause()), cause);
+      }
+      return new DataException(msg, cause);
+    }
+    if (cause instanceof InvalidConfigurationException) {
+      return new ConfigException(String.format("%s: %s", msg, cause.getMessage()));
+    }
+
+    if (cause instanceof IOException) {
+      if (ExceptionUtils.isNetworkConnectionException(cause)) {
+        return new NetworkException(networkMsg(op, cause), cause);
+      }
+      return new DataException(msg, cause);
+    }
+
+    if (cause instanceof RestClientException) {
+      RestClientException rce = (RestClientException) cause;
+      int status = rce.getStatus();
+      if (status == 401 || status == 403) {
+        return new ConnectException(String.format(
+            "%s: Schema Registry authentication error (status %d)", msg, status), cause);
+      }
+      if (RestService.isRestClientExceptionRetriable(rce)) {
+        return new RetriableException(msg, cause);
+      }
+      return new DataException(msg, cause);
+    }
+
+    return new ConnectException(
+        String.format("%s: unclassified %s", msg, cause.getClass().getName()), cause);
+  }
+
+  private static String networkMsg(String op, Throwable networkCause) {
+    return String.format("Network connection error during %s: %s",
+        op, networkCause.getMessage());
+  }
+}

--- a/kafka-connect-schema-backup-core/src/main/java/io/confluent/connect/schema/backup/core/BackupExceptionMapper.java
+++ b/kafka-connect-schema-backup-core/src/main/java/io/confluent/connect/schema/backup/core/BackupExceptionMapper.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.errors.NetworkException;
 import org.apache.kafka.common.errors.SerializationException;
-import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.errors.RetriableException;
@@ -39,7 +38,7 @@ public final class BackupExceptionMapper {
   public static KafkaException classify(String op, Throwable cause) {
     String msg = String.format("Failed to %s", op);
 
-    if (cause instanceof TimeoutException) {
+    if (cause instanceof org.apache.kafka.common.errors.RetriableException) {
       return new RetriableException(msg, cause);
     }
 

--- a/kafka-connect-schema-backup-core/src/main/java/io/confluent/connect/schema/backup/core/BackupExceptionMapper.java
+++ b/kafka-connect-schema-backup-core/src/main/java/io/confluent/connect/schema/backup/core/BackupExceptionMapper.java
@@ -31,10 +31,6 @@ import org.apache.kafka.connect.errors.RetriableException;
 
 import java.io.IOException;
 
-/**
- * Classifies backup and restore exceptions into the correct Connect type
- * so transient failures are retried and permanent ones fail fast.
- */
 public final class BackupExceptionMapper {
 
   private BackupExceptionMapper() {
@@ -43,39 +39,32 @@ public final class BackupExceptionMapper {
   public static KafkaException classify(String op, Throwable cause) {
     String msg = String.format("Failed to %s", op);
 
-    if (cause instanceof RetriableException) {
-      return (RetriableException) cause;
-    }
-    if (cause instanceof DataException) {
-      return (DataException) cause;
-    }
-
     if (cause instanceof TimeoutException) {
       return new RetriableException(msg, cause);
     }
+
     if (cause instanceof SerializationException) {
       if (ExceptionUtils.isNetworkConnectionException(cause.getCause())) {
-        return new NetworkException(networkMsg(op, cause.getCause()), cause);
+        return new NetworkException(String.format(
+            "Network connection error during %s: %s",
+            op, cause.getCause().getMessage()), cause);
       }
       return new DataException(msg, cause);
     }
+
     if (cause instanceof InvalidConfigurationException) {
       return new ConfigException(String.format("%s: %s", msg, cause.getMessage()));
     }
 
     if (cause instanceof IOException) {
-      if (ExceptionUtils.isNetworkConnectionException(cause)) {
-        return new NetworkException(networkMsg(op, cause), cause);
-      }
-      return new DataException(msg, cause);
+      return new RetriableException(msg, cause);
     }
 
     if (cause instanceof RestClientException) {
       RestClientException rce = (RestClientException) cause;
       int status = rce.getStatus();
       if (status == 401 || status == 403) {
-        return new ConnectException(String.format(
-            "%s: Schema Registry authentication error (status %d)", msg, status), cause);
+        return new ConfigException(String.format("%s: SR status %d", msg, status));
       }
       if (RestService.isRestClientExceptionRetriable(rce)) {
         return new RetriableException(msg, cause);
@@ -83,12 +72,14 @@ public final class BackupExceptionMapper {
       return new DataException(msg, cause);
     }
 
-    return new ConnectException(
-        String.format("%s: unclassified %s", msg, cause.getClass().getName()), cause);
-  }
+    if (cause instanceof KafkaException) {
+      return (KafkaException) cause;
+    }
 
-  private static String networkMsg(String op, Throwable networkCause) {
-    return String.format("Network connection error during %s: %s",
-        op, networkCause.getMessage());
+    if (cause instanceof RuntimeException) {
+      throw (RuntimeException) cause;
+    }
+
+    return new ConnectException(msg, cause);
   }
 }

--- a/kafka-connect-schema-backup-core/src/main/java/io/confluent/connect/schema/backup/core/BackupReferenceResolver.java
+++ b/kafka-connect-schema-backup-core/src/main/java/io/confluent/connect/schema/backup/core/BackupReferenceResolver.java
@@ -27,7 +27,6 @@ import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientExcept
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
-import org.apache.kafka.connect.errors.RetriableException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,8 +101,16 @@ public class BackupReferenceResolver {
     List<SchemaReference> directRefs =
         parseDirectRefs(directRefsJson);
 
-    if (refTree.isEmpty() || directRefs.isEmpty()) {
+    boolean treeEmpty = refTree.isEmpty();
+    boolean directRefsEmpty = directRefs.isEmpty();
+    if (treeEmpty && directRefsEmpty) {
       return ResolutionResult.empty();
+    }
+    if (treeEmpty || directRefsEmpty) {
+      throw new DataException(
+          "Corrupt backup wrapper: partial reference metadata "
+          + "(treeEmpty=" + treeEmpty
+          + ", directRefsEmpty=" + directRefsEmpty + ")");
     }
 
     List<SchemaReference> targetRefs = new ArrayList<>();
@@ -255,12 +262,9 @@ public class BackupReferenceResolver {
       log.debug("Registered reference: subject={}, "
           + "srcVersion={}, targetVersion={}",
           ref.getSubject(), ref.getVersion(), targetVersion);
-    } catch (IOException e) {
-      throw new RetriableException(
-          "Network error registering reference '" + ref.getSubject() + "'", e);
-    } catch (RestClientException e) {
-      throw new DataException(
-          "Failed to register reference '" + ref.getSubject() + "'", e);
+    } catch (IOException | RestClientException e) {
+      throw BackupExceptionMapper.classify(
+          "register reference " + ref.getSubject(), e);
     }
     targetRefsOut.add(new SchemaReference(
         ref.getName(), ref.getSubject(), targetVersion));

--- a/kafka-connect-schema-backup-core/src/main/java/io/confluent/connect/schema/backup/core/BackupSchemaFetcher.java
+++ b/kafka-connect-schema-backup-core/src/main/java/io/confluent/connect/schema/backup/core/BackupSchemaFetcher.java
@@ -23,8 +23,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.kafka.connect.errors.DataException;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -39,7 +38,6 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class BackupSchemaFetcher {
 
-  private static final Logger log = LoggerFactory.getLogger(BackupSchemaFetcher.class);
   private static final ObjectMapper JSON = new ObjectMapper();
   private static final int MAX_DEPTH = SchemaBackupConfig.MAX_REFERENCE_DEPTH;
 
@@ -70,13 +68,8 @@ public class BackupSchemaFetcher {
         ? JSON.writeValueAsString(directRefs) : null;
 
     Map<String, Integer> versionsBySubject = new HashMap<>();
-    try {
-      for (SubjectVersion sv : schemaRegistry.getAllVersionsById(schemaId)) {
-        versionsBySubject.put(sv.getSubject(), sv.getVersion());
-      }
-    } catch (IOException | RestClientException e) {
-      log.warn("Could not fetch versions for schemaId={}: {}",
-          schemaId, e.getMessage());
+    for (SubjectVersion sv : schemaRegistry.getAllVersionsById(schemaId)) {
+      versionsBySubject.put(sv.getSubject(), sv.getVersion());
     }
 
     BackupSchemaInfo info = new BackupSchemaInfo(rawText, directRefs, tree,
@@ -117,7 +110,7 @@ public class BackupSchemaFetcher {
       return;
     }
     if (depth >= MAX_DEPTH) {
-      throw new IOException(
+      throw new DataException(
           "Reference tree depth limit (" + MAX_DEPTH + ") exceeded. "
           + "Possible circular reference chain.");
     }

--- a/kafka-connect-schema-backup-core/src/test/java/io/confluent/connect/schema/backup/core/BackupExceptionMapperTest.java
+++ b/kafka-connect-schema-backup-core/src/test/java/io/confluent/connect/schema/backup/core/BackupExceptionMapperTest.java
@@ -17,6 +17,7 @@
 package io.confluent.connect.schema.backup.core;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -28,9 +29,13 @@ import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.errors.AuthenticationException;
+import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.errors.DisconnectException;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.errors.NetworkException;
 import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.errors.ThrottlingQuotaExceededException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
@@ -42,21 +47,7 @@ public class BackupExceptionMapperTest {
   private static final String OP = "wrap Avro backup metadata for topic orders";
 
   @Test
-  public void passesThroughRetriableException() {
-    RetriableException original = new RetriableException("already classified");
-    KafkaException result = BackupExceptionMapper.classify(OP, original);
-    assertSame(original, result);
-  }
-
-  @Test
-  public void passesThroughDataException() {
-    DataException original = new DataException("already classified");
-    KafkaException result = BackupExceptionMapper.classify(OP, original);
-    assertSame(original, result);
-  }
-
-  @Test
-  public void mapsKafkaTimeoutExceptionToRetriable() {
+  public void mapsTimeoutExceptionToConnectRetriable() {
     TimeoutException cause = new TimeoutException("SR timed out");
     KafkaException result = BackupExceptionMapper.classify(OP, cause);
     assertTrue(result instanceof RetriableException);
@@ -66,8 +57,8 @@ public class BackupExceptionMapperTest {
 
   @Test
   public void mapsSerializationExceptionWithNetworkCauseToNetworkException() {
-    SerializationException cause =
-        new SerializationException("SR unreachable", new SocketTimeoutException("connect timed out"));
+    SocketTimeoutException networkCause = new SocketTimeoutException("connect timed out");
+    SerializationException cause = new SerializationException("SR unreachable", networkCause);
     KafkaException result = BackupExceptionMapper.classify(OP, cause);
     assertTrue(result instanceof NetworkException);
     assertSame(cause, result.getCause());
@@ -89,69 +80,78 @@ public class BackupExceptionMapperTest {
     InvalidConfigurationException cause = new InvalidConfigurationException("bad url");
     KafkaException result = BackupExceptionMapper.classify(OP, cause);
     assertTrue(result instanceof ConfigException);
-    assertTrue(result.getMessage().contains("bad url"));
+    assertTrue(result.getMessage(), result.getMessage().contains("bad url"));
   }
 
   @Test
-  public void mapsPlainIoExceptionToDataException() {
+  public void mapsAuthenticationExceptionToConfigException() {
+    AuthenticationException cause = new AuthenticationException("bad token");
+    KafkaException result = BackupExceptionMapper.classify(OP, cause);
+    assertTrue(result instanceof ConfigException);
+    assertFalse("auth errors must not be retriable", result instanceof RetriableException);
+    assertTrue(result.getMessage(), result.getMessage().contains("bad token"));
+  }
+
+  @Test
+  public void mapsAuthorizationExceptionToConfigException() {
+    AuthorizationException cause = new AuthorizationException("no access");
+    KafkaException result = BackupExceptionMapper.classify(OP, cause);
+    assertTrue(result instanceof ConfigException);
+    assertFalse(result instanceof RetriableException);
+    assertTrue(result.getMessage(), result.getMessage().contains("no access"));
+  }
+
+  @Test
+  public void mapsPlainIoExceptionToRetriable() {
     IOException cause = new IOException("connection reset");
     KafkaException result = BackupExceptionMapper.classify(OP, cause);
-    assertTrue(result instanceof DataException);
+    assertTrue("SR transport IOException must retry", result instanceof RetriableException);
     assertSame(cause, result.getCause());
   }
 
   @Test
-  public void mapsInterruptedIoExceptionToDataException() {
-    InterruptedIOException cause = new InterruptedIOException("read interrupted");
-    KafkaException result = BackupExceptionMapper.classify(OP, cause);
-    assertTrue(result instanceof DataException);
-    assertSame(cause, result.getCause());
+  public void mapsInterruptedIoExceptionToRetriable() {
+    KafkaException result = BackupExceptionMapper.classify(OP,
+        new InterruptedIOException("read interrupted"));
+    assertTrue(result instanceof RetriableException);
   }
 
   @Test
-  public void mapsEofExceptionToDataException() {
-    EOFException cause = new EOFException("stream closed");
-    KafkaException result = BackupExceptionMapper.classify(OP, cause);
-    assertTrue(result instanceof DataException);
-    assertSame(cause, result.getCause());
+  public void mapsEofExceptionToRetriable() {
+    KafkaException result = BackupExceptionMapper.classify(OP, new EOFException("stream closed"));
+    assertTrue(result instanceof RetriableException);
   }
 
   @Test
-  public void mapsSocketExceptionToNetworkException() {
-    SocketException cause = new SocketException("connection refused");
-    KafkaException result = BackupExceptionMapper.classify(OP, cause);
-    assertTrue(result instanceof NetworkException);
-    assertSame(cause, result.getCause());
-    assertTrue(result.getMessage(), result.getMessage().contains("Network connection error"));
-    assertTrue(result.getMessage(), result.getMessage().contains("connection refused"));
+  public void mapsSocketExceptionToRetriable() {
+    KafkaException result = BackupExceptionMapper.classify(OP,
+        new SocketException("connection refused"));
+    assertTrue(result instanceof RetriableException);
   }
 
   @Test
-  public void mapsSocketTimeoutExceptionToNetworkException() {
-    SocketTimeoutException cause = new SocketTimeoutException("read timed out");
-    KafkaException result = BackupExceptionMapper.classify(OP, cause);
-    assertTrue(result instanceof NetworkException);
-    assertSame(cause, result.getCause());
-    assertTrue(result.getMessage(), result.getMessage().contains("Network connection error"));
-    assertTrue(result.getMessage(), result.getMessage().contains("read timed out"));
+  public void mapsSocketTimeoutExceptionToRetriable() {
+    KafkaException result = BackupExceptionMapper.classify(OP,
+        new SocketTimeoutException("read timed out"));
+    assertTrue(result instanceof RetriableException);
   }
 
   @Test
-  public void mapsRestClientException401ToConnectException() {
+  public void mapsRestClientException401ToConfigException() {
     RestClientException cause = new RestClientException("unauthorized", 401, 40101);
     KafkaException result = BackupExceptionMapper.classify(OP, cause);
-    assertTrue(result instanceof ConnectException);
-    assertTrue(result.getMessage().contains("authentication"));
-    assertTrue(result.getMessage().contains("401"));
-    assertSame(cause, result.getCause());
+    assertTrue(result instanceof ConfigException);
+    assertFalse(result instanceof RetriableException);
+    assertTrue(result.getMessage(), result.getMessage().contains("401"));
   }
 
   @Test
-  public void mapsRestClientException403ToConnectException() {
+  public void mapsRestClientException403ToConfigException() {
     RestClientException cause = new RestClientException("forbidden", 403, 40301);
     KafkaException result = BackupExceptionMapper.classify(OP, cause);
-    assertTrue(result instanceof ConnectException);
-    assertTrue(result.getMessage().contains("403"));
+    assertTrue(result instanceof ConfigException);
+    assertFalse(result instanceof RetriableException);
+    assertTrue(result.getMessage(), result.getMessage().contains("403"));
   }
 
   @Test
@@ -175,12 +175,72 @@ public class BackupExceptionMapperTest {
   }
 
   @Test
-  public void mapsUnknownExceptionToConnectException() {
-    IllegalStateException cause = new IllegalStateException("unexpected");
+  public void passesThroughConnectRetriableException() {
+    RetriableException original = new RetriableException("already classified");
+    KafkaException result = BackupExceptionMapper.classify(OP, original);
+    assertSame(original, result);
+  }
+
+  @Test
+  public void passesThroughDataException() {
+    DataException original = new DataException("already classified");
+    KafkaException result = BackupExceptionMapper.classify(OP, original);
+    assertSame(original, result);
+  }
+
+  @Test
+  public void passesThroughConfigException() {
+    ConfigException original = new ConfigException("bad url");
+    KafkaException result = BackupExceptionMapper.classify(OP, original);
+    assertSame(original, result);
+  }
+
+  @Test
+  public void passesThroughThrottlingQuotaExceededException() {
+    ThrottlingQuotaExceededException original =
+        new ThrottlingQuotaExceededException("too many requests");
+    KafkaException result = BackupExceptionMapper.classify(OP, original);
+    assertSame(original, result);
+  }
+
+  @Test
+  public void passesThroughDisconnectException() {
+    DisconnectException original = new DisconnectException("bad gateway");
+    KafkaException result = BackupExceptionMapper.classify(OP, original);
+    assertSame(original, result);
+  }
+
+  @Test
+  public void passesThroughUnknownKafkaException() {
+    KafkaException original = new KafkaException("something bespoke");
+    KafkaException result = BackupExceptionMapper.classify(OP, original);
+    assertSame(original, result);
+  }
+
+  @Test
+  public void idempotentOnDoubleClassifyOfTimeoutException() {
+    TimeoutException cause = new TimeoutException("SR timed out");
+    KafkaException first = BackupExceptionMapper.classify(OP, cause);
+    KafkaException second = BackupExceptionMapper.classify(OP, first);
+    assertSame(first, second);
+    assertTrue(second instanceof RetriableException);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void rethrowsUnknownRuntimeExceptionAsIs() {
+    BackupExceptionMapper.classify(OP, new IllegalStateException("unexpected"));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void rethrowsUnknownNullPointerExceptionAsIs() {
+    BackupExceptionMapper.classify(OP, new NullPointerException("nope"));
+  }
+
+  @Test
+  public void wrapsCheckedThrowableInConnectException() {
+    Exception cause = new Exception("some checked");
     KafkaException result = BackupExceptionMapper.classify(OP, cause);
     assertTrue(result instanceof ConnectException);
-    assertTrue(result.getMessage().contains("unclassified"));
-    assertTrue(result.getMessage().contains("IllegalStateException"));
     assertSame(cause, result.getCause());
   }
 

--- a/kafka-connect-schema-backup-core/src/test/java/io/confluent/connect/schema/backup/core/BackupExceptionMapperTest.java
+++ b/kafka-connect-schema-backup-core/src/test/java/io/confluent/connect/schema/backup/core/BackupExceptionMapperTest.java
@@ -196,18 +196,28 @@ public class BackupExceptionMapperTest {
   }
 
   @Test
-  public void passesThroughThrottlingQuotaExceededException() {
-    ThrottlingQuotaExceededException original =
+  public void mapsThrottlingQuotaExceededExceptionToRetriable() {
+    ThrottlingQuotaExceededException cause =
         new ThrottlingQuotaExceededException("too many requests");
-    KafkaException result = BackupExceptionMapper.classify(OP, original);
-    assertSame(original, result);
+    KafkaException result = BackupExceptionMapper.classify(OP, cause);
+    assertTrue(result instanceof RetriableException);
+    assertSame(cause, result.getCause());
   }
 
   @Test
-  public void passesThroughDisconnectException() {
-    DisconnectException original = new DisconnectException("bad gateway");
-    KafkaException result = BackupExceptionMapper.classify(OP, original);
-    assertSame(original, result);
+  public void mapsDisconnectExceptionToRetriable() {
+    DisconnectException cause = new DisconnectException("bad gateway");
+    KafkaException result = BackupExceptionMapper.classify(OP, cause);
+    assertTrue(result instanceof RetriableException);
+    assertSame(cause, result.getCause());
+  }
+
+  @Test
+  public void mapsCommonNetworkExceptionToRetriable() {
+    NetworkException cause = new NetworkException("connection reset");
+    KafkaException result = BackupExceptionMapper.classify(OP, cause);
+    assertTrue(result instanceof RetriableException);
+    assertSame(cause, result.getCause());
   }
 
   @Test

--- a/kafka-connect-schema-backup-core/src/test/java/io/confluent/connect/schema/backup/core/BackupExceptionMapperTest.java
+++ b/kafka-connect-schema-backup-core/src/test/java/io/confluent/connect/schema/backup/core/BackupExceptionMapperTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.schema.backup.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import org.apache.kafka.common.KafkaException;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.errors.InvalidConfigurationException;
+import org.apache.kafka.common.errors.NetworkException;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.errors.RetriableException;
+import org.junit.Test;
+
+public class BackupExceptionMapperTest {
+
+  private static final String OP = "wrap Avro backup metadata for topic orders";
+
+  @Test
+  public void passesThroughRetriableException() {
+    RetriableException original = new RetriableException("already classified");
+    KafkaException result = BackupExceptionMapper.classify(OP, original);
+    assertSame(original, result);
+  }
+
+  @Test
+  public void passesThroughDataException() {
+    DataException original = new DataException("already classified");
+    KafkaException result = BackupExceptionMapper.classify(OP, original);
+    assertSame(original, result);
+  }
+
+  @Test
+  public void mapsKafkaTimeoutExceptionToRetriable() {
+    TimeoutException cause = new TimeoutException("SR timed out");
+    KafkaException result = BackupExceptionMapper.classify(OP, cause);
+    assertTrue(result instanceof RetriableException);
+    assertSame(cause, result.getCause());
+    assertMessage(result);
+  }
+
+  @Test
+  public void mapsSerializationExceptionWithNetworkCauseToNetworkException() {
+    SerializationException cause =
+        new SerializationException("SR unreachable", new SocketTimeoutException("connect timed out"));
+    KafkaException result = BackupExceptionMapper.classify(OP, cause);
+    assertTrue(result instanceof NetworkException);
+    assertSame(cause, result.getCause());
+    assertTrue(result.getMessage(), result.getMessage().contains("Network connection error"));
+    assertTrue(result.getMessage(), result.getMessage().contains("connect timed out"));
+  }
+
+  @Test
+  public void mapsSerializationExceptionWithoutNetworkCauseToDataException() {
+    SerializationException cause =
+        new SerializationException("bad bytes", new IllegalArgumentException("truncated"));
+    KafkaException result = BackupExceptionMapper.classify(OP, cause);
+    assertTrue(result instanceof DataException);
+    assertSame(cause, result.getCause());
+  }
+
+  @Test
+  public void mapsInvalidConfigurationExceptionToConfigException() {
+    InvalidConfigurationException cause = new InvalidConfigurationException("bad url");
+    KafkaException result = BackupExceptionMapper.classify(OP, cause);
+    assertTrue(result instanceof ConfigException);
+    assertTrue(result.getMessage().contains("bad url"));
+  }
+
+  @Test
+  public void mapsPlainIoExceptionToDataException() {
+    IOException cause = new IOException("connection reset");
+    KafkaException result = BackupExceptionMapper.classify(OP, cause);
+    assertTrue(result instanceof DataException);
+    assertSame(cause, result.getCause());
+  }
+
+  @Test
+  public void mapsInterruptedIoExceptionToDataException() {
+    InterruptedIOException cause = new InterruptedIOException("read interrupted");
+    KafkaException result = BackupExceptionMapper.classify(OP, cause);
+    assertTrue(result instanceof DataException);
+    assertSame(cause, result.getCause());
+  }
+
+  @Test
+  public void mapsEofExceptionToDataException() {
+    EOFException cause = new EOFException("stream closed");
+    KafkaException result = BackupExceptionMapper.classify(OP, cause);
+    assertTrue(result instanceof DataException);
+    assertSame(cause, result.getCause());
+  }
+
+  @Test
+  public void mapsSocketExceptionToNetworkException() {
+    SocketException cause = new SocketException("connection refused");
+    KafkaException result = BackupExceptionMapper.classify(OP, cause);
+    assertTrue(result instanceof NetworkException);
+    assertSame(cause, result.getCause());
+    assertTrue(result.getMessage(), result.getMessage().contains("Network connection error"));
+    assertTrue(result.getMessage(), result.getMessage().contains("connection refused"));
+  }
+
+  @Test
+  public void mapsSocketTimeoutExceptionToNetworkException() {
+    SocketTimeoutException cause = new SocketTimeoutException("read timed out");
+    KafkaException result = BackupExceptionMapper.classify(OP, cause);
+    assertTrue(result instanceof NetworkException);
+    assertSame(cause, result.getCause());
+    assertTrue(result.getMessage(), result.getMessage().contains("Network connection error"));
+    assertTrue(result.getMessage(), result.getMessage().contains("read timed out"));
+  }
+
+  @Test
+  public void mapsRestClientException401ToConnectException() {
+    RestClientException cause = new RestClientException("unauthorized", 401, 40101);
+    KafkaException result = BackupExceptionMapper.classify(OP, cause);
+    assertTrue(result instanceof ConnectException);
+    assertTrue(result.getMessage().contains("authentication"));
+    assertTrue(result.getMessage().contains("401"));
+    assertSame(cause, result.getCause());
+  }
+
+  @Test
+  public void mapsRestClientException403ToConnectException() {
+    RestClientException cause = new RestClientException("forbidden", 403, 40301);
+    KafkaException result = BackupExceptionMapper.classify(OP, cause);
+    assertTrue(result instanceof ConnectException);
+    assertTrue(result.getMessage().contains("403"));
+  }
+
+  @Test
+  public void mapsRetriableStatusesToRetriable() {
+    for (int status : new int[] {408, 429, 500, 502, 503, 504}) {
+      RestClientException cause = new RestClientException("server error", status, 0);
+      KafkaException result = BackupExceptionMapper.classify(OP, cause);
+      assertTrue("status " + status + " should be retriable, got " + result.getClass(),
+          result instanceof RetriableException);
+    }
+  }
+
+  @Test
+  public void mapsNonRetriableClientErrorsToDataException() {
+    for (int status : new int[] {404, 409, 422}) {
+      RestClientException cause = new RestClientException("client error", status, 0);
+      KafkaException result = BackupExceptionMapper.classify(OP, cause);
+      assertTrue("status " + status + " should be DataException, got " + result.getClass(),
+          result instanceof DataException);
+    }
+  }
+
+  @Test
+  public void mapsUnknownExceptionToConnectException() {
+    IllegalStateException cause = new IllegalStateException("unexpected");
+    KafkaException result = BackupExceptionMapper.classify(OP, cause);
+    assertTrue(result instanceof ConnectException);
+    assertTrue(result.getMessage().contains("unclassified"));
+    assertTrue(result.getMessage().contains("IllegalStateException"));
+    assertSame(cause, result.getCause());
+  }
+
+  @Test
+  public void messageFollowsRepoConvention() {
+    IOException cause = new IOException("boom");
+    KafkaException result = BackupExceptionMapper.classify(OP, cause);
+    assertEquals("Failed to " + OP, result.getMessage());
+  }
+
+  private static void assertMessage(KafkaException result) {
+    assertTrue(result.getMessage(), result.getMessage().startsWith("Failed to " + OP));
+  }
+}

--- a/kafka-connect-schema-backup-core/src/test/java/io/confluent/connect/schema/backup/core/BackupReferenceResolverTest.java
+++ b/kafka-connect-schema-backup-core/src/test/java/io/confluent/connect/schema/backup/core/BackupReferenceResolverTest.java
@@ -23,18 +23,24 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import io.confluent.connect.schema.backup.api.BackupWrapper;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import java.io.IOException;
+import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.kafka.common.errors.NetworkException;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.errors.RetriableException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -450,7 +456,7 @@ public class BackupReferenceResolverTest {
   }
 
   @Test
-  public void testResolveFromWrapperTreeWithoutDirectRefs() {
+  public void testResolveFromWrapperTreeWithoutDirectRefsThrows() {
     String treeJson = "{\"" + ADDRESS_FQCN + "\":{"
         + "\"subject\":\"" + ADDRESS_VALUE_SUBJECT + "\","
         + "\"version\":1,"
@@ -462,15 +468,41 @@ public class BackupReferenceResolverTest {
     Schema dataSchema = Schema.STRING_SCHEMA;
     Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
     BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
-        1, 1, SCHEMA_TYPE_AVRO,USER_VALUE_SUBJECT, ADDRESS_SCHEMA,
+        1, 1, SCHEMA_TYPE_AVRO, USER_VALUE_SUBJECT, ADDRESS_SCHEMA,
         treeJson, null);
     Struct wrapper = BackupWrapper.buildWrapper(
         wrapperSchema, TEST_DATA, fields);
 
-    BackupReferenceResolver.ResolutionResult result =
-        resolver.resolveFromWrapper(wrapperSchema, wrapper, avroFactory);
+    try {
+      resolver.resolveFromWrapper(wrapperSchema, wrapper, avroFactory);
+      fail(EXPECTED_DATA_EXCEPTION);
+    } catch (DataException e) {
+      assertTrue(e.getMessage(), e.getMessage().contains("Corrupt backup wrapper"));
+      assertTrue(e.getMessage(), e.getMessage().contains("directRefsEmpty=true"));
+    }
+  }
 
-    assertFalse(result.hasReferences());
+  @Test
+  public void testResolveFromWrapperDirectRefsWithoutTreeThrows() {
+    String directRefsJson = "[{\"name\":\"" + ADDRESS_FQCN + "\","
+        + "\"subject\":\"" + ADDRESS_VALUE_SUBJECT + "\","
+        + "\"version\":1}]";
+
+    Schema dataSchema = Schema.STRING_SCHEMA;
+    Schema wrapperSchema = BackupWrapper.buildSchema(dataSchema);
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        1, 1, SCHEMA_TYPE_AVRO, USER_VALUE_SUBJECT, ADDRESS_SCHEMA,
+        null, directRefsJson);
+    Struct wrapper = BackupWrapper.buildWrapper(
+        wrapperSchema, TEST_DATA, fields);
+
+    try {
+      resolver.resolveFromWrapper(wrapperSchema, wrapper, avroFactory);
+      fail(EXPECTED_DATA_EXCEPTION);
+    } catch (DataException e) {
+      assertTrue(e.getMessage(), e.getMessage().contains("Corrupt backup wrapper"));
+      assertTrue(e.getMessage(), e.getMessage().contains("treeEmpty=true"));
+    }
   }
 
   @Test
@@ -580,5 +612,71 @@ public class BackupReferenceResolverTest {
 
   private static String quote(String s) {
     return "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+  }
+
+  @Test
+  public void testRegisterSingleRefPlainIoExceptionMapsToDataException() {
+    assertRegisterFails(new MockSchemaRegistryClient() {
+      @Override
+      public int register(String subject, ParsedSchema schema)
+          throws IOException {
+        throw new IOException("SR unreachable");
+      }
+    }, DataException.class);
+  }
+
+  @Test
+  public void testRegisterSingleRefNetworkIoExceptionMapsToNetworkException() {
+    assertRegisterFails(new MockSchemaRegistryClient() {
+      @Override
+      public int register(String subject, ParsedSchema schema)
+          throws IOException {
+        throw new SocketException("connection refused");
+      }
+    }, NetworkException.class);
+  }
+
+  @Test
+  public void testRegisterSingleRefRetriableStatusMapsToRetriable() {
+    assertRegisterFails(new MockSchemaRegistryClient() {
+      @Override
+      public int register(String subject, ParsedSchema schema)
+          throws RestClientException {
+        throw new RestClientException("SR unavailable", 503, 50301);
+      }
+    }, RetriableException.class);
+  }
+
+  @Test
+  public void testRegisterSingleRefNonRetriableStatusMapsToDataException() {
+    assertRegisterFails(new MockSchemaRegistryClient() {
+      @Override
+      public int register(String subject, ParsedSchema schema)
+          throws RestClientException {
+        throw new RestClientException("conflict", 409, 40901);
+      }
+    }, DataException.class);
+  }
+
+  private void assertRegisterFails(
+      SchemaRegistryClient failingMock,
+      Class<? extends RuntimeException> expected) {
+    BackupReferenceResolver failingResolver =
+        new BackupReferenceResolver(failingMock);
+    try {
+      failingResolver.registerRefsRecursive(
+          Collections.singletonList(new SchemaReference(
+              ADDRESS_FQCN, ADDRESS_VALUE_SUBJECT, 1)),
+          Collections.singletonMap(ADDRESS_FQCN,
+              new BackupSchemaFetcher.RefTreeEntry(
+                  ADDRESS_VALUE_SUBJECT, 1, ADDRESS_SCHEMA,
+                  Collections.emptyList(), 42, SCHEMA_TYPE_AVRO)),
+          avroFactory, new ArrayList<>(), new HashMap<>());
+      fail("Expected " + expected.getSimpleName());
+    } catch (RuntimeException e) {
+      assertTrue("Expected " + expected.getSimpleName() + " but got " + e.getClass(),
+          expected.isInstance(e));
+      assertTrue(e.getMessage(), e.getMessage().contains("register reference"));
+    }
   }
 }

--- a/kafka-connect-schema-backup-core/src/test/java/io/confluent/connect/schema/backup/core/BackupReferenceResolverTest.java
+++ b/kafka-connect-schema-backup-core/src/test/java/io/confluent/connect/schema/backup/core/BackupReferenceResolverTest.java
@@ -36,7 +36,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.kafka.common.errors.NetworkException;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.DataException;
@@ -615,25 +614,25 @@ public class BackupReferenceResolverTest {
   }
 
   @Test
-  public void testRegisterSingleRefPlainIoExceptionMapsToDataException() {
+  public void testRegisterSingleRefPlainIoExceptionMapsToRetriable() {
     assertRegisterFails(new MockSchemaRegistryClient() {
       @Override
       public int register(String subject, ParsedSchema schema)
           throws IOException {
         throw new IOException("SR unreachable");
       }
-    }, DataException.class);
+    }, RetriableException.class);
   }
 
   @Test
-  public void testRegisterSingleRefNetworkIoExceptionMapsToNetworkException() {
+  public void testRegisterSingleRefNetworkIoExceptionMapsToRetriable() {
     assertRegisterFails(new MockSchemaRegistryClient() {
       @Override
       public int register(String subject, ParsedSchema schema)
           throws IOException {
         throw new SocketException("connection refused");
       }
-    }, NetworkException.class);
+    }, RetriableException.class);
   }
 
   @Test

--- a/kafka-connect-schema-backup-core/src/test/java/io/confluent/connect/schema/backup/core/BackupSchemaFetcherTest.java
+++ b/kafka-connect-schema-backup-core/src/test/java/io/confluent/connect/schema/backup/core/BackupSchemaFetcherTest.java
@@ -21,11 +21,17 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -287,5 +293,28 @@ public class BackupSchemaFetcherTest {
     assertEquals(schemaV1.canonicalString(), info1.getRawSchema());
     assertEquals(schemaV2.canonicalString(), info2.getRawSchema());
     assertEquals(schemaV3.canonicalString(), info3.getRawSchema());
+  }
+
+  @Test
+  public void testGetAllVersionsByIdFailurePropagates() throws Exception {
+    final AvroSchema avro = new AvroSchema(USER_SCHEMA);
+    BackupSchemaFetcher failingFetcher = new BackupSchemaFetcher(
+        new MockSchemaRegistryClient() {
+          @Override
+          public ParsedSchema getSchemaById(int id) {
+            return avro;
+          }
+
+          @Override
+          public Collection<SubjectVersion> getAllVersionsById(int id) {
+            throw new UncheckedIOException(new IOException("SR unreachable"));
+          }
+        });
+    try {
+      failingFetcher.fetchSchemaInfo(1);
+      fail("Expected exception to propagate instead of being swallowed as WARN");
+    } catch (UncheckedIOException expected) {
+      assertTrue(expected.getCause() instanceof IOException);
+    }
   }
 }

--- a/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufConverter.java
+++ b/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufConverter.java
@@ -176,6 +176,11 @@ public class ProtobufConverter implements Converter {
       Object actualData = wrapper.get(BackupWrapper.FIELD_DATA);
       Schema actualConnectSchema = wrapperSchema.field(BackupWrapper.FIELD_DATA).schema();
       String rawSchema = wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA);
+      if (rawSchema == null) {
+        throw new DataException(
+            "Malformed backup wrapper: missing '" + BackupWrapper.FIELD_RAW_SCHEMA
+            + "' for topic " + topic + ". Cannot guarantee pristine restore.");
+      }
 
       BackupReferenceResolver.ResolutionResult resolved =
           backupHelper.getReferenceResolver().resolveFromWrapper(
@@ -185,15 +190,10 @@ public class ProtobufConverter implements Converter {
           protobufData.fromConnectData(actualConnectSchema, actualData);
       Object v = schemaAndValue.getValue();
 
-      ProtobufSchema serializeSchema;
-      if (rawSchema != null) {
-        serializeSchema = resolved.hasReferences()
-            ? new ProtobufSchema(rawSchema, resolved.getTargetRefs(),
-                resolved.getResolvedSchemas(), null, null)
-            : new ProtobufSchema(rawSchema);
-      } else {
-        serializeSchema = schemaAndValue.getSchema();
-      }
+      ProtobufSchema serializeSchema = resolved.hasReferences()
+          ? new ProtobufSchema(rawSchema, resolved.getTargetRefs(),
+              resolved.getResolvedSchemas(), null, null)
+          : new ProtobufSchema(rawSchema);
 
       if (v instanceof Message) {
         return serializer.serialize(topic, isKey, headers,

--- a/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufConverter.java
+++ b/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufConverter.java
@@ -19,6 +19,7 @@ import com.google.protobuf.Message;
 import io.confluent.connect.schema.backup.api.BackupWrapper;
 import io.confluent.connect.schema.backup.api.SchemaBackupConfig;
 import io.confluent.connect.schema.backup.core.BackupConverterHelper;
+import io.confluent.connect.schema.backup.core.BackupExceptionMapper;
 import io.confluent.connect.schema.backup.core.BackupReferenceResolver;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.ParsedSchemaAndValue;
@@ -200,11 +201,9 @@ public class ProtobufConverter implements Converter {
       }
       throw new DataException("Unsupported type during restore: "
           + (v != null ? v.getClass().getName() : "null"));
-    } catch (DataException e) {
-      throw e;
     } catch (Exception e) {
-      throw new DataException(
-          String.format("Failed to restore Protobuf data for topic %s", topic), e);
+      throw BackupExceptionMapper.classify(
+          "restore Protobuf backup for topic " + topic, e);
     }
   }
 
@@ -275,8 +274,8 @@ public class ProtobufConverter implements Converter {
           SchemaBackupConfig.TYPE_PROTOBUF, isKey,
           PROTOBUF_SCHEMA_FACTORY, serializer::computeSubjectName);
     } catch (Exception e) {
-      throw new DataException(
-          String.format("Failed to wrap backup metadata for topic %s", topic), e);
+      throw BackupExceptionMapper.classify(
+          "wrap Protobuf backup for topic " + topic, e);
     }
   }
 

--- a/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufConverter.java
+++ b/protobuf-converter/src/main/java/io/confluent/connect/protobuf/ProtobufConverter.java
@@ -163,10 +163,10 @@ public class ProtobufConverter implements Converter {
   private byte[] restoreFromWrapper(
       String topic, Headers headers, Schema wrapperSchema, Struct wrapper) {
     try {
-      if (wrapperSchema.field(BackupWrapper.FIELD_DATA) == null) {
-        throw new DataException("Malformed backup wrapper: missing '"
-            + BackupWrapper.FIELD_DATA + "' field");
-      }
+      BackupWrapper.requireFields(wrapperSchema,
+          BackupWrapper.FIELD_DATA,
+          BackupWrapper.FIELD_SCHEMA_TYPE,
+          BackupWrapper.FIELD_RAW_SCHEMA);
       String schemaType = wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE);
       if (!SchemaBackupConfig.TYPE_PROTOBUF.equals(schemaType)) {
         throw new DataException(

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufConverterBackupTest.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufConverterBackupTest.java
@@ -983,7 +983,7 @@ public class ProtobufConverterBackupTest {
   }
 
   @Test
-  public void testBackupRestoreNullRawSchemaFallback() {
+  public void testBackupRestoreNullRawSchemaThrows() {
     Schema schema = SchemaBuilder.struct()
         .name("FallbackMsg")
         .field(FIELD_NAME, Schema.STRING_SCHEMA)
@@ -1004,8 +1004,14 @@ public class ProtobufConverterBackupTest {
     Struct modifiedWrapper = BackupWrapper.buildWrapper(
         wrapperSchema, original.get(BackupWrapper.FIELD_DATA), fields);
 
-    byte[] restored = converter.fromConnectData(TOPIC, wrapperSchema, modifiedWrapper);
-    assertNotNull(restored);
-    assertEquals(0x00, restored[0]);
+    try {
+      converter.fromConnectData(TOPIC, wrapperSchema, modifiedWrapper);
+      fail("Expected DataException for null rawSchema");
+    } catch (DataException e) {
+      assertTrue(e.getMessage(),
+          e.getMessage().contains(BackupWrapper.FIELD_RAW_SCHEMA));
+      assertTrue(e.getMessage(),
+          e.getMessage().contains("pristine restore"));
+    }
   }
 }

--- a/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufConverterBackupTest.java
+++ b/protobuf-converter/src/test/java/io/confluent/connect/protobuf/ProtobufConverterBackupTest.java
@@ -25,22 +25,34 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
-
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.Message;
 import io.confluent.connect.schema.backup.api.BackupWrapper;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
+import io.confluent.kafka.serializers.schema.id.HeaderSchemaIdSerializer;
+import io.confluent.kafka.serializers.schema.id.SchemaId;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -53,26 +65,76 @@ public class ProtobufConverterBackupTest {
 
   private static final String TOPIC = "test-topic";
   private static final String SCHEMA_TYPE = "PROTOBUF";
-  private static final String SCHEMA_REGISTRY_URL_CONFIG = "schema.registry.url";
-  private static final String FAKE_SCHEMA_REGISTRY_URL = "http://fake-url";
-  private static final String SCHEMA_BACKUP_ENABLED_CONFIG = "schema.backup.enabled";
+  private static final String SR_URL_KEY = "schema.registry.url";
+  private static final String FAKE_SR_URL = "http://fake-url";
+  private static final String BACKUP_ENABLED_KEY = "schema.backup.enabled";
+
   private static final String FIELD_NAME = "name";
-  private static final String FIELD_TEXT = "text";
   private static final String FIELD_VALUE = "value";
-  private static final String FIELD_DATA = "data";
   private static final String FIELD_KEY = "key";
   private static final String FIELD_ID = "id";
   private static final String FIELD_CITY = "city";
-  private static final String FIELD_HOST = "host";
-  private static final String FIELD_PORT = "port";
+  private static final String FIELD_STREET = "street";
+  private static final String FIELD_COUNTRY = "country";
   private static final String VALUE_ALICE = "Alice";
   private static final String VALUE_BOB = "Bob";
+  private static final String VALUE_US = "US";
 
+  private static final String PROTO_HEADER =
+      "syntax = \"proto3\";\n"
+      + "package io.confluent.test;\n";
+
+  private static final String KITCHEN_SINK_PROTO =
+      PROTO_HEADER
+      + "message ComplexEvent {\n"
+      + "  string id = 1;\n"
+      + "  Priority priority = 2;\n"
+      + "  Address home_addr = 3;\n"
+      + "  Address work_addr = 4;\n"
+      + "  repeated Contact contacts = 5;\n"
+      + "  map<string, Metadata> attributes = 6;\n"
+      + "  oneof target {\n"
+      + "    string url = 7;\n"
+      + "    Endpoint endpoint = 8;\n"
+      + "  }\n"
+      + "  message Nested {\n"
+      + "    string label = 1;\n"
+      + "    enum Kind { A = 0; B = 1; C = 2; }\n"
+      + "    Kind kind = 2;\n"
+      + "  }\n"
+      + "  Nested nested = 9;\n"
+      + "}\n"
+      + "message Address {\n"
+      + "  string street = 1;\n"
+      + "  string city = 2;\n"
+      + "  string country = 3;\n"
+      + "}\n"
+      + "message Contact {\n"
+      + "  string name = 1;\n"
+      + "  Address address = 2;\n"
+      + "}\n"
+      + "message Metadata {\n"
+      + "  string key = 1;\n"
+      + "  string value = 2;\n"
+      + "}\n"
+      + "message Endpoint {\n"
+      + "  string host = 1;\n"
+      + "  int32 port = 2;\n"
+      + "}\n"
+      + "enum Priority { LOW = 0; MEDIUM = 1; HIGH = 2; }\n";
+
+  // Source-cluster SR + converters (default for all tests).
   private final SchemaRegistryClient schemaRegistry;
   private final ProtobufConverter converter;
   private final ProtobufConverter plainConverter;
   private KafkaProtobufSerializer<DynamicMessage> serializer;
   private KafkaProtobufDeserializer<DynamicMessage> deserializer;
+
+  // Target-cluster SR + converter for cross-cluster restore tests.
+  private final SchemaRegistryClient targetSchemaRegistry;
+  private final ProtobufConverter targetConverter;
+  private KafkaProtobufDeserializer<DynamicMessage> targetDeserializer;
+
   private int topicCounter = 0;
 
   public ProtobufConverterBackupTest() {
@@ -80,18 +142,20 @@ public class ProtobufConverterBackupTest {
         ImmutableList.of(new ProtobufSchemaProvider()));
     converter = new ProtobufConverter(schemaRegistry);
     plainConverter = new ProtobufConverter(schemaRegistry);
+    targetSchemaRegistry = new MockSchemaRegistryClient(
+        ImmutableList.of(new ProtobufSchemaProvider()));
+    targetConverter = new ProtobufConverter(targetSchemaRegistry);
   }
 
   @Before
   public void setUp() {
     Map<String, Object> backupConfig = new HashMap<>();
-    backupConfig.put(SCHEMA_REGISTRY_URL_CONFIG, FAKE_SCHEMA_REGISTRY_URL);
-    backupConfig.put(SCHEMA_BACKUP_ENABLED_CONFIG, "true");
+    backupConfig.put(SR_URL_KEY, FAKE_SR_URL);
+    backupConfig.put(BACKUP_ENABLED_KEY, "true");
     converter.configure(backupConfig, false);
+    targetConverter.configure(backupConfig, false);
 
-    Map<String, Object> plainConfig =
-        Collections.singletonMap(SCHEMA_REGISTRY_URL_CONFIG, FAKE_SCHEMA_REGISTRY_URL);
-
+    Map<String, Object> plainConfig = Collections.singletonMap(SR_URL_KEY, FAKE_SR_URL);
     plainConverter.configure(plainConfig, false);
 
     serializer = new KafkaProtobufSerializer<>(schemaRegistry);
@@ -99,234 +163,210 @@ public class ProtobufConverterBackupTest {
 
     deserializer = new KafkaProtobufDeserializer<>(schemaRegistry);
     deserializer.configure(plainConfig, false);
+
+    targetDeserializer = new KafkaProtobufDeserializer<>(targetSchemaRegistry);
+    targetDeserializer.configure(plainConfig, false);
+  }
+
+  private static KafkaProtobufSerializer<DynamicMessage> newReferenceAwareProtobufSerializer(
+      SchemaRegistryClient sr) {
+    Map<String, Object> cfg = new HashMap<>();
+    cfg.put(SR_URL_KEY, FAKE_SR_URL);
+    cfg.put("auto.register.schemas", "false");
+    cfg.put("use.latest.version", "true");
+    KafkaProtobufSerializer<DynamicMessage> s = new KafkaProtobufSerializer<>(sr);
+    s.configure(cfg, false);
+    return s;
   }
 
   private String nextTopic() {
     return TOPIC + "-" + (topicCounter++);
   }
 
-  private void assertBackupRoundTrip(String topic, ProtobufSchema schema,
-      DynamicMessage message) {
-    byte[] originalBytes = serializer.serialize(topic, null, message, schema);
-    assertNotNull("Serialization should produce bytes", originalBytes);
-
-    SchemaAndValue wrapped = converter.toConnectData(topic, originalBytes);
-    assertEquals(BackupWrapper.NAME, wrapped.schema().name());
-    Struct wrapper = (Struct) wrapped.value();
-    assertNotNull("Raw schema should be captured",
-        wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA));
-
-    byte[] restoredBytes = converter.fromConnectData(
-        topic, wrapped.schema(), wrapped.value());
-    assertNotNull("Restored bytes should not be null", restoredBytes);
-
-    Message original = deserializer.deserialize(topic, originalBytes);
-    Message restored = deserializer.deserialize(topic, restoredBytes);
-    assertEquals("Restored protobuf message must equal original", original, restored);
-    assertFalse("Restored bytes should not be empty", restoredBytes.length == 0);
+  private static void assertWrapperShape(SchemaAndValue wrapped, String expectedType) {
+    assertNotNull("wrapped result", wrapped);
+    assertNotNull("wrapped schema", wrapped.schema());
+    assertEquals("wrapper schema name", BackupWrapper.NAME, wrapped.schema().name());
+    Struct w = (Struct) wrapped.value();
+    assertEquals("schema type", expectedType, w.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
+    assertNotNull("schema subject", w.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT));
+    assertNotNull("raw schema", w.getString(BackupWrapper.FIELD_RAW_SCHEMA));
+    assertNotNull("data field", w.get(BackupWrapper.FIELD_DATA));
+    assertNotNull("schema ID", w.getInt32(BackupWrapper.FIELD_SCHEMA_ID));
+    assertTrue("schema ID > 0", w.getInt32(BackupWrapper.FIELD_SCHEMA_ID) > 0);
+    assertNotNull("schema version", w.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION));
   }
 
+  private static void assertBytesExact(byte[] original, byte[] restored) {
+    assertNotNull("original bytes", original);
+    assertNotNull("restored bytes", restored);
+    assertArrayEquals("byte-exact roundtrip", original, restored);
+  }
+
+  private static void assertWireSchemaIdPreserved(byte[] original, byte[] restored) {
+    assertTrue("original wire-format long enough", original.length >= 5);
+    assertTrue("restored wire-format long enough", restored.length >= 5);
+    assertEquals("original magic byte", (byte) 0x00, original[0]);
+    assertEquals("restored magic byte", (byte) 0x00, restored[0]);
+    int origId = ByteBuffer.wrap(original, 1, 4).getInt();
+    int restoredId = ByteBuffer.wrap(restored, 1, 4).getInt();
+    assertEquals("wire-format schema ID preserved", origId, restoredId);
+  }
+
+  private static void assertRawSchemaEquivalent(SchemaAndValue wrapped, ProtobufSchema original) {
+    String raw = ((Struct) wrapped.value()).getString(BackupWrapper.FIELD_RAW_SCHEMA);
+    assertNotNull("raw schema in wrapper", raw);
+    ProtobufSchema restored = new ProtobufSchema(raw);
+    assertEquals("raw schema canonical equality",
+        original.canonicalString(), restored.canonicalString());
+  }
+
+  private static void assertValueEqual(Object originalDeser, Object restoredDeser) {
+    assertEquals("deserialized value equality", originalDeser, restoredDeser);
+  }
+
+  private static void assertWrapperSchemaIdMatchesSource(
+      SchemaAndValue wrapped, byte[] sourceBytes) {
+    int sourceWireId = ByteBuffer.wrap(sourceBytes, 1, 4).getInt();
+    Integer wrapperId = ((Struct) wrapped.value()).getInt32(BackupWrapper.FIELD_SCHEMA_ID);
+    assertNotNull("wrapper schema ID populated", wrapperId);
+    assertEquals("wrapper.schemaId matches source wire ID at bytes[1..4]",
+        sourceWireId, wrapperId.intValue());
+  }
+
+  private void assertRawSchemaMatchesSourceRegistered(
+      SchemaAndValue wrapped, byte[] sourceBytes) throws Exception {
+    int sourceWireId = ByteBuffer.wrap(sourceBytes, 1, 4).getInt();
+    ParsedSchema sourceRegistered = schemaRegistry.getSchemaById(sourceWireId);
+    String wrapperRaw = ((Struct) wrapped.value()).getString(BackupWrapper.FIELD_RAW_SCHEMA);
+    assertNotNull("wrapper rawSchema populated", wrapperRaw);
+    assertEquals("wrapper rawSchema canonically equals source-registered schema",
+        sourceRegistered.canonicalString(), new ProtobufSchema(wrapperRaw).canonicalString());
+  }
+
+  private static void assertPayloadBytesEqual(byte[] source, byte[] restored) {
+    assertTrue("source has 5-byte header + payload", source.length >= 5);
+    assertTrue("restored has 5-byte header + payload", restored.length >= 5);
+    byte[] sourcePayload = Arrays.copyOfRange(source, 5, source.length);
+    byte[] restoredPayload = Arrays.copyOfRange(restored, 5, restored.length);
+    assertArrayEquals("payload bytes (bytes[5..end]) equal", sourcePayload, restoredPayload);
+  }
+
+  private static void assertCrossClusterBytesEquivalent(byte[] sourceBytes,
+      byte[] restoredBytes) {
+    assertTrue("source has 5-byte header + payload", sourceBytes.length >= 5);
+    assertTrue("restored has 5-byte header + payload", restoredBytes.length >= 5);
+    assertEquals("source magic byte", (byte) 0x00, sourceBytes[0]);
+    assertEquals("restored magic byte", (byte) 0x00, restoredBytes[0]);
+    int sourceId = ByteBuffer.wrap(sourceBytes, 1, 4).getInt();
+    int restoredId = ByteBuffer.wrap(restoredBytes, 1, 4).getInt();
+    assertTrue("source wire ID positive", sourceId > 0);
+    assertTrue("restored wire ID positive", restoredId > 0);
+    assertPayloadBytesEqual(sourceBytes, restoredBytes);
+  }
+
+  private void assertFullFidelityRoundTrip(String topic, ProtobufSchema schema,
+      DynamicMessage message) {
+    byte[] originalBytes = serializer.serialize(topic, null, message, schema);
+    assertNotNull("serialization produced bytes", originalBytes);
+
+    SchemaAndValue wrapped = converter.toConnectData(topic, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    assertWrapperShape(wrapped, SCHEMA_TYPE);
+    assertBytesExact(originalBytes, restoredBytes);
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
+    assertRawSchemaEquivalent(wrapped, schema);
+    Message originalDeser = deserializer.deserialize(topic, originalBytes);
+    Message restoredDeser = deserializer.deserialize(topic, restoredBytes);
+    assertValueEqual(originalDeser, restoredDeser);
+  }
+
+  private Map<String, Object> backupConfigWith(String key, String value) {
+    Map<String, Object> cfg = new HashMap<>();
+    cfg.put(SR_URL_KEY, FAKE_SR_URL);
+    cfg.put(BACKUP_ENABLED_KEY, "true");
+    cfg.put(key, value);
+    return cfg;
+  }
+
+  // ================ Default-behavior gates ================
+
   @Test
-  public void testBackupToConnectDataWrapsMetadata() {
+  public void testDefaultWrapperShape() {
     Schema schema = SchemaBuilder.struct()
         .name("TestRecord")
         .field(FIELD_ID, Schema.STRING_SCHEMA)
         .field("count", Schema.INT32_SCHEMA)
         .build();
-    Struct value = new Struct(schema)
-        .put(FIELD_ID, "rec-1")
-        .put("count", 10);
+    Struct value = new Struct(schema).put(FIELD_ID, "rec-1").put("count", 10);
 
     byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
-    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, serialized);
 
-    assertNotNull(result);
-    assertNotNull(result.schema());
-    assertEquals(BackupWrapper.NAME, result.schema().name());
-
-    Struct wrapper = (Struct) result.value();
-    assertNotNull(wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_ID));
-    assertEquals(SCHEMA_TYPE, wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
-    assertNotNull(wrapper.getString(BackupWrapper.FIELD_RAW_SCHEMA));
-    assertNotNull(wrapper.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT));
-    assertNotNull(wrapper.get(BackupWrapper.FIELD_DATA));
+    assertWrapperShape(wrapped, SCHEMA_TYPE);
+    Struct w = (Struct) wrapped.value();
+    assertTrue("subject contains topic",
+        w.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT).contains(TOPIC));
   }
 
   @Test
-  public void testBackupFromConnectDataRestores() {
-    Schema schema = SchemaBuilder.struct()
-        .name("SimpleMsg")
-        .field(FIELD_TEXT, Schema.STRING_SCHEMA)
-        .build();
-    Struct value = new Struct(schema).put(FIELD_TEXT, "hello");
-
-    byte[] original = plainConverter.fromConnectData(TOPIC, schema, value);
-    assertNotNull(original);
-
-    SchemaAndValue wrapped = converter.toConnectData(TOPIC, original);
-    assertEquals(BackupWrapper.NAME, wrapped.schema().name());
-
-    byte[] restored = converter.fromConnectData(
-        TOPIC, wrapped.schema(), wrapped.value());
-
-    assertNotNull(restored);
-    assertEquals(0x00, restored[0]);
-  }
-
-  @Test
-  public void testBackupRoundTrip() {
-    Schema schema = SchemaBuilder.struct()
-        .name("RoundTripMsg")
-        .field(FIELD_NAME, Schema.STRING_SCHEMA)
-        .field(FIELD_VALUE, Schema.INT32_SCHEMA)
-        .build();
-    Struct original = new Struct(schema)
-        .put(FIELD_NAME, "test")
-        .put(FIELD_VALUE, 99);
-
-    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, original);
-
-    // Backup wraps, then restore unwraps
-    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
-    byte[] restoredBytes = converter.fromConnectData(
-        TOPIC, wrapped.schema(), wrapped.value());
-
-    SchemaAndValue restoredData = plainConverter.toConnectData(TOPIC, restoredBytes);
-    Struct restored = (Struct) restoredData.value();
-    assertEquals("test", restored.getString(FIELD_NAME));
-    assertEquals(Integer.valueOf(99), restored.getInt32(FIELD_VALUE));
-  }
-
-  @Test
-  public void testBackupDisabledNoWrapping() {
-    Schema schema = SchemaBuilder.struct()
-        .name("NoBackupMsg")
-        .field("x", Schema.INT32_SCHEMA)
-        .build();
-    Struct value = new Struct(schema).put("x", 1);
-
-    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
-    SchemaAndValue result = plainConverter.toConnectData(TOPIC, serialized);
-
-    assertNotNull(result.schema());
-    assertNotEquals(BackupWrapper.NAME, result.schema().name());
-  }
-
-  @Test
-  public void testBackupNullValue() {
-    SchemaAndValue result = converter.toConnectData(TOPIC, null);
-    assertNull(result.schema());
-    assertNull(result.value());
-  }
-
-  @Test
-  public void testBackupPrimitiveType() {
-    Schema schema = SchemaBuilder.struct()
-        .name("PrimitiveHolder")
-        .field("val", Schema.STRING_SCHEMA)
-        .build();
-    Struct value = new Struct(schema).put("val", "test");
-
-    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
-    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
-
-    assertEquals(BackupWrapper.NAME, result.schema().name());
-    Struct wrapper = (Struct) result.value();
-    assertEquals(SCHEMA_TYPE, wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
-  }
-
-  @Test
-  public void testBackupWrapperFields() {
-    Schema schema = SchemaBuilder.struct()
-        .name("FieldCheck")
-        .field(FIELD_DATA, Schema.STRING_SCHEMA)
-        .build();
-    Struct value = new Struct(schema).put(FIELD_DATA, "check");
-
-    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
-    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
-
-    Struct wrapper = (Struct) result.value();
-    assertEquals(SCHEMA_TYPE, wrapper.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
-    assertTrue(wrapper.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT)
-        .contains(TOPIC));
-  }
-
-  @Test
-  public void testBackupSchemaIdExtracted() {
-    Schema schema = SchemaBuilder.struct()
-        .name("IdCheck")
-        .field("n", Schema.INT32_SCHEMA)
-        .build();
-    Struct value = new Struct(schema).put("n", 7);
-
-    byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
-    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
-
-    Struct wrapper = (Struct) result.value();
-    int wrappedId = wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_ID);
-    assertTrue(wrappedId > 0);
-  }
-
-  @Test
-  public void testBackupNonWrapperSchemaNormalSerialization() {
-    Schema schema = SchemaBuilder.struct()
-        .name("DirectMsg")
-        .field(FIELD_TEXT, Schema.STRING_SCHEMA)
-        .build();
-    Struct value = new Struct(schema).put(FIELD_TEXT, "direct");
-
-    byte[] result = converter.fromConnectData(TOPIC, schema, value);
-    assertNotNull(result);
-    assertTrue(result.length > 5);
-    assertEquals(0x00, result[0]);
-  }
-
-  @Test
-  public void testBackupRestoreMissingDataField() {
-    Schema badSchema = SchemaBuilder.struct()
-        .name(BackupWrapper.NAME)
-        .field(BackupWrapper.FIELD_SCHEMA_ID, Schema.INT32_SCHEMA)
-        .build();
-    Struct badWrapper = new Struct(badSchema)
-        .put(BackupWrapper.FIELD_SCHEMA_ID, 1);
-
-    try {
-      converter.fromConnectData(TOPIC, badSchema, badWrapper);
-      fail("Expected DataException");
-    } catch (DataException e) {
-      assertTrue(e.getMessage().contains("data")
-          || e.getMessage().contains("restore")
-          || e.getMessage().contains("Failed"));
-    }
-  }
-
-  @Test
-  public void testBackupRoundTripBytesExact() {
+  public void testDefaultBytesExactForStruct() {
     Schema schema = SchemaBuilder.struct()
         .name("ExactMsg")
         .field(FIELD_NAME, Schema.STRING_SCHEMA)
         .field(FIELD_VALUE, Schema.INT32_SCHEMA)
         .build();
-    Struct original = new Struct(schema)
-        .put(FIELD_NAME, "exact")
-        .put(FIELD_VALUE, 77);
+    Struct original = new Struct(schema).put(FIELD_NAME, "exact").put(FIELD_VALUE, 77);
 
-    byte[] originalBytes = plainConverter.fromConnectData(
-        TOPIC, schema, original);
-
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, original);
     SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
-    byte[] restoredBytes = converter.fromConnectData(
-        TOPIC, wrapped.schema(), wrapped.value());
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
 
-    assertArrayEquals(originalBytes, restoredBytes);
+    assertBytesExact(originalBytes, restoredBytes);
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
   }
 
   @Test
-  public void testBackupRoundTripSharedMessageType() {
+  public void testDefaultWireSchemaIdPreserved() {
+    Schema schema = SchemaBuilder.struct()
+        .name("IdCheck")
+        .field(FIELD_ID, Schema.INT32_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, 42);
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
+  }
+
+  @Test
+  public void testDefaultRawSchemaSemanticallyEqual() {
     String topic = nextTopic();
-    String proto = "syntax = \"proto3\";\n"
-        + "package io.confluent.test;\n"
+    String proto = PROTO_HEADER
+        + "message Simple {\n"
+        + "  string name = 1;\n"
+        + "  int32 value = 2;\n"
+        + "}\n";
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor desc = schema.toDescriptor();
+    DynamicMessage message = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName(FIELD_NAME), "raw-check")
+        .setField(desc.findFieldByName(FIELD_VALUE), 42)
+        .build();
+
+    byte[] originalBytes = serializer.serialize(topic, null, message, schema);
+    SchemaAndValue wrapped = converter.toConnectData(topic, originalBytes);
+
+    assertRawSchemaEquivalent(wrapped, schema);
+  }
+
+  @Test
+  public void testDefaultSharedMessageTypeAtMultipleFieldsSurvives() {
+    String topic = nextTopic();
+    String proto = PROTO_HEADER
         + "message Person {\n"
         + "  string name = 1;\n"
         + "  Address home_addr = 2;\n"
@@ -336,374 +376,31 @@ public class ProtobufConverterBackupTest {
         + "  string street = 1;\n"
         + "  string city = 2;\n"
         + "}\n";
-
     ProtobufSchema schema = new ProtobufSchema(proto);
     Descriptor personDesc = schema.toDescriptor();
     Descriptor addressDesc = personDesc.findFieldByName("home_addr").getMessageType();
 
     DynamicMessage homeAddr = DynamicMessage.newBuilder(addressDesc)
-        .setField(addressDesc.findFieldByName("street"), "123 Home St")
+        .setField(addressDesc.findFieldByName(FIELD_STREET), "123 Home St")
         .setField(addressDesc.findFieldByName(FIELD_CITY), "Hometown")
         .build();
     DynamicMessage workAddr = DynamicMessage.newBuilder(addressDesc)
-        .setField(addressDesc.findFieldByName("street"), "456 Work Ave")
+        .setField(addressDesc.findFieldByName(FIELD_STREET), "456 Work Ave")
         .setField(addressDesc.findFieldByName(FIELD_CITY), "Workville")
         .build();
     DynamicMessage person = DynamicMessage.newBuilder(personDesc)
-        .setField(personDesc.findFieldByName("name"), VALUE_ALICE)
+        .setField(personDesc.findFieldByName(FIELD_NAME), VALUE_ALICE)
         .setField(personDesc.findFieldByName("home_addr"), homeAddr)
         .setField(personDesc.findFieldByName("work_addr"), workAddr)
         .build();
 
-    assertBackupRoundTrip(topic, schema, person);
+    assertFullFidelityRoundTrip(topic, schema, person);
   }
 
   @Test
-  public void testBackupRoundTripAllPrimitiveTypes() {
+  public void testDefaultSharedTypeAtThreeFields() {
     String topic = nextTopic();
-    String proto = "syntax = \"proto3\";\n"
-        + "package io.confluent.test;\n"
-        + "message AllPrimitives {\n"
-        + "  int32 int32_val = 1;\n"
-        + "  int64 int64_val = 2;\n"
-        + "  float float_val = 3;\n"
-        + "  double double_val = 4;\n"
-        + "  bool bool_val = 5;\n"
-        + "  string string_val = 6;\n"
-        + "  bytes bytes_val = 7;\n"
-        + "  uint32 uint32_val = 8;\n"
-        + "  uint64 uint64_val = 9;\n"
-        + "  sint32 sint32_val = 10;\n"
-        + "  sint64 sint64_val = 11;\n"
-        + "  fixed32 fixed32_val = 12;\n"
-        + "  fixed64 fixed64_val = 13;\n"
-        + "  sfixed32 sfixed32_val = 14;\n"
-        + "  sfixed64 sfixed64_val = 15;\n"
-        + "}\n";
-
-    ProtobufSchema schema = new ProtobufSchema(proto);
-    Descriptor desc = schema.toDescriptor();
-
-    DynamicMessage message = DynamicMessage.newBuilder(desc)
-        .setField(desc.findFieldByName("int32_val"), 42)
-        .setField(desc.findFieldByName("int64_val"), 123456789L)
-        .setField(desc.findFieldByName("float_val"), 3.14f)
-        .setField(desc.findFieldByName("double_val"), 2.718281828)
-        .setField(desc.findFieldByName("bool_val"), true)
-        .setField(desc.findFieldByName("string_val"), "hello")
-        .setField(desc.findFieldByName("bytes_val"),
-            ByteString.copyFrom(new byte[]{0x01, 0x02, 0x03}))
-        .setField(desc.findFieldByName("uint32_val"), 100)
-        .setField(desc.findFieldByName("uint64_val"), 999999L)
-        .setField(desc.findFieldByName("sint32_val"), -42)
-        .setField(desc.findFieldByName("sint64_val"), -123456789L)
-        .setField(desc.findFieldByName("fixed32_val"), 77)
-        .setField(desc.findFieldByName("fixed64_val"), 88L)
-        .setField(desc.findFieldByName("sfixed32_val"), -77)
-        .setField(desc.findFieldByName("sfixed64_val"), -88L)
-        .build();
-
-    assertBackupRoundTrip(topic, schema, message);
-  }
-
-  @Test
-  public void testBackupRoundTripNestedMessages() {
-    String topic = nextTopic();
-    String proto = "syntax = \"proto3\";\n"
-        + "package io.confluent.test;\n"
-        + "message Order {\n"
-        + "  int32 id = 1;\n"
-        + "  Customer customer = 2;\n"
-        + "  Address shipping = 3;\n"
-        + "}\n"
-        + "message Customer {\n"
-        + "  string name = 1;\n"
-        + "  Address billing = 2;\n"
-        + "}\n"
-        + "message Address {\n"
-        + "  string street = 1;\n"
-        + "  string city = 2;\n"
-        + "  string zip = 3;\n"
-        + "}\n";
-
-    ProtobufSchema schema = new ProtobufSchema(proto);
-    Descriptor orderDesc = schema.toDescriptor();
-    Descriptor custDesc = orderDesc.findFieldByName("customer").getMessageType();
-    Descriptor addrDesc = orderDesc.findFieldByName("shipping").getMessageType();
-
-    DynamicMessage billingAddr = DynamicMessage.newBuilder(addrDesc)
-        .setField(addrDesc.findFieldByName("street"), "100 Bill Ln")
-        .setField(addrDesc.findFieldByName(FIELD_CITY), "Billtown")
-        .setField(addrDesc.findFieldByName("zip"), "11111")
-        .build();
-    DynamicMessage shippingAddr = DynamicMessage.newBuilder(addrDesc)
-        .setField(addrDesc.findFieldByName("street"), "200 Ship Rd")
-        .setField(addrDesc.findFieldByName(FIELD_CITY), "Shipville")
-        .setField(addrDesc.findFieldByName("zip"), "22222")
-        .build();
-    DynamicMessage customer = DynamicMessage.newBuilder(custDesc)
-        .setField(custDesc.findFieldByName("name"), VALUE_BOB)
-        .setField(custDesc.findFieldByName("billing"), billingAddr)
-        .build();
-    DynamicMessage order = DynamicMessage.newBuilder(orderDesc)
-        .setField(orderDesc.findFieldByName(FIELD_ID), 1001)
-        .setField(orderDesc.findFieldByName("customer"), customer)
-        .setField(orderDesc.findFieldByName("shipping"), shippingAddr)
-        .build();
-
-    assertBackupRoundTrip(topic, schema, order);
-  }
-
-  @Test
-  public void testBackupRoundTripRepeatedFields() {
-    String topic = nextTopic();
-    String proto = "syntax = \"proto3\";\n"
-        + "package io.confluent.test;\n"
-        + "message Classroom {\n"
-        + "  string name = 1;\n"
-        + "  repeated string students = 2;\n"
-        + "  repeated int32 scores = 3;\n"
-        + "  repeated Student enrollments = 4;\n"
-        + "}\n"
-        + "message Student {\n"
-        + "  string name = 1;\n"
-        + "  int32 grade = 2;\n"
-        + "}\n";
-
-    ProtobufSchema schema = new ProtobufSchema(proto);
-    Descriptor classDesc = schema.toDescriptor();
-    Descriptor studentDesc = classDesc.findFieldByName("enrollments").getMessageType();
-
-    DynamicMessage s1 = DynamicMessage.newBuilder(studentDesc)
-        .setField(studentDesc.findFieldByName("name"), VALUE_ALICE)
-        .setField(studentDesc.findFieldByName("grade"), 95)
-        .build();
-    DynamicMessage s2 = DynamicMessage.newBuilder(studentDesc)
-        .setField(studentDesc.findFieldByName("name"), VALUE_BOB)
-        .setField(studentDesc.findFieldByName("grade"), 88)
-        .build();
-
-    DynamicMessage classroom = DynamicMessage.newBuilder(classDesc)
-        .setField(classDesc.findFieldByName("name"), "Math 101")
-        .addRepeatedField(classDesc.findFieldByName("students"), VALUE_ALICE)
-        .addRepeatedField(classDesc.findFieldByName("students"), VALUE_BOB)
-        .addRepeatedField(classDesc.findFieldByName("students"), "Charlie")
-        .addRepeatedField(classDesc.findFieldByName("scores"), 95)
-        .addRepeatedField(classDesc.findFieldByName("scores"), 88)
-        .addRepeatedField(classDesc.findFieldByName("scores"), 72)
-        .addRepeatedField(classDesc.findFieldByName("enrollments"), s1)
-        .addRepeatedField(classDesc.findFieldByName("enrollments"), s2)
-        .build();
-
-    assertBackupRoundTrip(topic, schema, classroom);
-  }
-
-  @Test
-  public void testBackupRoundTripMapFields() {
-    String topic = nextTopic();
-    String proto = "syntax = \"proto3\";\n"
-        + "package io.confluent.test;\n"
-        + "message Config {\n"
-        + "  string name = 1;\n"
-        + "  map<string, string> properties = 2;\n"
-        + "  map<string, int32> counts = 3;\n"
-        + "  map<int32, string> id_names = 4;\n"
-        + "}\n";
-
-    ProtobufSchema schema = new ProtobufSchema(proto);
-    Descriptor desc = schema.toDescriptor();
-
-    FieldDescriptor propsField = desc.findFieldByName("properties");
-    Descriptor propsEntry = propsField.getMessageType();
-    FieldDescriptor countsField = desc.findFieldByName("counts");
-    Descriptor countsEntry = countsField.getMessageType();
-    FieldDescriptor idNamesField = desc.findFieldByName("id_names");
-    Descriptor idNamesEntry = idNamesField.getMessageType();
-
-    DynamicMessage.Builder builder = DynamicMessage.newBuilder(desc)
-        .setField(desc.findFieldByName("name"), "test-config");
-
-    builder.addRepeatedField(propsField,
-        DynamicMessage.newBuilder(propsEntry)
-            .setField(propsEntry.findFieldByName(FIELD_KEY), FIELD_HOST)
-            .setField(propsEntry.findFieldByName("value"), "localhost")
-            .build());
-    builder.addRepeatedField(propsField,
-        DynamicMessage.newBuilder(propsEntry)
-            .setField(propsEntry.findFieldByName(FIELD_KEY), FIELD_PORT)
-            .setField(propsEntry.findFieldByName("value"), "8080")
-            .build());
-
-    builder.addRepeatedField(countsField,
-        DynamicMessage.newBuilder(countsEntry)
-            .setField(countsEntry.findFieldByName(FIELD_KEY), "errors")
-            .setField(countsEntry.findFieldByName("value"), 5)
-            .build());
-
-    builder.addRepeatedField(idNamesField,
-        DynamicMessage.newBuilder(idNamesEntry)
-            .setField(idNamesEntry.findFieldByName(FIELD_KEY), 1)
-            .setField(idNamesEntry.findFieldByName("value"), "first")
-            .build());
-
-    assertBackupRoundTrip(topic, schema, builder.build());
-  }
-
-  @Test
-  public void testBackupRoundTripEnumType() {
-    String topic = nextTopic();
-    String proto = "syntax = \"proto3\";\n"
-        + "package io.confluent.test;\n"
-        + "message Event {\n"
-        + "  string id = 1;\n"
-        + "  EventType type = 2;\n"
-        + "  Priority priority = 3;\n"
-        + "}\n"
-        + "enum EventType {\n"
-        + "  UNKNOWN = 0;\n"
-        + "  CLICK = 1;\n"
-        + "  VIEW = 2;\n"
-        + "  PURCHASE = 3;\n"
-        + "}\n"
-        + "enum Priority {\n"
-        + "  LOW = 0;\n"
-        + "  MEDIUM = 1;\n"
-        + "  HIGH = 2;\n"
-        + "}\n";
-
-    ProtobufSchema schema = new ProtobufSchema(proto);
-    Descriptor desc = schema.toDescriptor();
-
-    DynamicMessage event = DynamicMessage.newBuilder(desc)
-        .setField(desc.findFieldByName(FIELD_ID), "evt-123")
-        .setField(desc.findFieldByName("type"),
-            desc.findFieldByName("type").getEnumType().findValueByName("PURCHASE"))
-        .setField(desc.findFieldByName("priority"),
-            desc.findFieldByName("priority").getEnumType().findValueByName("HIGH"))
-        .build();
-
-    assertBackupRoundTrip(topic, schema, event);
-  }
-
-  @Test
-  public void testBackupRoundTripOneofFields() {
-    String topic = nextTopic();
-    String proto = "syntax = \"proto3\";\n"
-        + "package io.confluent.test;\n"
-        + "message Notification {\n"
-        + "  string id = 1;\n"
-        + "  oneof channel {\n"
-        + "    string email = 2;\n"
-        + "    string sms = 3;\n"
-        + "    PushConfig push = 4;\n"
-        + "  }\n"
-        + "}\n"
-        + "message PushConfig {\n"
-        + "  string device_token = 1;\n"
-        + "  bool silent = 2;\n"
-        + "}\n";
-
-    ProtobufSchema schema = new ProtobufSchema(proto);
-    Descriptor notifDesc = schema.toDescriptor();
-    Descriptor pushDesc = notifDesc.findFieldByName("push").getMessageType();
-
-    // Test with string oneof branch
-    DynamicMessage emailNotif = DynamicMessage.newBuilder(notifDesc)
-        .setField(notifDesc.findFieldByName(FIELD_ID), "n-1")
-        .setField(notifDesc.findFieldByName("email"), "user@test.com")
-        .build();
-    assertBackupRoundTrip(topic, schema, emailNotif);
-
-    // Test with message oneof branch
-    String topic2 = nextTopic();
-    DynamicMessage pushNotif = DynamicMessage.newBuilder(notifDesc)
-        .setField(notifDesc.findFieldByName(FIELD_ID), "n-2")
-        .setField(notifDesc.findFieldByName("push"),
-            DynamicMessage.newBuilder(pushDesc)
-                .setField(pushDesc.findFieldByName("device_token"), "tok-abc")
-                .setField(pushDesc.findFieldByName("silent"), true)
-                .build())
-        .build();
-    assertBackupRoundTrip(topic2, schema, pushNotif);
-  }
-
-  @Test
-  public void testBackupRoundTripOptionalFields() {
-    String topic = nextTopic();
-    String proto = "syntax = \"proto3\";\n"
-        + "package io.confluent.test;\n"
-        + "message Profile {\n"
-        + "  string name = 1;\n"
-        + "  optional string nickname = 2;\n"
-        + "  optional int32 age = 3;\n"
-        + "  optional bool active = 4;\n"
-        + "  string email = 5;\n"
-        + "}\n";
-
-    ProtobufSchema schema = new ProtobufSchema(proto);
-    Descriptor desc = schema.toDescriptor();
-
-    // With optional fields set
-    DynamicMessage withOptionals = DynamicMessage.newBuilder(desc)
-        .setField(desc.findFieldByName("name"), VALUE_ALICE)
-        .setField(desc.findFieldByName("nickname"), "Ali")
-        .setField(desc.findFieldByName("age"), 30)
-        .setField(desc.findFieldByName("active"), true)
-        .setField(desc.findFieldByName("email"), "alice@test.com")
-        .build();
-    assertBackupRoundTrip(topic, schema, withOptionals);
-
-    // With optional fields NOT set (defaults)
-    String topic2 = nextTopic();
-    DynamicMessage withoutOptionals = DynamicMessage.newBuilder(desc)
-        .setField(desc.findFieldByName("name"), VALUE_BOB)
-        .setField(desc.findFieldByName("email"), "bob@test.com")
-        .build();
-    assertBackupRoundTrip(topic2, schema, withoutOptionals);
-  }
-
-  @Test
-  public void testBackupRoundTripNestedEnum() {
-    String topic = nextTopic();
-    String proto = "syntax = \"proto3\";\n"
-        + "package io.confluent.test;\n"
-        + "message Outer {\n"
-        + "  string label = 1;\n"
-        + "  Inner details = 2;\n"
-        + "  message Inner {\n"
-        + "    string value = 1;\n"
-        + "    enum Status {\n"
-        + "      DRAFT = 0;\n"
-        + "      PUBLISHED = 1;\n"
-        + "      ARCHIVED = 2;\n"
-        + "    }\n"
-        + "    Status status = 2;\n"
-        + "  }\n"
-        + "}\n";
-
-    ProtobufSchema schema = new ProtobufSchema(proto);
-    Descriptor outerDesc = schema.toDescriptor();
-    Descriptor innerDesc = outerDesc.findFieldByName("details").getMessageType();
-
-    DynamicMessage inner = DynamicMessage.newBuilder(innerDesc)
-        .setField(innerDesc.findFieldByName("value"), "content")
-        .setField(innerDesc.findFieldByName("status"),
-            innerDesc.findFieldByName("status").getEnumType()
-                .findValueByName("PUBLISHED"))
-        .build();
-    DynamicMessage outer = DynamicMessage.newBuilder(outerDesc)
-        .setField(outerDesc.findFieldByName("label"), "doc-1")
-        .setField(outerDesc.findFieldByName("details"), inner)
-        .build();
-
-    assertBackupRoundTrip(topic, schema, outer);
-  }
-
-  @Test
-  public void testBackupRoundTripSharedTypeAtThreeFields() {
-    String topic = nextTopic();
-    String proto = "syntax = \"proto3\";\n"
-        + "package io.confluent.test;\n"
+    String proto = PROTO_HEADER
         + "message Company {\n"
         + "  string name = 1;\n"
         + "  Address hq = 2;\n"
@@ -715,7 +412,6 @@ public class ProtobufConverterBackupTest {
         + "  string city = 2;\n"
         + "  string country = 3;\n"
         + "}\n";
-
     ProtobufSchema schema = new ProtobufSchema(proto);
     Descriptor companyDesc = schema.toDescriptor();
     Descriptor addrDesc = companyDesc.findFieldByName("hq").getMessageType();
@@ -723,58 +419,32 @@ public class ProtobufConverterBackupTest {
     DynamicMessage hq = DynamicMessage.newBuilder(addrDesc)
         .setField(addrDesc.findFieldByName("line1"), "1 HQ Plaza")
         .setField(addrDesc.findFieldByName(FIELD_CITY), "San Francisco")
-        .setField(addrDesc.findFieldByName("country"), "US")
+        .setField(addrDesc.findFieldByName(FIELD_COUNTRY), VALUE_US)
         .build();
     DynamicMessage warehouse = DynamicMessage.newBuilder(addrDesc)
         .setField(addrDesc.findFieldByName("line1"), "50 Warehouse Dr")
         .setField(addrDesc.findFieldByName(FIELD_CITY), "Denver")
-        .setField(addrDesc.findFieldByName("country"), "US")
+        .setField(addrDesc.findFieldByName(FIELD_COUNTRY), VALUE_US)
         .build();
     DynamicMessage billing = DynamicMessage.newBuilder(addrDesc)
         .setField(addrDesc.findFieldByName("line1"), "PO Box 100")
         .setField(addrDesc.findFieldByName(FIELD_CITY), "Austin")
-        .setField(addrDesc.findFieldByName("country"), "US")
+        .setField(addrDesc.findFieldByName(FIELD_COUNTRY), VALUE_US)
         .build();
     DynamicMessage company = DynamicMessage.newBuilder(companyDesc)
-        .setField(companyDesc.findFieldByName("name"), "Confluent")
+        .setField(companyDesc.findFieldByName(FIELD_NAME), "Confluent")
         .setField(companyDesc.findFieldByName("hq"), hq)
         .setField(companyDesc.findFieldByName("warehouse"), warehouse)
         .setField(companyDesc.findFieldByName("billing"), billing)
         .build();
 
-    assertBackupRoundTrip(topic, schema, company);
+    assertFullFidelityRoundTrip(topic, schema, company);
   }
 
   @Test
-  public void testBackupRoundTripNonContiguousTags() {
+  public void testDefaultRepeatedNestedWithSharedType() {
     String topic = nextTopic();
-    String proto = "syntax = \"proto3\";\n"
-        + "package io.confluent.test;\n"
-        + "message Sparse {\n"
-        + "  string name = 1;\n"
-        + "  int32 code = 5;\n"
-        + "  bool active = 10;\n"
-        + "  string desc = 20;\n"
-        + "}\n";
-
-    ProtobufSchema schema = new ProtobufSchema(proto);
-    Descriptor desc = schema.toDescriptor();
-
-    DynamicMessage message = DynamicMessage.newBuilder(desc)
-        .setField(desc.findFieldByName("name"), "sparse-test")
-        .setField(desc.findFieldByName("code"), 404)
-        .setField(desc.findFieldByName("active"), false)
-        .setField(desc.findFieldByName("desc"), "not found")
-        .build();
-
-    assertBackupRoundTrip(topic, schema, message);
-  }
-
-  @Test
-  public void testBackupRoundTripRepeatedNestedWithSharedType() {
-    String topic = nextTopic();
-    String proto = "syntax = \"proto3\";\n"
-        + "package io.confluent.test;\n"
+    String proto = PROTO_HEADER
         + "message Team {\n"
         + "  string name = 1;\n"
         + "  repeated Member members = 2;\n"
@@ -787,7 +457,6 @@ public class ProtobufConverterBackupTest {
         + "  string title = 1;\n"
         + "  int32 level = 2;\n"
         + "}\n";
-
     ProtobufSchema schema = new ProtobufSchema(proto);
     Descriptor teamDesc = schema.toDescriptor();
     Descriptor memberDesc = teamDesc.findFieldByName("members").getMessageType();
@@ -802,190 +471,852 @@ public class ProtobufConverterBackupTest {
         .setField(roleDesc.findFieldByName("level"), 5)
         .build();
     DynamicMessage m1 = DynamicMessage.newBuilder(memberDesc)
-        .setField(memberDesc.findFieldByName("name"), VALUE_ALICE)
+        .setField(memberDesc.findFieldByName(FIELD_NAME), VALUE_ALICE)
         .setField(memberDesc.findFieldByName("role"), r1)
         .build();
     DynamicMessage m2 = DynamicMessage.newBuilder(memberDesc)
-        .setField(memberDesc.findFieldByName("name"), VALUE_BOB)
+        .setField(memberDesc.findFieldByName(FIELD_NAME), VALUE_BOB)
         .setField(memberDesc.findFieldByName("role"), r2)
         .build();
     DynamicMessage team = DynamicMessage.newBuilder(teamDesc)
-        .setField(teamDesc.findFieldByName("name"), "Platform")
+        .setField(teamDesc.findFieldByName(FIELD_NAME), "Platform")
         .addRepeatedField(teamDesc.findFieldByName("members"), m1)
         .addRepeatedField(teamDesc.findFieldByName("members"), m2)
         .build();
 
-    assertBackupRoundTrip(topic, schema, team);
+    assertFullFidelityRoundTrip(topic, schema, team);
   }
 
   @Test
-  public void testBackupRoundTripMapWithMessageValue() {
+  public void testDefaultComplexRealisticSchemaAllAxesPass() {
     String topic = nextTopic();
-    String proto = "syntax = \"proto3\";\n"
-        + "package io.confluent.test;\n"
-        + "message Registry {\n"
+    ProtobufSchema schema = new ProtobufSchema(KITCHEN_SINK_PROTO);
+    Descriptor eventDesc = schema.toDescriptor();
+    Descriptor addressDesc = eventDesc.findFieldByName("home_addr").getMessageType();
+    Descriptor contactDesc = eventDesc.findFieldByName("contacts").getMessageType();
+    Descriptor endpointDesc = eventDesc.findFieldByName("endpoint").getMessageType();
+    Descriptor nestedDesc = eventDesc.findFieldByName("nested").getMessageType();
+    FieldDescriptor attrsField = eventDesc.findFieldByName("attributes");
+    Descriptor metaEntry = attrsField.getMessageType();
+    // The map value type is Metadata (a message), not a plain string.
+    Descriptor metadataDesc = metaEntry.findFieldByName(FIELD_VALUE).getMessageType();
+
+    DynamicMessage homeAddr = DynamicMessage.newBuilder(addressDesc)
+        .setField(addressDesc.findFieldByName(FIELD_STREET), "1 Home")
+        .setField(addressDesc.findFieldByName(FIELD_CITY), "Hometown")
+        .setField(addressDesc.findFieldByName(FIELD_COUNTRY), VALUE_US)
+        .build();
+    DynamicMessage workAddr = DynamicMessage.newBuilder(addressDesc)
+        .setField(addressDesc.findFieldByName(FIELD_STREET), "2 Work")
+        .setField(addressDesc.findFieldByName(FIELD_CITY), "Worktown")
+        .setField(addressDesc.findFieldByName(FIELD_COUNTRY), VALUE_US)
+        .build();
+    DynamicMessage contactAddr = DynamicMessage.newBuilder(addressDesc)
+        .setField(addressDesc.findFieldByName(FIELD_STREET), "3 Friend Ln")
+        .setField(addressDesc.findFieldByName(FIELD_CITY), "Elsewhere")
+        .setField(addressDesc.findFieldByName(FIELD_COUNTRY), VALUE_US)
+        .build();
+    DynamicMessage contact = DynamicMessage.newBuilder(contactDesc)
+        .setField(contactDesc.findFieldByName(FIELD_NAME), VALUE_BOB)
+        .setField(contactDesc.findFieldByName("address"), contactAddr)
+        .build();
+    DynamicMessage endpoint = DynamicMessage.newBuilder(endpointDesc)
+        .setField(endpointDesc.findFieldByName("host"), "api.local")
+        .setField(endpointDesc.findFieldByName("port"), 443)
+        .build();
+    DynamicMessage nested = DynamicMessage.newBuilder(nestedDesc)
+        .setField(nestedDesc.findFieldByName("label"), "n1")
+        .setField(nestedDesc.findFieldByName("kind"),
+            nestedDesc.findFieldByName("kind").getEnumType().findValueByName("B"))
+        .build();
+
+    DynamicMessage event = DynamicMessage.newBuilder(eventDesc)
+        .setField(eventDesc.findFieldByName(FIELD_ID), "evt-1")
+        .setField(eventDesc.findFieldByName("priority"),
+            eventDesc.findFieldByName("priority").getEnumType().findValueByName("HIGH"))
+        .setField(eventDesc.findFieldByName("home_addr"), homeAddr)
+        .setField(eventDesc.findFieldByName("work_addr"), workAddr)
+        .addRepeatedField(eventDesc.findFieldByName("contacts"), contact)
+        .addRepeatedField(attrsField,
+            DynamicMessage.newBuilder(metaEntry)
+                .setField(metaEntry.findFieldByName(FIELD_KEY), "env")
+                .setField(metaEntry.findFieldByName(FIELD_VALUE),
+                    DynamicMessage.newBuilder(metadataDesc)
+                        .setField(metadataDesc.findFieldByName(FIELD_KEY), "env-key")
+                        .setField(metadataDesc.findFieldByName(FIELD_VALUE), "prod")
+                        .build())
+                .build())
+        .setField(eventDesc.findFieldByName("endpoint"), endpoint)
+        .setField(eventDesc.findFieldByName("nested"), nested)
+        .build();
+
+    assertFullFidelityRoundTrip(topic, schema, event);
+  }
+
+  @Test
+  public void testIdempotencyKitchenSinkStableAcrossCycles() {
+    Schema schema = SchemaBuilder.struct()
+        .name("IdempotencyTarget")
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .field(FIELD_VALUE, Schema.INT32_SCHEMA)
+        .field(FIELD_NAME, Schema.OPTIONAL_STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema)
+        .put(FIELD_ID, "idem-1")
+        .put(FIELD_VALUE, 42)
+        .put(FIELD_NAME, "stable");
+
+    byte[] wire0 = plainConverter.fromConnectData(TOPIC, schema, value);
+    int id0 = ByteBuffer.wrap(wire0, 1, 4).getInt();
+
+    SchemaAndValue wrapped1 = converter.toConnectData(TOPIC, wire0);
+    byte[] restored1 = converter.fromConnectData(TOPIC, wrapped1.schema(), wrapped1.value());
+    int id1 = ByteBuffer.wrap(restored1, 1, 4).getInt();
+
+    SchemaAndValue wrapped2 = converter.toConnectData(TOPIC, restored1);
+    byte[] restored2 = converter.fromConnectData(TOPIC, wrapped2.schema(), wrapped2.value());
+    int id2 = ByteBuffer.wrap(restored2, 1, 4).getInt();
+
+    assertEquals("schema ID stable across cycle 1", id0, id1);
+    assertEquals("schema ID stable across cycle 2", id1, id2);
+    assertArrayEquals("wire bytes stable across cycles", restored1, restored2);
+
+    Struct w1 = (Struct) wrapped1.value();
+    Struct w2 = (Struct) wrapped2.value();
+    assertEquals("wrapper raw schema stable",
+        w1.getString(BackupWrapper.FIELD_RAW_SCHEMA),
+        w2.getString(BackupWrapper.FIELD_RAW_SCHEMA));
+    assertEquals("wrapper schema ID stable",
+        w1.getInt32(BackupWrapper.FIELD_SCHEMA_ID),
+        w2.getInt32(BackupWrapper.FIELD_SCHEMA_ID));
+  }
+
+  @Test
+  public void testDefaultBytesFieldPreserved() {
+    String topic = nextTopic();
+    String proto = PROTO_HEADER
+        + "message BytesRec {\n"
         + "  string id = 1;\n"
-        + "  map<string, Service> services = 2;\n"
-        + "}\n"
-        + "message Service {\n"
-        + "  string host = 1;\n"
-        + "  int32 port = 2;\n"
-        + "  bool healthy = 3;\n"
+        + "  bytes payload = 2;\n"
         + "}\n";
-
-    ProtobufSchema schema = new ProtobufSchema(proto);
-    Descriptor regDesc = schema.toDescriptor();
-    FieldDescriptor svcField = regDesc.findFieldByName("services");
-    Descriptor entryDesc = svcField.getMessageType();
-    Descriptor svcDesc = entryDesc.findFieldByName("value").getMessageType();
-
-    DynamicMessage svc1 = DynamicMessage.newBuilder(svcDesc)
-        .setField(svcDesc.findFieldByName(FIELD_HOST), "api.local")
-        .setField(svcDesc.findFieldByName(FIELD_PORT), 8080)
-        .setField(svcDesc.findFieldByName("healthy"), true)
-        .build();
-    DynamicMessage svc2 = DynamicMessage.newBuilder(svcDesc)
-        .setField(svcDesc.findFieldByName(FIELD_HOST), "db.local")
-        .setField(svcDesc.findFieldByName(FIELD_PORT), 5432)
-        .setField(svcDesc.findFieldByName("healthy"), false)
-        .build();
-
-    DynamicMessage registry = DynamicMessage.newBuilder(regDesc)
-        .setField(regDesc.findFieldByName(FIELD_ID), "cluster-1")
-        .addRepeatedField(svcField,
-            DynamicMessage.newBuilder(entryDesc)
-                .setField(entryDesc.findFieldByName(FIELD_KEY), "api")
-                .setField(entryDesc.findFieldByName("value"), svc1)
-                .build())
-        .addRepeatedField(svcField,
-            DynamicMessage.newBuilder(entryDesc)
-                .setField(entryDesc.findFieldByName(FIELD_KEY), "database")
-                .setField(entryDesc.findFieldByName("value"), svc2)
-                .build())
-        .build();
-
-    assertBackupRoundTrip(topic, schema, registry);
-  }
-
-  @Test
-  public void testBackupRoundTripDefaultsAndEmpty() {
-    String topic = nextTopic();
-    String proto = "syntax = \"proto3\";\n"
-        + "package io.confluent.test;\n"
-        + "message Defaults {\n"
-        + "  string name = 1;\n"
-        + "  int32 count = 2;\n"
-        + "  bool flag = 3;\n"
-        + "  double rate = 4;\n"
-        + "}\n";
-
     ProtobufSchema schema = new ProtobufSchema(proto);
     Descriptor desc = schema.toDescriptor();
-
-    // All defaults (empty message — proto3 defaults are 0/""/false)
-    DynamicMessage empty = DynamicMessage.newBuilder(desc).build();
-    assertBackupRoundTrip(topic, schema, empty);
+    byte[] payload = new byte[]{0x00, 0x7F, (byte) 0x80, (byte) 0xFF};
+    DynamicMessage msg = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName(FIELD_ID), "b-1")
+        .setField(desc.findFieldByName("payload"), ByteString.copyFrom(payload))
+        .build();
+    assertFullFidelityRoundTrip(topic, schema, msg);
   }
 
   @Test
-  public void testBackupRoundTripComplexCombined() {
+  public void testDefaultEmptyCollectionsPreserved() {
     String topic = nextTopic();
-    String proto = "syntax = \"proto3\";\n"
-        + "package io.confluent.test;\n"
-        + "message ComplexRecord {\n"
+    String proto = PROTO_HEADER
+        + "message EmptyColl {\n"
         + "  string id = 1;\n"
-        + "  repeated Tag tags = 2;\n"
-        + "  map<string, string> metadata = 3;\n"
-        + "  optional string description = 4;\n"
-        + "  Status status = 5;\n"
-        + "  oneof target {\n"
-        + "    string url = 6;\n"
-        + "    Endpoint endpoint = 7;\n"
-        + "  }\n"
-        + "  Endpoint primary = 8;\n"
-        + "  Endpoint secondary = 9;\n"
-        + "}\n"
-        + "message Tag {\n"
-        + "  string key = 1;\n"
-        + "  string value = 2;\n"
-        + "}\n"
-        + "message Endpoint {\n"
-        + "  string host = 1;\n"
-        + "  int32 port = 2;\n"
-        + "}\n"
-        + "enum Status {\n"
-        + "  UNKNOWN = 0;\n"
-        + "  ACTIVE = 1;\n"
-        + "  INACTIVE = 2;\n"
+        + "  repeated string tags = 2;\n"
+        + "  map<string, int32> scores = 3;\n"
         + "}\n";
-
     ProtobufSchema schema = new ProtobufSchema(proto);
-    Descriptor recDesc = schema.toDescriptor();
-    Descriptor tagDesc = recDesc.findFieldByName("tags").getMessageType();
-    Descriptor epDesc = recDesc.findFieldByName("primary").getMessageType();
-    FieldDescriptor metaField = recDesc.findFieldByName("metadata");
-    Descriptor metaEntry = metaField.getMessageType();
-
-    DynamicMessage tag1 = DynamicMessage.newBuilder(tagDesc)
-        .setField(tagDesc.findFieldByName(FIELD_KEY), "env")
-        .setField(tagDesc.findFieldByName("value"), "prod")
+    Descriptor desc = schema.toDescriptor();
+    DynamicMessage msg = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName(FIELD_ID), "e-1")
         .build();
-    DynamicMessage tag2 = DynamicMessage.newBuilder(tagDesc)
-        .setField(tagDesc.findFieldByName(FIELD_KEY), "region")
-        .setField(tagDesc.findFieldByName("value"), "us-west")
-        .build();
-    DynamicMessage primary = DynamicMessage.newBuilder(epDesc)
-        .setField(epDesc.findFieldByName(FIELD_HOST), "primary.local")
-        .setField(epDesc.findFieldByName(FIELD_PORT), 443)
-        .build();
-    DynamicMessage secondary = DynamicMessage.newBuilder(epDesc)
-        .setField(epDesc.findFieldByName(FIELD_HOST), "secondary.local")
-        .setField(epDesc.findFieldByName(FIELD_PORT), 8443)
-        .build();
-    DynamicMessage oneofEndpoint = DynamicMessage.newBuilder(epDesc)
-        .setField(epDesc.findFieldByName(FIELD_HOST), "target.local")
-        .setField(epDesc.findFieldByName(FIELD_PORT), 9090)
-        .build();
-
-    DynamicMessage record = DynamicMessage.newBuilder(recDesc)
-        .setField(recDesc.findFieldByName(FIELD_ID), "rec-complex")
-        .addRepeatedField(recDesc.findFieldByName("tags"), tag1)
-        .addRepeatedField(recDesc.findFieldByName("tags"), tag2)
-        .addRepeatedField(metaField,
-            DynamicMessage.newBuilder(metaEntry)
-                .setField(metaEntry.findFieldByName(FIELD_KEY), "owner")
-                .setField(metaEntry.findFieldByName("value"), "team-a")
-                .build())
-        .setField(recDesc.findFieldByName("description"), "complex test")
-        .setField(recDesc.findFieldByName("status"),
-            recDesc.findFieldByName("status").getEnumType().findValueByName("ACTIVE"))
-        .setField(recDesc.findFieldByName("endpoint"), oneofEndpoint)
-        .setField(recDesc.findFieldByName("primary"), primary)
-        .setField(recDesc.findFieldByName("secondary"), secondary)
-        .build();
-
-    assertBackupRoundTrip(topic, schema, record);
+    assertFullFidelityRoundTrip(topic, schema, msg);
   }
 
   @Test
-  public void testBackupSchemaVersionPresent() {
+  public void testDefaultUnicodeInPayloadPreserved() {
+    String topic = nextTopic();
+    String proto = PROTO_HEADER
+        + "message UniRec {\n"
+        + "  string id = 1;\n"
+        + "  string label = 2;\n"
+        + "}\n";
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor desc = schema.toDescriptor();
+    DynamicMessage msg = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName(FIELD_ID), "u-1")
+        .setField(desc.findFieldByName("label"), "Hello world unicode: cafe naive")
+        .build();
+    assertFullFidelityRoundTrip(topic, schema, msg);
+  }
+
+  @Test
+  public void testDefaultMapFieldSemanticEquivalencePermittedReorder() {
+    // Protobuf wire format has no defined element order for maps, so byte fidelity is
+    // not asserted here; multi-entry maps may re-emit entries in a different order.
+    String topic = nextTopic();
+    String proto = PROTO_HEADER
+        + "message MapRec {\n"
+        + "  string id = 1;\n"
+        + "  map<string, int32> scores = 2;\n"
+        + "}\n";
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor desc = schema.toDescriptor();
+    FieldDescriptor scoresField = desc.findFieldByName("scores");
+    Descriptor entryDesc = scoresField.getMessageType();
+    Map<String, Integer> scores = new HashMap<>();
+    scores.put("engagement", 95);
+    scores.put("risk", 10);
+    scores.put("velocity", 42);
+    DynamicMessage.Builder builder = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName(FIELD_ID), "m-1");
+    for (Map.Entry<String, Integer> e : scores.entrySet()) {
+      builder.addRepeatedField(scoresField,
+          DynamicMessage.newBuilder(entryDesc)
+              .setField(entryDesc.findFieldByName(FIELD_KEY), e.getKey())
+              .setField(entryDesc.findFieldByName(FIELD_VALUE), e.getValue())
+              .build());
+    }
+    DynamicMessage msg = builder.build();
+
+    byte[] originalBytes = serializer.serialize(topic, null, msg, schema);
+    SchemaAndValue wrapped = converter.toConnectData(topic, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    assertWrapperShape(wrapped, SCHEMA_TYPE);
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
+    Message originalDeser = deserializer.deserialize(topic, originalBytes);
+    Message restoredDeser = deserializer.deserialize(topic, restoredBytes);
+    assertValueEqual(originalDeser, restoredDeser);
+  }
+
+  @Test
+  public void testDefaultPristineRestoreWithRawProtoProducer() throws Exception {
+    String topic = nextTopic();
+    String proto = PROTO_HEADER
+        + "message PristineEvent {\n"
+        + "  string id = 1;\n"
+        + "  int32 count = 2;\n"
+        + "  string note = 3;\n"
+        + "}\n";
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor desc = schema.toDescriptor();
+    DynamicMessage msg = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName(FIELD_ID), "pristine-1")
+        .setField(desc.findFieldByName("count"), 42)
+        .setField(desc.findFieldByName("note"), "e2e")
+        .build();
+
+    byte[] sourceBytes = serializer.serialize(topic, null, msg, schema);
+    SchemaAndValue wrapped = converter.toConnectData(topic, sourceBytes);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    assertWrapperShape(wrapped, SCHEMA_TYPE);
+    assertWrapperSchemaIdMatchesSource(wrapped, sourceBytes);
+    assertRawSchemaMatchesSourceRegistered(wrapped, sourceBytes);
+    assertWireSchemaIdPreserved(sourceBytes, restoredBytes);
+    assertPayloadBytesEqual(sourceBytes, restoredBytes);
+    assertBytesExact(sourceBytes, restoredBytes);
+    Message originalDeser = deserializer.deserialize(topic, sourceBytes);
+    Message restoredDeser = deserializer.deserialize(topic, restoredBytes);
+    assertValueEqual(originalDeser, restoredDeser);
+  }
+
+  @Test
+  public void testDefaultPristineRestoreMegaKitchenSinkAllTypesAndReferences() throws Exception {
+    // wrapper.for.raw.primitives=false is required because the mega schema contains
+    // google.protobuf.*Value fields; default true unwraps them and corrupts wire fidelity.
+    converter.configure(backupConfigWith("wrapper.for.raw.primitives", "false"), false);
+
+    String topic = nextTopic();
+
+    String addressProto = "syntax = \"proto3\";\n"
+        + "package io.confluent.test.shared;\n"
+        + "message Address {\n"
+        + "  string street = 1;\n"
+        + "  string city = 2;\n"
+        + "  string country = 3;\n"
+        + "}\n";
+    ProtobufSchema addressSchema = new ProtobufSchema(addressProto);
+    schemaRegistry.register(ADDRESS_REFNAME, addressSchema);
+
+    String personProto = "syntax = \"proto3\";\n"
+        + "package io.confluent.test;\n"
+        + "import \"shared/address.proto\";\n"
+        + "import \"google/protobuf/wrappers.proto\";\n"
+        + "message MegaPerson {\n"
+        + "  string id = 1;\n"
+        + "  int32 age = 2;\n"
+        + "  int64 balance_cents = 3;\n"
+        + "  double rating = 4;\n"
+        + "  bool active = 5;\n"
+        + "  bytes payload = 6;\n"
+        + "  Priority priority = 7;\n"
+        + "  io.confluent.test.shared.Address home_addr = 8;\n"
+        + "  io.confluent.test.shared.Address work_addr = 9;\n"
+        + "  google.protobuf.StringValue nickname = 10;\n"
+        + "  google.protobuf.Int32Value score = 11;\n"
+        + "  google.protobuf.BoolValue verified = 12;\n"
+        + "  optional string tagline = 13;\n"
+        + "  repeated string tags = 14;\n"
+        + "  map<string, int32> attrs = 15;\n"
+        + "  oneof contact {\n"
+        + "    string email = 16;\n"
+        + "    string phone = 17;\n"
+        + "  }\n"
+        + "  Nested nested = 18;\n"
+        + "  message Nested {\n"
+        + "    string label = 1;\n"
+        + "    enum Kind { A = 0; B = 1; C = 2; }\n"
+        + "    Kind kind = 2;\n"
+        + "  }\n"
+        + "}\n"
+        + "enum Priority { LOW = 0; MEDIUM = 1; HIGH = 2; }\n";
+    SchemaReference addressRef =
+        new SchemaReference(ADDRESS_REFNAME, ADDRESS_REFNAME, 1);
+    Map<String, String> resolvedRefs = new HashMap<>();
+    resolvedRefs.put(ADDRESS_REFNAME, addressProto);
+    ProtobufSchema personSchema = new ProtobufSchema(
+        personProto, Collections.singletonList(addressRef), resolvedRefs, null, null);
+    schemaRegistry.register(topic + "-value", personSchema);
+
+    Descriptor personDesc = personSchema.toDescriptor();
+    Descriptor addressDesc = personDesc.findFieldByName("home_addr").getMessageType();
+    Descriptor nestedDesc = personDesc.findFieldByName("nested").getMessageType();
+
+    DynamicMessage home = DynamicMessage.newBuilder(addressDesc)
+        .setField(addressDesc.findFieldByName(FIELD_STREET), "1 Home Ln")
+        .setField(addressDesc.findFieldByName(FIELD_CITY), "Hometown")
+        .setField(addressDesc.findFieldByName(FIELD_COUNTRY), VALUE_US)
+        .build();
+    DynamicMessage work = DynamicMessage.newBuilder(addressDesc)
+        .setField(addressDesc.findFieldByName(FIELD_STREET), "2 Work Ave")
+        .setField(addressDesc.findFieldByName(FIELD_CITY), "Workville")
+        .setField(addressDesc.findFieldByName(FIELD_COUNTRY), VALUE_US)
+        .build();
+    DynamicMessage nested = DynamicMessage.newBuilder(nestedDesc)
+        .setField(nestedDesc.findFieldByName("label"), "n1")
+        .setField(nestedDesc.findFieldByName("kind"),
+            nestedDesc.findFieldByName("kind").getEnumType().findValueByName("B"))
+        .build();
+    // Build wrapper submessages
+    Descriptor strValDesc = personDesc.findFieldByName("nickname").getMessageType();
+    Descriptor intValDesc = personDesc.findFieldByName("score").getMessageType();
+    Descriptor boolValDesc = personDesc.findFieldByName("verified").getMessageType();
+    DynamicMessage nickname = DynamicMessage.newBuilder(strValDesc)
+        .setField(strValDesc.findFieldByName(FIELD_VALUE), "nick1").build();
+    DynamicMessage score = DynamicMessage.newBuilder(intValDesc)
+        .setField(intValDesc.findFieldByName(FIELD_VALUE), 100).build();
+    DynamicMessage verified = DynamicMessage.newBuilder(boolValDesc)
+        .setField(boolValDesc.findFieldByName(FIELD_VALUE), true).build();
+    // Single-key map to avoid Protobuf-spec-permitted reorder
+    FieldDescriptor attrsField = personDesc.findFieldByName("attrs");
+    Descriptor attrsEntryDesc = attrsField.getMessageType();
+    DynamicMessage attrEntry = DynamicMessage.newBuilder(attrsEntryDesc)
+        .setField(attrsEntryDesc.findFieldByName(FIELD_KEY), "env")
+        .setField(attrsEntryDesc.findFieldByName(FIELD_VALUE), 1)
+        .build();
+
+    DynamicMessage person = DynamicMessage.newBuilder(personDesc)
+        .setField(personDesc.findFieldByName(FIELD_ID), "person-1")
+        .setField(personDesc.findFieldByName("age"), 30)
+        .setField(personDesc.findFieldByName("balance_cents"), 100_000L)
+        .setField(personDesc.findFieldByName("rating"), 4.5)
+        .setField(personDesc.findFieldByName("active"), true)
+        .setField(personDesc.findFieldByName("payload"),
+            ByteString.copyFrom(new byte[]{0x00, 0x7F, (byte) 0x80, (byte) 0xFF}))
+        .setField(personDesc.findFieldByName("priority"),
+            personDesc.findFieldByName("priority").getEnumType().findValueByName("HIGH"))
+        .setField(personDesc.findFieldByName("home_addr"), home)
+        .setField(personDesc.findFieldByName("work_addr"), work)
+        .setField(personDesc.findFieldByName("nickname"), nickname)
+        .setField(personDesc.findFieldByName("score"), score)
+        .setField(personDesc.findFieldByName("verified"), verified)
+        .setField(personDesc.findFieldByName("tagline"), "Mega tagline")
+        .addRepeatedField(personDesc.findFieldByName("tags"), "premium")
+        .addRepeatedField(attrsField, attrEntry)
+        .setField(personDesc.findFieldByName("email"), "person@x.com")
+        .setField(personDesc.findFieldByName("nested"), nested)
+        .build();
+
+    byte[] sourceBytes = serializer.serialize(topic, null, person, personSchema);
+
+    SchemaAndValue wrapped = converter.toConnectData(topic, sourceBytes);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    assertWrapperShape(wrapped, SCHEMA_TYPE);
+    assertWrapperSchemaIdMatchesSource(wrapped, sourceBytes);
+    assertWireSchemaIdPreserved(sourceBytes, restoredBytes);
+    assertPayloadBytesEqual(sourceBytes, restoredBytes);
+    assertBytesExact(sourceBytes, restoredBytes);
+
+    // Cross-subject reference metadata explicitly captured on the wrapper.
+    Struct wrapperStruct = (Struct) wrapped.value();
+    String refTree = wrapperStruct.getString(BackupWrapper.FIELD_REFERENCE_TREE);
+    String directRefs = wrapperStruct.getString(BackupWrapper.FIELD_DIRECT_REFS);
+    assertNotNull("mega wrapper captures reference tree", refTree);
+    assertNotNull("mega wrapper captures direct refs", directRefs);
+    assertTrue("reference tree mentions Address refName: " + refTree,
+        refTree.contains(ADDRESS_REFNAME));
+    assertTrue("direct refs mention Address subject: " + directRefs,
+        directRefs.contains(ADDRESS_REFNAME));
+
+    // Source SR still resolves both the main schema (with its reference) and the Address schema.
+    ParsedSchema registeredPerson = schemaRegistry.getLatestSchemaMetadata(topic + "-value") != null
+        ? schemaRegistry.getSchemaBySubjectAndId(topic + "-value",
+            schemaRegistry.getLatestSchemaMetadata(topic + "-value").getId())
+        : null;
+    assertNotNull("Person schema resolvable from source SR after restore", registeredPerson);
+    List<SchemaReference> personRefs = registeredPerson.references();
+    assertEquals("Person has one direct reference (Address)", 1, personRefs.size());
+    assertEquals("Person reference refName matches Address",
+        ADDRESS_REFNAME, personRefs.get(0).getName());
+    assertEquals("Person reference subject matches Address",
+        ADDRESS_REFNAME, personRefs.get(0).getSubject());
+    assertNotNull("Address schema resolvable from source SR by subject",
+        schemaRegistry.getLatestSchemaMetadata(ADDRESS_REFNAME));
+
+    // Semantic: restored bytes still parse via the same schema + reference chain.
+    Message restoredDeser = deserializer.deserialize(topic, restoredBytes);
+    assertNotNull("restored bytes parseable via schema", restoredDeser);
+    assertEquals("restored bytes deserialize to the same message",
+        person.toString(), restoredDeser.toString());
+  }
+
+  private static final String ADDRESS_SCHEMA_PROTO =
+      "syntax = \"proto3\";\n"
+          + "package io.confluent.test.shared;\n"
+          + "message Address {\n"
+          + "  string street = 1;\n"
+          + "  string city = 2;\n"
+          + "  string country = 3;\n"
+          + "}\n";
+  // For Protobuf references, both the refName and the SR subject use the .proto filename.
+  private static final String ADDRESS_REFNAME = "shared/address.proto";
+  private static final String ADDRESS_SUBJECT = "shared/address.proto";
+
+  private static final String PERSON_WITH_REF_SCHEMA_PROTO =
+      "syntax = \"proto3\";\n"
+          + "package io.confluent.test;\n"
+          + "import \"shared/address.proto\";\n"
+          + "message PersonRef {\n"
+          + "  string name = 1;\n"
+          + "  io.confluent.test.shared.Address home_addr = 2;\n"
+          + "  io.confluent.test.shared.Address work_addr = 3;\n"
+          + "}\n";
+
+  private RefTestFixture registerAndProducePersonWithAddressRef() throws Exception {
+    String topic = nextTopic();
+    ProtobufSchema addressSchema = new ProtobufSchema(ADDRESS_SCHEMA_PROTO);
+    schemaRegistry.register(ADDRESS_SUBJECT, addressSchema);
+    SchemaReference addressRef = new SchemaReference(ADDRESS_REFNAME, ADDRESS_SUBJECT, 1);
+    Map<String, String> resolved = new HashMap<>();
+    resolved.put(ADDRESS_REFNAME, ADDRESS_SCHEMA_PROTO);
+    ProtobufSchema personSchema = new ProtobufSchema(
+        PERSON_WITH_REF_SCHEMA_PROTO, Collections.singletonList(addressRef),
+        resolved, null, null);
+    schemaRegistry.register(topic + "-value", personSchema);
+
+    Descriptor personDesc = personSchema.toDescriptor();
+    Descriptor addressDesc = personDesc.findFieldByName("home_addr").getMessageType();
+    DynamicMessage addr = DynamicMessage.newBuilder(addressDesc)
+        .setField(addressDesc.findFieldByName(FIELD_STREET), "1 Main St")
+        .setField(addressDesc.findFieldByName(FIELD_CITY), "Springfield")
+        .setField(addressDesc.findFieldByName(FIELD_COUNTRY), VALUE_US)
+        .build();
+    DynamicMessage person = DynamicMessage.newBuilder(personDesc)
+        .setField(personDesc.findFieldByName(FIELD_NAME), VALUE_ALICE)
+        .setField(personDesc.findFieldByName("home_addr"), addr)
+        .setField(personDesc.findFieldByName("work_addr"), addr)
+        .build();
+    KafkaProtobufSerializer<DynamicMessage> refSerializer =
+        newReferenceAwareProtobufSerializer(schemaRegistry);
+    byte[] sourceBytes = refSerializer.serialize(topic, person);
+    return new RefTestFixture(topic, sourceBytes);
+  }
+
+  private static final class RefTestFixture {
+    final String topic;
+    final byte[] sourceBytes;
+    RefTestFixture(String topic, byte[] sourceBytes) {
+      this.topic = topic;
+      this.sourceBytes = sourceBytes;
+    }
+  }
+
+  @Test
+  public void testDefaultPristineRestoreCrossClusterWithCrossSubjectReferences()
+      throws Exception {
+    RefTestFixture fx = registerAndProducePersonWithAddressRef();
+    int sourceWireId = ByteBuffer.wrap(fx.sourceBytes, 1, 4).getInt();
+    String sourcePersonCanonical =
+        schemaRegistry.getSchemaById(sourceWireId).canonicalString();
+
+    SchemaAndValue wrapped = converter.toConnectData(fx.topic, fx.sourceBytes);
+
+    assertWrapperShape(wrapped, SCHEMA_TYPE);
+    assertWrapperSchemaIdMatchesSource(wrapped, fx.sourceBytes);
+    Struct wrapperStruct = (Struct) wrapped.value();
+    assertEquals("wrapper rawSchema equals source-registered canonical form",
+        sourcePersonCanonical,
+        wrapperStruct.getString(BackupWrapper.FIELD_RAW_SCHEMA));
+    String refTree = wrapperStruct.getString(BackupWrapper.FIELD_REFERENCE_TREE);
+    String directRefs = wrapperStruct.getString(BackupWrapper.FIELD_DIRECT_REFS);
+    assertNotNull("reference tree captured", refTree);
+    assertNotNull("direct refs captured", directRefs);
+    assertTrue("reference tree mentions Address refName: " + refTree,
+        refTree.contains(ADDRESS_REFNAME));
+    assertTrue("direct refs mention Address subject: " + directRefs,
+        directRefs.contains(ADDRESS_SUBJECT));
+
+    assertTrue("target SR is empty before restore",
+        targetSchemaRegistry.getAllSubjects().isEmpty());
+    byte[] restoredBytes = targetConverter.fromConnectData(
+        fx.topic, wrapped.schema(), wrapped.value());
+
+    assertTrue("target SR has Address subject",
+        targetSchemaRegistry.getAllSubjects().contains(ADDRESS_SUBJECT));
+    assertTrue("target SR has Person subject",
+        targetSchemaRegistry.getAllSubjects().contains(fx.topic + "-value"));
+
+    assertCrossClusterBytesEquivalent(fx.sourceBytes, restoredBytes);
+
+    int targetWireId = ByteBuffer.wrap(restoredBytes, 1, 4).getInt();
+    ParsedSchema targetPersonSchema = targetSchemaRegistry.getSchemaById(targetWireId);
+    assertNotNull("target SR resolves the restored wire ID", targetPersonSchema);
+    assertEquals("target Person canonical == source Person canonical",
+        sourcePersonCanonical, targetPersonSchema.canonicalString());
+    List<SchemaReference> targetRefs = targetPersonSchema.references();
+    assertEquals("target Person has one direct reference (Address)", 1, targetRefs.size());
+    assertEquals("target ref refName matches source",
+        ADDRESS_REFNAME, targetRefs.get(0).getName());
+    assertEquals("target ref subject matches source", ADDRESS_SUBJECT,
+        targetRefs.get(0).getSubject());
+    assertTrue("target ref version is a positive integer",
+        targetRefs.get(0).getVersion() > 0);
+
+    Message sourceValue = deserializer.deserialize(fx.topic, fx.sourceBytes);
+    Message targetValue = targetDeserializer.deserialize(fx.topic, restoredBytes);
+    assertNotNull("source deserialized non-null", sourceValue);
+    assertNotNull("target deserialized non-null", targetValue);
+    assertEquals("Protobuf textual form of restored record equals source's",
+        sourceValue.toString(), targetValue.toString());
+  }
+
+  // ================ Cross-subject reference negatives ================
+
+  @Test
+  public void testEdgeReferenceTreeMissingEntryThrows() throws Exception {
+    RefTestFixture fx = registerAndProducePersonWithAddressRef();
+    SchemaAndValue wrapped = converter.toConnectData(fx.topic, fx.sourceBytes);
+
+    Struct original = (Struct) wrapped.value();
+    Schema wrapperSchema = wrapped.schema();
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_ID),
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION),
+        original.getString(BackupWrapper.FIELD_SCHEMA_TYPE),
+        original.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT),
+        original.getString(BackupWrapper.FIELD_RAW_SCHEMA),
+        "{}",
+        original.getString(BackupWrapper.FIELD_DIRECT_REFS));
+    Struct badWrapper = BackupWrapper.buildWrapper(
+        wrapperSchema, original.get(BackupWrapper.FIELD_DATA), fields);
+
+    try {
+      converter.fromConnectData(fx.topic, wrapperSchema, badWrapper);
+      fail("Expected DataException for empty reference tree with populated direct refs");
+    } catch (DataException e) {
+      assertEquals("Corrupt backup wrapper: partial reference metadata "
+          + "(treeEmpty=true, directRefsEmpty=false)", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testEdgeCorruptReferenceTreeJsonThrows() throws Exception {
+    RefTestFixture fx = registerAndProducePersonWithAddressRef();
+    SchemaAndValue wrapped = converter.toConnectData(fx.topic, fx.sourceBytes);
+
+    Struct original = (Struct) wrapped.value();
+    Schema wrapperSchema = wrapped.schema();
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_ID),
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION),
+        original.getString(BackupWrapper.FIELD_SCHEMA_TYPE),
+        original.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT),
+        original.getString(BackupWrapper.FIELD_RAW_SCHEMA),
+        "{ not valid json",
+        original.getString(BackupWrapper.FIELD_DIRECT_REFS));
+    Struct badWrapper = BackupWrapper.buildWrapper(
+        wrapperSchema, original.get(BackupWrapper.FIELD_DATA), fields);
+
+    try {
+      converter.fromConnectData(fx.topic, wrapperSchema, badWrapper);
+      fail("Expected DataException on corrupt reference tree JSON");
+    } catch (DataException e) {
+      assertEquals("Cannot parse reference tree JSON for restore. "
+          + "Backup metadata may be corrupt.", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testEdgeDirectRefsWithoutReferenceTreeThrows() throws Exception {
+    RefTestFixture fx = registerAndProducePersonWithAddressRef();
+    SchemaAndValue wrapped = converter.toConnectData(fx.topic, fx.sourceBytes);
+
+    Struct original = (Struct) wrapped.value();
+    Schema wrapperSchema = wrapped.schema();
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_ID),
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION),
+        original.getString(BackupWrapper.FIELD_SCHEMA_TYPE),
+        original.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT),
+        original.getString(BackupWrapper.FIELD_RAW_SCHEMA),
+        null,
+        original.getString(BackupWrapper.FIELD_DIRECT_REFS));
+    Struct badWrapper = BackupWrapper.buildWrapper(
+        wrapperSchema, original.get(BackupWrapper.FIELD_DATA), fields);
+
+    try {
+      converter.fromConnectData(fx.topic, wrapperSchema, badWrapper);
+      fail("Expected DataException on directRefs-without-reference-tree corruption");
+    } catch (DataException e) {
+      assertEquals("Corrupt backup wrapper: partial reference metadata "
+          + "(treeEmpty=true, directRefsEmpty=false)", e.getMessage());
+    }
+  }
+
+  // ================ Config-lossiness pairs (same config on/off) ================
+
+  @Test
+  public void testEnumNamesIntForEnumsOffSurvive() {
+    // Use default configuration (int.for.enums defaults to false).
+    String topic = nextTopic();
+    String proto = PROTO_HEADER
+        + "message Event {\n"
+        + "  string id = 1;\n"
+        + "  EventType type = 2;\n"
+        + "}\n"
+        + "enum EventType { UNKNOWN = 0; CLICK = 1; VIEW = 2; PURCHASE = 3; }\n";
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor desc = schema.toDescriptor();
+    DynamicMessage event = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName(FIELD_ID), "evt-1")
+        .setField(desc.findFieldByName("type"),
+            desc.findFieldByName("type").getEnumType().findValueByName("PURCHASE"))
+        .build();
+
+    assertFullFidelityRoundTrip(topic, schema, event);
+    // Confirm the raw schema still declares the enum symbol names.
+    byte[] originalBytes = serializer.serialize(topic, null, event, schema);
+    SchemaAndValue wrapped = converter.toConnectData(topic, originalBytes);
+    String raw = ((Struct) wrapped.value()).getString(BackupWrapper.FIELD_RAW_SCHEMA);
+    assertTrue("raw schema retains enum symbol PURCHASE", raw.contains("PURCHASE"));
+  }
+
+  @Test
+  public void testEnumNamesIntForEnumsOnConnectSchemaLosesSymbols() {
+    // Re-configure with int.for.enums=true
+    converter.configure(backupConfigWith("int.for.enums", "true"), false);
+
+    String topic = nextTopic();
+    String proto = PROTO_HEADER
+        + "message Event {\n"
+        + "  string id = 1;\n"
+        + "  EventType type = 2;\n"
+        + "}\n"
+        + "enum EventType { UNKNOWN = 0; CLICK = 1; VIEW = 2; PURCHASE = 3; }\n";
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor desc = schema.toDescriptor();
+    DynamicMessage event = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName(FIELD_ID), "evt-1")
+        .setField(desc.findFieldByName("type"),
+            desc.findFieldByName("type").getEnumType().findValueByName("PURCHASE"))
+        .build();
+
+    byte[] originalBytes = serializer.serialize(topic, null, event, schema);
+    SchemaAndValue wrapped = converter.toConnectData(topic, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    // Bytes and wire ID still preserved. restore path uses the raw .proto.
+    assertBytesExact(originalBytes, restoredBytes);
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
+    // Raw .proto text is still source-of-truth so it still contains the symbols.
+    String raw = ((Struct) wrapped.value()).getString(BackupWrapper.FIELD_RAW_SCHEMA);
+    assertTrue("raw .proto DSL still contains PURCHASE", raw.contains("PURCHASE"));
+  }
+
+  @Test
+  public void testConnectMetaDataOnSharedTypeSurvives() {
+    // Default config. connect.meta.data defaults to true.
+    testDefaultSharedMessageTypeAtMultipleFieldsSurvives();
+  }
+
+  @Test
+  public void testConnectMetaDataOffConnectSchemaLosesTags() {
+    converter.configure(backupConfigWith("connect.meta.data", "false"), false);
+
+    String topic = nextTopic();
+    String proto = PROTO_HEADER
+        + "message Person {\n"
+        + "  string name = 1;\n"
+        + "  Address home_addr = 2;\n"
+        + "  Address work_addr = 3;\n"
+        + "}\n"
+        + "message Address {\n"
+        + "  string street = 1;\n"
+        + "  string city = 2;\n"
+        + "}\n";
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor personDesc = schema.toDescriptor();
+    Descriptor addressDesc = personDesc.findFieldByName("home_addr").getMessageType();
+
+    DynamicMessage homeAddr = DynamicMessage.newBuilder(addressDesc)
+        .setField(addressDesc.findFieldByName(FIELD_STREET), "1 Home")
+        .setField(addressDesc.findFieldByName(FIELD_CITY), "Hometown")
+        .build();
+    DynamicMessage workAddr = DynamicMessage.newBuilder(addressDesc)
+        .setField(addressDesc.findFieldByName(FIELD_STREET), "2 Work")
+        .setField(addressDesc.findFieldByName(FIELD_CITY), "Worktown")
+        .build();
+    DynamicMessage person = DynamicMessage.newBuilder(personDesc)
+        .setField(personDesc.findFieldByName(FIELD_NAME), VALUE_ALICE)
+        .setField(personDesc.findFieldByName("home_addr"), homeAddr)
+        .setField(personDesc.findFieldByName("work_addr"), workAddr)
+        .build();
+
+    byte[] originalBytes = serializer.serialize(topic, null, person, schema);
+    SchemaAndValue wrapped = converter.toConnectData(topic, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    // Converter-only roundtrip: raw .proto restores wire bytes fine.
+    assertBytesExact(originalBytes, restoredBytes);
+    // But the Connect schema built from these bytes lacks field-tag parameters,
+    // which is what an AvroFormat writer would need for the shared-type case.
+  }
+
+  @Test
+  public void testWrapperForRawPrimitivesFalsePreservesNestedWrappers() throws Exception {
+    converter.configure(backupConfigWith("wrapper.for.raw.primitives", "false"), false);
+
+    String topic = nextTopic();
+    String proto = PROTO_HEADER
+        + "import \"google/protobuf/wrappers.proto\";\n"
+        + "message WrapMsg {\n"
+        + "  string id = 1;\n"
+        + "  google.protobuf.StringValue nickname = 2;\n"
+        + "  google.protobuf.Int32Value score = 3;\n"
+        + "}\n";
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor desc = schema.toDescriptor();
+    Descriptor strValDesc = desc.findFieldByName("nickname").getMessageType();
+    Descriptor intValDesc = desc.findFieldByName("score").getMessageType();
+    DynamicMessage nickname = DynamicMessage.newBuilder(strValDesc)
+        .setField(strValDesc.findFieldByName(FIELD_VALUE), "nick").build();
+    DynamicMessage score = DynamicMessage.newBuilder(intValDesc)
+        .setField(intValDesc.findFieldByName(FIELD_VALUE), 42).build();
+    DynamicMessage msg = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName(FIELD_ID), "w-1")
+        .setField(desc.findFieldByName("nickname"), nickname)
+        .setField(desc.findFieldByName("score"), score)
+        .build();
+
+    byte[] originalBytes = serializer.serialize(topic, null, msg, schema);
+    SchemaAndValue wrapped = converter.toConnectData(topic, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    assertBytesExact(originalBytes, restoredBytes);
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
+    // Semantic: restored bytes parse as the same message with wrapper fields intact
+    Message restoredDeser = deserializer.deserialize(topic, restoredBytes);
+    assertEquals("nickname wrapper preserved after restore",
+        msg.toString(), restoredDeser.toString());
+  }
+
+  @Test
+  public void testWrapperForRawPrimitivesTrueDefaultCorruptsNestedWrappers() throws Exception {
+    // Default true unwraps nested google.protobuf.*Value wrappers during toConnectData;
+    // restored bytes differ from the original and may not deserialize via the same schema.
+    String topic = nextTopic();
+    String proto = PROTO_HEADER
+        + "import \"google/protobuf/wrappers.proto\";\n"
+        + "message WrapMsgCorrupt {\n"
+        + "  string id = 1;\n"
+        + "  google.protobuf.StringValue nickname = 2;\n"
+        + "}\n";
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor desc = schema.toDescriptor();
+    Descriptor strValDesc = desc.findFieldByName("nickname").getMessageType();
+    DynamicMessage nickname = DynamicMessage.newBuilder(strValDesc)
+        .setField(strValDesc.findFieldByName(FIELD_VALUE), "nick").build();
+    DynamicMessage msg = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName(FIELD_ID), "corrupt-1")
+        .setField(desc.findFieldByName("nickname"), nickname)
+        .build();
+
+    byte[] originalBytes = serializer.serialize(topic, null, msg, schema);
+    SchemaAndValue wrapped = converter.toConnectData(topic, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    // Wire schema ID is preserved (SR content dedupe), but bytes differ because nested
+    // wrappers get unwrapped to primitives.
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
+    assertFalse("restored bytes differ from original (wrappers unwrapped)",
+        Arrays.equals(originalBytes, restoredBytes));
+  }
+
+  // ================ Edge cases and error handling ================
+
+  @Test
+  public void testEdgeNullValue() {
+    SchemaAndValue result = converter.toConnectData(TOPIC, null);
+    assertNull(result.schema());
+    assertNull(result.value());
+  }
+
+  @Test
+  public void testEdgeBackupDisabledNoWrapping() {
     Schema schema = SchemaBuilder.struct()
-        .name("VersionCheck")
+        .name("NoBackup")
         .field("x", Schema.INT32_SCHEMA)
         .build();
-    Struct value = new Struct(schema).put("x", 42);
+    Struct value = new Struct(schema).put("x", 1);
 
     byte[] serialized = plainConverter.fromConnectData(TOPIC, schema, value);
-    SchemaAndValue result = converter.toConnectData(TOPIC, serialized);
+    SchemaAndValue result = plainConverter.toConnectData(TOPIC, serialized);
 
-    Struct wrapper = (Struct) result.value();
-    assertNotNull(wrapper.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION));
+    assertNotNull(result.schema());
+    assertNotEquals(BackupWrapper.NAME, result.schema().name());
   }
 
   @Test
-  public void testBackupRestoreNullRawSchemaThrows() {
+  public void testEdgeNonWrapperSchemaSerializesNormally() {
     Schema schema = SchemaBuilder.struct()
-        .name("FallbackMsg")
+        .name("DirectMsg")
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_NAME, "direct");
+
+    byte[] result = converter.fromConnectData(TOPIC, schema, value);
+    assertNotNull(result);
+    assertTrue(result.length > 5);
+    assertEquals(0x00, result[0]);
+  }
+
+  @Test
+  public void testEdgeMissingDataFieldThrows() {
+    Schema badSchema = SchemaBuilder.struct()
+        .name(BackupWrapper.NAME)
+        .field(BackupWrapper.FIELD_SCHEMA_ID, Schema.INT32_SCHEMA)
+        .build();
+    Struct badWrapper = new Struct(badSchema).put(BackupWrapper.FIELD_SCHEMA_ID, 1);
+
+    try {
+      converter.fromConnectData(TOPIC, badSchema, badWrapper);
+      fail("Expected DataException for wrapper missing 'data' field");
+    } catch (DataException e) {
+      assertEquals("Malformed backup wrapper: missing '" + BackupWrapper.FIELD_DATA + "' field",
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testEdgeNullRawSchemaThrows() {
+    Schema schema = SchemaBuilder.struct()
+        .name("Fallback")
         .field(FIELD_NAME, Schema.STRING_SCHEMA)
         .build();
     Struct value = new Struct(schema).put(FIELD_NAME, "fallback");
@@ -1008,10 +1339,300 @@ public class ProtobufConverterBackupTest {
       converter.fromConnectData(TOPIC, wrapperSchema, modifiedWrapper);
       fail("Expected DataException for null rawSchema");
     } catch (DataException e) {
-      assertTrue(e.getMessage(),
+      assertTrue("message references rawSchema field: " + e.getMessage(),
           e.getMessage().contains(BackupWrapper.FIELD_RAW_SCHEMA));
-      assertTrue(e.getMessage(),
+      assertTrue("message mentions pristine restore: " + e.getMessage(),
           e.getMessage().contains("pristine restore"));
     }
+  }
+
+  @Test
+  public void testEdgeBasicRoundtripDeserializes() {
+    Schema schema = SchemaBuilder.struct()
+        .name("RoundTripMsg")
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
+        .field(FIELD_VALUE, Schema.INT32_SCHEMA)
+        .build();
+    Struct original = new Struct(schema)
+        .put(FIELD_NAME, "test")
+        .put(FIELD_VALUE, 99);
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, original);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+    byte[] restoredBytes = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    SchemaAndValue restoredData = plainConverter.toConnectData(TOPIC, restoredBytes);
+    Struct restored = (Struct) restoredData.value();
+    assertEquals("test", restored.getString(FIELD_NAME));
+    assertEquals(Integer.valueOf(99), restored.getInt32(FIELD_VALUE));
+  }
+
+  @Test
+  public void testEdgeRestoreProducesMagicByte() {
+    Schema schema = SchemaBuilder.struct()
+        .name("SimpleMsg")
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_NAME, "hello");
+
+    byte[] original = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, original);
+    byte[] restored = converter.fromConnectData(TOPIC, wrapped.schema(), wrapped.value());
+
+    assertNotNull(restored);
+    assertTrue("restored bytes non-empty", restored.length > 0);
+    assertEquals("restored bytes start with magic byte", 0x00, restored[0]);
+  }
+
+  @Test
+  public void testEdgeSchemaTypeMismatchThrows() {
+    Schema schema = SchemaBuilder.struct()
+        .name("Mismatch")
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, "type-mismatch");
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    SchemaAndValue wrapped = converter.toConnectData(TOPIC, originalBytes);
+
+    Struct original = (Struct) wrapped.value();
+    Schema wrapperSchema = wrapped.schema();
+    BackupWrapper.WrapperFields fields = new BackupWrapper.WrapperFields(
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_ID),
+        original.getInt32(BackupWrapper.FIELD_SCHEMA_VERSION),
+        "AVRO",
+        original.getString(BackupWrapper.FIELD_SCHEMA_SUBJECT),
+        original.getString(BackupWrapper.FIELD_RAW_SCHEMA),
+        null, null);
+    Struct badWrapper = BackupWrapper.buildWrapper(
+        wrapperSchema, original.get(BackupWrapper.FIELD_DATA), fields);
+
+    try {
+      converter.fromConnectData(TOPIC, wrapperSchema, badWrapper);
+      fail("Expected DataException on schema type mismatch");
+    } catch (DataException e) {
+      assertEquals("ProtobufConverter received wrapper with schemaType='AVRO', "
+          + "expected 'PROTOBUF'", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testEdgeCorruptedWireIdRejected() {
+    Schema schema = SchemaBuilder.struct()
+        .name("Corrupt")
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, "corrupt");
+
+    byte[] originalBytes = plainConverter.fromConnectData(TOPIC, schema, value);
+    byte[] corrupted = originalBytes.clone();
+    ByteBuffer.wrap(corrupted, 1, 4).putInt(Integer.MAX_VALUE - 1);
+
+    try {
+      converter.toConnectData(TOPIC, corrupted);
+      fail("Expected DataException for corrupted wire schema ID");
+    } catch (DataException e) {
+      assertEquals("Failed to deserialize data for topic " + TOPIC + " to Protobuf:",
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testEdgeEmptyPayloadHandled() {
+    byte[] empty = new byte[0];
+    try {
+      converter.toConnectData(TOPIC, empty);
+      fail("Expected DataException for zero-length payload");
+    } catch (DataException e) {
+      assertEquals("Failed to deserialize data for topic " + TOPIC + " to Protobuf:",
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testEdgeSinkWrapErrorClassifiedAsBackupException() throws Exception {
+    // A SR client that fetches individual schemas normally (so deserialize succeeds)
+    // but throws on getAllVersionsById, which only the wrap path uses.
+    SchemaRegistryClient wrapFailingSr = new MockSchemaRegistryClient(
+        ImmutableList.of(new ProtobufSchemaProvider())) {
+      @Override
+      public Collection<SubjectVersion> getAllVersionsById(int id) {
+        throw new SerializationException("simulated SR unavailable during wrap");
+      }
+    };
+    ProtobufConverter wrapFailingConverter = new ProtobufConverter(wrapFailingSr);
+    Map<String, Object> cfg = new HashMap<>();
+    cfg.put(SR_URL_KEY, FAKE_SR_URL);
+    cfg.put(BACKUP_ENABLED_KEY, "true");
+    wrapFailingConverter.configure(cfg, false);
+
+    String topic = nextTopic();
+    String protoDef = "syntax = \"proto3\"; package io.confluent.test; "
+        + "message WrapFail { string id = 1; }";
+    ProtobufSchema protoSchema = new ProtobufSchema(protoDef);
+    wrapFailingSr.register(topic + "-value", protoSchema);
+    Descriptor desc = protoSchema.toDescriptor();
+    DynamicMessage msg = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName("id"), "wrap-fail").build();
+    KafkaProtobufSerializer<DynamicMessage> refSerializer =
+        newReferenceAwareProtobufSerializer(wrapFailingSr);
+    byte[] bytes = refSerializer.serialize(topic, null, msg, protoSchema);
+
+    try {
+      wrapFailingConverter.toConnectData(topic, bytes);
+      fail("Expected DataException when wrap-path SR call fails");
+    } catch (DataException e) {
+      assertEquals("Failed to wrap Protobuf backup for topic " + topic, e.getMessage());
+      assertTrue("cause is the simulated SerializationException",
+          e.getCause() instanceof SerializationException);
+    }
+  }
+
+  @Test
+  public void testHeaderSchemaIdSerializerBackupCapturesSchemaId() {
+    SchemaRegistryClient sr = new MockSchemaRegistryClient(
+        ImmutableList.of(new ProtobufSchemaProvider()));
+    ProtobufConverter headerBackupConverter = new ProtobufConverter(sr);
+    ProtobufConverter headerPlainConverter = new ProtobufConverter(sr);
+    Map<String, Object> backupCfg = new HashMap<>();
+    backupCfg.put(SR_URL_KEY, FAKE_SR_URL);
+    backupCfg.put(BACKUP_ENABLED_KEY, "true");
+    backupCfg.put(AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_SERIALIZER,
+        HeaderSchemaIdSerializer.class.getName());
+    backupCfg.put(AbstractKafkaSchemaSerDeConfig.VALUE_SCHEMA_ID_DESERIALIZER,
+        "io.confluent.kafka.serializers.schema.id.DualSchemaIdDeserializer");
+    headerBackupConverter.configure(backupCfg, false);
+    Map<String, Object> plainCfg = new HashMap<>(backupCfg);
+    plainCfg.remove(BACKUP_ENABLED_KEY);
+    headerPlainConverter.configure(plainCfg, false);
+
+    Schema schema = SchemaBuilder.struct()
+        .name("io.confluent.test.HeaderIdRecord")
+        .field(FIELD_ID, Schema.STRING_SCHEMA)
+        .field(FIELD_NAME, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema).put(FIELD_ID, "h-1").put(FIELD_NAME, "header-test");
+
+    Headers headers = new RecordHeaders();
+    byte[] serialized = headerPlainConverter.fromConnectData(TOPIC, headers, schema, value);
+    assertNotNull("value schema ID header present",
+        headers.lastHeader(SchemaId.VALUE_SCHEMA_ID_HEADER));
+
+    SchemaAndValue wrapped = headerBackupConverter.toConnectData(TOPIC, headers, serialized);
+
+    assertNotNull("wrapper produced", wrapped);
+    assertEquals("wrapper schema name", BackupWrapper.NAME, wrapped.schema().name());
+    Struct w = (Struct) wrapped.value();
+    assertEquals("schema type", SCHEMA_TYPE, w.getString(BackupWrapper.FIELD_SCHEMA_TYPE));
+    assertNotNull("raw schema captured", w.getString(BackupWrapper.FIELD_RAW_SCHEMA));
+    assertNotNull("wrapper populates schemaGuid from header",
+        w.getString(BackupWrapper.FIELD_SCHEMA_GUID));
+
+    Headers restoredHeaders = new RecordHeaders();
+    byte[] restoredBytes = headerBackupConverter.fromConnectData(
+        TOPIC, restoredHeaders, wrapped.schema(), wrapped.value());
+    assertNotNull("restored value schema ID header present",
+        restoredHeaders.lastHeader(SchemaId.VALUE_SCHEMA_ID_HEADER));
+
+    SchemaAndValue restoredDeser = headerPlainConverter.toConnectData(
+        TOPIC, restoredHeaders, restoredBytes);
+    Struct restored = (Struct) restoredDeser.value();
+    assertEquals("id preserved", "h-1", restored.getString(FIELD_ID));
+    assertEquals("name preserved", "header-test", restored.getString(FIELD_NAME));
+  }
+
+  // ================ Config-mismatch scenarios (backup with X, restore with X flipped) ================
+
+  @Test
+  public void testConfigMismatchWrapperForRawPrimitivesFalseOnSinkOnlyStillWorks()
+      throws Exception {
+    // Sink sets wrapper.for.raw.primitives=false; source uses default (true). Restore
+    // reconstructs the schema from the wrapper's raw .proto, so source-side default is safe.
+    converter.configure(backupConfigWith("wrapper.for.raw.primitives", "false"), false);
+
+    String topic = nextTopic();
+    String proto = PROTO_HEADER
+        + "import \"google/protobuf/wrappers.proto\";\n"
+        + "message MismatchMsg {\n"
+        + "  string id = 1;\n"
+        + "  google.protobuf.StringValue nickname = 2;\n"
+        + "}\n";
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor desc = schema.toDescriptor();
+    Descriptor strValDesc = desc.findFieldByName("nickname").getMessageType();
+    DynamicMessage nickname = DynamicMessage.newBuilder(strValDesc)
+        .setField(strValDesc.findFieldByName(FIELD_VALUE), "nick").build();
+    DynamicMessage msg = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName(FIELD_ID), "mm-1")
+        .setField(desc.findFieldByName("nickname"), nickname)
+        .build();
+
+    byte[] originalBytes = serializer.serialize(topic, null, msg, schema);
+    SchemaAndValue wrapped = converter.toConnectData(topic, originalBytes);
+
+    // Flip the same converter to default (true). represents source-side default config.
+    converter.configure(backupConfigWith("wrapper.for.raw.primitives", "true"), false);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    assertBytesExact(originalBytes, restoredBytes);
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
+  }
+
+  @Test
+  public void testConfigMismatchWrapperForNullablesTrueOnSinkFailsOnProto3Optional() {
+    // wrapper.for.nullables=true does not mark proto3 explicit optional scalars as .optional()
+    // in the derived Connect schema, so records that omit the field fail Struct validation.
+    converter.configure(backupConfigWith("wrapper.for.nullables", "true"), false);
+
+    String topic = nextTopic();
+    String proto = PROTO_HEADER
+        + "message OptionalMsg {\n"
+        + "  string id = 1;\n"
+        + "  optional string tagline = 2;\n"
+        + "}\n";
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor desc = schema.toDescriptor();
+    // Record OMITS 'tagline' (proto3 explicit optional not set)
+    DynamicMessage msg = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName(FIELD_ID), "no-tagline")
+        .build();
+    byte[] originalBytes = serializer.serialize(topic, null, msg, schema);
+
+    try {
+      converter.toConnectData(topic, originalBytes);
+      fail("Expected DataException on proto3 optional + wrapper.for.nullables=true "
+          + "with tagline field absent from the record");
+    } catch (DataException e) {
+      assertTrue("message mentions required-field violation: " + e.getMessage(),
+          e.getMessage().contains("Invalid value: null used for required field"));
+      assertTrue("message identifies the tagline field: " + e.getMessage(),
+          e.getMessage().contains("tagline"));
+    }
+  }
+
+  @Test
+  public void testConfigMismatchConnectMetaDataOnRestoreOffDocumentedLoss() {
+    String topic = nextTopic();
+    String proto = PROTO_HEADER
+        + "message MetaMismatch {\n"
+        + "  string id = 1;\n"
+        + "  int32 count = 2;\n"
+        + "}\n";
+    ProtobufSchema schema = new ProtobufSchema(proto);
+    Descriptor desc = schema.toDescriptor();
+    DynamicMessage msg = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName(FIELD_ID), "meta-1")
+        .setField(desc.findFieldByName("count"), 7)
+        .build();
+
+    byte[] originalBytes = serializer.serialize(topic, null, msg, schema);
+    SchemaAndValue wrapped = converter.toConnectData(topic, originalBytes);
+
+    // Flip restore side to connect.meta.data=false; wrapper's raw .proto still drives restore.
+    converter.configure(backupConfigWith("connect.meta.data", "false"), false);
+    byte[] restoredBytes = converter.fromConnectData(topic, wrapped.schema(), wrapped.value());
+
+    assertBytesExact(originalBytes, restoredBytes);
+    assertWireSchemaIdPreserved(originalBytes, restoredBytes);
   }
 }


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
Hardens the backup/restore converter path (INIT-5113) with three commits:

1. **Classify SR and storage errors** — new `BackupExceptionMapper` converts SR/network/storage exceptions into the appropriate Connect error type (`RetriableException`, `NetworkException`, `DataException`, `ConfigException`). Wired into `AvroConverter`, `ProtobufConverter`, `JsonSchemaConverter`, `BackupReferenceResolver`, and `BackupSchemaFetcher`.
2. **Fail loud on missing rawSchema during restore** — throws `DataException` with a clear message instead of a silent partial restore. Adds `FIELD_SCHEMA_GUID` to `BackupWrapper` for header-based schema ID paths.
3. **Rewrite converter backup tests into consistent 5-banner structure** — restructures the 3 backup test suites into an identical layout (default gates / cross-subject reference negatives / config-lossiness pairs / edge cases / config-mismatch). Adds mega kitchen-sink tests, cross-cluster restore verification, raw-serializer round trips, and E2E-driven trip-wires (JSON Schema `use.optional.for.nonrequired`, additionalProperties data loss, Protobuf nested wrapper fidelity, header-based schema ID, sink-wrap error classification).

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
    - Restore now fails fast with an explicit `DataException` on malformed/incomplete backup wrappers instead of silent partial restore.
    - SR/network/storage errors are classified into the correct Connect error type, so transient failures are retried and permanent ones fail fast.
- **[N]** Is this change gated behind config(s)?
    - Yes under`schema.backup.enabled=true` (existing config, no new toggle).
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - 113 backup-mode tests across the 3 converters (37 Avro + 40 Protobuf + 36 JSON Schema) + 17 tests in `BackupExceptionMapperTest`. All passing.
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - JUnit-only. 
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - Depends on #4458 (already merged to master).

References
----------
JIRA: https://confluentinc.atlassian.net/browse/INIT-5113
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->
Full test run:

    mvn -pl avro-converter,protobuf-converter,json-schema-converter,kafka-connect-schema-backup-core test

Focused error-handling test:

    mvn -pl kafka-connect-schema-backup-core test -Dtest=BackupExceptionMapperTest

Suggested review order:
1. `BackupExceptionMapper.java` and its test — the new error-classification logic.
2. Converter call sites (`AvroConverter`, `ProtobufConverter`, `JsonSchemaConverter`) — how the mapper is wired in and where `restoreFromWrapper` / `wrapWithBackupMetadata` catch and re-throw.
3. `BackupWrapper.FIELD_SCHEMA_GUID` addition — new field for header-based schema ID support.
4. The 3 backup test files — same 5-banner structure across all three; verify consistency.

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->
- Docker E2E discovery surfaced JSON Schema `additionalProperties` silent data loss (map values dropped on restore). Encoded as failure trip-wire tests in this PR; the code fix is out of scope and tracked separately.
- Storage-format-level failures for JSON Schema `oneOf` on AvroFormat/ParquetFormat storage live in the sink connector repo, not here.

<!--
Review stakeholders
------------------
Optional: mention stakeholders or if special context that is required to review.
-->
