### PR TITLE
DGS-25010: reject creating topic-owned subjects through the schema API

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClient.java
@@ -108,6 +108,11 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
 
   private static final String NO_SUBJECT = "";
 
+  private static final String LKC_CONTEXT_PREFIX =
+      QualifiedSubject.CONTEXT_SEPARATOR + "lkc-";
+  private static final String KEY_ASSOCIATION_SUFFIX = "-key";
+  private static final String VALUE_ASSOCIATION_SUFFIX = "-value";
+
   private static class ResourceAndAssocType {
     String resourceId;
     String resourceType;
@@ -340,6 +345,19 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
   }
 
   private RegisterSchemaResponse registerWithResponse(
+      String subject, ParsedSchema schema, int version, int id,
+      boolean normalize, boolean propagateSchemaTags)
+      throws IOException, RestClientException {
+    checkNotNewTopicOwnedSubject(subject);
+    return registerInternal(subject, schema, version, id, normalize, propagateSchemaTags);
+  }
+
+  /**
+   * Registration that skips the reserved-name check. Associations register their own schemas
+   * under the very names the check protects, mirroring how the server registers internally
+   * rather than through the REST entry point.
+   */
+  private RegisterSchemaResponse registerInternal(
       String subject, ParsedSchema schema, int version, int id,
       boolean normalize, boolean propagateSchemaTags)
       throws IOException, RestClientException {
@@ -634,6 +652,40 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
     } else {
       throw new RestClientException("Subject Not Found", 404, 40401);
     }
+  }
+
+  /**
+   * True if the subject is named :.lkc-*:&lt;topic&gt;-key or -value. Duplicated from
+   * {@code AbstractSchemaRegistry} because that check is server-side; the two must agree.
+   */
+  private boolean isTopicOwnedSubjectName(String subject) {
+    QualifiedSubject qs = QualifiedSubject.create(DEFAULT_TENANT, subject);
+    if (qs == null || !qs.getContext().startsWith(LKC_CONTEXT_PREFIX)) {
+      return false;
+    }
+    String unqualified = qs.getSubject();
+    return unqualified.endsWith(KEY_ASSOCIATION_SUFFIX)
+        || unqualified.endsWith(VALUE_ASSOCIATION_SUFFIX);
+  }
+
+  /**
+   * Mirrors the server rule: a name a topic's strong association owns cannot be created here.
+   * An existing subject is evolution, and IMPORT mode is how replication recreates them.
+   */
+  private void checkNotNewTopicOwnedSubject(String subject) throws RestClientException {
+    if (!isTopicOwnedSubjectName(subject)
+        || !allVersions(subject).isEmpty()
+        || "IMPORT".equals(modeInScope(subject))) {
+      return;
+    }
+    throw new RestClientException("Subject " + subject
+        + " is reserved for the topic of that name; create it through the topic,"
+        + " or use IMPORT mode", 422, 42205);
+  }
+
+  private String modeInScope(String subject) {
+    String mode = modes.get(subject);
+    return mode != null ? mode : modes.getOrDefault(WILDCARD, "READWRITE");
   }
 
   private List<Integer> allVersions(String subject) {
@@ -1204,11 +1256,12 @@ public class MockSchemaRegistryClient implements SchemaRegistryClient {
           throws RestClientException, IOException {
     for (AssociationCreateOrUpdateInfo associationInRequest : request.getAssociations()) {
       if (associationInRequest.getSchema() != null) {
-        register(associationInRequest.getSubject(),
+        registerInternal(associationInRequest.getSubject(),
                 parseSchema(new Schema(
                         associationInRequest.getSubject(),
                         associationInRequest.getSchema())).get(),
-                Boolean.TRUE.equals(associationInRequest.getNormalize()));
+                0, -1,
+                Boolean.TRUE.equals(associationInRequest.getNormalize()), false);
       }
     }
   }

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClientTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/MockSchemaRegistryClientTest.java
@@ -1196,4 +1196,52 @@ public class MockSchemaRegistryClientTest {
         }
     }
 
+    @Test
+    public void testTopicOwnedSubjectCannotBeCreatedDirectly() throws Exception {
+        String canonical = ":.lkc-abc123:topic1-key";
+        AvroSchema schema = new AvroSchema(SIMPLE_AVRO_SCHEMA);
+
+        // Mirrors the server: the name belongs to the topic, so it cannot be created here.
+        assertThrows(RestClientException.class, () -> client.register(canonical, schema));
+
+        // Same name shape in a user context is ordinary usage.
+        client.register(":.staging:topic1-key", schema);
+        assertEquals(1, client.getAllVersions(":.staging:topic1-key").size());
+
+        // IMPORT mode is how replication recreates these subjects.
+        client.setMode("IMPORT", canonical);
+        client.register(canonical, schema);
+        assertEquals(1, client.getAllVersions(canonical).size());
+    }
+
+    @Test
+    public void testStrongAssociationCanStillCreateItsOwnSubject() throws Exception {
+        String namespace = "lkc-abc123";
+        String resourceName = "topic3";
+        String canonical = ":." + namespace + ":" + resourceName + "-key";
+
+        // The association registers this subject itself, so the reservation must not block it.
+        AssociationCreateOrUpdateRequest request = new AssociationCreateOrUpdateRequest(
+            resourceName, namespace, "res-mock", "topic",
+            Collections.singletonList(new AssociationCreateOrUpdateInfo(
+                canonical, KEY, LifecyclePolicy.STRONG, true,
+                new RegisterSchemaRequest(new AvroSchema(SIMPLE_AVRO_SCHEMA)), null)));
+        client.createAssociation(request);
+
+        assertEquals(1, client.getAllVersions(canonical).size());
+    }
+
+    @Test
+    public void testTopicOwnedSubjectCanBeEvolvedOnceItExists() throws Exception {
+        String canonical = ":.lkc-abc123:topic2-value";
+
+        // Seed it the way replication would, then evolution through the ordinary path works.
+        client.setMode("IMPORT", canonical);
+        client.register(canonical, new AvroSchema(SIMPLE_AVRO_SCHEMA));
+        client.setMode("READWRITE", canonical);
+
+        client.register(canonical, new AvroSchema(EVOLVED_AVRO_SCHEMA));
+        assertEquals(2, client.getAllVersions(canonical).size());
+    }
+
 }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -181,6 +181,11 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
     }
   };
 
+  private static final String LKC_CONTEXT_PREFIX =
+      QualifiedSubject.CONTEXT_SEPARATOR + "lkc-";
+  private static final String KEY_ASSOCIATION_SUFFIX = "-key";
+  private static final String VALUE_ASSOCIATION_SUFFIX = "-value";
+
   protected Store<SchemaRegistryKey, SchemaRegistryValue> store;
 
   protected final SchemaRegistryConfig config;
@@ -206,6 +211,7 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
   protected final int contextSearchDefaultLimit;
   protected final int subjectSearchMaxLimit;
   protected final boolean allowModeChanges;
+  protected final boolean associationsEnabled;
   protected final AtomicBoolean initialized;
   protected final Time time;
 
@@ -269,6 +275,7 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
     this.subjectSearchMaxLimit =
         config.getInt(SchemaRegistryConfig.SUBJECT_SEARCH_MAX_LIMIT_CONFIG);
     this.allowModeChanges = config.getBoolean(SchemaRegistryConfig.MODE_MUTABILITY);
+    this.associationsEnabled = config.getBoolean(SchemaRegistryConfig.ASSOCIATIONS_ENABLE);
     this.initialized = new AtomicBoolean(false);
     this.time = config.getTime();
   }
@@ -402,6 +409,38 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
   protected boolean isReadOnlyMode(String subject) throws SchemaRegistryStoreException {
     Mode subjectMode = getModeInScope(subject);
     return subjectMode == Mode.READONLY || subjectMode == Mode.READONLY_OVERRIDE;
+  }
+
+  /**
+   * True if the subject is named :.lkc-*:&lt;topic&gt;-key or -value, the canonical name a topic's
+   * strong association uses. Only lkc-* contexts are reserved: a user context such as ".staging"
+   * holding "orders-value" is ordinary TopicNameStrategy usage and must keep working.
+   *
+   * <p>{@code MockSchemaRegistryClient} carries the same check and the two must agree.
+   */
+  private boolean isTopicOwnedSubjectName(String subject) {
+    QualifiedSubject qs = QualifiedSubject.create(tenant(), subject);
+    if (qs == null || !qs.getContext().startsWith(LKC_CONTEXT_PREFIX)) {
+      return false;
+    }
+    String unqualified = qs.getSubject();
+    return unqualified.endsWith(KEY_ASSOCIATION_SUFFIX)
+        || unqualified.endsWith(VALUE_ASSOCIATION_SUFFIX);
+  }
+
+  /**
+   * True if this subject would newly claim a name belonging to a topic: the canonical form
+   * above, with no schema ever registered under it. Soft-deleted versions still count as
+   * claimed, so a delete does not re-expose the name.
+   */
+  protected boolean isNewlyCreatedTopicOwnedSubject(String subject)
+      throws SchemaRegistryException {
+    if (!isTopicOwnedSubjectName(subject)) {
+      return false;
+    }
+    // Ranged over this subject's keys only. hasSubjects() would answer the same question by
+    // streaming the whole store, and the miss case here is exactly its worst case.
+    return !getAllVersions(subject, LookupFilter.INCLUDE_DELETED).hasNext();
   }
 
   protected void checkRegisterMode(

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -611,6 +611,16 @@ public class KafkaSchemaRegistry extends AbstractSchemaRegistry implements
                                   boolean normalize,
                                   Map<String, String> headerProperties)
       throws SchemaRegistryException {
+    // Only registrations that arrive through the REST API reach here; associations register
+    // their own schemas internally, so they are unaffected.
+    if (associationsEnabled
+        && isNewlyCreatedTopicOwnedSubject(subject)
+        && getModeInScope(subject) != Mode.IMPORT) {
+      log.debug("Rejecting registration of {}: reserved for the topic of that name", subject);
+      throw new OperationNotPermittedException("Subject " + subject
+          + " is reserved for the topic of that name; create it through the topic,"
+          + " or use IMPORT mode");
+    }
     Schema schema = new Schema(subject, request);
     Config config = getConfigInScope(subject);
     boolean isLatestVersion = schema.getVersion() == -1;

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
@@ -45,6 +45,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.requests.Associati
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationResult;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationUpsertOp;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
+import io.confluent.kafka.schemaregistry.storage.Mode;
 import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 import io.confluent.kafka.schemaregistry.utils.TestUtils;
 import java.io.InputStream;
@@ -3740,6 +3741,69 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     } finally {
       conn.disconnect();
     }
+  }
+
+  @Test
+  public void testTopicOwnedSubjectCannotBeCreatedDirectly() throws Exception {
+    String namespace = "lkc-abc123";
+    List<String> schemas = TestUtils.getRandomCanonicalAvroString(3);
+
+    // A canonical name in an lkc context belongs to its topic, so a direct POST is rejected.
+    assertThrows(Exception.class, () ->
+        restApp.restClient.registerSchema(schemas.get(0), ":." + namespace + ":topic1-key"));
+    assertThrows(Exception.class, () ->
+        restApp.restClient.registerSchema(schemas.get(0), ":." + namespace + ":topic1-value"));
+
+    // Same shape in a user context is ordinary TopicNameStrategy usage.
+    restApp.restClient.registerSchema(schemas.get(1), ":.staging:topic1-key");
+    assertEquals(1, restApp.restClient.getAllVersions(":.staging:topic1-key").size());
+
+    // An lkc context with a name that is not a canonical association subject is unaffected.
+    restApp.restClient.registerSchema(schemas.get(2), ":." + namespace + ":topic1-other");
+    assertEquals(1,
+        restApp.restClient.getAllVersions(":." + namespace + ":topic1-other").size());
+  }
+
+  @Test
+  public void testTopicOwnedSubjectCanBeEvolvedThroughSchemaApi() throws Exception {
+    String namespace = "lkc-abc123";
+    String resourceName = "topic1";
+    String canonicalSubject = ":." + namespace + ":" + resourceName + "-key";
+    String schemaV1 =
+        "{\"type\":\"record\",\"name\":\"R\","
+            + "\"fields\":[{\"name\":\"f\",\"type\":\"string\"}]}";
+    String schemaV2 =
+        "{\"type\":\"record\",\"name\":\"R\",\"fields\":["
+            + "{\"name\":\"f\",\"type\":\"string\"},"
+            + "{\"name\":\"g\",\"type\":\"int\",\"default\":0}]}";
+
+    RegisterSchemaRequest keyRequest = new RegisterSchemaRequest();
+    keyRequest.setSchema(schemaV1);
+
+    // Kafka creates the strong association, which registers v1 under the canonical subject.
+    AssociationCreateOrUpdateRequest request = new AssociationCreateOrUpdateRequest(
+        resourceName, namespace, "res-evolve", "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            null, "key", LifecyclePolicy.STRONG, true, keyRequest, null)));
+    AssociationResponse response = restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, request);
+    assertEquals(canonicalSubject, response.getAssociations().get(0).getSubject());
+
+    // The topic owns the name now, so evolving it through the schema API is allowed.
+    restApp.restClient.registerSchema(schemaV2, canonicalSubject);
+    assertEquals(2, restApp.restClient.getAllVersions(canonicalSubject).size());
+  }
+
+  @Test
+  public void testImportModeAllowsTopicOwnedSubjectCreation() throws Exception {
+    String canonicalSubject = ":.lkc-abc123:topic2-key";
+    List<String> schemas = TestUtils.getRandomCanonicalAvroString(1);
+
+    // IMPORT mode is how replication recreates these subjects, so the reservation must not
+    // apply. Registration there carries an explicit version and id.
+    restApp.restClient.setMode(Mode.IMPORT.name(), canonicalSubject, true);
+    restApp.restClient.registerSchema(schemas.get(0), canonicalSubject, 1, 1);
+    assertEquals(1, restApp.restClient.getAllVersions(canonicalSubject).size());
   }
 
 }


### PR DESCRIPTION
## What

A subject named `:.lkc-*:<topic>-key` or `-value` is the canonical name a topic's strong association uses, so it belongs to the topic of that name whether or not that topic exists yet. Creating one through `POST /subjects/{subject}/versions` lets a subject be claimed before its topic can claim it, and sidesteps the association flow that owns the subject's lifecycle.

This rejects such a registration when no schema has ever been registered under the name.

## Rules

| Case | Outcome |
|---|---|
| Name has never been registered | rejected (`42205`) |
| Subject already exists | allowed — this is schema evolution, not a claim |
| Subject soft-deleted | rejected — a delete does not re-expose the name |
| IMPORT mode | allowed — how replication and migration recreate these |
| Non-`lkc-*` context (e.g. `.staging:orders-value`) | allowed — ordinary TopicNameStrategy usage |
| `lkc-*` context, non-canonical name | allowed |

## Where the check lives

In `registerOrForward`, whose only caller is `SubjectVersionsResource`, so it applies to REST registrations only. Associations register their own schemas internally via `register()` at `AbstractSchemaRegistry:2343` and are unaffected — putting the check on the shared path would have broken all topic-owned association creation.

`MockSchemaRegistryClient` carries the same rule, with `registerInternal` as the unchecked path its association helper uses.

## Notes for reviewers

- **Existence is checked with a keyed range query** (`getAllVersions(subject, INCLUDE_DELETED)`), not `hasSubjects()`, which streams the entire store — and whose worst case is exactly the reject path here.
- **The `lkc-` prefix is the one heuristic.** SR has no notion of cluster ids, so there is nothing to distinguish a cluster namespace from a user context. The natural upgrade is a configured namespace list, which would replace a single constant.
- **Error code is `42205`** (`OPERATION_NOT_PERMITTED`), not `42212` (`INVALID_ASSOCIATION`) — this is the schema API, not an association request.
- **Gated on `associations.enable`** (default `true`). There is no dedicated flag for this rejection alone.
- **Pre-existing data is grandfathered.** A canonical-named subject that already exists keeps working, so the invariant holds for everything created from here on rather than for the whole store. Same for subjects created under IMPORT mode.

## Testing

- `RestApiAssociationTest` — 3 new tests: rejection on both `-key`/`-value`, the two negative controls, association-creation-then-evolution to v2, and IMPORT-mode creation. **71/71 pass**, including the 68 pre-existing.
- `MockSchemaRegistryClientTest` — 3 new tests, including one that a strong association can still create its own subject. **310/310 client tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)