### PR TITLE
Allow RetryExecutor to accept a custom retriability predicate

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -677,13 +677,14 @@ public class RestService implements Closeable, Configurable {
   }
 
   /**
-   * Check if the given exception should not be retried.
-   * For RestClientException, determine whether to retry based on its HTTP status code.
+   * Check if the given exception should not be retried against the next base URL.
+   * For RestClientException, defers to the retry executor's own retriability predicate so that
+   * failover honours a custom predicate rather than only the default status codes.
    * For other exceptions, check if it is a network connection exception.
    */
   private boolean isNonRetriableException(Exception e) {
     if (e instanceof RestClientException) {
-      return !isRestClientExceptionRetriable((RestClientException) e);
+      return !retryExecutor.isRetriable((RestClientException) e);
     }
     return !ExceptionUtils.isNetworkConnectionException(e);
   }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RetryExecutor.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RetryExecutor.java
@@ -21,8 +21,13 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Random;
 import java.util.concurrent.Callable;
+import java.util.function.Predicate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RetryExecutor {
+  private static final Logger log = LoggerFactory.getLogger(RetryExecutor.class);
+
   /*
    * Max permitted retry times. To prevent exponentialDelay from overflow, there must be
    * 2 ^ retriesAttempted &lt;= 2 ^ 31 - 1, which means retriesAttempted &lt;= 30, so that
@@ -35,16 +40,29 @@ public class RetryExecutor {
   private final Duration initialWaitMs;
   private final Duration maxWaitMs;
   private final Random random;
+  private final Predicate<RestClientException> isRetriablePredicate;
 
   public RetryExecutor(int maxRetries, int initialWaitMs, int maxWaitMs) {
-    this(maxRetries, initialWaitMs, maxWaitMs, new Random());
+    this(maxRetries, initialWaitMs, maxWaitMs, new Random(),
+        RestService::isRestClientExceptionRetriable);
   }
 
   public RetryExecutor(int maxRetries, int initialWaitMs, int maxWaitMs, Random random) {
+    this(maxRetries, initialWaitMs, maxWaitMs, random, RestService::isRestClientExceptionRetriable);
+  }
+
+  public RetryExecutor(int maxRetries, int initialWaitMs, int maxWaitMs,
+      Predicate<RestClientException> isRetriablePredicate) {
+    this(maxRetries, initialWaitMs, maxWaitMs, new Random(), isRetriablePredicate);
+  }
+
+  public RetryExecutor(int maxRetries, int initialWaitMs, int maxWaitMs, Random random,
+      Predicate<RestClientException> isRetriablePredicate) {
     this.maxRetries = maxRetries;
     this.initialWaitMs = Duration.ofMillis(initialWaitMs);
     this.maxWaitMs = Duration.ofMillis(maxWaitMs);
     this.random = random;
+    this.isRetriablePredicate = isRetriablePredicate;
   }
 
   public <T> T retry(Callable<T> callable) throws RestClientException, IOException {
@@ -52,9 +70,11 @@ public class RetryExecutor {
       try {
         return callable.call();
       } catch (RestClientException e) {
-        if (i >= maxRetries || !RestService.isRestClientExceptionRetriable(e)) {
+        if (i >= maxRetries || !isRetriablePredicate.test(e)) {
           throw e;
         }
+        log.warn("Retriable error on attempt {}/{}, status {}: {}. Retrying...",
+            i + 1, maxRetries + 1, e.getStatus(), e.getMessage());
       } catch (IOException e) {
         if (i >= maxRetries) {
           throw e;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RetryExecutor.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RetryExecutor.java
@@ -19,6 +19,7 @@ package io.confluent.kafka.schemaregistry.client.rest;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.function.Predicate;
@@ -51,18 +52,29 @@ public class RetryExecutor {
     this(maxRetries, initialWaitMs, maxWaitMs, random, RestService::isRestClientExceptionRetriable);
   }
 
-  public RetryExecutor(int maxRetries, int initialWaitMs, int maxWaitMs,
-      Predicate<RestClientException> isRetriablePredicate) {
-    this(maxRetries, initialWaitMs, maxWaitMs, new Random(), isRetriablePredicate);
-  }
-
+  /**
+   * Deliberately the only constructor accepting a predicate: a four-arg overload taking just a
+   * predicate would be ambiguous with the {@link Random} one for a {@code null} literal, which
+   * fails to compile rather than reporting a bad argument. Requiring the caller to supply the
+   * {@link Random} keeps every four-arg call unambiguous.
+   */
   public RetryExecutor(int maxRetries, int initialWaitMs, int maxWaitMs, Random random,
       Predicate<RestClientException> isRetriablePredicate) {
     this.maxRetries = maxRetries;
     this.initialWaitMs = Duration.ofMillis(initialWaitMs);
     this.maxWaitMs = Duration.ofMillis(maxWaitMs);
-    this.random = random;
-    this.isRetriablePredicate = isRetriablePredicate;
+    this.random = Objects.requireNonNull(random, "random cannot be null");
+    this.isRetriablePredicate =
+        Objects.requireNonNull(isRetriablePredicate, "isRetriablePredicate cannot be null");
+  }
+
+  /**
+   * Whether this executor treats the given exception as retriable. Exposed so that callers
+   * sharing this executor's retry policy -- notably {@code RestService}'s URL failover -- make
+   * the same decision as {@link #retry(Callable)} rather than re-deriving it from the default.
+   */
+  public boolean isRetriable(RestClientException e) {
+    return isRetriablePredicate.test(e);
   }
 
   public <T> T retry(Callable<T> callable) throws RestClientException, IOException {
@@ -70,10 +82,18 @@ public class RetryExecutor {
       try {
         return callable.call();
       } catch (RestClientException e) {
-        if (i >= maxRetries || !isRetriablePredicate.test(e)) {
+        if (!isRetriablePredicate.test(e)) {
           throw e;
         }
-        log.warn("Retriable error on attempt {}/{}, status {}: {}. Retrying...",
+        if (i >= maxRetries) {
+          // Only meaningful when retries are enabled; with maxRetries == 0 nothing was retried.
+          if (maxRetries > 0) {
+            log.warn("Retries exhausted after {} attempts, status {}: {}",
+                maxRetries + 1, e.getStatus(), e.getMessage());
+          }
+          throw e;
+        }
+        log.debug("Retriable error on attempt {}/{}, status {}: {}. Retrying...",
             i + 1, maxRetries + 1, e.getStatus(), e.getMessage());
       } catch (IOException e) {
         if (i >= maxRetries) {

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/RetryExecutorTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/RetryExecutorTest.java
@@ -19,7 +19,9 @@ package io.confluent.kafka.schemaregistry.client.rest;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import java.io.IOException;
 import java.net.SocketException;
+import java.util.Random;
 import java.util.concurrent.Callable;
+import java.util.function.Predicate;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -63,6 +65,91 @@ public class RetryExecutorTest {
     Assert.assertThrows(RestClientException.class, () -> retryExecutor.retry(testCallable));
   }
 
+  @Test
+  public void testCustomPredicateRetriesStatusDefaultWouldNot()
+      throws IOException, RestClientException {
+    // 409 is not retriable by default; the custom predicate opts into it.
+    RetryExecutor retryExecutor =
+        new RetryExecutor(3, 0, 0, new Random(), e -> e.getStatus() == 409);
+    TestCallableWithStatus testCallable = new TestCallableWithStatus(409, 3);
+    int result = retryExecutor.retry(testCallable);
+    Assert.assertEquals(3, result);
+  }
+
+  @Test
+  public void testDefaultPredicateDoesNotRetryConflict() {
+    // Guards the flip side of the above: without a custom predicate, 409 must still fail fast.
+    RetryExecutor retryExecutor = new RetryExecutor(3, 0, 0);
+    TestCallableWithStatus testCallable = new TestCallableWithStatus(409, 3);
+    Assert.assertThrows(RestClientException.class, () -> retryExecutor.retry(testCallable));
+    Assert.assertEquals(1, testCallable.count);
+  }
+
+  @Test
+  public void testCustomPredicateDoesNotRetryStatusDefaultWould() {
+    // The predicate replaces the default rather than widening it: 500 is retriable by default
+    // but excluded here, so the call must fail on its first attempt.
+    RetryExecutor retryExecutor =
+        new RetryExecutor(3, 0, 0, new Random(), e -> e.getStatus() == 409);
+    TestCallableWithStatus testCallable = new TestCallableWithStatus(500, 3);
+    Assert.assertThrows(RestClientException.class, () -> retryExecutor.retry(testCallable));
+    Assert.assertEquals(1, testCallable.count);
+  }
+
+  @Test
+  public void testNullFourthArgBindsToRandomAndIsRejected() {
+    // Locks in why there is no four-arg predicate overload: with Random as the only four-arg
+    // parameter, a bare null resolves unambiguously and is reported as a bad argument at
+    // construction, instead of failing to compile with an ambiguous-reference error.
+    Assert.assertThrows(NullPointerException.class, () -> new RetryExecutor(3, 0, 0, null));
+  }
+
+  @Test
+  public void testCustomPredicateComposedWithDefault() throws IOException, RestClientException {
+    // The expected real-world usage: the default statuses plus an extra one.
+    Predicate<RestClientException> predicate =
+        ((Predicate<RestClientException>) RestService::isRestClientExceptionRetriable)
+            .or(e -> e.getStatus() == 409);
+    RetryExecutor retryExecutor = new RetryExecutor(3, 0, 0, new Random(), predicate);
+    Assert.assertEquals(3, (int) retryExecutor.retry(new TestCallableWithStatus(409, 3)));
+    Assert.assertEquals(3, (int) retryExecutor.retry(new TestCallableWithStatus(503, 3)));
+  }
+
+  @Test
+  public void testRetriesExhaustedWithCustomPredicate() {
+    RetryExecutor retryExecutor =
+        new RetryExecutor(2, 0, 0, new Random(), e -> e.getStatus() == 409);
+    TestCallableWithStatus testCallable = new TestCallableWithStatus(409, 5);
+    Assert.assertThrows(RestClientException.class, () -> retryExecutor.retry(testCallable));
+    Assert.assertEquals(3, testCallable.count);
+  }
+
+  @Test
+  public void testNullPredicateRejected() {
+    Assert.assertThrows(NullPointerException.class,
+        () -> new RetryExecutor(3, 0, 0, new Random(), null));
+  }
+
+  @Test
+  public void testNullRandomRejected() {
+    // Deferred otherwise: a null Random only fails at the first backoff, and only when
+    // initialWaitMs > 0, so it would survive every test that uses a zero wait.
+    Assert.assertThrows(NullPointerException.class,
+        () -> new RetryExecutor(3, 1000, 20000, null, e -> e.getStatus() == 409));
+  }
+
+  @Test
+  public void testIsRetriableReflectsPredicate() {
+    RetryExecutor custom =
+        new RetryExecutor(3, 0, 0, new Random(), e -> e.getStatus() == 409);
+    Assert.assertTrue(custom.isRetriable(new RestClientException("test", 409, 40901)));
+    Assert.assertFalse(custom.isRetriable(new RestClientException("test", 503, 50301)));
+
+    RetryExecutor defaultExecutor = new RetryExecutor(3, 0, 0);
+    Assert.assertFalse(defaultExecutor.isRetriable(new RestClientException("test", 409, 40901)));
+    Assert.assertTrue(defaultExecutor.isRetriable(new RestClientException("test", 503, 50301)));
+  }
+
   static class TestCallable implements Callable<Integer> {
     private int count = 0;
     @Override
@@ -93,6 +180,27 @@ public class RetryExecutorTest {
     public Void call() throws RestClientException {
       count++;
       return null;
+    }
+  }
+
+  /** Fails with the given status until {@code failures} attempts have been made. */
+  static class TestCallableWithStatus implements Callable<Integer> {
+    private final int status;
+    private final int failures;
+    private int count = 0;
+
+    TestCallableWithStatus(int status, int failures) {
+      this.status = status;
+      this.failures = failures;
+    }
+
+    @Override
+    public Integer call() throws RestClientException {
+      if (count < failures) {
+        count++;
+        throw new RestClientException("test", status, status * 100 + 1);
+      }
+      return count;
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds constructor overloads to `RetryExecutor` that accept a custom `Predicate<RestClientException>` for retriability, defaulting to the existing `RestService::isRestClientExceptionRetriable` behavior when not supplied
- Logs a warning on each retry attempt with status and message

## Why
Callers like the schema exporter need to treat additional statuses (e.g. HTTP 409) as retriable without duplicating backoff/retry logic. See companion PR in schema-registry-plugins (DGS-24997-3).

## Test plan
- [x] `RetryExecutorTest` / `RetryExecutorBackoffTest`: 23/23 pass
- [x] Full `mvn install` (checkstyle, spotbugs, unit + integration goals) on the `client` module: clean