### PR TITLE
INIT-5113 Preserve JSON Schema additionalProperties via opt-in config

### DIFF
--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
@@ -106,6 +106,31 @@ public class JsonSchemaData {
   public static final String CONNECT_TYPE_BYTES = "bytes";
   public static final String CONNECT_TYPE_MAP = "map";
 
+  public static final String ADDITIONAL_PROPERTIES_FIELD = "__connect_additional_properties__";
+
+  private static boolean isExtrasField(Field field) {
+    if (field == null || !ADDITIONAL_PROPERTIES_FIELD.equals(field.name())) {
+      return false;
+    }
+    Schema s = field.schema();
+    if (s == null || s.type() != Schema.Type.MAP) {
+      return false;
+    }
+    Schema keySchema = s.keySchema();
+    if (keySchema == null || keySchema.type() != Schema.Type.STRING) {
+      return false;
+    }
+    return ConnectVariant.isVariant(s.valueSchema());
+  }
+
+  private static Field findExtrasField(Schema schema, JsonSchemaDataConfig config) {
+    if (schema == null || !config.preserveAdditionalProperties()) {
+      return null;
+    }
+    Field candidate = schema.field(ADDITIONAL_PROPERTIES_FIELD);
+    return isExtrasField(candidate) ? candidate : null;
+  }
+
   public static final String DEFAULT_ID_PREFIX = "#id";
   public static final String JSON_ID_PROP = NAMESPACE + ".Id";
   public static final String JSON_TYPE_ENUM = NAMESPACE + ".Enum";
@@ -232,10 +257,41 @@ public class JsonSchemaData {
         }
 
         Struct result = new Struct(schema.schema());
+        Field extrasField = findExtrasField(schema, data.config);
+        Set<String> declaredFieldNames = extrasField == null
+            ? Collections.emptySet() : new HashSet<>();
         for (Field field : schema.fields()) {
+          if (extrasField != null && extrasField.name().equals(field.name())) {
+            continue;
+          }
+          if (extrasField != null) {
+            declaredFieldNames.add(field.name());
+          }
           Object fieldValue = data.toConnectData(field.schema(), value.get(field.name()));
           if (fieldValue != null) {
             result.put(field, fieldValue);
+          }
+        }
+        if (extrasField != null) {
+          Schema variantSchema = extrasField.schema().valueSchema();
+          Map<String, Struct> extras = new LinkedHashMap<>();
+          Iterator<Entry<String, JsonNode>> it = value.fields();
+          while (it.hasNext()) {
+            Entry<String, JsonNode> entry = it.next();
+            String key = entry.getKey();
+            if (declaredFieldNames.contains(key)) {
+              continue;
+            }
+            if (ADDITIONAL_PROPERTIES_FIELD.equals(key)) {
+              throw new DataException("JSON payload contains a property named '"
+                  + ADDITIONAL_PROPERTIES_FIELD + "' which collides with the reserved field "
+                  + "name for preserve.additional.properties=true. Rename the property in the "
+                  + "source data or disable the config.");
+            }
+            extras.put(key, ConnectVariant.toLogical(variantSchema, entry.getValue()));
+          }
+          if (!extras.isEmpty()) {
+            result.put(extrasField, extras);
           }
         }
 
@@ -576,15 +632,33 @@ public class JsonSchemaData {
             return fromConnectData(schema, null);
           } else {
             ObjectNode obj = JSON_NODE_FACTORY.objectNode();
+            Field extrasField = findExtrasField(schema, config);
             List<Field> fields = schema.fields();
             int numFields = fields.size();
             for (int i = 0; i < numFields; i++) {
               Field field = fields.get(i);
+              if (extrasField != null && extrasField.name().equals(field.name())) {
+                continue;
+              }
               Object fieldValue = config.ignoreDefaultForNullables()
                   ? struct.getWithoutDefault(field.name()) : struct.get(field);
               JsonNode jsonNode = fromConnectData(field.schema(), fieldValue);
               if (jsonNode != null) {
                 obj.set(field.name(), jsonNode);
+              }
+            }
+            if (extrasField != null) {
+              @SuppressWarnings("unchecked")
+              Map<String, Struct> extras = (Map<String, Struct>) struct.get(extrasField);
+              if (extras != null) {
+                Schema variantSchema = extrasField.schema().valueSchema();
+                for (Entry<String, Struct> entry : extras.entrySet()) {
+                  if (entry.getValue() == null) {
+                    continue;
+                  }
+                  obj.set(entry.getKey(),
+                      ConnectVariant.fromLogical(variantSchema, entry.getValue()));
+                }
               }
             }
             return obj;
@@ -819,6 +893,9 @@ public class JsonSchemaData {
         } else {
           ObjectSchema.Builder objectBuilder = ObjectSchema.builder();
           for (Field field : schema.fields()) {
+            if (config.preserveAdditionalProperties() && isExtrasField(field)) {
+              continue;
+            }
             Schema fieldSchema = field.schema();
             String fieldRefId = null;
             if (fieldSchema.parameters() != null
@@ -1130,6 +1207,16 @@ public class JsonSchemaData {
             toConnectSchema(ctx, objectSchema.getSchemaOfAdditionalProperties())
         );
       } else {
+        boolean addExtrasField = config.preserveAdditionalProperties()
+            && objectSchema.permitsAdditionalProperties();
+        if (addExtrasField
+            && objectSchema.getPropertySchemas().containsKey(ADDITIONAL_PROPERTIES_FIELD)) {
+          throw new DataException("JSON Schema property name '"
+              + ADDITIONAL_PROPERTIES_FIELD
+              + "' collides with the reserved field name for "
+              + "preserve.additional.properties=true. "
+              + "Rename the property or disable the config.");
+        }
         builder = SchemaBuilder.struct();
         ctx.put(objectSchema, builder);
         Map<String, org.everit.json.schema.Schema> properties = objectSchema.getPropertySchemas();
@@ -1149,6 +1236,12 @@ public class JsonSchemaData {
           boolean isFieldOptional = config.useOptionalForNonRequiredProperties()
               && !objectSchema.getRequiredProperties().contains(subFieldName);
           builder.field(subFieldName, toConnectSchema(ctx, subSchema, null, isFieldOptional));
+        }
+        if (addExtrasField) {
+          builder.field(ADDITIONAL_PROPERTIES_FIELD,
+              SchemaBuilder.map(Schema.STRING_SCHEMA, ConnectVariant.builder().build())
+                  .optional()
+                  .build());
         }
       }
     } else if (jsonSchema instanceof ReferenceSchema) {

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaData.java
@@ -106,6 +106,31 @@ public class JsonSchemaData {
   public static final String CONNECT_TYPE_BYTES = "bytes";
   public static final String CONNECT_TYPE_MAP = "map";
 
+  public static final String ADDITIONAL_PROPERTIES_FIELD = "__connect_additional_properties__";
+
+  private static boolean isExtrasField(Field field) {
+    if (field == null || !ADDITIONAL_PROPERTIES_FIELD.equals(field.name())) {
+      return false;
+    }
+    Schema s = field.schema();
+    if (s == null || s.type() != Schema.Type.MAP) {
+      return false;
+    }
+    Schema keySchema = s.keySchema();
+    if (keySchema == null || keySchema.type() != Schema.Type.STRING) {
+      return false;
+    }
+    return ConnectVariant.isVariant(s.valueSchema());
+  }
+
+  private static Field findExtrasField(Schema schema, JsonSchemaDataConfig config) {
+    if (schema == null || !config.preserveAdditionalProperties()) {
+      return null;
+    }
+    Field candidate = schema.field(ADDITIONAL_PROPERTIES_FIELD);
+    return isExtrasField(candidate) ? candidate : null;
+  }
+
   public static final String DEFAULT_ID_PREFIX = "#id";
   public static final String JSON_ID_PROP = NAMESPACE + ".Id";
   public static final String JSON_TYPE_ENUM = NAMESPACE + ".Enum";
@@ -232,10 +257,42 @@ public class JsonSchemaData {
         }
 
         Struct result = new Struct(schema.schema());
+        Field extrasField = findExtrasField(schema, data.config);
+        Set<String> declaredFieldNames = extrasField == null
+            ? Collections.emptySet() : new HashSet<>();
         for (Field field : schema.fields()) {
+          if (extrasField != null && extrasField.name().equals(field.name())) {
+            continue;
+          }
+          if (extrasField != null) {
+            declaredFieldNames.add(field.name());
+          }
           Object fieldValue = data.toConnectData(field.schema(), value.get(field.name()));
           if (fieldValue != null) {
             result.put(field, fieldValue);
+          }
+        }
+        if (extrasField != null) {
+          Schema variantSchema = extrasField.schema().valueSchema();
+          Map<String, Struct> extras = new LinkedHashMap<>();
+          Iterator<Entry<String, JsonNode>> it = value.fields();
+          while (it.hasNext()) {
+            Entry<String, JsonNode> entry = it.next();
+            String key = entry.getKey();
+            if (declaredFieldNames.contains(key)) {
+              continue;
+            }
+            if (ADDITIONAL_PROPERTIES_FIELD.equals(key)) {
+              throw new DataException("JSON payload contains a property named '"
+                  + ADDITIONAL_PROPERTIES_FIELD + "' which collides with the reserved field "
+                  + "name for "
+                  + JsonSchemaDataConfig.PRESERVE_ADDITIONAL_PROPERTIES_CONFIG + "=true. "
+                  + "Rename the property in the source data or disable the config.");
+            }
+            extras.put(key, ConnectVariant.toLogical(variantSchema, entry.getValue()));
+          }
+          if (!extras.isEmpty()) {
+            result.put(extrasField, extras);
           }
         }
 
@@ -576,15 +633,30 @@ public class JsonSchemaData {
             return fromConnectData(schema, null);
           } else {
             ObjectNode obj = JSON_NODE_FACTORY.objectNode();
+            Field extrasField = findExtrasField(schema, config);
             List<Field> fields = schema.fields();
             int numFields = fields.size();
             for (int i = 0; i < numFields; i++) {
               Field field = fields.get(i);
+              if (extrasField != null && extrasField.name().equals(field.name())) {
+                continue;
+              }
               Object fieldValue = config.ignoreDefaultForNullables()
                   ? struct.getWithoutDefault(field.name()) : struct.get(field);
               JsonNode jsonNode = fromConnectData(field.schema(), fieldValue);
               if (jsonNode != null) {
                 obj.set(field.name(), jsonNode);
+              }
+            }
+            if (extrasField != null) {
+              @SuppressWarnings("unchecked")
+              Map<String, Struct> extras = (Map<String, Struct>) struct.get(extrasField);
+              if (extras != null) {
+                Schema variantSchema = extrasField.schema().valueSchema();
+                for (Entry<String, Struct> entry : extras.entrySet()) {
+                  obj.set(entry.getKey(),
+                      ConnectVariant.fromLogical(variantSchema, entry.getValue()));
+                }
               }
             }
             return obj;
@@ -819,6 +891,9 @@ public class JsonSchemaData {
         } else {
           ObjectSchema.Builder objectBuilder = ObjectSchema.builder();
           for (Field field : schema.fields()) {
+            if (config.preserveAdditionalProperties() && isExtrasField(field)) {
+              continue;
+            }
             Schema fieldSchema = field.schema();
             String fieldRefId = null;
             if (fieldSchema.parameters() != null
@@ -1130,6 +1205,16 @@ public class JsonSchemaData {
             toConnectSchema(ctx, objectSchema.getSchemaOfAdditionalProperties())
         );
       } else {
+        boolean addExtrasField = config.preserveAdditionalProperties()
+            && objectSchema.permitsAdditionalProperties();
+        if (addExtrasField
+            && objectSchema.getPropertySchemas().containsKey(ADDITIONAL_PROPERTIES_FIELD)) {
+          throw new DataException("JSON Schema property name '"
+              + ADDITIONAL_PROPERTIES_FIELD
+              + "' collides with the reserved field name for "
+              + JsonSchemaDataConfig.PRESERVE_ADDITIONAL_PROPERTIES_CONFIG + "=true. "
+              + "Rename the property or disable the config.");
+        }
         builder = SchemaBuilder.struct();
         ctx.put(objectSchema, builder);
         Map<String, org.everit.json.schema.Schema> properties = objectSchema.getPropertySchemas();
@@ -1149,6 +1234,12 @@ public class JsonSchemaData {
           boolean isFieldOptional = config.useOptionalForNonRequiredProperties()
               && !objectSchema.getRequiredProperties().contains(subFieldName);
           builder.field(subFieldName, toConnectSchema(ctx, subSchema, null, isFieldOptional));
+        }
+        if (addExtrasField) {
+          builder.field(ADDITIONAL_PROPERTIES_FIELD,
+              SchemaBuilder.map(Schema.STRING_SCHEMA, ConnectVariant.builder().build())
+                  .optional()
+                  .build());
         }
       }
     } else if (jsonSchema instanceof ReferenceSchema) {

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaDataConfig.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaDataConfig.java
@@ -56,6 +56,14 @@ public class JsonSchemaDataConfig extends AbstractDataConfig {
   public static final boolean FLATTEN_SINGLETON_UNIONS_DEFAULT = true;
   public static final String FLATTEN_SINGLETON_UNIONS_DOC = "Whether to flatten singleton unions";
 
+  public static final String PRESERVE_ADDITIONAL_PROPERTIES_CONFIG =
+      "preserve.additional.properties";
+  public static final boolean PRESERVE_ADDITIONAL_PROPERTIES_DEFAULT = false;
+  public static final String PRESERVE_ADDITIONAL_PROPERTIES_DOC =
+      "When true, JSON properties not declared in the schema but allowed by additionalProperties "
+          + "are preserved through this converter with their original values and data types "
+          + "intact. Default false drops such properties (existing behavior).";
+
   public static ConfigDef baseConfigDef() {
     return AbstractDataConfig.baseConfigDef().define(
         OBJECT_ADDITIONAL_PROPERTIES_CONFIG,
@@ -89,7 +97,13 @@ public class JsonSchemaDataConfig extends AbstractDataConfig {
         ConfigDef.Type.BOOLEAN,
         FLATTEN_SINGLETON_UNIONS_DEFAULT,
         ConfigDef.Importance.LOW,
-        FLATTEN_SINGLETON_UNIONS_DOC);
+        FLATTEN_SINGLETON_UNIONS_DOC
+    ).define(
+        PRESERVE_ADDITIONAL_PROPERTIES_CONFIG,
+        ConfigDef.Type.BOOLEAN,
+        PRESERVE_ADDITIONAL_PROPERTIES_DEFAULT,
+        ConfigDef.Importance.MEDIUM,
+        PRESERVE_ADDITIONAL_PROPERTIES_DOC);
   }
 
   public JsonSchemaDataConfig(Map<?, ?> props) {
@@ -119,6 +133,10 @@ public class JsonSchemaDataConfig extends AbstractDataConfig {
 
   public boolean isFlattenSingletonUnions() {
     return this.getBoolean(FLATTEN_SINGLETON_UNIONS_CONFIG);
+  }
+
+  public boolean preserveAdditionalProperties() {
+    return getBoolean(PRESERVE_ADDITIONAL_PROPERTIES_CONFIG);
   }
 
   public static class Builder {

--- a/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaDataConfig.java
+++ b/json-schema-converter/src/main/java/io/confluent/connect/json/JsonSchemaDataConfig.java
@@ -56,6 +56,15 @@ public class JsonSchemaDataConfig extends AbstractDataConfig {
   public static final boolean FLATTEN_SINGLETON_UNIONS_DEFAULT = true;
   public static final String FLATTEN_SINGLETON_UNIONS_DOC = "Whether to flatten singleton unions";
 
+  public static final String PRESERVE_ADDITIONAL_PROPERTIES_CONFIG =
+      "preserve.additional.properties";
+  public static final boolean PRESERVE_ADDITIONAL_PROPERTIES_DEFAULT = false;
+  public static final String PRESERVE_ADDITIONAL_PROPERTIES_DOC =
+      "When true, this converter preserves undeclared JSON properties permitted by the "
+          + "schema (JSON Schema permits them by default unless additionalProperties is set "
+          + "to false). Preserves the original value and data type of each property. "
+          + "Default false drops such properties (existing behavior).";
+
   public static ConfigDef baseConfigDef() {
     return AbstractDataConfig.baseConfigDef().define(
         OBJECT_ADDITIONAL_PROPERTIES_CONFIG,
@@ -89,7 +98,13 @@ public class JsonSchemaDataConfig extends AbstractDataConfig {
         ConfigDef.Type.BOOLEAN,
         FLATTEN_SINGLETON_UNIONS_DEFAULT,
         ConfigDef.Importance.LOW,
-        FLATTEN_SINGLETON_UNIONS_DOC);
+        FLATTEN_SINGLETON_UNIONS_DOC
+    ).define(
+        PRESERVE_ADDITIONAL_PROPERTIES_CONFIG,
+        ConfigDef.Type.BOOLEAN,
+        PRESERVE_ADDITIONAL_PROPERTIES_DEFAULT,
+        ConfigDef.Importance.MEDIUM,
+        PRESERVE_ADDITIONAL_PROPERTIES_DOC);
   }
 
   public JsonSchemaDataConfig(Map<?, ?> props) {
@@ -119,6 +134,10 @@ public class JsonSchemaDataConfig extends AbstractDataConfig {
 
   public boolean isFlattenSingletonUnions() {
     return this.getBoolean(FLATTEN_SINGLETON_UNIONS_CONFIG);
+  }
+
+  public boolean preserveAdditionalProperties() {
+    return getBoolean(PRESERVE_ADDITIONAL_PROPERTIES_CONFIG);
   }
 
   public static class Builder {

--- a/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
+++ b/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
@@ -87,6 +87,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class JsonSchemaDataTest {
 
@@ -2604,5 +2605,334 @@ public class JsonSchemaDataTest {
     byte[] bytes = new byte[buffer.remaining()];
     buffer.duplicate().get(bytes);
     return bytes;
+  }
+
+  private JsonSchemaData preserveExtrasData() {
+    return new JsonSchemaData(new JsonSchemaDataConfig(
+        Collections.singletonMap(
+            JsonSchemaDataConfig.PRESERVE_ADDITIONAL_PROPERTIES_CONFIG, "true")));
+  }
+
+  private static ObjectNode obj(String json) {
+    try {
+      return (ObjectNode) Jackson.newObjectMapper().readTree(json);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesShapeATypedMapRoundTrip() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .schemaOfAdditionalProperties(NumberSchema.builder().requiresInteger(true).build())
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    assertNotNull("extras field must be present when config is on",
+        connectSchema.field(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+
+    ObjectNode payload = obj("{\"a\":1,\"b\":2}");
+    Object connectValue = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, connectValue);
+    assertEquals(payload, restored);
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesShapeBLooseBagRoundTrip() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder().build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+
+    ObjectNode payload = obj(
+        "{\"n\":42,\"s\":\"hi\",\"b\":true,\"nested\":{\"a\":1},\"arr\":[1,2,3]}");
+    Object connectValue = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, connectValue);
+    assertEquals(payload, restored);
+    assertTrue("number stays number", restored.get("n").isIntegralNumber());
+    assertTrue("string stays string", restored.get("s").isTextual());
+    assertTrue("boolean stays boolean", restored.get("b").isBoolean());
+    assertTrue("nested stays object", restored.get("nested").isObject());
+    assertTrue("array stays array", restored.get("arr").isArray());
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesShapeDHybridTypedRoundTrip() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .addPropertySchema("name", StringSchema.builder().build())
+        .schemaOfAdditionalProperties(NumberSchema.builder().requiresInteger(true).build())
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    assertNotNull(connectSchema.field("name"));
+    assertNotNull(connectSchema.field(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+
+    ObjectNode payload = obj("{\"name\":\"Alice\",\"score\":42,\"rank\":7}");
+    Object connectValue = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, connectValue);
+    assertEquals("Alice", restored.get("name").textValue());
+    assertEquals(42, restored.get("score").intValue());
+    assertEquals(7, restored.get("rank").intValue());
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesShapeEHybridLooseRoundTrip() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .addPropertySchema("name", StringSchema.builder().build())
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+
+    ObjectNode payload = obj(
+        "{\"name\":\"Alice\",\"nickname\":\"Ali\",\"score\":42,\"nested\":{\"a\":1}}");
+    Object connectValue = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, connectValue);
+    assertEquals("Alice", restored.get("name").textValue());
+    assertEquals("Ali", restored.get("nickname").textValue());
+    assertEquals(42, restored.get("score").intValue());
+    assertEquals(1, restored.get("nested").get("a").intValue());
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesNestedRoundTrip() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema addressSchema = ObjectSchema.builder()
+        .addPropertySchema("street", StringSchema.builder().build())
+        .build();
+    ObjectSchema personSchema = ObjectSchema.builder()
+        .addPropertySchema("name", StringSchema.builder().build())
+        .addPropertySchema("address", addressSchema)
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(personSchema.toString()));
+    Schema addressConnect = connectSchema.field("address").schema();
+    assertNotNull("nested address must also carry extras field",
+        addressConnect.field(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+
+    ObjectNode payload = obj(
+        "{\"name\":\"Alice\",\"address\":{\"street\":\"Main St\",\"city\":\"Seattle\"}}");
+    Object connectValue = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, connectValue);
+    assertEquals("Main St", restored.get("address").get("street").textValue());
+    assertEquals("Seattle", restored.get("address").get("city").textValue());
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesDefaultOffPreservesLossyBehavior() {
+    JsonSchemaData data = new JsonSchemaData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .schemaOfAdditionalProperties(NumberSchema.builder().requiresInteger(true).build())
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    assertNull("extras field must NOT be present when config is off (default)",
+        connectSchema.field(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+
+    ObjectNode payload = obj("{\"a\":1,\"b\":2}");
+    Object connectValue = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, connectValue);
+    assertEquals("existing lossy behavior: entries dropped", 0, restored.size());
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesReservedNameCollisionFailsFast() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .addPropertySchema(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD,
+            StringSchema.builder().build())
+        .build();
+    try {
+      data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+      fail("expected DataException on reserved-name collision");
+    } catch (DataException e) {
+      assertTrue("error must name the reserved field",
+          e.getMessage().contains(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+      assertTrue("error must mention the config",
+          e.getMessage().contains("preserve.additional.properties"));
+    }
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesReverseSchemaDoesNotIncludeReservedField() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .addPropertySchema("name", StringSchema.builder().build())
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    assertNotNull(connectSchema.field(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+    JsonSchema derived = data.fromConnectSchema(connectSchema);
+    assertFalse("reserved field must not leak into derived JSON Schema",
+        derived.rawSchema().toString().contains(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesFullRoundTripSurvivesRereadWithFlagOn() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .addPropertySchema("name", StringSchema.builder().build())
+        .build();
+    Schema connectSchema1 = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    JsonSchema derived = data.fromConnectSchema(connectSchema1);
+    Schema connectSchema2 = data.toConnectSchema(derived);
+    assertNotNull("extras field must be present on re-parse",
+        connectSchema2.field(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+    assertNotNull(connectSchema2.field("name"));
+
+    ObjectNode payload = obj("{\"name\":\"Alice\",\"extra\":42}");
+    Object value = data.toConnectData(connectSchema2, payload);
+    JsonNode restored = data.fromConnectData(connectSchema2, value);
+    assertEquals("Alice", restored.get("name").textValue());
+    assertEquals(42, restored.get("extra").intValue());
+  }
+
+  @Test
+  public void testDefaultOffLegitimateReservedNameStringFieldRoundTripsNormally() {
+    JsonSchemaData data = new JsonSchemaData();
+    Schema schema = SchemaBuilder.struct()
+        .field(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema)
+        .put(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD, "hello");
+    JsonNode restored = data.fromConnectData(schema, value);
+    assertEquals("hello",
+        restored.get(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD).textValue());
+    ObjectNode payload = obj(
+        "{\"__connect_additional_properties__\":\"hello\"}");
+    Object result = data.toConnectData(schema, payload);
+    assertEquals("hello", ((Struct) result)
+        .getString(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+  }
+
+  @Test
+  public void testDefaultOffLegitimateReservedNameIntFieldRoundTripsNormally() {
+    JsonSchemaData data = new JsonSchemaData();
+    Schema schema = SchemaBuilder.struct()
+        .field(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD, Schema.INT32_SCHEMA)
+        .build();
+    Struct value = new Struct(schema)
+        .put(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD, 7);
+    JsonNode restored = data.fromConnectData(schema, value);
+    assertEquals(7,
+        restored.get(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD).intValue());
+  }
+
+  @Test
+  public void testFlagOnReservedNameWrongShapeIsInertDefensive() {
+    JsonSchemaData data = preserveExtrasData();
+    Schema schema = SchemaBuilder.struct()
+        .field(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema)
+        .put(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD, "hello");
+    JsonNode restored = data.fromConnectData(schema, value);
+    assertEquals("hello",
+        restored.get(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD).textValue());
+    ObjectNode payload = obj(
+        "{\"__connect_additional_properties__\":\"hello\"}");
+    Object result = data.toConnectData(schema, payload);
+    assertEquals("hello", ((Struct) result)
+        .getString(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesNullValueInExtras() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder().build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    ObjectNode payload = obj("{\"nullable\":null,\"real\":\"present\"}");
+    Object value = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, value);
+    assertTrue("null preserved as JSON null", restored.has("nullable"));
+    assertTrue("null value is a null node", restored.get("nullable").isNull());
+    assertEquals("present", restored.get("real").textValue());
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesEmptyExtrasStillRoundTrips() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .addPropertySchema("name", StringSchema.builder().build())
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    ObjectNode payload = obj("{\"name\":\"only-named\"}");
+    Object value = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, value);
+    assertEquals("only-named", restored.get("name").textValue());
+    assertEquals("payload has only the named field, no leaked extras",
+        1, restored.size());
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesLongNumberPrecision() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder().build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    long bigLong = 9_000_000_000L;
+    ObjectNode payload = obj("{\"big\":" + bigLong + "}");
+    Object value = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, value);
+    assertEquals(bigLong, restored.get("big").longValue());
+    assertTrue("value stays integral, not widened to float",
+        restored.get("big").isIntegralNumber());
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesDecimalNumberPrecision() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder().build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    ObjectNode payload = obj("{\"pi\":3.14}");
+    Object value = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, value);
+    assertEquals(3.14, restored.get("pi").doubleValue(), 0.0000001);
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesEmptyExtrasFieldIsUnsetOnStruct() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .addPropertySchema("name", StringSchema.builder().build())
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    ObjectNode payload = obj("{\"name\":\"only-named\"}");
+    Struct result = (Struct) data.toConnectData(connectSchema, payload);
+    assertNull("extras field must be unset (null) when payload has no extras, not an empty map",
+        result.get(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+    JsonNode restored = data.fromConnectData(connectSchema, result);
+    assertEquals("only-named", restored.get("name").textValue());
+    assertEquals("round trip has only the named field",
+        1, restored.size());
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesPayloadWithReservedNameFailsFast() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .addPropertySchema("name", StringSchema.builder().build())
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    ObjectNode payload = obj("{\"name\":\"Alice\",\"__connect_additional_properties__\":\"hi\"}");
+    try {
+      data.toConnectData(connectSchema, payload);
+      fail("expected DataException on reserved name in payload");
+    } catch (DataException e) {
+      assertTrue("error must name the reserved field",
+          e.getMessage().contains(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+      assertTrue("error must mention the config",
+          e.getMessage().contains("preserve.additional.properties"));
+    }
+  }
+
+  @Test
+  public void testDefaultOffPayloadWithReservedNameIsSilentlyDropped() {
+    JsonSchemaData data = new JsonSchemaData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .addPropertySchema("name", StringSchema.builder().build())
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    ObjectNode payload = obj("{\"name\":\"Alice\",\"__connect_additional_properties__\":\"hi\"}");
+    Struct result = (Struct) data.toConnectData(connectSchema, payload);
+    assertEquals("Alice", result.getString("name"));
+    JsonNode restored = data.fromConnectData(connectSchema, result);
+    assertEquals("Alice", restored.get("name").textValue());
+    assertEquals("with flag OFF, extras (including reserved name) are dropped as before",
+        1, restored.size());
   }
 }

--- a/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
+++ b/json-schema-converter/src/test/java/io/confluent/connect/json/JsonSchemaDataTest.java
@@ -16,6 +16,7 @@
 package io.confluent.connect.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.BinaryNode;
 import com.fasterxml.jackson.databind.node.BooleanNode;
@@ -87,8 +88,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class JsonSchemaDataTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = Jackson.newObjectMapper();
 
   private static final Schema NAMED_MAP_SCHEMA = SchemaBuilder.map(Schema.STRING_SCHEMA,
       Schema.INT32_SCHEMA
@@ -2604,5 +2608,415 @@ public class JsonSchemaDataTest {
     byte[] bytes = new byte[buffer.remaining()];
     buffer.duplicate().get(bytes);
     return bytes;
+  }
+
+  private JsonSchemaData preserveExtrasData() {
+    return new JsonSchemaData(new JsonSchemaDataConfig(
+        Collections.singletonMap(
+            JsonSchemaDataConfig.PRESERVE_ADDITIONAL_PROPERTIES_CONFIG, true)));
+  }
+
+  private static ObjectNode obj(String json) {
+    try {
+      return (ObjectNode) OBJECT_MAPPER.readTree(json);
+    } catch (Exception e) {
+      throw new AssertionError("Failed to parse test JSON: " + json, e);
+    }
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesShapeATypedMapRoundTrip() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .schemaOfAdditionalProperties(NumberSchema.builder().requiresInteger(true).build())
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    assertNotNull("extras field must be present when config is on",
+        connectSchema.field(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+
+    ObjectNode payload = obj("{\"a\":1,\"b\":2}");
+    Object connectValue = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, connectValue);
+    assertEquals(payload, restored);
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesShapeBLooseBagRoundTrip() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder().build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+
+    ObjectNode payload = obj(
+        "{\"n\":42,\"s\":\"hi\",\"b\":true,\"nested\":{\"a\":1},\"arr\":[1,2,3]}");
+    Object connectValue = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, connectValue);
+    assertEquals(payload, restored);
+    assertTrue("number stays number", restored.get("n").isIntegralNumber());
+    assertTrue("string stays string", restored.get("s").isTextual());
+    assertTrue("boolean stays boolean", restored.get("b").isBoolean());
+    assertTrue("nested stays object", restored.get("nested").isObject());
+    assertTrue("array stays array", restored.get("arr").isArray());
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesShapeDHybridTypedRoundTrip() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .addPropertySchema("name", StringSchema.builder().build())
+        .schemaOfAdditionalProperties(NumberSchema.builder().requiresInteger(true).build())
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    assertNotNull(connectSchema.field("name"));
+    assertNotNull(connectSchema.field(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+
+    ObjectNode payload = obj("{\"name\":\"Alice\",\"score\":42,\"rank\":7}");
+    Object connectValue = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, connectValue);
+    assertEquals("Alice", restored.get("name").textValue());
+    assertEquals(42, restored.get("score").intValue());
+    assertEquals(7, restored.get("rank").intValue());
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesShapeEHybridLooseRoundTrip() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .addPropertySchema("name", StringSchema.builder().build())
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+
+    ObjectNode payload = obj(
+        "{\"name\":\"Alice\",\"nickname\":\"Ali\",\"score\":42,\"nested\":{\"a\":1}}");
+    Object connectValue = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, connectValue);
+    assertEquals("Alice", restored.get("name").textValue());
+    assertEquals("Ali", restored.get("nickname").textValue());
+    assertEquals(42, restored.get("score").intValue());
+    assertEquals(1, restored.get("nested").get("a").intValue());
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesNestedRoundTrip() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema addressSchema = ObjectSchema.builder()
+        .addPropertySchema("street", StringSchema.builder().build())
+        .build();
+    ObjectSchema personSchema = ObjectSchema.builder()
+        .addPropertySchema("name", StringSchema.builder().build())
+        .addPropertySchema("address", addressSchema)
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(personSchema.toString()));
+    Schema addressConnect = connectSchema.field("address").schema();
+    assertNotNull("nested address must also carry extras field",
+        addressConnect.field(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+
+    ObjectNode payload = obj(
+        "{\"name\":\"Alice\",\"address\":{\"street\":\"Main St\",\"city\":\"Seattle\"}}");
+    Object connectValue = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, connectValue);
+    assertEquals("Main St", restored.get("address").get("street").textValue());
+    assertEquals("Seattle", restored.get("address").get("city").textValue());
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesDefaultOffPreservesLossyBehavior() {
+    JsonSchemaData data = new JsonSchemaData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .schemaOfAdditionalProperties(NumberSchema.builder().requiresInteger(true).build())
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    assertNull("extras field must NOT be present when config is off (default)",
+        connectSchema.field(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+
+    ObjectNode payload = obj("{\"a\":1,\"b\":2}");
+    Object connectValue = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, connectValue);
+    assertEquals("existing lossy behavior: entries dropped", 0, restored.size());
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesReservedNameCollisionFailsFast() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .addPropertySchema(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD,
+            StringSchema.builder().build())
+        .build();
+    try {
+      data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+      fail("expected DataException on reserved-name collision");
+    } catch (DataException e) {
+      assertTrue("error must name the reserved field",
+          e.getMessage().contains(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+      assertTrue("error must mention the config",
+          e.getMessage().contains("preserve.additional.properties"));
+    }
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesReverseSchemaDoesNotIncludeReservedField() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .addPropertySchema("name", StringSchema.builder().build())
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    assertNotNull(connectSchema.field(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+    JsonSchema derived = data.fromConnectSchema(connectSchema);
+    assertFalse("reserved field must not leak into derived JSON Schema",
+        derived.rawSchema().toString().contains(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesFullRoundTripSurvivesRereadWithFlagOn() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .addPropertySchema("name", StringSchema.builder().build())
+        .build();
+    Schema connectSchema1 = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    JsonSchema derived = data.fromConnectSchema(connectSchema1);
+    Schema connectSchema2 = data.toConnectSchema(derived);
+    assertNotNull("extras field must be present on re-parse",
+        connectSchema2.field(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+    assertNotNull(connectSchema2.field("name"));
+
+    ObjectNode payload = obj("{\"name\":\"Alice\",\"extra\":42}");
+    Object value = data.toConnectData(connectSchema2, payload);
+    JsonNode restored = data.fromConnectData(connectSchema2, value);
+    assertEquals("Alice", restored.get("name").textValue());
+    assertEquals(42, restored.get("extra").intValue());
+  }
+
+  @Test
+  public void testDefaultOffLegitimateReservedNameStringFieldRoundTripsNormally() {
+    JsonSchemaData data = new JsonSchemaData();
+    Schema schema = SchemaBuilder.struct()
+        .field(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema)
+        .put(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD, "hello");
+    JsonNode restored = data.fromConnectData(schema, value);
+    assertEquals("hello",
+        restored.get(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD).textValue());
+    ObjectNode payload = obj(
+        "{\"__connect_additional_properties__\":\"hello\"}");
+    Object result = data.toConnectData(schema, payload);
+    assertEquals("hello", ((Struct) result)
+        .getString(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+  }
+
+  @Test
+  public void testDefaultOffLegitimateReservedNameIntFieldRoundTripsNormally() {
+    JsonSchemaData data = new JsonSchemaData();
+    Schema schema = SchemaBuilder.struct()
+        .field(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD, Schema.INT32_SCHEMA)
+        .build();
+    Struct value = new Struct(schema)
+        .put(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD, 7);
+    JsonNode restored = data.fromConnectData(schema, value);
+    assertEquals(7,
+        restored.get(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD).intValue());
+  }
+
+  @Test
+  public void testFlagOnReservedNameWrongShapeIsInertDefensive() {
+    JsonSchemaData data = preserveExtrasData();
+    Schema schema = SchemaBuilder.struct()
+        .field(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD, Schema.STRING_SCHEMA)
+        .build();
+    Struct value = new Struct(schema)
+        .put(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD, "hello");
+    JsonNode restored = data.fromConnectData(schema, value);
+    assertEquals("hello",
+        restored.get(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD).textValue());
+    ObjectNode payload = obj(
+        "{\"__connect_additional_properties__\":\"hello\"}");
+    Object result = data.toConnectData(schema, payload);
+    assertEquals("hello", ((Struct) result)
+        .getString(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesNullValueInExtras() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder().build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    ObjectNode payload = obj("{\"nullable\":null,\"real\":\"present\"}");
+    Object value = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, value);
+    assertTrue("null preserved as JSON null", restored.has("nullable"));
+    assertTrue("null value is a null node", restored.get("nullable").isNull());
+    assertEquals("present", restored.get("real").textValue());
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesEmptyExtrasStillRoundTrips() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .addPropertySchema("name", StringSchema.builder().build())
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    ObjectNode payload = obj("{\"name\":\"only-named\"}");
+    Object value = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, value);
+    assertEquals("only-named", restored.get("name").textValue());
+    assertEquals("payload has only the named field, no leaked extras",
+        1, restored.size());
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesLongNumberPrecision() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder().build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    long bigLong = 9_000_000_000L;
+    ObjectNode payload = obj("{\"big\":" + bigLong + "}");
+    Object value = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, value);
+    assertEquals(bigLong, restored.get("big").longValue());
+    assertTrue("value stays integral, not widened to float",
+        restored.get("big").isIntegralNumber());
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesDecimalNumberPrecision() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder().build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    ObjectNode payload = obj("{\"pi\":3.14}");
+    Object value = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, value);
+    assertEquals(3.14, restored.get("pi").doubleValue(), 0.0000001);
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesEmptyExtrasFieldIsUnsetOnStruct() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .addPropertySchema("name", StringSchema.builder().build())
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    ObjectNode payload = obj("{\"name\":\"only-named\"}");
+    Struct result = (Struct) data.toConnectData(connectSchema, payload);
+    assertNull("extras field must be unset (null) when payload has no extras, not an empty map",
+        result.get(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+    JsonNode restored = data.fromConnectData(connectSchema, result);
+    assertEquals("only-named", restored.get("name").textValue());
+    assertEquals("round trip has only the named field",
+        1, restored.size());
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesPayloadWithReservedNameFailsFast() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .addPropertySchema("name", StringSchema.builder().build())
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    ObjectNode payload = obj("{\"name\":\"Alice\",\"__connect_additional_properties__\":\"hi\"}");
+    try {
+      data.toConnectData(connectSchema, payload);
+      fail("expected DataException on reserved name in payload");
+    } catch (DataException e) {
+      assertTrue("error must name the reserved field",
+          e.getMessage().contains(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+      assertTrue("error must mention the config",
+          e.getMessage().contains("preserve.additional.properties"));
+    }
+  }
+
+  @Test
+  public void testDefaultOffPayloadWithReservedNameIsSilentlyDropped() {
+    JsonSchemaData data = new JsonSchemaData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .addPropertySchema("name", StringSchema.builder().build())
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    ObjectNode payload = obj("{\"name\":\"Alice\",\"__connect_additional_properties__\":\"hi\"}");
+    Struct result = (Struct) data.toConnectData(connectSchema, payload);
+    assertEquals("Alice", result.getString("name"));
+    JsonNode restored = data.fromConnectData(connectSchema, result);
+    assertEquals("Alice", restored.get("name").textValue());
+    assertEquals("with flag OFF, extras (including reserved name) are dropped as before",
+        1, restored.size());
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesJsonNullFromPayloadLandsAsNonNullVariantStruct() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder().build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    ObjectNode payload = obj("{\"nullable\":null}");
+    Struct result = (Struct) data.toConnectData(connectSchema, payload);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Struct> extras = (Map<String, Struct>)
+        result.get(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD);
+    assertNotNull("extras map must be present when payload has extras", extras);
+    assertTrue("nullable key must survive into extras map", extras.containsKey("nullable"));
+    assertNotNull("JSON null must land as a real Variant Struct (not Java null); "
+            + "the null-defense in fromConnectData never triggers for JSON nulls",
+        extras.get("nullable"));
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesJsonNullAuditNestedAndArrayAndMixed() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .addPropertySchema("id", NumberSchema.builder().requiresInteger(true).build())
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+
+    ObjectNode payload = obj(
+        "{"
+            + "\"id\":1,"
+            + "\"top_null\":null,"
+            + "\"nested_obj\":{\"inner_val\":42,\"inner_null\":null},"
+            + "\"arr_with_null\":[1,null,3],"
+            + "\"real_value\":\"hello\""
+            + "}");
+
+    Object value = data.toConnectData(connectSchema, payload);
+    JsonNode restored = data.fromConnectData(connectSchema, value);
+
+    assertEquals("declared field preserved", 1, restored.get("id").intValue());
+    assertTrue("top-level JSON null in extras: key survives", restored.has("top_null"));
+    assertTrue("top-level JSON null in extras: value is JSON null",
+        restored.get("top_null").isNull());
+    assertEquals("string in extras preserved with type",
+        "hello", restored.get("real_value").textValue());
+
+    JsonNode nested = restored.get("nested_obj");
+    assertNotNull("nested object in extras: key survives", nested);
+    assertEquals("nested non-null value preserved", 42, nested.get("inner_val").intValue());
+    assertTrue("nested JSON null: key survives", nested.has("inner_null"));
+    assertTrue("nested JSON null: value is JSON null", nested.get("inner_null").isNull());
+
+    JsonNode arr = restored.get("arr_with_null");
+    assertNotNull("array in extras: key survives", arr);
+    assertEquals("array length preserved", 3, arr.size());
+    assertEquals("array[0] preserved", 1, arr.get(0).intValue());
+    assertTrue("array[1] is JSON null (element preserved)", arr.get(1).isNull());
+    assertEquals("array[2] preserved", 3, arr.get(2).intValue());
+  }
+
+  @Test
+  public void testPreserveAdditionalPropertiesJavaNullInExtrasMapIsRejectedByStructValidation() {
+    JsonSchemaData data = preserveExtrasData();
+    ObjectSchema jsonSchema = ObjectSchema.builder()
+        .addPropertySchema("name", StringSchema.builder().build())
+        .build();
+    Schema connectSchema = data.toConnectSchema(new JsonSchema(jsonSchema.toString()));
+    assertNotNull(connectSchema.field(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+
+    Map<String, Struct> extras = new LinkedHashMap<>();
+    extras.put("bad", null);
+    Struct struct = new Struct(connectSchema).put("name", "Alice");
+    try {
+      struct.put(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD, extras);
+      fail("expected Struct validation to reject a Java-null map entry (value schema is "
+          + "non-optional ConnectVariant)");
+    } catch (DataException e) {
+      assertTrue("error must name the reserved field",
+          e.getMessage().contains(JsonSchemaData.ADDITIONAL_PROPERTIES_FIELD));
+    }
   }
 }


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->
Adds opt-in config `preserve.additional.properties` (default `false`) to `JsonSchemaConverter` that preserves JSON Schema `additionalProperties` values with original data types on round trip. Fixes silent data loss for pure typed maps, pure loose bags, and hybrid variants of `additionalProperties`. Reuses the existing `ConnectVariant` type already used to represent any-typed JSON values in `JsonSchemaData` and `ProtobufData`.

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
    - New opt-in config. Default preserves existing behavior. When enabled, adds a reserved field name at every nested object level; schemas literally using that reserved name fail fast with a clear error.
- **[Y]** Is this change gated behind config(s)?
    - `preserve.additional.properties` (boolean, default `false`). Enable on both sink and source converters for end-to-end preservation.
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - 7 new unit tests in `JsonSchemaDataTest` covering all four broken shapes, nested extras, default-off preservation, reserved-name collision. All 145 module tests pass. Docker E2E verified end-to-end with byte + semantic checkers.
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - JUnit-only.
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - Independent, applies cleanly on master.

References
----------
JIRA: https://confluentinc.atlassian.net/browse/INIT-5113
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->
Test run:

    mvn -pl json-schema-converter test

Suggested review order:
1. `JsonSchemaDataConfig.java` — new opt-in config.
2. `JsonSchemaData.java` — reserved field name constant + additions to `toConnectSchema`, `toConnectData` STRUCT converter, and `fromConnectData` STRUCT case.
3. `JsonSchemaDataTest.java` — 7 tests appended.

At-rest note: with JsonFormat + `format.json.schema.enable=true`, each captured extra shows up in S3 as base64-encoded `ConnectVariant` bytes. That's standard Connect JSON encoding for `BYTES` fields. Restore decodes back to native JSON types.

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->
- Uses `ConnectVariant` uniformly as the extras map value type. A narrower typed value (e.g. `INT32`) for `additionalProperties: {type: integer}` would be more compact but adds branching. Open to switching.
- Reverse path (`rawSchemaFromConnectSchema`) is out of scope. Fine for backup (which stores the raw JSON Schema on the wrapper); worth revisiting for general Struct → Schema → Struct round trips.
- Companion `JsonSchemaConverterBackupTest` round-trip test written locally, depends on helpers in sister branch `INIT-5113-BackupRestore-ErrorHandling`. Will be added once that branch merges.

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
