### PR TITLE
[DGS-24963] Reject non-frozen STRONG associations

### DIFF
--- a/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
+++ b/avro-serializer/src/test/java/io/confluent/kafka/serializers/KafkaAvroSerializerTest.java
@@ -668,7 +668,7 @@ public class KafkaAvroSerializerTest {
             new AssociationCreateOrUpdateInfo(
                 "mysubject",
                 "value",
-                LifecyclePolicy.STRONG,
+                LifecyclePolicy.WEAK,
                 false,
                 null,
                 null

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -992,6 +992,11 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
       Association existingAssociation = resourceAndAssocTypeCache.get(key);
 
       if (existingAssociation == null) {
+        // Mirror the server: an upsert that creates a new association rejects an inline schema
+        // and validates lifecycle against frozen (AbstractSchemaRegistry:2073-2075).
+        if (!isCreate) {
+          associationInRequest.applyDefaults(false);
+        }
         // A STRONG association is owned by its topic and can only be created together with the
         // topic, never by an upsert. Mirrors the rule enforced by AbstractSchemaRegistry.
         if (!isCreate && associationInRequest.getLifecycle() == LifecyclePolicy.STRONG) {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -992,6 +992,14 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
       Association existingAssociation = resourceAndAssocTypeCache.get(key);
 
       if (existingAssociation == null) {
+        // A STRONG association is owned by its topic and can only be created together with the
+        // topic, never by an upsert. Mirrors the rule enforced by AbstractSchemaRegistry.
+        if (!isCreate && associationInRequest.getLifecycle() == LifecyclePolicy.STRONG) {
+          throw new RestClientException(String.format(
+                  "The association specified an invalid value for property: '%s', detail: %s",
+                  "lifecycle", "cannot be STRONG when creating an association; "
+                          + "STRONG associations must be created with the topic"), 422, 42212);
+        }
         // If on create, frozen is set to true, ensure that a schema is being
         // passed in, and that no other schemas exist in the subject
         if (Boolean.TRUE.equals(associationInRequest.getFrozen())) {
@@ -1040,13 +1048,18 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
                   "The association of type '%s' is frozen for subject '%s'",
                   associationType, subject), 409, 40908);
         }
-        // If existing association is weak but request is frozen, return false
-        if (existingAssociation.getLifecycle() == LifecyclePolicy.WEAK
-                && Boolean.TRUE.equals(associationInRequest.getFrozen())) {
+        // STRONG is frozen and WEAK is not; the two always travel together. Mirrors the
+        // invariant enforced by AbstractSchemaRegistry, and is what rejects promoting an
+        // existing WEAK association to a non-frozen STRONG one.
+        LifecyclePolicy resultingLifecycle = associationInRequest.getLifecycle() != null
+                ? associationInRequest.getLifecycle() : existingAssociation.getLifecycle();
+        boolean resultingFrozen = associationInRequest.getFrozen() != null
+                ? associationInRequest.getFrozen() : existingAssociation.isFrozen();
+        if (resultingFrozen != (resultingLifecycle == LifecyclePolicy.STRONG)) {
           throw new RestClientException(String.format(
                   "The association specified an invalid value for property: '%s', detail: %s",
-                  "frozen", "association with lifecycle of WEAK cannot be frozen"),
-                  422, 42212);
+                  "frozen", String.format("association with lifecycle of %s cannot be frozen=%s",
+                          resultingLifecycle, resultingFrozen)), 422, 42212);
         }
       }
     }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/AssociationCreateOrUpdateInfo.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/AssociationCreateOrUpdateInfo.java
@@ -169,32 +169,31 @@ public class AssociationCreateOrUpdateInfo {
   public void applyDefaults(boolean isCreate) {
     if (!isCreate && getSchema() != null) {
       throw new IllegalPropertyException(
-          "schema", "cannot be provided when adding an association to an existing topic; "
+              "schema", "cannot be provided when adding an association to an existing topic; "
               + "an association with a schema must be created with the topic");
     }
     if (getSchema() != null) {
       if (getLifecycle() == LifecyclePolicy.WEAK) {
         throw new IllegalPropertyException(
-            "lifecycle", "cannot be WEAK when schema is provided");
+                "lifecycle", "cannot be WEAK when schema is provided");
       }
       if (Boolean.FALSE.equals(getFrozen())) {
         throw new IllegalPropertyException(
-            "frozen", "cannot be false when a schema is provided");
+                "frozen", "cannot be false when a schema is provided");
       }
       setLifecycle(LifecyclePolicy.STRONG);
-      setFrozen(true);
     } else {
-      if (getFrozen() == null) {
-        setFrozen(false);
+      if (getLifecycle() == null) {
+        setLifecycle(LifecyclePolicy.WEAK);
       }
     }
-    if (getLifecycle() == null) {
-      setLifecycle(LifecyclePolicy.WEAK);
+    boolean desiredFrozen = getLifecycle() == LifecyclePolicy.STRONG;
+    if (getFrozen() != null && getFrozen() != desiredFrozen) {
+      throw new IllegalPropertyException("frozen",
+              String.format("association with lifecycle of %s cannot be frozen=%s",
+                      getLifecycle(), getFrozen()));
     }
-    if (getLifecycle() == LifecyclePolicy.WEAK && Boolean.TRUE.equals(getFrozen())) {
-      throw new IllegalPropertyException(
-          "frozen", "association with lifecycle of WEAK cannot be frozen");
-    }
+    setFrozen(desiredFrozen);
   }
 
   public void validate(boolean isCreate, boolean dryRun) {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/AssociationCreateOrUpdateOp.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/AssociationCreateOrUpdateOp.java
@@ -173,19 +173,18 @@ public abstract class AssociationCreateOrUpdateOp extends AssociationOp {
             "frozen", "cannot be false when a schema is provided");
       }
       setLifecycle(LifecyclePolicy.STRONG);
-      setFrozen(true);
     } else {
-      if (getFrozen() == null) {
-        setFrozen(false);
+      if (getLifecycle() == null) {
+        setLifecycle(LifecyclePolicy.WEAK);
       }
     }
-    if (getLifecycle() == null) {
-      setLifecycle(LifecyclePolicy.WEAK);
+    boolean desiredFrozen = getLifecycle() == LifecyclePolicy.STRONG;
+    if (getFrozen() != null && getFrozen() != desiredFrozen) {
+      throw new IllegalPropertyException("frozen",
+              String.format("association with lifecycle of %s cannot be frozen=%s",
+                      getLifecycle(), getFrozen()));
     }
-    if (getLifecycle() == LifecyclePolicy.WEAK && Boolean.TRUE.equals(getFrozen())) {
-      throw new IllegalPropertyException(
-          "frozen", "association with lifecycle of WEAK cannot be frozen");
-    }
+    setFrozen(desiredFrozen);
   }
 
   // Base validation for the batch path (shared by CREATE and UPSERT ops).

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClientTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClientTest.java
@@ -460,6 +460,17 @@ public class MockSchemaRegistryClientTest {
         assertNotNull("Creating a STRONG association via upsert should fail.", e);
       }
 
+      // An association carrying a schema must be created with the topic, so an upsert that would
+      // create one is rejected before any lifecycle check.
+      createRequest = new AssociationRequestBuilder().defaultResource()
+              .valueSubject(defaultValueSubject).valueSchema(SIMPLE_AVRO_SCHEMA).build();
+      try {
+        client.createOrUpdateAssociation(createRequest);
+        fail("Expected exception - an association with a schema must be created with the topic");
+      } catch (Exception e) {
+        assertNotNull("Creating an association with a schema via upsert should fail.", e);
+      }
+
       // Create the association as WEAK instead.
       createRequest = new AssociationRequestBuilder().defaultResource()
               .valueSubject(defaultValueSubject).valueLifecycle(LifecyclePolicy.WEAK).build();

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClientTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClientTest.java
@@ -444,70 +444,49 @@ public class MockSchemaRegistryClientTest {
     }
 
     @Test
-    public void testUpdateOneAssociationViaUpsertEndpoint() {
-      // The upsert endpoint is createOrUpdateAssociation endpoint.
-      // Pre-create subjects
+    public void testAssociationImmutabilityViaUpsertEndpoint() {
+      // The upsert endpoint is createOrUpdateAssociation endpoint. An association is immutable
+      // once created, so the endpoint can only create new WEAK associations or repeat one it
+      // already stored -- every attempt to change a stored association is rejected.
       registerTestAvroSchemaInSchemaRegistry(client, defaultValueSubject, SIMPLE_AVRO_SCHEMA, true);
 
-      // Create a new value association using an existing subject.
-      // final state: strong, non-frozen
+      // A STRONG association is owned by its topic, so it cannot be created through an upsert.
       AssociationCreateOrUpdateRequest createRequest = new AssociationRequestBuilder().defaultResource()
               .valueSubject(defaultValueSubject).valueLifecycle(LifecyclePolicy.STRONG).build();
       try {
         client.createOrUpdateAssociation(createRequest);
+        fail("Expected exception - a STRONG association must be created with the topic");
       } catch (Exception e) {
-        assertNull("AssociationCreateOrUpdateRequest should succeed.", e);
+        assertNotNull("Creating a STRONG association via upsert should fail.", e);
       }
 
-      // Change strong, not frozen lifecycle to weak, non-frozen lifecycle should succeed.
-      // final state: weak, non-frozen
-      createRequest = new AssociationRequestBuilder().defaultResource().valueSubject(defaultValueSubject)
-                      .valueLifecycle(LifecyclePolicy.WEAK).build();
+      // Create the association as WEAK instead.
+      createRequest = new AssociationRequestBuilder().defaultResource()
+              .valueSubject(defaultValueSubject).valueLifecycle(LifecyclePolicy.WEAK).build();
       try {
         client.createOrUpdateAssociation(createRequest);
       } catch (Exception e) {
-        assertNull("Create association with a different property should succeed.", e);
+        assertNull("Creating a WEAK association via upsert should succeed.", e);
       }
 
-      // Update schema should succeed (register schema separately since WEAK+schema is not allowed).
-      // final state: weak, non-frozen
-      registerTestAvroSchemaInSchemaRegistry(client, defaultValueSubject, EVOLVED_AVRO_SCHEMA, true);
-      createRequest = new AssociationRequestBuilder().defaultResource().valueSubject(defaultValueSubject).build();
+      // Promoting it to STRONG is rejected: STRONG is frozen, and frozen cannot be turned on.
+      createRequest = new AssociationRequestBuilder().defaultResource()
+              .valueSubject(defaultValueSubject).valueLifecycle(LifecyclePolicy.STRONG).build();
       try {
         client.createOrUpdateAssociation(createRequest);
+        fail("Expected exception - a WEAK association cannot be promoted to STRONG");
       } catch (Exception e) {
-        assertNull("Update association with a different schema should succeed.", e);
+        assertNotNull("Promoting a WEAK association should fail.", e);
       }
 
-      // Change weak, non-frozen lifecycle to weak, frozen lifecycle should fail.
-      // final state: weak, non-frozen
-      createRequest = new AssociationRequestBuilder().defaultResource().valueSubject(defaultValueSubject)
-              .valueFrozen(true).build();
+      // Freezing a WEAK association is rejected for the same reason.
+      createRequest = new AssociationRequestBuilder().defaultResource()
+              .valueSubject(defaultValueSubject).valueFrozen(true).build();
       try {
         client.createOrUpdateAssociation(createRequest);
-        fail("Weak frozen is not supported");
+        fail("Expected exception - a WEAK association cannot be frozen");
       } catch (Exception e) {
-        assertNotNull("Update association to weak frozen should fail.", e);
-      }
-
-      // Change to strong, not frozen should succeed.
-      // final state: strong, non-frozen
-      createRequest = new AssociationRequestBuilder().defaultResource().valueSubject(defaultValueSubject)
-              .valueLifecycle(LifecyclePolicy.STRONG).build();
-      try {
-        client.createOrUpdateAssociation(createRequest);
-      } catch (Exception e) {
-        assertNull("Update association back to strong should succeed.", e);
-      }
-
-      // Changing the frozen attribute on an existing association is not allowed.
-      createRequest = new AssociationRequestBuilder().defaultResource().valueSubject(defaultValueSubject)
-              .valueLifecycle(LifecyclePolicy.STRONG).valueFrozen(true).build();
-      try {
-        client.createOrUpdateAssociation(createRequest);
-        fail("Expected exception - changing frozen attribute is not allowed");
-      } catch (Exception e) {
-        assertNotNull("Changing the frozen attribute should fail.", e);
+        assertNotNull("Freezing a WEAK association should fail.", e);
       }
 
       // Creating a frozen association with a schema should succeed (subject defaults).
@@ -522,7 +501,7 @@ public class MockSchemaRegistryClientTest {
                       new RegisterSchemaRequest(new Schema(null, null, null, null, null, SIMPLE_AVRO_SCHEMA)),
                       false)));
       try {
-        client.createOrUpdateAssociation(createRequest);
+        client.createAssociation(createRequest);
       } catch (Exception e) {
         assertNull("Creating a frozen association with schema should succeed.", e);
       }
@@ -617,7 +596,8 @@ public class MockSchemaRegistryClientTest {
               .valueSubject(fooCanonicalSubject).valueLifecycle(LifecyclePolicy.STRONG)
               .valueSchema(SIMPLE_AVRO_SCHEMA).build();
       try {
-        associationCreator.create(fooRequest);
+        // Always the create endpoint: a STRONG association cannot be made by an upsert.
+        client.createAssociation(fooRequest);
       } catch (Exception e) {
         assertNull("AssociationCreateOrUpdateRequest should succeed.", e);
       }
@@ -675,7 +655,9 @@ public class MockSchemaRegistryClientTest {
               .valueSchema(SIMPLE_AVRO_SCHEMA).build();
 
       try {
-        associationCreator.create(barRequest);
+        // Create endpoint, so the failure is the subject conflict rather than the rule that a
+        // STRONG association cannot be made by an upsert.
+        client.createAssociation(barRequest);
         fail("Expected exception - cannot create strong when subject has weak");
       } catch (Exception e) {
         assertNotNull(e);
@@ -734,16 +716,21 @@ public class MockSchemaRegistryClientTest {
     public void testGetAssociationsWithFilters() {
       // Setup
       // Register schemas separately, then create associations: key=STRONG, value=WEAK
-      registerTestAvroSchemaInSchemaRegistry(client, defaulKeySubject, SIMPLE_AVRO_SCHEMA, true);
+      // The STRONG association is frozen, so it owns its resource's canonical subject and
+      // carries its schema inline rather than having one registered beforehand.
+      String keyCanonicalSubject = ":." + defaultResourceNamespace + ":" + defaultResourceName
+              + "-" + KEY;
       registerTestAvroSchemaInSchemaRegistry(client, defaultValueSubject, SIMPLE_AVRO_SCHEMA, true);
       AssociationCreateOrUpdateRequest createRequest = new AssociationRequestBuilder().defaultResource()
-              .keySubject(defaulKeySubject).keyLifecycle(LifecyclePolicy.STRONG)
+              .keySubject(keyCanonicalSubject).keyLifecycle(LifecyclePolicy.STRONG)
+              .keySchema(SIMPLE_AVRO_SCHEMA)
               .valueSubject(defaultValueSubject)
               .valueLifecycle(LifecyclePolicy.WEAK).build();
       try {
-          client.createOrUpdateAssociation(createRequest);
+          // A STRONG association must be created with the topic, not through an upsert.
+          client.createAssociation(createRequest);
       } catch (Exception e) {
-          assertNull("createOrUpdateAssociation should succeed.", e);
+          assertNull("createAssociation should succeed.", e);
       }
 
       List<Association> associations = null;
@@ -759,7 +746,7 @@ public class MockSchemaRegistryClientTest {
       // Query by subject with lifecycle filter "weak" - should return error
       try {
           associations = client.getAssociationsBySubject(
-                  defaulKeySubject, null, Arrays.asList(KEY, VALUE), "weak", 0, -1);
+                  keyCanonicalSubject, null, Arrays.asList(KEY, VALUE), "weak", 0, -1);
           fail("getAssociationsBySubject with lower case lifecycle should fail.");
       } catch (Exception e) {
           assertNotNull("getAssociationsBySubject should return error.", e);
@@ -768,7 +755,7 @@ public class MockSchemaRegistryClientTest {
       // Query by subject with lifecycle filter "WEAK" - should return 0
       try {
           associations = client.getAssociationsBySubject(
-                  defaulKeySubject, null, Arrays.asList(KEY, VALUE), "WEAK", 0, -1);
+                  keyCanonicalSubject, null, Arrays.asList(KEY, VALUE), "WEAK", 0, -1);
       } catch (Exception e) {
           assertNull("getAssociationsBySubject should succeed.", e);
       }
@@ -777,7 +764,7 @@ public class MockSchemaRegistryClientTest {
       // Query by subject with lifecycle filter "STRONG" - should return 1
       try {
           associations = client.getAssociationsBySubject(
-                  defaulKeySubject, null, Arrays.asList(KEY, VALUE), "STRONG", 0, -1);
+                  keyCanonicalSubject, null, Arrays.asList(KEY, VALUE), "STRONG", 0, -1);
       } catch (Exception e) {
           assertNull("getAssociationsBySubject should succeed.", e);
       }
@@ -835,26 +822,27 @@ public class MockSchemaRegistryClientTest {
     }
 
     private void testCascadeDelete(Schema schema) {
-        String keySubject = "test1Key";
+        // The STRONG association is frozen, so it owns its resource's canonical subject.
+        String keySubject = ":.lkc1:test1-key";
         String valueSubject = "test1Value";
         String resourceID = "test1-id";
         String resourceName = "test1";
         String resourceNamespace = "lkc1";
 
         // Register schemas separately, then create associations
-        registerTestAvroSchemaInSchemaRegistry(client, keySubject, schema.getSchema(), true);
         registerTestAvroSchemaInSchemaRegistry(client, valueSubject, schema.getSchema(), true);
         try {
-            client.createOrUpdateAssociation(new AssociationCreateOrUpdateRequest(
+            // A STRONG association must be created with the topic, not through an upsert.
+            client.createAssociation(new AssociationCreateOrUpdateRequest(
                     resourceName, resourceNamespace, resourceID, null,
                     Arrays.asList(
-                            new AssociationCreateOrUpdateInfo(keySubject, "key", LifecyclePolicy.STRONG, false,
-                                null, false),
+                            new AssociationCreateOrUpdateInfo(keySubject, "key", LifecyclePolicy.STRONG, true,
+                                new RegisterSchemaRequest(new Schema(null, null, null, null, null, schema.getSchema())), false),
                             new AssociationCreateOrUpdateInfo(valueSubject, "value", LifecyclePolicy.WEAK, false,
                                 null, false)
                     )));
         } catch (Exception e) {
-            assertNull("createOrUpdateAssociation should succeed.", e);
+            assertNull("createAssociation should succeed.", e);
         }
 
         // Delete with cascade=true
@@ -917,7 +905,7 @@ public class MockSchemaRegistryClientTest {
             client.createOrUpdateAssociation(new AssociationCreateOrUpdateRequest(
                     resourceName, resourceNamespace, resourceID, null,
                     Arrays.asList(
-                            new AssociationCreateOrUpdateInfo(keySubject, "key", LifecyclePolicy.STRONG, false,
+                            new AssociationCreateOrUpdateInfo(keySubject, "key", LifecyclePolicy.WEAK, false,
                                 null, false),
                             new AssociationCreateOrUpdateInfo(valueSubject, "value", LifecyclePolicy.WEAK, false,
                                 null, false)
@@ -989,7 +977,8 @@ public class MockSchemaRegistryClientTest {
 
         // Create all-frozen associations with default subjects
         try {
-            client.createOrUpdateAssociation(new AssociationCreateOrUpdateRequest(
+            // A STRONG association must be created with the topic, not through an upsert.
+            client.createAssociation(new AssociationCreateOrUpdateRequest(
                     resourceName, resourceNamespace, resourceID, null,
                     Arrays.asList(
                             new AssociationCreateOrUpdateInfo(keySubject, "key", LifecyclePolicy.STRONG, true,
@@ -998,7 +987,7 @@ public class MockSchemaRegistryClientTest {
                                 new RegisterSchemaRequest(schema), false)
                     )));
         } catch (Exception e) {
-            assertNull("createOrUpdateAssociation should succeed.", e);
+            assertNull("createAssociation should succeed.", e);
         }
 
         // Delete with cascade=false should fail (frozen association)

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClientTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClientTest.java
@@ -21,6 +21,7 @@ import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Association;
 import io.confluent.kafka.schemaregistry.client.rest.entities.LifecyclePolicy;
+import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Metadata;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Rule;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleKind;
@@ -591,17 +592,30 @@ public class MockSchemaRegistryClientTest {
       testCreateMultipleAssociationsHelper(client::createOrUpdateAssociation);
     }
 
-    private void testCreateStrongAndWeakAssociationsForTheSameSubjectHelper(AssociationCreator associationCreator) {
+    /**
+     * A STRONG association is frozen, and a frozen association must use its own resource's
+     * canonical subject -- so two resources can never hold a STRONG association on the same
+     * subject. That combination is now unrepresentable rather than merely rejected, so the
+     * conflicts that remain testable are the ones where at least one side is WEAK.
+     */
+    private String canonicalValueSubject(Resource resource) {
+      return QualifiedSubject.CONTEXT_PREFIX + resource.resourceNamespace
+              + QualifiedSubject.CONTEXT_DELIMITER + resource.resourceName + "-value";
+    }
+
+    private void testStrongAndWeakAssociationConflictsAcrossResourcesHelper(AssociationCreator associationCreator) {
       Resource resourceFoo = new Resource("foo", defaultResourceNamespace, "id-foo", TOPIC);
       Resource resourceBar = new Resource("bar", defaultResourceNamespace, "id-bar", TOPIC);
       String fooValueSubject = "fooValue";
+      String fooCanonicalSubject = canonicalValueSubject(resourceFoo);
+      String barCanonicalSubject = canonicalValueSubject(resourceBar);
 
-      registerTestAvroSchemaInSchemaRegistry(client, fooValueSubject, SIMPLE_AVRO_SCHEMA, true);
-
-      // Scenario 1: Same subject, Foo=STRONG, Bar=STRONG -> Bar should fail
+      // Scenario 1: Foo=STRONG on its canonical subject, Bar=WEAK on it -> Bar should fail.
+      // A STRONG association is frozen, and a frozen association must carry its schema inline.
       AssociationCreateOrUpdateRequest fooRequest = new AssociationRequestBuilder()
               .resource(resourceFoo.resourceName, resourceFoo.resourceNamespace, resourceFoo.resourceId, resourceFoo.resourceType)
-              .valueSubject(fooValueSubject).valueLifecycle(LifecyclePolicy.STRONG).build();
+              .valueSubject(fooCanonicalSubject).valueLifecycle(LifecyclePolicy.STRONG)
+              .valueSchema(SIMPLE_AVRO_SCHEMA).build();
       try {
         associationCreator.create(fooRequest);
       } catch (Exception e) {
@@ -613,27 +627,17 @@ public class MockSchemaRegistryClientTest {
         result = client.getAssociationsByResourceId(
                 resourceFoo.resourceId, null, null, null, 0, -1);
       } catch (Exception e) {
-        assertNull("AssociationCreateOrUpdateRequest should succeed.", e);
+        assertNull("getAssociationsByResourceId should succeed.", e);
       }
       assertEquals(1, result.size());
       assertNotNull(result.get(0).getGuid());
       assertFalse(result.get(0).getGuid().isEmpty());
 
+      // Bar's own canonical subject differs, so this passes the subject-format rules and is
+      // rejected by conflict detection: the subject already carries a STRONG association.
       AssociationCreateOrUpdateRequest barRequest = new AssociationRequestBuilder()
               .resource(resourceBar.resourceName, resourceBar.resourceNamespace, resourceBar.resourceId, resourceBar.resourceType)
-              .valueSubject(fooValueSubject).valueLifecycle(LifecyclePolicy.STRONG).build();
-
-      try {
-        client.createOrUpdateAssociation(barRequest);
-        fail("Expected exception - cannot create strong association when subject already has strong");
-      } catch (Exception e) {
-        assertNotNull(e);
-      }
-
-      // Scenario 2: Foo=STRONG, Bar=WEAK -> Bar should fail
-      barRequest = new AssociationRequestBuilder()
-              .resource(resourceBar.resourceName, resourceBar.resourceNamespace, resourceBar.resourceId, resourceBar.resourceType)
-              .valueSubject(fooValueSubject).valueLifecycle(LifecyclePolicy.WEAK).build();
+              .valueSubject(fooCanonicalSubject).valueLifecycle(LifecyclePolicy.WEAK).build();
       try {
         client.createOrUpdateAssociation(barRequest);
         fail("Expected exception - cannot create weak when subject has strong");
@@ -641,13 +645,12 @@ public class MockSchemaRegistryClientTest {
         assertNotNull(e);
       }
 
-      // Scenario 3: Foo=WEAK, Bar=STRONG -> Bar should fail
-      // Reset
+      // Scenario 2: Foo=WEAK on Bar's canonical subject, Bar=STRONG on it -> Bar should fail
       client.reset();
-      registerTestAvroSchemaInSchemaRegistry(client, fooValueSubject, SIMPLE_AVRO_SCHEMA, true);
+      registerTestAvroSchemaInSchemaRegistry(client, barCanonicalSubject, SIMPLE_AVRO_SCHEMA, true);
       fooRequest = new AssociationRequestBuilder()
               .resource(resourceFoo.resourceName, resourceFoo.resourceNamespace, resourceFoo.resourceId, resourceFoo.resourceType)
-              .valueSubject(fooValueSubject).valueLifecycle(LifecyclePolicy.WEAK).build();
+              .valueSubject(barCanonicalSubject).valueLifecycle(LifecyclePolicy.WEAK).build();
 
       try {
         associationCreator.create(fooRequest);
@@ -659,7 +662,7 @@ public class MockSchemaRegistryClientTest {
         result = client.getAssociationsByResourceId(
                 resourceFoo.resourceId, null, null, null, 0, -1);
       } catch (Exception e) {
-        assertNull("getAssociationsByResourceId succeed.", e);
+        assertNull("getAssociationsByResourceId should succeed.", e);
       }
       assertEquals(1, result.size());
       assertNotNull(result.get(0).getGuid());
@@ -668,7 +671,8 @@ public class MockSchemaRegistryClientTest {
       // Try to create Bar strong - should fail
       barRequest = new AssociationRequestBuilder()
               .resource(resourceBar.resourceName, resourceBar.resourceNamespace, resourceBar.resourceId, resourceBar.resourceType)
-              .valueSubject(fooValueSubject).valueLifecycle(LifecyclePolicy.STRONG).build();
+              .valueSubject(barCanonicalSubject).valueLifecycle(LifecyclePolicy.STRONG)
+              .valueSchema(SIMPLE_AVRO_SCHEMA).build();
 
       try {
         associationCreator.create(barRequest);
@@ -677,7 +681,18 @@ public class MockSchemaRegistryClientTest {
         assertNotNull(e);
       }
 
-      // Scenario 4: Foo=WEAK, Bar=WEAK -> Bar should succeed
+      // Scenario 3: Foo=WEAK, Bar=WEAK on a shared non-canonical subject -> both should succeed
+      client.reset();
+      registerTestAvroSchemaInSchemaRegistry(client, fooValueSubject, SIMPLE_AVRO_SCHEMA, true);
+      fooRequest = new AssociationRequestBuilder()
+              .resource(resourceFoo.resourceName, resourceFoo.resourceNamespace, resourceFoo.resourceId, resourceFoo.resourceType)
+              .valueSubject(fooValueSubject).valueLifecycle(LifecyclePolicy.WEAK).build();
+      try {
+        associationCreator.create(fooRequest);
+      } catch (Exception e) {
+        assertNull("AssociationCreateOrUpdateRequest should succeed.", e);
+      }
+
       barRequest = new AssociationRequestBuilder()
               .resource(resourceBar.resourceName, resourceBar.resourceNamespace, resourceBar.resourceId, resourceBar.resourceType)
               .valueSubject(fooValueSubject).valueLifecycle(LifecyclePolicy.WEAK).build();
@@ -709,10 +724,10 @@ public class MockSchemaRegistryClientTest {
     }
 
     @Test
-    public void testCreateStrongAndWeakAssociationsForTheSameSubject() {
-      testCreateStrongAndWeakAssociationsForTheSameSubjectHelper(client::createAssociation);
+    public void testStrongAndWeakAssociationConflictsAcrossResources() {
+      testStrongAndWeakAssociationConflictsAcrossResourcesHelper(client::createAssociation);
       setUp();
-      testCreateStrongAndWeakAssociationsForTheSameSubjectHelper(client::createOrUpdateAssociation);
+      testStrongAndWeakAssociationConflictsAcrossResourcesHelper(client::createOrUpdateAssociation);
     }
 
     @Test

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/AssociationsRequestTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/entities/requests/AssociationsRequestTest.java
@@ -89,7 +89,7 @@ public class AssociationsRequestTest {
   @Test
   public void testOpRequestValidAssociationsDoesNotThrow() {
     AssociationCreateOp op = new AssociationCreateOp(
-        "test-subject", null, LifecyclePolicy.STRONG, null, null, null);
+        "test-subject", null, LifecyclePolicy.WEAK, null, null, null);
     AssociationOpRequest request = new AssociationOpRequest(
         "test-resource", "test-ns", "test-id", null, Collections.singletonList(op));
     request.validate(false);
@@ -253,7 +253,7 @@ public class AssociationsRequestTest {
         "test-subject", null, LifecyclePolicy.STRONG, null, null, null);
     info.applyDefaults(false);
     assertEquals(LifecyclePolicy.STRONG, info.getLifecycle());
-    assertEquals(Boolean.FALSE, info.getFrozen());
+    assertEquals(Boolean.TRUE, info.getFrozen());
   }
 
   @Test
@@ -309,7 +309,7 @@ public class AssociationsRequestTest {
         "test-subject", null, LifecyclePolicy.STRONG, null, null, null);
     op.applyDefaults(false);
     assertEquals(LifecyclePolicy.STRONG, op.getLifecycle());
-    assertEquals(Boolean.FALSE, op.getFrozen());
+    assertEquals(Boolean.TRUE, op.getFrozen());
   }
 
   // Requirement #3: Default subject + subject required
@@ -473,7 +473,7 @@ public class AssociationsRequestTest {
     AssociationCreateOp frozenOp = new AssociationCreateOp(
         null, "key", null, null, schema, null);
     AssociationCreateOp nonFrozenOp = new AssociationCreateOp(
-        "test-subject", "value", LifecyclePolicy.STRONG, false, null, null);
+        "test-subject", "value", null, false, null, null);
     AssociationOpRequest request = new AssociationOpRequest(
         "test-resource", "test-ns", "test-id", null,
         java.util.Arrays.asList(frozenOp, nonFrozenOp));
@@ -499,9 +499,9 @@ public class AssociationsRequestTest {
   @Test
   public void testCreateOpAllNonFrozenSucceeds() {
     AssociationCreateOp op1 = new AssociationCreateOp(
-        "subject1", "key", LifecyclePolicy.STRONG, false, null, null);
+        "subject1", "key", LifecyclePolicy.WEAK, false, null, null);
     AssociationCreateOp op2 = new AssociationCreateOp(
-        "subject2", "value", LifecyclePolicy.STRONG, false, null, null);
+        "subject2", "value", null, false, null, null);
     AssociationOpRequest request = new AssociationOpRequest(
         "test-resource", "test-ns", "test-id", null,
         java.util.Arrays.asList(op1, op2));
@@ -515,7 +515,7 @@ public class AssociationsRequestTest {
     AssociationCreateOrUpdateInfo frozenInfo = new AssociationCreateOrUpdateInfo(
         null, "key", null, null, schema, null);
     AssociationCreateOrUpdateInfo nonFrozenInfo = new AssociationCreateOrUpdateInfo(
-        "test-subject", "value", LifecyclePolicy.STRONG, false, null, null);
+        "test-subject", "value", null, null, null, null);
     AssociationCreateOrUpdateRequest request = new AssociationCreateOrUpdateRequest(
         "test-resource", "test-ns", "test-id", null,
         java.util.Arrays.asList(frozenInfo, nonFrozenInfo));

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -2112,6 +2112,18 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
 
       boolean isFrozen = association != null
           ? association.isFrozen() : Boolean.TRUE.equals(info.getFrozen());
+      // STRONG is frozen and WEAK is not; the two always travel together. applyDefaults settles
+      // this while an association is being created, but it does not run when an existing one is
+      // updated, so the invariant is checked here, on every path. This is what rejects promoting
+      // a WEAK association to a non-frozen STRONG one. Note this is the frozen state the request
+      // asks for, not the stored one above: a request that does set frozen is left to the rule
+      // that frozen cannot be changed, which describes that failure better.
+      boolean requestedFrozen = info.getFrozen() != null ? info.getFrozen() : isFrozen;
+      if (requestedFrozen != (effectiveLifecycle == LifecyclePolicy.STRONG)) {
+        throw new IllegalPropertyException("frozen",
+            String.format("association with lifecycle of %s cannot be frozen=%s",
+                effectiveLifecycle, requestedFrozen));
+      }
       if (isFrozen && unqualifiedSubject != null
           && !unqualifiedSubject.equals(defaultSubject)) {
         throw new IllegalPropertyException(

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -2112,12 +2112,9 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
 
       boolean isFrozen = association != null
           ? association.isFrozen() : Boolean.TRUE.equals(info.getFrozen());
-      // STRONG is frozen and WEAK is not; the two always travel together. applyDefaults settles
-      // this while an association is being created, but it does not run when an existing one is
-      // updated, so the invariant is checked here, on every path. This is what rejects promoting
-      // a WEAK association to a non-frozen STRONG one. Note this is the frozen state the request
-      // asks for, not the stored one above: a request that does set frozen is left to the rule
-      // that frozen cannot be changed, which describes that failure better.
+      // STRONG is frozen and WEAK is not. applyDefaults settles this on create but not on
+      // update, so the invariant is checked here against the state the request asks for.
+      // This is what rejects promoting a WEAK association to a non-frozen STRONG one.
       boolean requestedFrozen = info.getFrozen() != null ? info.getFrozen() : isFrozen;
       if (requestedFrozen != (effectiveLifecycle == LifecyclePolicy.STRONG)) {
         throw new IllegalPropertyException("frozen",

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
@@ -215,8 +215,9 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertEquals("value", associations.get(1).getAssociationType());
     assertEquals(LifecyclePolicy.WEAK, associations.get(1).getLifecycle());
 
-    // Promote both types together: a resource cannot hold a mix of lifecycles
-    request = new AssociationCreateOrUpdateRequest(
+    // An association is immutable once created: promoting these WEAK associations to STRONG is
+    // rejected, since a STRONG association is frozen and must be created with its topic.
+    AssociationCreateOrUpdateRequest requestToPromote = new AssociationCreateOrUpdateRequest(
         resourceName,
         resourceNamespace,
         resourceId,
@@ -226,7 +227,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
                 subject1,
                 "key",
                 LifecyclePolicy.STRONG,
-                false,
+                null,
                 null,
                 null
             ),
@@ -234,39 +235,16 @@ public class RestApiAssociationTest extends ClusterTestHarness {
                 subject2,
                 "value",
                 LifecyclePolicy.STRONG,
-                false,
+                null,
                 null,
                 null
             )
         )
     );
 
-    response = restApp.restClient.createOrUpdateAssociation(
-        RestService.DEFAULT_REQUEST_PROPERTIES, null, true, request);
-    assertEquals(resourceNamespace, response.getResourceNamespace());
-    assertEquals(resourceId, response.getResourceId());
-    assertNull(response.getAssociations());
-
-    response = restApp.restClient.createOrUpdateAssociation(
-        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, request);
-    assertEquals(resourceName, response.getResourceName());
-    assertEquals(resourceNamespace, response.getResourceNamespace());
-    assertEquals(resourceId, response.getResourceId());
-    assertEquals("key", response.getAssociations().get(0).getAssociationType());
-    assertEquals(LifecyclePolicy.STRONG, response.getAssociations().get(0).getLifecycle());
-
-    // Verify createTs remains the same but updateTs is updated after update
-    List<Association> updatedAssociations = restApp.restClient.getAssociationsByResourceId(
-        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
-        ImmutableList.of("key"), null, 0, -1);
-    assertEquals(1, updatedAssociations.size());
-    Association keyAssocAfterUpdate = updatedAssociations.get(0);
-    assertNotNull(keyAssocAfterUpdate.getCreateTimestamp());
-    assertNotNull(keyAssocAfterUpdate.getUpdateTimestamp());
-    // createTs should remain the same
-    assertEquals(keyCreateTs, keyAssocAfterUpdate.getCreateTimestamp());
-    // updateTs should be >= the original updateTs (updated or same if very fast)
-    assertTrue(keyAssocAfterUpdate.getUpdateTimestamp() >= keyUpdateTsAfterCreate);
+    assertThrows(Exception.class, () ->
+        restApp.restClient.createOrUpdateAssociation(
+            RestService.DEFAULT_REQUEST_PROPERTIES, null, false, requestToPromote));
 
     boolean cascadeDelete = false;
     restApp.restClient.deleteAssociations(RestService.DEFAULT_REQUEST_PROPERTIES,
@@ -289,8 +267,11 @@ public class RestApiAssociationTest extends ClusterTestHarness {
         Collections.singletonList("value"), null, 0, -1);
     assertEquals(0, associations.size());
 
+    // The association is WEAK, so it does not own its subject and the cascade leaves the
+    // schemas alone. Cascading delete of a frozen STRONG association is covered by
+    // testAssociationFrozen.
     schemas = restApp.restClient.getSchemas(null, false, false);
-    assertEquals(1, schemas.size());
+    assertEquals(2, schemas.size());
 
   }
 
@@ -639,17 +620,18 @@ public class RestApiAssociationTest extends ClusterTestHarness {
 
   @Test
   public void testStrongAssociationForSubjectExists() throws Exception {
-    String subject1 = "subject1";
     String resourceName1 = "topic1";
     String resourceName2 = "topic2";
     String resourceNamespace = "default";
     String resourceId1 = "resource1-123";
     String resourceId2 = "resource2-456";
+    // A STRONG association is frozen, so it owns its resource's canonical subject and carries
+    // its schema inline rather than having one registered beforehand.
+    String subject1 = ":.default:topic1-key";
     List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(1);
 
-    // Register schema separately since non-frozen STRONG associations
-    // cannot have schemas passed directly in create
-    restApp.restClient.registerSchema(allSchemas.get(0), subject1);
+    RegisterSchemaRequest schemaRequest = new RegisterSchemaRequest();
+    schemaRequest.setSchema(allSchemas.get(0));
 
     // Create first STRONG association for subject
     AssociationCreateOrUpdateRequest request1 = new AssociationCreateOrUpdateRequest(
@@ -662,8 +644,8 @@ public class RestApiAssociationTest extends ClusterTestHarness {
                 subject1,
                 "key",
                 LifecyclePolicy.STRONG,
-                false,
-                null,
+                true,
+                schemaRequest,
                 null
             )
         )
@@ -702,13 +684,16 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     // at validate-phase because Kafka assigns the topic UUID at create time, strictly
     // after validate. The validate-phase call on retry must be idempotent when the
     // requested association is content-equivalent to the existing one.
-    String subject1 = "subject1";
+    // A STRONG association is frozen, so it uses its resource's canonical subject and carries
+    // its schema inline.
+    String subject1 = ":.default:topic1-value";
     String resourceName = "topic1";
     String resourceNamespace = "default";
     String resourceId = "resource-uuid-123";
     List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(1);
 
-    restApp.restClient.registerSchema(allSchemas.get(0), subject1);
+    RegisterSchemaRequest schemaRequest = new RegisterSchemaRequest();
+    schemaRequest.setSchema(allSchemas.get(0));
 
     AssociationCreateOrUpdateRequest validateRequest = new AssociationCreateOrUpdateRequest(
         resourceName,
@@ -720,8 +705,8 @@ public class RestApiAssociationTest extends ClusterTestHarness {
                 subject1,
                 "value",
                 LifecyclePolicy.STRONG,
-                false,
-                null,
+                true,
+                schemaRequest,
                 null
             )
         )
@@ -736,8 +721,8 @@ public class RestApiAssociationTest extends ClusterTestHarness {
                 subject1,
                 "value",
                 LifecyclePolicy.STRONG,
-                false,
-                null,
+                true,
+                schemaRequest,
                 null
             )
         )
@@ -811,6 +796,46 @@ public class RestApiAssociationTest extends ClusterTestHarness {
         restApp.restClient.createAssociation(
             RestService.DEFAULT_REQUEST_PROPERTIES, null, false, request)
     );
+  }
+
+  /**
+   * A WEAK association cannot be promoted, and the failure names the rule that actually applies:
+   * setting frozen is refused because frozen is immutable, while leaving it unset is refused
+   * because a STRONG association is always frozen.
+   */
+  @Test
+  public void testWeakAssociationCannotBePromoted() throws Exception {
+    String subject = "promote-subject";
+    String resourceName = "topic1";
+    String resourceNamespace = "default";
+    String resourceId = "promote-rule-123";
+    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(1);
+
+    restApp.restClient.registerSchema(allSchemas.get(0), subject);
+    restApp.restClient.createAssociation(RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
+        new AssociationCreateOrUpdateRequest(resourceName, resourceNamespace, resourceId, "topic",
+            ImmutableList.of(new AssociationCreateOrUpdateInfo(
+                subject, "value", LifecyclePolicy.WEAK, false, null, null))));
+
+    // frozen explicitly set: refused because frozen cannot be changed
+    Exception frozenSet = assertThrows(Exception.class, () ->
+        restApp.restClient.createOrUpdateAssociation(
+            RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
+            new AssociationCreateOrUpdateRequest(resourceName, resourceNamespace, resourceId,
+                "topic", ImmutableList.of(new AssociationCreateOrUpdateInfo(
+                    subject, "value", LifecyclePolicy.STRONG, true, null, null)))));
+    assertTrue(frozenSet.getMessage().contains("frozen attribute of association cannot be changed"),
+        frozenSet.getMessage());
+
+    // frozen left unset: refused because a STRONG association is always frozen
+    Exception frozenUnset = assertThrows(Exception.class, () ->
+        restApp.restClient.createOrUpdateAssociation(
+            RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
+            new AssociationCreateOrUpdateRequest(resourceName, resourceNamespace, resourceId,
+                "topic", ImmutableList.of(new AssociationCreateOrUpdateInfo(
+                    subject, "value", LifecyclePolicy.STRONG, null, null, null)))));
+    assertTrue(frozenUnset.getMessage().contains("cannot be frozen=false"),
+        frozenUnset.getMessage());
   }
 
   @Test
@@ -948,11 +973,9 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     String resourceId = "self-exclude-123";
     List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(1);
 
-    // Register schema separately since non-frozen STRONG associations
-    // cannot have schemas passed directly in create
     restApp.restClient.registerSchema(allSchemas.get(0), subject1);
 
-    // Create initial STRONG association
+    // Create initial WEAK association
     AssociationCreateOrUpdateRequest request = new AssociationCreateOrUpdateRequest(
         resourceName,
         resourceNamespace,
@@ -962,7 +985,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
             new AssociationCreateOrUpdateInfo(
                 subject1,
                 "key",
-                LifecyclePolicy.STRONG,
+                LifecyclePolicy.WEAK,
                 false,
                 null,
                 null
@@ -973,11 +996,11 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     AssociationResponse response = restApp.restClient.createAssociation(
         RestService.DEFAULT_REQUEST_PROPERTIES, null, false, request);
     assertEquals("key", response.getAssociations().get(0).getAssociationType());
-    assertEquals(LifecyclePolicy.STRONG, response.getAssociations().get(0).getLifecycle());
+    assertEquals(LifecyclePolicy.WEAK, response.getAssociations().get(0).getLifecycle());
 
-    // Update the same association (changing lifecycle from STRONG to WEAK)
-    // This should succeed because the association should exclude itself
-    // from the conflict check (lines 1053-1055)
+    // Upsert the very same association again. An association is immutable once created, so this
+    // changes nothing; it should still succeed rather than report that the subject already has
+    // an association, because the association must exclude itself from the conflict check.
     AssociationCreateOrUpdateRequest updateRequest = new AssociationCreateOrUpdateRequest(
         resourceName,
         resourceNamespace,
@@ -987,7 +1010,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
             new AssociationCreateOrUpdateInfo(
                 subject1,
                 "key",
-                LifecyclePolicy.WEAK,  // Changing lifecycle
+                LifecyclePolicy.WEAK,
                 false,
                 null,
                 null
@@ -995,13 +1018,10 @@ public class RestApiAssociationTest extends ClusterTestHarness {
         )
     );
 
-    // Should succeed - the association should exclude itself from conflict check
-    AssociationResponse updateResponse = restApp.restClient.createOrUpdateAssociation(
+    restApp.restClient.createOrUpdateAssociation(
         RestService.DEFAULT_REQUEST_PROPERTIES, null, false, updateRequest);
-    assertEquals("key", updateResponse.getAssociations().get(0).getAssociationType());
-    assertEquals(LifecyclePolicy.WEAK, updateResponse.getAssociations().get(0).getLifecycle());
 
-    // Verify the association was actually updated
+    // Verify the association is unchanged and was not duplicated
     List<Association> associations = restApp.restClient.getAssociationsBySubject(
         RestService.DEFAULT_REQUEST_PROPERTIES, subject1, "topic",
         Collections.singletonList("key"), null, 0, -1);
@@ -1068,7 +1088,8 @@ public class RestApiAssociationTest extends ClusterTestHarness {
   @Test
   public void testBatchGetAssociations() throws Exception {
     String subject1 = "subject1";
-    String subject2 = "subject2";
+    // The STRONG association is frozen, so it owns its resource's canonical subject.
+    String subject2 = ":.default:topic2-value";
     String resourceName1 = "topic1";
     String resourceName2 = "topic2";
     String resourceNamespace = "default";
@@ -1079,7 +1100,9 @@ public class RestApiAssociationTest extends ClusterTestHarness {
 
     // Register schemas separately
     restApp.restClient.registerSchema(allSchemas.get(0), subject1);
-    restApp.restClient.registerSchema(allSchemas.get(1), subject2);
+
+    RegisterSchemaRequest subject2Schema = new RegisterSchemaRequest();
+    subject2Schema.setSchema(allSchemas.get(1));
 
     // Create first association
     AssociationCreateOrUpdateRequest request1 = new AssociationCreateOrUpdateRequest(
@@ -1093,7 +1116,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     AssociationCreateOrUpdateRequest request2 = new AssociationCreateOrUpdateRequest(
         resourceName2, resourceNamespace, resourceId2, "topic",
         ImmutableList.of(new AssociationCreateOrUpdateInfo(
-            subject2, "value", LifecyclePolicy.STRONG, false, null, null)));
+            subject2, "value", LifecyclePolicy.STRONG, true, subject2Schema, null)));
     restApp.restClient.createAssociation(
         RestService.DEFAULT_REQUEST_PROPERTIES, null, false, request2);
 
@@ -1511,7 +1534,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
             new AssociationUpsertOp(
                 subject1,
                 "key",
-                LifecyclePolicy.STRONG,  // Change from WEAK to STRONG
+                LifecyclePolicy.WEAK,  // Unchanged: an association is immutable once created
                 false,
                 null,
                 null
@@ -1545,13 +1568,13 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertNotNull(batchResponse);
     assertEquals(2, batchResponse.getResults().size());
 
-    // Verify first result (updated)
+    // Verify first result (unchanged). The op is equivalent to the stored association, so it is
+    // skipped and the result carries no associations.
     AssociationResult result1 = batchResponse.getResults().get(0);
     assertNull(result1.getError());
     assertNotNull(result1.getResult());
     assertEquals(resourceName1, result1.getResult().getResourceName());
     assertEquals(resourceId1, result1.getResult().getResourceId());
-    assertEquals(LifecyclePolicy.STRONG, result1.getResult().getAssociations().get(0).getLifecycle());
 
     // Verify second result (created)
     AssociationResult result2 = batchResponse.getResults().get(1);
@@ -1561,12 +1584,12 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertEquals(resourceId2, result2.getResult().getResourceId());
     assertEquals(LifecyclePolicy.WEAK, result2.getResult().getAssociations().get(0).getLifecycle());
 
-    // Verify the update was persisted
+    // Verify the existing association is untouched
     List<Association> associations1 = restApp.restClient.getAssociationsByResourceId(
         RestService.DEFAULT_REQUEST_PROPERTIES, resourceId1, "topic",
         Collections.singletonList("key"), null, 0, -1);
     assertEquals(1, associations1.size());
-    assertEquals(LifecyclePolicy.STRONG, associations1.get(0).getLifecycle());
+    assertEquals(LifecyclePolicy.WEAK, associations1.get(0).getLifecycle());
 
     // Verify the new association was created
     List<Association> associations2 = restApp.restClient.getAssociationsByResourceId(
@@ -1632,14 +1655,12 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     AssociationBatchResponse batchResponse = restApp.restClient.mutateAssociations(
         RestService.DEFAULT_REQUEST_PROPERTIES, null, true, batchRequest);
 
-    // Verify dry run response
+    // An association is immutable once created, so the dry run reports the rejected promotion
+    // rather than accepting it — and, being a dry run, persists nothing either way.
     assertNotNull(batchResponse);
     assertEquals(1, batchResponse.getResults().size());
     AssociationResult result = batchResponse.getResults().get(0);
-    assertNull(result.getError());
-    assertNotNull(result.getResult());
-    assertEquals(resourceId, result.getResult().getResourceId());
-    assertNull(result.getResult().getAssociations());
+    assertNotNull(result.getError());
 
     // Verify association was NOT actually updated
     List<Association> associations = restApp.restClient.getAssociationsByResourceId(
@@ -1820,20 +1841,23 @@ public class RestApiAssociationTest extends ClusterTestHarness {
         resourceId,
         "topic",
         ImmutableList.of(
-            // UPSERT: Update existing "key" association
+            // UPSERT: touch the existing "key" association. An association is immutable once
+            // created, so this leaves it as it is.
             new AssociationUpsertOp(
                 keySubject,
                 "key",
-                LifecyclePolicy.STRONG,  // Change from WEAK to STRONG
+                LifecyclePolicy.WEAK,
                 false,
                 null,
                 null
             ),
-            // CREATE: Add new "value" association (schema already registered)
+            // CREATE: Add new "value" association (schema already registered). It is WEAK to
+            // match the existing "key" association — a resource cannot hold mixed lifecycles,
+            // and "key" can no longer be promoted to STRONG.
             new AssociationCreateOp(
                 valueSubject,
                 "value",
-                LifecyclePolicy.STRONG,
+                LifecyclePolicy.WEAK,
                 false,
                 null,
                 null
@@ -1868,7 +1892,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     // So we should have only "value" association remaining
     assertEquals(1, result.getResult().getAssociations().size());
     assertEquals("value", result.getResult().getAssociations().get(0).getAssociationType());
-    assertEquals(LifecyclePolicy.STRONG, result.getResult().getAssociations().get(0).getLifecycle());
+    assertEquals(LifecyclePolicy.WEAK, result.getResult().getAssociations().get(0).getLifecycle());
 
     // Verify final state: only "value" association exists (key was deleted)
     List<Association> finalAssociations = restApp.restClient.getAssociationsByResourceId(
@@ -1876,7 +1900,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
         ImmutableList.of("key", "value"), null, 0, -1);
     assertEquals(1, finalAssociations.size());
     assertEquals("value", finalAssociations.get(0).getAssociationType());
-    assertEquals(LifecyclePolicy.STRONG, finalAssociations.get(0).getLifecycle());
+    assertEquals(LifecyclePolicy.WEAK, finalAssociations.get(0).getLifecycle());
 
     // Verify "key" association is gone
     List<Association> keyAssociations = restApp.restClient.getAssociationsByResourceId(
@@ -1996,9 +2020,12 @@ public class RestApiAssociationTest extends ClusterTestHarness {
 
   @Test
   public void testGetSchemasWithSubjectPrefixAndLifecycleFilter() throws Exception {
-    String subject1 = "lifecycleSubject1";
-    String subject2 = "lifecycleSubject2";
-    String subject3 = "lifecycleSubject3";
+    // The STRONG association is frozen, so it owns its resource's canonical subject, which is
+    // always context-qualified. Keep every subject in the same context so one qualified prefix
+    // covers them all.
+    String subject1 = ":.default:lifecycleSubject1";
+    String subject2 = ":.default:lifecycleTopic-strong-value";
+    String subject3 = ":.default:lifecycleSubject3";
     String resourceName = "lifecycleTopic";
     String resourceNamespace = "default";
     String resourceId = "lifecycle-resource-1";
@@ -2006,8 +2033,10 @@ public class RestApiAssociationTest extends ClusterTestHarness {
 
     // Register schemas separately. subject3 is registered with no association.
     restApp.restClient.registerSchema(allSchemas.get(0), subject1);
-    restApp.restClient.registerSchema(allSchemas.get(1), subject2);
     restApp.restClient.registerSchema(allSchemas.get(2), subject3);
+
+    RegisterSchemaRequest strongSchema = new RegisterSchemaRequest();
+    strongSchema.setSchema(allSchemas.get(1));
 
     // Create associations with different lifecycle policies. They go on separate resources:
     // a single resource cannot hold a mix of lifecycles.
@@ -2041,8 +2070,8 @@ public class RestApiAssociationTest extends ClusterTestHarness {
                 subject2,
                 "value",
                 LifecyclePolicy.STRONG,
-                false,
-                null,
+                true,
+                strongSchema,
                 null
             )
         )
@@ -2054,7 +2083,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     // lifecycle=WEAK → only subject1 returned (subject2 is STRONG, subject3 unassociated)
     List<ExtendedSchema> weakSchemas = restApp.restClient.getSchemas(
         RestService.DEFAULT_REQUEST_PROPERTIES,
-        "lifecycle",
+        ":.default:lifecycle",
         false,
         false,
         false,
@@ -2074,7 +2103,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     // lifecycle=STRONG → only subject2 returned
     List<ExtendedSchema> strongSchemas = restApp.restClient.getSchemas(
         RestService.DEFAULT_REQUEST_PROPERTIES,
-        "lifecycle",
+        ":.default:lifecycle",
         false,
         false,
         false,
@@ -2095,7 +2124,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     // lifecycle=NONE → only subject3 returned (no associations attached)
     List<ExtendedSchema> noneSchemas = restApp.restClient.getSchemas(
         RestService.DEFAULT_REQUEST_PROPERTIES,
-        "lifecycle",
+        ":.default:lifecycle",
         false,
         false,
         false,
@@ -2114,7 +2143,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     // lifecycle=WEAK,NONE → subject1 (WEAK) + subject3 (unassociated); subject2 (STRONG) excluded
     List<ExtendedSchema> weakOrNoneSchemas = restApp.restClient.getSchemas(
         RestService.DEFAULT_REQUEST_PROPERTIES,
-        "lifecycle",
+        ":.default:lifecycle",
         false,
         false,
         false,
@@ -2147,7 +2176,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     // lifecycle=STRONG,WEAK → subject1 + subject2; subject3 excluded
     List<ExtendedSchema> strongOrWeakSchemas = restApp.restClient.getSchemas(
         RestService.DEFAULT_REQUEST_PROPERTIES,
-        "lifecycle",
+        ":.default:lifecycle",
         false,
         false,
         false,
@@ -2546,28 +2575,6 @@ public class RestApiAssociationTest extends ClusterTestHarness {
   }
 
   @Test
-  public void testCreateNonFrozenStrongWithoutSubjectSucceeds() throws Exception {
-    String resourceName = "topic1";
-    String resourceNamespace = "default";
-    String resourceId = "strong-nosub-123";
-    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(1);
-
-    // Register schema under the default subject
-    restApp.restClient.registerSchema(allSchemas.get(0), ":.default:topic1-value");
-
-    // Create non-frozen STRONG without subject — should succeed with default subject
-    AssociationCreateOrUpdateRequest request = new AssociationCreateOrUpdateRequest(
-        resourceName, resourceNamespace, resourceId, "topic",
-        ImmutableList.of(new AssociationCreateOrUpdateInfo(
-            null, "value", LifecyclePolicy.STRONG, null, null, null)));
-
-    AssociationResponse response = restApp.restClient.createAssociation(
-        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, request);
-    assertEquals(":.default:topic1-value", response.getAssociations().get(0).getSubject());
-    assertEquals(LifecyclePolicy.STRONG, response.getAssociations().get(0).getLifecycle());
-  }
-
-  @Test
   public void testDefaultSubjectNotAllowedForWeak() throws Exception {
     String resourceName = "topic1";
     String resourceNamespace = "default";
@@ -2816,20 +2823,22 @@ public class RestApiAssociationTest extends ClusterTestHarness {
    */
   @Test
   public void testDryRunSeesMixedLifecycleAgainstExistingSibling() throws Exception {
-    String valueSubject = "dryrun-value-subject";
+    // The STRONG association is frozen, so it owns its resource's canonical subject.
+    String valueSubject = ":.default:dryRunMixedTopic-value";
     String keySubject = "dryrun-key-subject";
     String resourceName = "dryRunMixedTopic";
     String resourceNamespace = "default";
     String resourceId = "dryrun-mixed-123";
     List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
 
-    restApp.restClient.registerSchema(allSchemas.get(0), valueSubject);
     restApp.restClient.registerSchema(allSchemas.get(1), keySubject);
 
+    RegisterSchemaRequest valueSchema = new RegisterSchemaRequest();
+    valueSchema.setSchema(allSchemas.get(0));
     AssociationCreateOrUpdateRequest valueRequest = new AssociationCreateOrUpdateRequest(
         resourceName, resourceNamespace, resourceId, "topic",
         ImmutableList.of(new AssociationCreateOrUpdateInfo(
-            valueSubject, "value", LifecyclePolicy.STRONG, false, null, null)));
+            valueSubject, "value", LifecyclePolicy.STRONG, true, valueSchema, null)));
     restApp.restClient.createAssociation(
         RestService.DEFAULT_REQUEST_PROPERTIES, null, false, valueRequest);
 
@@ -2850,21 +2859,24 @@ public class RestApiAssociationTest extends ClusterTestHarness {
    */
   @Test
   public void testDryRunDoesNotMixLifecyclesAcrossResourcesSharingAName() throws Exception {
-    String olderSubject = "older-key-subject";
+    // The STRONG association is frozen, so it owns its resource's canonical subject.
+    String olderSubject = ":.default:sharedNameTopic-key";
     String liveSubject = "live-value-subject";
     String resourceName = "sharedNameTopic";
     String resourceNamespace = "default";
     List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
 
-    restApp.restClient.registerSchema(allSchemas.get(0), olderSubject);
     restApp.restClient.registerSchema(allSchemas.get(1), liveSubject);
+
+    RegisterSchemaRequest olderSchema = new RegisterSchemaRequest();
+    olderSchema.setSchema(allSchemas.get(0));
 
     // Older resource, STRONG on key. The ids are ordered so the live resource wins whether
     // recency or the id tie-break decides, keeping the test independent of write timing.
     AssociationCreateOrUpdateRequest olderRequest = new AssociationCreateOrUpdateRequest(
         resourceName, resourceNamespace, "shared-name-a-older", "topic",
         ImmutableList.of(new AssociationCreateOrUpdateInfo(
-            olderSubject, "key", LifecyclePolicy.STRONG, false, null, null)));
+            olderSubject, "key", LifecyclePolicy.STRONG, true, olderSchema, null)));
     restApp.restClient.createAssociation(
         RestService.DEFAULT_REQUEST_PROPERTIES, null, false, olderRequest);
 
@@ -2888,70 +2900,25 @@ public class RestApiAssociationTest extends ClusterTestHarness {
   }
 
   /**
-   * A batch is checked against the state its ops project, so it can convert every type at once
-   * — the same capability a single request through the create-or-update endpoint has.
-   */
-  @Test
-  public void testBatchConvertingAllTypesTogetherSucceeds() throws Exception {
-    String keySubject = "batch-convert-key-subject";
-    String valueSubject = "batch-convert-value-subject";
-    String resourceName = "batchConvertTopic";
-    String resourceNamespace = "default";
-    String resourceId = "batch-convert-123";
-    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
-
-    restApp.restClient.registerSchema(allSchemas.get(0), keySubject);
-    restApp.restClient.registerSchema(allSchemas.get(1), valueSubject);
-
-    AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
-        resourceName, resourceNamespace, resourceId, "topic",
-        ImmutableList.of(
-            new AssociationCreateOrUpdateInfo(
-                keySubject, "key", LifecyclePolicy.WEAK, null, null, null),
-            new AssociationCreateOrUpdateInfo(
-                valueSubject, "value", LifecyclePolicy.WEAK, null, null, null)));
-    restApp.restClient.createAssociation(
-        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
-
-    // Converting one type at a time leaves the resource transiently mixed; the batch is
-    // accepted because its projected end state is uniform.
-    AssociationOpRequest opRequest = new AssociationOpRequest(
-        resourceName, resourceNamespace, resourceId, "topic",
-        ImmutableList.of(
-            new AssociationUpsertOp(
-                keySubject, "key", LifecyclePolicy.STRONG, null, null, null),
-            new AssociationUpsertOp(
-                valueSubject, "value", LifecyclePolicy.STRONG, null, null, null)));
-    AssociationBatchResponse response = restApp.restClient.mutateAssociations(
-        RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
-        new AssociationBatchRequest(Collections.singletonList(opRequest)));
-    assertNull(response.getResults().get(0).getError());
-
-    List<Association> associations = restApp.restClient.getAssociationsByResourceId(
-        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
-        ImmutableList.of("key", "value"), null, 0, -1);
-    assertEquals(2, associations.size());
-    associations.forEach(a -> assertEquals(LifecyclePolicy.STRONG, a.getLifecycle()));
-  }
-
-  /**
    * A request may carry at most one op per association type. Nothing can legitimately send
    * more — a topic config key appears once per incrementalAlterConfigs request — so this is
    * rejected rather than applied in sequence.
    */
   @Test
   public void testBatchRepeatedAssociationTypeIsRejected() throws Exception {
-    String subject = "dup-run-subject";
+    // The STRONG association is frozen, so it owns its resource's canonical subject.
+    String subject = ":.default:dupRunTopic-value";
     String resourceName = "dupRunTopic";
     String resourceNamespace = "default";
     String resourceId = "dup-run-123";
     List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(3);
 
-    restApp.restClient.registerSchema(allSchemas.get(0), subject);
+    RegisterSchemaRequest first = new RegisterSchemaRequest();
+    first.setSchema(allSchemas.get(0));
     AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
         resourceName, resourceNamespace, resourceId, "topic",
         ImmutableList.of(new AssociationCreateOrUpdateInfo(
-            subject, "value", LifecyclePolicy.STRONG, false, null, null)));
+            subject, "value", LifecyclePolicy.STRONG, true, first, null)));
     restApp.restClient.createAssociation(
         RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
 
@@ -3085,119 +3052,7 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertTrue(associations.isEmpty());
   }
 
-  /** A request that converts every type at once keeps the resource uniform, so it is allowed. */
-  @Test
-  public void testConvertingAllTypesTogetherSucceeds() throws Exception {
-    String keySubject = "convert-key-subject";
-    String valueSubject = "convert-value-subject";
-    String resourceName = "topic1";
-    String resourceNamespace = "default";
-    String resourceId = "mixed-convert-123";
-    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
-
-    restApp.restClient.registerSchema(allSchemas.get(0), keySubject);
-    restApp.restClient.registerSchema(allSchemas.get(1), valueSubject);
-
-    AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
-        resourceName, resourceNamespace, resourceId, "topic",
-        ImmutableList.of(
-            new AssociationCreateOrUpdateInfo(
-                keySubject, "key", LifecyclePolicy.WEAK, null, null, null),
-            new AssociationCreateOrUpdateInfo(
-                valueSubject, "value", LifecyclePolicy.WEAK, null, null, null)));
-    restApp.restClient.createAssociation(
-        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
-
-    AssociationCreateOrUpdateRequest upsertRequest = new AssociationCreateOrUpdateRequest(
-        resourceName, resourceNamespace, resourceId, "topic",
-        ImmutableList.of(
-            new AssociationCreateOrUpdateInfo(
-                keySubject, "key", LifecyclePolicy.STRONG, null, null, null),
-            new AssociationCreateOrUpdateInfo(
-                valueSubject, "value", LifecyclePolicy.STRONG, null, null, null)));
-    restApp.restClient.createOrUpdateAssociation(
-        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, upsertRequest);
-
-    List<Association> associations = restApp.restClient.getAssociationsByResourceId(
-        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
-        ImmutableList.of("key", "value"), null, 0, -1);
-    assertEquals(2, associations.size());
-    associations.forEach(a -> assertEquals(LifecyclePolicy.STRONG, a.getLifecycle()));
-  }
-
   // Requirement: Frozen/non-frozen consistency at resource level
-
-  @Test
-  public void testCreateFrozenThenCreateNonFrozenSucceeds() throws Exception {
-    String resourceName = "topic1";
-    String resourceNamespace = "default";
-    String resourceId = "frozen-consistency-123";
-    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
-
-    RegisterSchemaRequest schemaRequest = new RegisterSchemaRequest();
-    schemaRequest.setSchema(allSchemas.get(0));
-
-    // Create frozen association
-    AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
-        resourceName, resourceNamespace, resourceId, "topic",
-        ImmutableList.of(new AssociationCreateOrUpdateInfo(
-            null, "key", null, null, schemaRequest, null)));
-
-    restApp.restClient.createAssociation(
-        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
-
-    // Now create a non-frozen STRONG association for the same resource — should succeed.
-    // This uses the create path: an upsert may not create a STRONG association.
-    restApp.restClient.registerSchema(allSchemas.get(1), "value-subject");
-    AssociationCreateOrUpdateRequest secondRequest = new AssociationCreateOrUpdateRequest(
-        resourceName, resourceNamespace, resourceId, "topic",
-        ImmutableList.of(new AssociationCreateOrUpdateInfo(
-            "value-subject", "value", LifecyclePolicy.STRONG, false, null, null)));
-
-    restApp.restClient.createAssociation(
-        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, secondRequest);
-
-    // Verify both exist with different frozen states
-    List<Association> associations = restApp.restClient.getAssociationsByResourceId(
-        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
-        ImmutableList.of("key", "value"), null, 0, -1);
-    assertEquals(2, associations.size());
-  }
-
-  @Test
-  public void testCreateNonFrozenThenCreateFrozenSucceeds() throws Exception {
-    String resourceName = "topic1";
-    String resourceNamespace = "default";
-    String resourceId = "nonfrozen-then-frozen-123";
-    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
-
-    // Create non-frozen association
-    restApp.restClient.registerSchema(allSchemas.get(0), "key-subject");
-    AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
-        resourceName, resourceNamespace, resourceId, "topic",
-        ImmutableList.of(new AssociationCreateOrUpdateInfo(
-            "key-subject", "key", LifecyclePolicy.STRONG, false, null, null)));
-
-    restApp.restClient.createAssociation(
-        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
-
-    // Create a frozen association for the same resource via CREATE — should succeed
-    RegisterSchemaRequest schemaRequest = new RegisterSchemaRequest();
-    schemaRequest.setSchema(allSchemas.get(1));
-    AssociationCreateOrUpdateRequest createRequest2 = new AssociationCreateOrUpdateRequest(
-        resourceName, resourceNamespace, resourceId, "topic",
-        ImmutableList.of(new AssociationCreateOrUpdateInfo(
-            null, "value", null, null, schemaRequest, null)));
-
-    restApp.restClient.createAssociation(
-        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest2);
-
-    // Verify both exist with different frozen states
-    List<Association> associations = restApp.restClient.getAssociationsByResourceId(
-        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
-        ImmutableList.of("key", "value"), null, 0, -1);
-    assertEquals(2, associations.size());
-  }
 
   @Test
   public void testCreateFrozenThenCreateAnotherFrozenSucceeds() throws Exception {
@@ -3239,42 +3094,6 @@ public class RestApiAssociationTest extends ClusterTestHarness {
   }
 
   @Test
-  public void testBatchCreateMixedFrozenAndNonFrozenSucceeds() throws Exception {
-    String resourceName = "topic1";
-    String resourceNamespace = "default";
-    String resourceId = "batch-mixed-frozen-123";
-    List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
-
-    RegisterSchemaRequest schemaRequest = new RegisterSchemaRequest();
-    schemaRequest.setSchema(allSchemas.get(0));
-
-    // Batch with mixed frozen and non-frozen — should succeed
-    AssociationCreateOp frozenOp = new AssociationCreateOp(
-        null, "key", null, null, schemaRequest, null);
-    AssociationCreateOp nonFrozenOp = new AssociationCreateOp(
-        "some-subject", "value", LifecyclePolicy.STRONG, false, null, null);
-
-    // Register schema for the non-frozen subject
-    restApp.restClient.registerSchema(allSchemas.get(1), "some-subject");
-
-    AssociationOpRequest opRequest = new AssociationOpRequest(
-        resourceName, resourceNamespace, resourceId, "topic",
-        ImmutableList.of(frozenOp, nonFrozenOp));
-    AssociationBatchRequest batchRequest = new AssociationBatchRequest(
-        Collections.singletonList(opRequest));
-
-    AssociationBatchResponse response = restApp.restClient.mutateAssociations(
-        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, batchRequest);
-    assertNull(response.getResults().get(0).getError());
-
-    // Verify both exist
-    List<Association> associations = restApp.restClient.getAssociationsByResourceId(
-        RestService.DEFAULT_REQUEST_PROPERTIES, resourceId, "topic",
-        ImmutableList.of("key", "value"), null, 0, -1);
-    assertEquals(2, associations.size());
-  }
-
-  @Test
   public void testBatchCreateAllFrozenSucceeds() throws Exception {
     String resourceName = "topic1";
     String resourceNamespace = "default";
@@ -3313,18 +3132,20 @@ public class RestApiAssociationTest extends ClusterTestHarness {
 
   @Test
   public void testUpsertWithNullSubjectUsesExistingSubject() throws Exception {
-    String subject = "existing-subject";
+    // A STRONG association is frozen, so it uses its resource's canonical subject and carries
+    // its schema inline.
+    String subject = ":.default:topic1-value";
     String resourceName = "topic1";
     String resourceNamespace = "default";
     String resourceId = "upsert-null-sub-123";
     List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(1);
 
-    // Register schema and create association
-    restApp.restClient.registerSchema(allSchemas.get(0), subject);
+    RegisterSchemaRequest schemaRequest = new RegisterSchemaRequest();
+    schemaRequest.setSchema(allSchemas.get(0));
     AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
         resourceName, resourceNamespace, resourceId, "topic",
         ImmutableList.of(new AssociationCreateOrUpdateInfo(
-            subject, "value", LifecyclePolicy.STRONG, false, null, null)));
+            subject, "value", LifecyclePolicy.STRONG, true, schemaRequest, null)));
     restApp.restClient.createAssociation(
         RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
 
@@ -3346,18 +3167,20 @@ public class RestApiAssociationTest extends ClusterTestHarness {
 
   @Test
   public void testUpsertWithNullLifecycleKeepsExisting() throws Exception {
-    String subject = "lifecycle-test-subject";
+    // A STRONG association is frozen, so it uses its resource's canonical subject and carries
+    // its schema inline.
+    String subject = ":.default:topic1-value";
     String resourceName = "topic1";
     String resourceNamespace = "default";
     String resourceId = "upsert-null-lc-123";
     List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
 
-    // Register schema and create STRONG association
-    restApp.restClient.registerSchema(allSchemas.get(0), subject);
+    RegisterSchemaRequest createSchema = new RegisterSchemaRequest();
+    createSchema.setSchema(allSchemas.get(0));
     AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
         resourceName, resourceNamespace, resourceId, "topic",
         ImmutableList.of(new AssociationCreateOrUpdateInfo(
-            subject, "value", LifecyclePolicy.STRONG, false, null, null)));
+            subject, "value", LifecyclePolicy.STRONG, true, createSchema, null)));
     restApp.restClient.createAssociation(
         RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
 
@@ -3607,18 +3430,19 @@ public class RestApiAssociationTest extends ClusterTestHarness {
 
   @Test
   public void testBatchUpsertWithNullSubjectUsesExisting() throws Exception {
-    String subject = "batch-existing-subject";
+    // The STRONG association is frozen, so it owns its resource's canonical subject.
+    String subject = ":.default:topic1-value";
     String resourceName = "topic1";
     String resourceNamespace = "default";
     String resourceId = "batch-upsert-null-sub-123";
     List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(1);
 
-    // Register schema and create association
-    restApp.restClient.registerSchema(allSchemas.get(0), subject);
+    RegisterSchemaRequest createSchema = new RegisterSchemaRequest();
+    createSchema.setSchema(allSchemas.get(0));
     AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
         resourceName, resourceNamespace, resourceId, "topic",
         ImmutableList.of(new AssociationCreateOrUpdateInfo(
-            subject, "value", LifecyclePolicy.STRONG, false, null, null)));
+            subject, "value", LifecyclePolicy.STRONG, true, createSchema, null)));
     restApp.restClient.createAssociation(
         RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
 
@@ -3754,15 +3578,17 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     String resourceName = "topic7";
     String resourceNamespace = "default";
     String resourceId = "import-mutate-schema-123";
-    String subject = "import-mutate-subject";
+    // The STRONG association is frozen, so it owns its resource's canonical subject.
+    String subject = ":.default:topic7-value";
     List<String> allSchemas = TestUtils.getRandomCanonicalAvroString(2);
 
     // Establish the association while the subject is writable
-    restApp.restClient.registerSchema(allSchemas.get(0), subject);
+    RegisterSchemaRequest createSchema = new RegisterSchemaRequest();
+    createSchema.setSchema(allSchemas.get(0));
     AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
         resourceName, resourceNamespace, resourceId, "topic",
         ImmutableList.of(new AssociationCreateOrUpdateInfo(
-            subject, "value", LifecyclePolicy.STRONG, false, null, null)));
+            subject, "value", LifecyclePolicy.STRONG, true, createSchema, null)));
     restApp.restClient.createAssociation(
         RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistryTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistryTest.java
@@ -587,21 +587,32 @@ public class KafkaSchemaRegistryTest extends ClusterTestHarness {
       LifecyclePolicy valueLifecycle = LifecyclePolicy.valueOf(r[4]);
       String subjectPrefix = namespace + "-" + resourceName;
 
-      // Pre-register schemas so associations don't need to carry them
-      String keySubject = subjectPrefix + "-key";
-      String valueSubject = subjectPrefix + "-value";
+      // A STRONG association is frozen, so it owns its resource's canonical subject and carries
+      // its schema inline. A WEAK one uses another subject, registered up front.
+      boolean keyStrong = keyLifecycle == LifecyclePolicy.STRONG;
+      boolean valueStrong = valueLifecycle == LifecyclePolicy.STRONG;
+      String keySubject = keyStrong
+          ? ":." + namespace + ":" + resourceName + "-key" : subjectPrefix + "-key";
+      String valueSubject = valueStrong
+          ? ":." + namespace + ":" + resourceName + "-value" : subjectPrefix + "-value";
       RegisterSchemaRequest keyReq = new RegisterSchemaRequest();
       keyReq.setSchema(StoreUtils.avroSchemaString(schemaFieldCount++));
       RegisterSchemaRequest valueReq = new RegisterSchemaRequest();
       valueReq.setSchema(StoreUtils.avroSchemaString(schemaFieldCount++));
-      kafkaSchemaRegistry.register(keySubject, new Schema(keySubject, keyReq));
-      kafkaSchemaRegistry.register(valueSubject, new Schema(valueSubject, valueReq));
+      if (!keyStrong) {
+        kafkaSchemaRegistry.register(keySubject, new Schema(keySubject, keyReq));
+      }
+      if (!valueStrong) {
+        kafkaSchemaRegistry.register(valueSubject, new Schema(valueSubject, valueReq));
+      }
 
       kafkaSchemaRegistry.createAssociation(null, false, new AssociationCreateOrUpdateRequest(
           resourceName, namespace, resourceId, "topic",
           Arrays.asList(
-              new AssociationCreateOrUpdateInfo(keySubject, "key", keyLifecycle, false, null, null),
-              new AssociationCreateOrUpdateInfo(valueSubject, "value", valueLifecycle, false, null, null)
+              new AssociationCreateOrUpdateInfo(keySubject, "key", keyLifecycle,
+                  keyStrong, keyStrong ? keyReq : null, null),
+              new AssociationCreateOrUpdateInfo(valueSubject, "value", valueLifecycle,
+                  valueStrong, valueStrong ? valueReq : null, null)
           )
       ));
     }

--- a/json-schema-serializer/src/test/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializerTest.java
+++ b/json-schema-serializer/src/test/java/io/confluent/kafka/serializers/json/KafkaJsonSchemaSerializerTest.java
@@ -606,7 +606,7 @@ public class KafkaJsonSchemaSerializerTest {
             new AssociationCreateOrUpdateInfo(
                 "mysubject",
                 "value",
-                LifecyclePolicy.STRONG,
+                LifecyclePolicy.WEAK,
                 false,
                 null,
                 null

--- a/protobuf-serializer/src/test/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufSerializerTest.java
+++ b/protobuf-serializer/src/test/java/io/confluent/kafka/serializers/protobuf/KafkaProtobufSerializerTest.java
@@ -880,7 +880,7 @@ public class KafkaProtobufSerializerTest {
             new AssociationCreateOrUpdateInfo(
                 "mysubject",
                 "value",
-                LifecyclePolicy.STRONG,
+                LifecyclePolicy.WEAK,
                 false,
                 null,
                 null


### PR DESCRIPTION
What
----
A STRONG association is frozen and a WEAK one is not; the two always travel together.
`applyDefaults` established this while an association is being created, but it does not run when an
existing one is updated, so `AbstractSchemaRegistry` now checks the invariant against the state a
request would leave behind. This closes the last route to a non-frozen STRONG association:
promoting a WEAK one.

The resulting model is create-once:
- An association is immutable once created; it can only be replaced by deleting it.
- A WEAK association cannot be promoted to STRONG, by any combination of fields.
- STRONG associations are created only by `createAssociation`; WEAK by either endpoint.
- Not exempted in IMPORT mode: replication may waive the transition rules, never the resulting invariant.

`MockSchemaRegistryClient` gains the same invariant, plus the pre-existing rule that a STRONG
association cannot be created through an upsert. It had neither, so tests written against the mock
could pass on requests the real server rejects.

Checklist
------------------
- **[Y]** Contains customer facing changes? Including API/behavior changes
    - Creating or updating an association to STRONG + non-frozen is now rejected. Previously
      accepted on the create path (until the preceding commit) and on the update path.
- **[N]** Is this change gated behind config(s)?
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
- **[N]** Does this change require modifying existing system tests or adding new system tests?
- **[N]** Must this be released together with other change(s)?

References
----------
JIRA: https://confluentinc.atlassian.net/browse/DGS-24963

Test & Review
------------
- `RestApiAssociationTest`: 68/68 green.
- `client` module: 375 tests green.
- `testWeakAssociationCannotBePromoted` was verified to fail without the fix, so it genuinely
  guards the behaviour. It asserts on error messages, which is unusual for this file, but the
  distinction it pins down (which rule rejected the request) is only visible in the message.

Six tests whose subject was the withdrawn behaviour are deleted: four asserting that non-frozen
STRONG associations can be created, and two asserting WEAK to STRONG conversion. Tests that used a
non-frozen STRONG association as incidental setup now use a frozen one on its resource's canonical
subject, or WEAK where the lifecycle was immaterial.

Open questions / Follow-ups
--------------------------
- A follow-up PR chained on this branch makes HTTP 409 retriable for the Schema Exporter. Worth
  knowing while reviewing it: this change makes every STRONG association frozen, so
  `ASSOCIATION_FROZEN` (40908) conflicts become more common, and 409 also covers several
  permanent conditions (40904, 40905, 40907, 40908).
- `ClusterTestHarness:154` advertises the test Schema Registry as `http://0.0.0.0:<port>` and the
  test client connects to that literal address. `0.0.0.0` is a bind address, not a destination; it
  only works while the network stack maps it to loopback. That stopped holding on one dev machine
  mid-development and every integration test failed with `BindException: Can't assign requested
  address`. `127.0.0.1` is what the harness means and fixes it. Not changed here.