### PR TITLE
Block registration of subjects with the name `*`

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
@@ -500,16 +500,18 @@ public class QualifiedSubject implements Comparable<QualifiedSubject> {
 
   /**
    * Validates the given qualified subject for the given tenant, optionally rejecting the
-   * empty-string subject.
+   * empty-string or pure-wildcard subject.
    *
    * @param tenant the tenant
    * @param qualifiedSubject the subject with a tenant prefix
    * @param isConfigOrMode true if the subject is for config or mode settings
-   * @param allowEmpty if false, reject an empty-string subject as invalid
+   * @param allowEmptyOrWildcard if false, reject an empty-string or pure-wildcard
+   *                             subject as invalid
    * @return true if the qualified subject is valid, false otherwise
    */
   public static boolean isValidSubject(
-      String tenant, String qualifiedSubject, boolean isConfigOrMode, boolean allowEmpty) {
+      String tenant, String qualifiedSubject, boolean isConfigOrMode,
+      boolean allowEmptyOrWildcard) {
     if (qualifiedSubject == null || CharMatcher.javaIsoControl().matchesAnyOf(qualifiedSubject)) {
       return false;
     }
@@ -519,7 +521,7 @@ public class QualifiedSubject implements Comparable<QualifiedSubject> {
         || qs.getSubject().equals(EMPTY_SUBJECT_NAME)) {
       return false;
     }
-    if (!allowEmpty && qs.getSubject().isEmpty()) {
+    if (!allowEmptyOrWildcard && (qs.getSubject().isEmpty() || qs.getSubject().equals(WILDCARD))) {
       return false;
     }
     if (!isConfigOrMode && qs.getContext().equals(GLOBAL_CONTEXT_NAME)) {

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubject.java
@@ -488,6 +488,8 @@ public class QualifiedSubject implements Comparable<QualifiedSubject> {
    * must not be "__GLOBAL" or "__EMPTY", and must not be in the global context
    * unless isConfigOrMode is true.
    *
+   * <p>Note: the pure-wildcard subject {@code *} is always permitted by this overload.
+   *
    * @param tenant the tenant
    * @param qualifiedSubject the subject with a tenant prefix
    * @param isConfigOrMode true if the subject is for config or mode settings

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubjectTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/utils/QualifiedSubjectTest.java
@@ -215,24 +215,35 @@ public class QualifiedSubjectTest {
     assertTrue(QualifiedSubject.isValidSubject("default", "  "));
     assertFalse(QualifiedSubject.isValidSubject("default", "__GLOBAL"));
     assertFalse(QualifiedSubject.isValidSubject("default", "__EMPTY"));
+    // Legacy overload defaults to allowEmptyOrWildcard=true, so "*" is still permitted
+    assertTrue(QualifiedSubject.isValidSubject("default", "*"));
   }
 
   @Test
-  public void testSubjectValidationRejectEmpty() {
-    // allowEmpty=true mirrors the legacy overload
+  public void testSubjectValidationRejectEmptyOrWildcard() {
+    // allowEmptyOrWildcard=true mirrors the legacy overload
     assertTrue(QualifiedSubject.isValidSubject("default", "foo", false, true));
     assertTrue(QualifiedSubject.isValidSubject("default", "", false, true));
     assertTrue(QualifiedSubject.isValidSubject("default", ":.ctx:", false, true));
+    assertTrue(QualifiedSubject.isValidSubject("default", "*", false, true));
 
-    // Legacy 3-arg overload must still allow the empty-string subject (locks the contract)
+    // Legacy 3-arg overload must still allow the empty-string and wildcard subjects
+    // (locks the contract)
     assertTrue(QualifiedSubject.isValidSubject("default", "", false));
     assertTrue(QualifiedSubject.isValidSubject("default", ":.ctx:", false));
+    assertTrue(QualifiedSubject.isValidSubject("default", "*", false));
 
-    // allowEmpty=false rejects the empty-string subject in every context
+    // allowEmptyOrWildcard=false rejects the empty-string and pure-wildcard subject
+    // in every context
     assertTrue(QualifiedSubject.isValidSubject("default", "foo", false, false));
     assertFalse(QualifiedSubject.isValidSubject("default", "", false, false));
     assertFalse(QualifiedSubject.isValidSubject("default", ":.ctx:", false, false));
     assertTrue(QualifiedSubject.isValidSubject("default", ":.ctx:foo", false, false));
+    assertFalse(QualifiedSubject.isValidSubject("default", "*", false, false));
+    assertFalse(QualifiedSubject.isValidSubject("default", ":.ctx:*", false, false));
+    // A subject that merely contains a wildcard character is not the pure-wildcard subject
+    assertTrue(QualifiedSubject.isValidSubject("default", "*foo", false, false));
+    assertTrue(QualifiedSubject.isValidSubject("default", "foo*", false, false));
 
     // Pre-existing rules still apply with the new flag
     assertFalse(QualifiedSubject.isValidSubject("default", null, false, false));

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -1822,6 +1822,12 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
     return null;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Governed by {@link SchemaRegistryConfig#SCHEMA_REJECT_EMPTY_SUBJECT_CONFIG}, which despite
+   * its name also gates the pure-wildcard ({@code *}) subject, not just the empty-string subject.
+   */
   @Override
   public boolean allowEmptySubject() {
     return !config().getBoolean(SchemaRegistryConfig.SCHEMA_REJECT_EMPTY_SUBJECT_CONFIG);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
@@ -184,7 +184,8 @@ public interface SchemaRegistry extends SchemaVersionFetcher {
   }
 
   /**
-   * Whether the current registration context allows an empty-string subject name
+   * Whether the current registration context allows an empty-string or pure-wildcard
+   * ({@code *}) subject name
    */
   default boolean allowEmptySubject() {
     return true;

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiRejectEmptySubjectTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiRejectEmptySubjectTest.java
@@ -59,4 +59,12 @@ public abstract class RestApiRejectEmptySubjectTest {
     int id = restApp.restClient.registerSchema(SCHEMA_STRING, "normal-subject");
     assertTrue(id > 0, "non-empty subject registration should still succeed");
   }
+
+  @Test
+  public void testWildcardSubjectRejectedWhenFlagEnabled() {
+    RestClientException ex = assertThrows(RestClientException.class,
+        () -> restApp.restClient.registerSchema(SCHEMA_STRING, "*"));
+    assertEquals(Errors.INVALID_SUBJECT_ERROR_CODE, ex.getErrorCode());
+    assertEquals(422, ex.getStatus());
+  }
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiRejectEmptySubjectTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiRejectEmptySubjectTest.java
@@ -66,5 +66,6 @@ public abstract class RestApiRejectEmptySubjectTest {
         () -> restApp.restClient.registerSchema(SCHEMA_STRING, "*"));
     assertEquals(Errors.INVALID_SUBJECT_ERROR_CODE, ex.getErrorCode());
     assertEquals(422, ex.getStatus());
+    assertTrue(ex.getMessage().contains("*"), "error message should reference the rejected subject");
   }
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -1086,6 +1086,8 @@ public abstract class RestApiTest {
   public void testRegisterSchemaWithWildcardSubjectAllowedByDefault() throws Exception {
     // schema.reject.empty.subject defaults to false, so the pure-wildcard subject "*"
     // is still accepted, mirroring the empty-subject default behavior.
+    // Note: this only covers registration; downstream operations against a literal "*"
+    // subject (listSubjects, getSchemaBySubject, deleteSubject) are not exercised here.
     String schema = TestUtils.getRandomCanonicalAvroString(1).get(0);
     TestUtils.registerAndVerifySchema(restApp.restClient, schema, expectedSchemaId(1), "*");
   }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiTest.java
@@ -1083,6 +1083,14 @@ public abstract class RestApiTest {
   }
 
   @Test
+  public void testRegisterSchemaWithWildcardSubjectAllowedByDefault() throws Exception {
+    // schema.reject.empty.subject defaults to false, so the pure-wildcard subject "*"
+    // is still accepted, mirroring the empty-subject default behavior.
+    String schema = TestUtils.getRandomCanonicalAvroString(1).get(0);
+    TestUtils.registerAndVerifySchema(restApp.restClient, schema, expectedSchemaId(1), "*");
+  }
+
+  @Test
   public void testGetVersion() throws Exception {
     List<String> schemas = TestUtils.getRandomCanonicalAvroString(2);
     String subject = "test";


### PR DESCRIPTION
What
----
Blocks registration of subjects named `*` (the pure-wildcard subject). `QualifiedSubject.isValidSubject` already had an `allowEmpty` flag used to reject the empty-string subject; this reuses that same flag so `*` is rejected under the identical condition, tied to the existing `schema.reject.empty.subject` config rather than introducing a new one.

Test & Review
------------
- `QualifiedSubjectTest`: unit coverage locking the `isValidSubject` contract for `"*"` under both `allowEmptyOrWildcard` values, plus that a subject merely containing `*` (e.g. `"*foo"`) is unaffected.
- `RestApiRejectEmptySubjectTest` (+ its cluster subclass): register-endpoint test confirming `*` is rejected with `422`/`INVALID_SUBJECT_ERROR_CODE` when `schema.reject.empty.subject=true`.
- `RestApiTest`: register-endpoint test confirming `*` still registers successfully by default (flag off), matching the pre-existing empty-subject default behavior.

Checklist
------------------
- [x] Contains customer facing changes? Including API/behavior changes
- [x] Is this change gated behind config(s)?
    - `schema.reject.empty.subject` (pre-existing config; wildcard rejection now follows the same gate as empty-subject rejection)
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
- [ ] Does this change require modifying existing system tests or adding new system tests?
- [ ] Must this be released together with other change(s), either in this repo or another one?