### PR TITLE
DGS-24541: Schema reference rules for topic-owned subjects

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/exceptions/TopicOwnedSubjectReferenceException.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/exceptions/TopicOwnedSubjectReferenceException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.exceptions;
+
+/**
+ * Indicates a schema reference violates a topic-owned subject rule -- e.g. referencing a
+ * topic-owned subject, whose lifecycle follows its topic and would be blocked from deletion
+ * when the topic is deleted.
+ */
+public class TopicOwnedSubjectReferenceException extends SchemaRegistryException {
+
+  public TopicOwnedSubjectReferenceException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public TopicOwnedSubjectReferenceException(String message) {
+    super(message);
+  }
+
+  public TopicOwnedSubjectReferenceException(Throwable cause) {
+    super(cause);
+  }
+
+  public TopicOwnedSubjectReferenceException() {
+    super();
+  }
+}

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/Errors.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/Errors.java
@@ -83,6 +83,7 @@ public class Errors {
   public static final int INVALID_RULESET_ERROR_CODE = 42210;
   public static final int CONTEXT_NOT_EMPTY_ERROR_CODE = 42211;
   public static final int INVALID_ASSOCIATION_ERROR_CODE = 42212;
+  public static final int TOPIC_OWNED_SUBJECT_REFERENCE_ERROR_CODE = 42213;
 
   // HTTP 500
   public static final int STORE_ERROR_CODE = 50001;
@@ -204,6 +205,11 @@ public class Errors {
 
   public static RestReferenceExistsException referenceExistsException(String message) {
     return new RestReferenceExistsException(message);
+  }
+
+  public static RestTopicOwnedSubjectReferenceException topicOwnedSubjectReferenceException(
+      String message) {
+    return new RestTopicOwnedSubjectReferenceException(message);
   }
 
   public static RestException requestForwardingFailedException(String message, Throwable cause) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/RestTopicOwnedSubjectReferenceException.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/RestTopicOwnedSubjectReferenceException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rest.exceptions;
+
+import io.confluent.rest.exceptions.RestConstraintViolationException;
+
+/**
+ * Indicates a schema reference violates a topic-owned subject rule.
+ */
+public class RestTopicOwnedSubjectReferenceException extends RestConstraintViolationException {
+
+  public static final int ERROR_CODE = Errors.TOPIC_OWNED_SUBJECT_REFERENCE_ERROR_CODE;
+
+  public RestTopicOwnedSubjectReferenceException(String message) {
+    super(message, ERROR_CODE);
+  }
+}

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/AssociationsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/AssociationsResource.java
@@ -38,6 +38,7 @@ import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryTimeoutExcepti
 import io.confluent.kafka.schemaregistry.exceptions.SchemaTooLargeException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaVersionNotSoftDeletedException;
 import io.confluent.kafka.schemaregistry.exceptions.StrongAssociationForSubjectExistsException;
+import io.confluent.kafka.schemaregistry.exceptions.TopicOwnedSubjectReferenceException;
 import io.confluent.kafka.schemaregistry.exceptions.UnknownLeaderException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.exceptions.AssociationForResourceExistsException;
@@ -282,6 +283,8 @@ public class AssociationsResource {
       //throw Errors.tooManyAssociationsException(schemaRegistry.config().maxKeys());
     } catch (InvalidSchemaException e) {
       throw Errors.invalidSchemaException(e);
+    } catch (TopicOwnedSubjectReferenceException e) {
+      throw Errors.topicOwnedSubjectReferenceException(e.getMessage());
     } catch (SchemaTooLargeException e) {
       throw Errors.schemaTooLargeException("Register operation failed because schema is too large");
     } catch (IncompatibleSchemaException e) {
@@ -372,6 +375,8 @@ public class AssociationsResource {
       //throw Errors.tooManyAssociationsException(schemaRegistry.config().maxKeys());
     } catch (InvalidSchemaException e) {
       throw Errors.invalidSchemaException(e);
+    } catch (TopicOwnedSubjectReferenceException e) {
+      throw Errors.topicOwnedSubjectReferenceException(e.getMessage());
     } catch (SchemaTooLargeException e) {
       throw Errors.schemaTooLargeException("Register operation failed because schema is too large");
     } catch (IncompatibleSchemaException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -41,6 +41,7 @@ import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryTimeoutExcepti
 import io.confluent.kafka.schemaregistry.exceptions.SchemaTooLargeException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaVersionNotSoftDeletedException;
 import io.confluent.kafka.schemaregistry.exceptions.StrongAssociationForSubjectExistsException;
+import io.confluent.kafka.schemaregistry.exceptions.TopicOwnedSubjectReferenceException;
 import io.confluent.kafka.schemaregistry.exceptions.UnknownLeaderException;
 import io.confluent.kafka.schemaregistry.rest.VersionId;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
@@ -503,6 +504,8 @@ public class SubjectVersionsResource {
       throw Errors.idDoesNotMatchException(e);
     } catch (InvalidSchemaException e) {
       throw Errors.invalidSchemaException(e);
+    } catch (TopicOwnedSubjectReferenceException e) {
+      throw Errors.topicOwnedSubjectReferenceException(e.getMessage());
     } catch (SchemaTooLargeException e) {
       throw Errors.schemaTooLargeException("Register operation failed because schema is too large");
     } catch (OperationNotPermittedException e) {
@@ -717,6 +720,8 @@ public class SubjectVersionsResource {
       registerSchemaResponse = new RegisterSchemaResponse(result);
     } catch (InvalidSchemaException e) {
       throw Errors.invalidSchemaException(e);
+    } catch (TopicOwnedSubjectReferenceException e) {
+      throw Errors.topicOwnedSubjectReferenceException(e.getMessage());
     } catch (SchemaTooLargeException e) {
       throw Errors.schemaTooLargeException("Register operation failed because schema is too large");
     } catch (OperationNotPermittedException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -37,6 +37,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.Rule;
 import io.confluent.kafka.schemaregistry.client.rest.entities.RuleSet;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaTags;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
@@ -67,6 +68,7 @@ import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException
 import io.confluent.kafka.schemaregistry.exceptions.SchemaTooLargeException;
 import io.confluent.kafka.schemaregistry.exceptions.StrongAssociationForSubjectExistsException;
 import io.confluent.kafka.schemaregistry.exceptions.TooManyAssociationsException;
+import io.confluent.kafka.schemaregistry.exceptions.TopicOwnedSubjectReferenceException;
 import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.security.SslFactory;
@@ -115,6 +117,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -131,6 +134,7 @@ import static io.confluent.kafka.schemaregistry.rest.exceptions.Errors.NO_ACTIVE
 import static io.confluent.kafka.schemaregistry.rest.exceptions.Errors.SCHEMA_TOO_LARGE_ERROR_CODE;
 import static io.confluent.kafka.schemaregistry.rest.exceptions.Errors.STRONG_ASSOCIATION_FOR_SUBJECT_EXISTS_ERROR_CODE;
 import static io.confluent.kafka.schemaregistry.rest.exceptions.Errors.STRONG_ASSOCIATION_FOR_SUBJECT_EXISTS_MESSAGE_FORMAT;
+import static io.confluent.kafka.schemaregistry.rest.exceptions.Errors.TOPIC_OWNED_SUBJECT_REFERENCE_ERROR_CODE;
 import static io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidAssociationException.INVALID_ASSOCIATION_MESSAGE_FORMAT;
 
 import static io.confluent.kafka.schemaregistry.client.rest.entities.Metadata.mergeMetadata;
@@ -180,6 +184,13 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
       throw new UnsupportedOperationException();
     }
   };
+
+  // A Kafka cluster context. CC: lkc-*. CP: 22 characters.
+  // Allowed characters: A-Z, a-z, 0-9, -, _
+  private static final Pattern KAFKA_CLUSTER_CONTEXT = Pattern.compile(
+      Pattern.quote(QualifiedSubject.CONTEXT_SEPARATOR) + "(lkc-.+|[A-Za-z0-9_-]{22})");
+  private static final String KEY_ASSOCIATION_SUFFIX = "-key";
+  private static final String VALUE_ASSOCIATION_SUFFIX = "-value";
 
   protected Store<SchemaRegistryKey, SchemaRegistryValue> store;
 
@@ -402,6 +413,23 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
   protected boolean isReadOnlyMode(String subject) throws SchemaRegistryStoreException {
     Mode subjectMode = getModeInScope(subject);
     return subjectMode == Mode.READONLY || subjectMode == Mode.READONLY_OVERRIDE;
+  }
+
+  /**
+   * True if the subject is named :.lkc-*:&lt;topic&gt;-key or -value, the canonical name a topic's
+   * strong association uses. Only lkc-* contexts are reserved: a user context such as ".staging"
+   * holding "orders-value" is ordinary TopicNameStrategy usage and must keep working.
+   *
+   * <p>{@code MockSchemaRegistryClient} carries the same check and the two must agree.
+   */
+  private boolean matchesTopicOwnedSubjectName(String subject) {
+    QualifiedSubject qs = QualifiedSubject.create(tenant(), subject);
+    if (qs == null || !KAFKA_CLUSTER_CONTEXT.matcher(qs.getContext()).matches()) {
+      return false;
+    }
+    String unqualified = qs.getSubject();
+    return unqualified.endsWith(KEY_ASSOCIATION_SUFFIX)
+        || unqualified.endsWith(VALUE_ASSOCIATION_SUFFIX);
   }
 
   protected void checkRegisterMode(
@@ -637,6 +665,28 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
     }
     ParsedSchema parsedSchema = parseSchema(schema, validateAsNew, normalize);
     return maybeValidateAndNormalizeSchema(parsedSchema, schema, config, normalize);
+  }
+
+  /**
+   * Rejects a reference to a topic-owned subject: its lifecycle follows its topic, so the
+   * reference would block it from being deleted when the topic is deleted. Only checks this
+   * schema's own direct references, not the transitive closure of what they in turn reference
+   * -- sufficient because the reciprocal delete-time check ({@link #getReferencedBySubjects})
+   * is itself keyed on each schema's own direct references, so a chain is still guarded at
+   * every hop.
+   */
+  protected void checkNoReferencesToTopicOwnedSubjects(Schema schema)
+      throws SchemaRegistryException {
+    for (SchemaReference reference : schema.getReferences()) {
+      QualifiedSubject qualified = QualifiedSubject.qualifySubjectWithParent(
+          tenant(), schema.getSubject(), reference.getSubject());
+      String refSubject = qualified != null
+          ? qualified.toQualifiedSubject() : reference.getSubject();
+      if (matchesTopicOwnedSubjectName(refSubject)) {
+        throw new TopicOwnedSubjectReferenceException(
+            "Cannot reference topic-owned subject '" + refSubject + "'");
+      }
+    }
   }
 
   protected boolean isSubjectVersionDeleted(String subject, int version)
@@ -2629,6 +2679,11 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
       } catch (InvalidSchemaException e) {
         ErrorMessage errMsg = new ErrorMessage(
             INVALID_ASSOCIATION_ERROR_CODE,
+            e.getMessage());
+        results.add(new AssociationResult(errMsg, null));
+      } catch (TopicOwnedSubjectReferenceException e) {
+        ErrorMessage errMsg = new ErrorMessage(
+            TOPIC_OWNED_SUBJECT_REFERENCE_ERROR_CODE,
             e.getMessage());
         results.add(new AssociationResult(errMsg, null));
       } catch (SchemaTooLargeException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -689,6 +689,44 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
     }
   }
 
+  /**
+   * If this schema's own subject is topic-owned, its schema references -- the whole transitive
+   * closure, not just the direct ones -- must all resolve to subjects in the same context.
+   * Otherwise a topic-owned subject's dependency graph could leak outside the topic's own
+   * context through an indirect reference even when every direct reference is in-context.
+   */
+  protected void checkTopicOwnedSubjectReferencesSameContext(Schema schema)
+      throws SchemaRegistryException {
+    if (!matchesTopicOwnedSubjectName(schema.getSubject())) {
+      return;
+    }
+    QualifiedSubject owner = QualifiedSubject.create(tenant(), schema.getSubject());
+    checkReferencesInContext(schema, owner.getContext(), new HashSet<>());
+  }
+
+  private void checkReferencesInContext(
+      Schema schema, String requiredContext, Set<String> visited)
+      throws SchemaRegistryException {
+    for (SchemaReference reference : schema.getReferences()) {
+      QualifiedSubject qualified = QualifiedSubject.qualifySubjectWithParent(
+          tenant(), schema.getSubject(), reference.getSubject());
+      String refSubject = qualified != null
+          ? qualified.toQualifiedSubject() : reference.getSubject();
+      if (qualified == null || !requiredContext.equals(qualified.getContext())) {
+        throw new TopicOwnedSubjectReferenceException(
+            "Topic-owned subject '" + schema.getSubject()
+                + "' cannot reference subject directly or indirectly '" + refSubject
+                + "' in a different context");
+      }
+      if (visited.add(refSubject + "#" + reference.getVersion())) {
+        Schema refSchema = get(refSubject, reference.getVersion(), false);
+        if (refSchema != null) {
+          checkReferencesInContext(refSchema, requiredContext, visited);
+        }
+      }
+    }
+  }
+
   protected boolean isSubjectVersionDeleted(String subject, int version)
           throws SchemaRegistryException {
     try {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -703,11 +703,16 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
       return;
     }
     QualifiedSubject owner = QualifiedSubject.create(tenant(), schema.getSubject());
-    checkReferencesInContext(schema, owner.getContext(), new HashSet<>());
+    checkReferencesInContext(schema.getSubject(), schema, owner.getContext(), new HashSet<>());
   }
 
+  /**
+   * @param topicOwnedSubject the subject actually being registered, kept separate from {@code
+   *     schema} (which is rebound to each hop as the walk descends) so a violation found several
+   *     hops in still names the subject the caller registered, not the intermediate schema.
+   */
   private void checkReferencesInContext(
-      Schema schema, String requiredContext, Set<String> visited)
+      String topicOwnedSubject, Schema schema, String requiredContext, Set<String> visited)
       throws SchemaRegistryException {
     for (SchemaReference reference : schema.getReferences()) {
       QualifiedSubject qualified = QualifiedSubject.qualifySubjectWithParent(
@@ -716,9 +721,9 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
           ? qualified.toQualifiedSubject() : reference.getSubject();
       if (qualified == null || !requiredContext.equals(qualified.getContext())) {
         log.debug("Rejecting registration of {}: reference to {} is outside context {}",
-            schema.getSubject(), refSubject, requiredContext);
+            topicOwnedSubject, refSubject, requiredContext);
         throw new TopicOwnedSubjectReferenceException(
-            "Topic-owned subject '" + schema.getSubject()
+            "Topic-owned subject '" + topicOwnedSubject
                 + "' cannot reference subject directly or indirectly '" + refSubject
                 + "' in a different context");
       }
@@ -728,7 +733,7 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
         // to follow it too, or an out-of-context leak behind a soft-deleted hop goes unseen.
         Schema refSchema = get(refSubject, reference.getVersion(), true);
         if (refSchema != null) {
-          checkReferencesInContext(refSchema, requiredContext, visited);
+          checkReferencesInContext(topicOwnedSubject, refSchema, requiredContext, visited);
         }
       }
     }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -683,6 +683,8 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
       String refSubject = qualified != null
           ? qualified.toQualifiedSubject() : reference.getSubject();
       if (matchesTopicOwnedSubjectName(refSubject)) {
+        log.debug("Rejecting registration of {}: references topic-owned subject {}",
+            schema.getSubject(), refSubject);
         throw new TopicOwnedSubjectReferenceException(
             "Cannot reference topic-owned subject '" + refSubject + "'");
       }
@@ -713,13 +715,18 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
       String refSubject = qualified != null
           ? qualified.toQualifiedSubject() : reference.getSubject();
       if (qualified == null || !requiredContext.equals(qualified.getContext())) {
+        log.debug("Rejecting registration of {}: reference to {} is outside context {}",
+            schema.getSubject(), refSubject, requiredContext);
         throw new TopicOwnedSubjectReferenceException(
             "Topic-owned subject '" + schema.getSubject()
                 + "' cannot reference subject directly or indirectly '" + refSubject
                 + "' in a different context");
       }
       if (visited.add(refSubject + "#" + reference.getVersion())) {
-        Schema refSchema = get(refSubject, reference.getVersion(), false);
+        // returnDeletedSchema=true: reference resolution itself may have permitted a
+        // soft-deleted target (schema.validate.new.schemas=false), so the walk must be able
+        // to follow it too, or an out-of-context leak behind a soft-deleted hop goes unseen.
+        Schema refSchema = get(refSubject, reference.getVersion(), true);
         if (refSchema != null) {
           checkReferencesInContext(refSchema, requiredContext, visited);
         }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -477,6 +477,9 @@ public class KafkaSchemaRegistry extends AbstractSchemaRegistry implements
       int schemaId = schema.getId();
       boolean doValidation = schemaId < 0 && isSchemaNewSchemaValidationEnabled(config);
       ParsedSchema parsedSchema = canonicalizeSchema(schema, config, doValidation, normalize);
+      if (parsedSchema != null && mode != Mode.IMPORT) {
+        checkNoReferencesToTopicOwnedSubjects(schema);
+      }
 
       if (parsedSchema != null) {
         // see if the schema to be registered already exists

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -479,6 +479,7 @@ public class KafkaSchemaRegistry extends AbstractSchemaRegistry implements
       ParsedSchema parsedSchema = canonicalizeSchema(schema, config, doValidation, normalize);
       if (parsedSchema != null && mode != Mode.IMPORT) {
         checkNoReferencesToTopicOwnedSubjects(schema);
+        checkTopicOwnedSubjectReferencesSameContext(schema);
       }
 
       if (parsedSchema != null) {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
@@ -32,6 +33,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.ExtendedSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.LifecyclePolicy;
 import io.confluent.kafka.schemaregistry.client.rest.entities.LifecyclePolicyFilter;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationBatchGetRequest;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationBatchRequest;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationBatchResponse;
@@ -45,6 +47,8 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.requests.Associati
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationResult;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationUpsertOp;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 import io.confluent.kafka.schemaregistry.utils.TestUtils;
 import java.io.InputStream;
@@ -3727,6 +3731,113 @@ public class RestApiAssociationTest extends ClusterTestHarness {
         Collections.singletonList("value"), null, 0, -1);
     assertEquals(1, associations.size());
     assertTrue(associations.get(0).isFrozen());
+  }
+
+  @Test
+  public void testRegisterSchemaRejectsReferenceToTopicOwnedSubject() throws Exception {
+    List<String> schemas = TestUtils.getAvroSchemaWithReferences();
+    String resourceName = "owned-topic";
+    String resourceNamespace = "lkc-abc123";
+    String resourceId = "topic-owned-ref-123";
+    // Frozen (STRONG) associations must use the auto-derived default subject format, which
+    // also happens to be what matchesTopicOwnedSubjectName looks for.
+    String ownedSubject = ":." + resourceNamespace + ":" + resourceName + "-value";
+
+    RegisterSchemaRequest ownedSchema = new RegisterSchemaRequest();
+    ownedSchema.setSchema(schemas.get(0));
+    AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            ownedSubject, "value", LifecyclePolicy.STRONG, true, ownedSchema, null)));
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
+
+    RegisterSchemaRequest referrer = new RegisterSchemaRequest();
+    referrer.setSchema(schemas.get(1));
+    referrer.setReferences(Collections.singletonList(
+        new SchemaReference("otherns.Subrecord", ownedSubject, 1)));
+
+    try {
+      restApp.restClient.registerSchema(referrer, "referrer-subject", false);
+      fail("Registering a reference to a topic-owned subject should fail with "
+          + Errors.TOPIC_OWNED_SUBJECT_REFERENCE_ERROR_CODE);
+    } catch (RestClientException rce) {
+      assertEquals(
+          Errors.TOPIC_OWNED_SUBJECT_REFERENCE_ERROR_CODE,
+          rce.getErrorCode(),
+          "Reference to topic-owned subject should be rejected");
+    }
+  }
+
+  @Test
+  public void testRegisterSchemaAllowsReferenceToTopicOwnedSubjectInImportMode() throws Exception {
+    List<String> schemas = TestUtils.getAvroSchemaWithReferences();
+    String resourceName = "owned-topic-import";
+    String resourceNamespace = "lkc-abc123";
+    String resourceId = "topic-owned-ref-import-123";
+    String ownedSubject = ":." + resourceNamespace + ":" + resourceName + "-value";
+
+    RegisterSchemaRequest ownedSchema = new RegisterSchemaRequest();
+    ownedSchema.setSchema(schemas.get(0));
+    AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            ownedSubject, "value", LifecyclePolicy.STRONG, true, ownedSchema, null)));
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
+
+    String referrerSubject = "referrer-subject-import";
+    restApp.restClient.setMode("IMPORT", referrerSubject, true);
+
+    RegisterSchemaRequest referrer = new RegisterSchemaRequest();
+    referrer.setSchema(schemas.get(1));
+    referrer.setReferences(Collections.singletonList(
+        new SchemaReference("otherns.Subrecord", ownedSubject, 1)));
+    referrer.setVersion(1);
+    referrer.setId(1001);
+
+    int registeredId =
+        restApp.restClient.registerSchema(referrer, referrerSubject, false).getId();
+    assertEquals(1001, registeredId,
+        "IMPORT mode should be exempt from the topic-owned-subject reference check");
+  }
+
+  @Test
+  public void testRegisterSchemaRejectsReferenceToTopicOwnedSubjectAcrossContexts()
+      throws Exception {
+    List<String> schemas = TestUtils.getAvroSchemaWithReferences();
+    String resourceName = "owned-topic-ctx";
+    String resourceNamespace = "lkc-ctx1";
+    String resourceId = "topic-owned-ref-ctx-123";
+    String ownedSubject = ":." + resourceNamespace + ":" + resourceName + "-value";
+
+    RegisterSchemaRequest ownedSchema = new RegisterSchemaRequest();
+    ownedSchema.setSchema(schemas.get(0));
+    AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            ownedSubject, "value", LifecyclePolicy.STRONG, true, ownedSchema, null)));
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
+
+    // Referrer lives in the same context and references the owned subject by its bare
+    // (unqualified) name -- exercises reference resolution's parent-context inheritance,
+    // which is what the topic-owned check must also honor to avoid checking the wrong subject.
+    RegisterSchemaRequest referrer = new RegisterSchemaRequest();
+    referrer.setSchema(schemas.get(1));
+    referrer.setReferences(Collections.singletonList(
+        new SchemaReference("otherns.Subrecord", resourceName + "-value", 1)));
+
+    try {
+      restApp.restClient.registerSchema(referrer, ":.lkc-ctx1:referrer-subject-ctx", false);
+      fail("Registering a reference to a topic-owned subject should fail with "
+          + Errors.TOPIC_OWNED_SUBJECT_REFERENCE_ERROR_CODE);
+    } catch (RestClientException rce) {
+      assertEquals(
+          Errors.TOPIC_OWNED_SUBJECT_REFERENCE_ERROR_CODE,
+          rce.getErrorCode(),
+          "Cross-context reference to topic-owned subject should be rejected");
+    }
   }
 
   private String rawGet(String path) throws Exception {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
@@ -3933,6 +3933,10 @@ public class RestApiAssociationTest extends ClusterTestHarness {
           rce.getErrorCode(),
           "Topic-owned subject's transitive reference to a different context should be "
               + "rejected even though its direct reference is in-context");
+      assertTrue(rce.getMessage().contains(ownedSubject),
+          "Error message should name the subject actually being registered ("
+              + ownedSubject + "), not the intermediate hop that surfaced the violation: "
+              + rce.getMessage());
     }
   }
 
@@ -3982,6 +3986,10 @@ public class RestApiAssociationTest extends ClusterTestHarness {
           Errors.TOPIC_OWNED_SUBJECT_REFERENCE_ERROR_CODE,
           rce.getErrorCode(),
           "A soft-deleted intermediate reference must not let an out-of-context leak through");
+      assertTrue(rce.getMessage().contains(ownedSubject),
+          "Error message should name the subject actually being registered ("
+              + ownedSubject + "), not the intermediate hop that surfaced the violation: "
+              + rce.getMessage());
     }
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
@@ -3840,6 +3840,114 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     }
   }
 
+  @Test
+  public void testTopicOwnedSubjectAllowsReferenceInSameContext() throws Exception {
+    String resourceNamespace = "lkc-samectx";
+    String ownedSubject = ":." + resourceNamespace + ":owned-topic-samectx-value";
+    String targetSubject = ":." + resourceNamespace + ":target-subject";
+
+    createTopicOwnedSubject(resourceNamespace, "owned-topic-samectx", ownedSubject);
+    restApp.restClient.registerSchema(
+        "{\"type\":\"record\",\"name\":\"LeafRecord\",\"namespace\":\"chainns\","
+            + "\"fields\":[{\"name\":\"f\",\"type\":\"string\"}]}",
+        targetSubject);
+
+    RegisterSchemaRequest v2 = new RegisterSchemaRequest();
+    v2.setSchema("{\"type\":\"record\",\"name\":\"TopRecord\",\"namespace\":\"chainns\","
+        + "\"fields\":[{\"name\":\"leaf\",\"type\":\"chainns.LeafRecord\"}]}");
+    v2.setReferences(Collections.singletonList(
+        new SchemaReference("chainns.LeafRecord", targetSubject, 1)));
+
+    int registeredId = restApp.restClient.registerSchema(v2, ownedSubject, false).getId();
+    assertTrue(registeredId >= 0);
+    assertEquals(2, restApp.restClient.getAllVersions(ownedSubject).size());
+  }
+
+  @Test
+  public void testTopicOwnedSubjectRejectsDirectReferenceInDifferentContext() throws Exception {
+    String resourceNamespace = "lkc-diffctx";
+    String ownedSubject = ":." + resourceNamespace + ":owned-topic-diffctx-value";
+    String targetSubject = ":.other-ctx:target-subject-diffctx";
+
+    createTopicOwnedSubject(resourceNamespace, "owned-topic-diffctx", ownedSubject);
+    restApp.restClient.registerSchema(
+        "{\"type\":\"record\",\"name\":\"LeafRecord\",\"namespace\":\"chainns\","
+            + "\"fields\":[{\"name\":\"f\",\"type\":\"string\"}]}",
+        targetSubject);
+
+    RegisterSchemaRequest v2 = new RegisterSchemaRequest();
+    v2.setSchema("{\"type\":\"record\",\"name\":\"TopRecord\",\"namespace\":\"chainns\","
+        + "\"fields\":[{\"name\":\"leaf\",\"type\":\"chainns.LeafRecord\"}]}");
+    v2.setReferences(Collections.singletonList(
+        new SchemaReference("chainns.LeafRecord", targetSubject, 1)));
+
+    try {
+      restApp.restClient.registerSchema(v2, ownedSubject, false);
+      fail("A topic-owned subject referencing a different context should be rejected with "
+          + Errors.TOPIC_OWNED_SUBJECT_REFERENCE_ERROR_CODE);
+    } catch (RestClientException rce) {
+      assertEquals(
+          Errors.TOPIC_OWNED_SUBJECT_REFERENCE_ERROR_CODE,
+          rce.getErrorCode(),
+          "Topic-owned subject's reference to a different context should be rejected");
+    }
+  }
+
+  @Test
+  public void testTopicOwnedSubjectRejectsTransitiveReferenceInDifferentContext()
+      throws Exception {
+    String resourceNamespace = "lkc-chainctx";
+    String ownedSubject = ":." + resourceNamespace + ":owned-topic-chainctx-value";
+    // Same context as the owned subject -- the direct reference is fine on its own.
+    String middleSubject = ":." + resourceNamespace + ":middle-subject-chainctx";
+    // A different context, reached only by following middleSubject's own reference.
+    String leafSubject = ":.other-ctx:leaf-subject-chainctx";
+
+    createTopicOwnedSubject(resourceNamespace, "owned-topic-chainctx", ownedSubject);
+    restApp.restClient.registerSchema(
+        "{\"type\":\"record\",\"name\":\"LeafRecord\",\"namespace\":\"chainns\","
+            + "\"fields\":[{\"name\":\"f\",\"type\":\"string\"}]}",
+        leafSubject);
+
+    RegisterSchemaRequest middle = new RegisterSchemaRequest();
+    middle.setSchema("{\"type\":\"record\",\"name\":\"MiddleRecord\",\"namespace\":\"chainns\","
+        + "\"fields\":[{\"name\":\"leaf\",\"type\":\"chainns.LeafRecord\"}]}");
+    middle.setReferences(Collections.singletonList(
+        new SchemaReference("chainns.LeafRecord", leafSubject, 1)));
+    restApp.restClient.registerSchema(middle, middleSubject, false);
+
+    RegisterSchemaRequest v2 = new RegisterSchemaRequest();
+    v2.setSchema("{\"type\":\"record\",\"name\":\"TopRecord\",\"namespace\":\"chainns\","
+        + "\"fields\":[{\"name\":\"mid\",\"type\":\"chainns.MiddleRecord\"}]}");
+    v2.setReferences(Collections.singletonList(
+        new SchemaReference("chainns.MiddleRecord", middleSubject, 1)));
+
+    try {
+      restApp.restClient.registerSchema(v2, ownedSubject, false);
+      fail("A topic-owned subject's transitive reference to a different context should be "
+          + "rejected with " + Errors.TOPIC_OWNED_SUBJECT_REFERENCE_ERROR_CODE);
+    } catch (RestClientException rce) {
+      assertEquals(
+          Errors.TOPIC_OWNED_SUBJECT_REFERENCE_ERROR_CODE,
+          rce.getErrorCode(),
+          "Topic-owned subject's transitive reference to a different context should be "
+              + "rejected even though its direct reference is in-context");
+    }
+  }
+
+  private void createTopicOwnedSubject(
+      String resourceNamespace, String resourceName, String expectedSubject) throws Exception {
+    List<String> schemas = TestUtils.getRandomCanonicalAvroString(1);
+    RegisterSchemaRequest v1 = new RegisterSchemaRequest();
+    v1.setSchema(schemas.get(0));
+    AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceName + "-id", "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            expectedSubject, "value", LifecyclePolicy.STRONG, true, v1, null)));
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
+  }
+
   private String rawGet(String path) throws Exception {
     URL url = new URL(restApp.restConnect + path);
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
@@ -46,6 +46,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.requests.Associati
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationResponse;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationResult;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationUpsertOp;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.ConfigUpdateRequest;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
@@ -3932,6 +3933,94 @@ public class RestApiAssociationTest extends ClusterTestHarness {
           rce.getErrorCode(),
           "Topic-owned subject's transitive reference to a different context should be "
               + "rejected even though its direct reference is in-context");
+    }
+  }
+
+  @Test
+  public void testTopicOwnedSubjectRejectsTransitiveReferenceBehindSoftDeletedHop()
+      throws Exception {
+    String resourceNamespace = "lkc-softdel";
+    String ownedSubject = ":." + resourceNamespace + ":owned-topic-softdel-value";
+    String middleSubject = ":." + resourceNamespace + ":middle-subject-softdel";
+    String leafSubject = ":.other-ctx:leaf-subject-softdel";
+
+    createTopicOwnedSubject(resourceNamespace, "owned-topic-softdel", ownedSubject);
+    restApp.restClient.registerSchema(
+        "{\"type\":\"record\",\"name\":\"LeafRecord\",\"namespace\":\"chainns\","
+            + "\"fields\":[{\"name\":\"f\",\"type\":\"string\"}]}",
+        leafSubject);
+
+    RegisterSchemaRequest middle = new RegisterSchemaRequest();
+    middle.setSchema("{\"type\":\"record\",\"name\":\"MiddleRecord\",\"namespace\":\"chainns\","
+        + "\"fields\":[{\"name\":\"leaf\",\"type\":\"chainns.LeafRecord\"}]}");
+    middle.setReferences(Collections.singletonList(
+        new SchemaReference("chainns.LeafRecord", leafSubject, 1)));
+    restApp.restClient.registerSchema(middle, middleSubject, false);
+
+    // Soft-delete the only version of the middle hop, then disable new-schema validation so a
+    // reference to it still resolves -- this is exactly the condition the transitive walk must
+    // also be able to follow, not just the initial reference resolution.
+    restApp.restClient.deleteSchemaVersion(
+        RestService.DEFAULT_REQUEST_PROPERTIES, middleSubject, "1", false);
+    ConfigUpdateRequest configUpdateRequest = new ConfigUpdateRequest();
+    configUpdateRequest.setValidateNewSchemas(false);
+    restApp.restClient.updateConfig(configUpdateRequest, ownedSubject);
+
+    RegisterSchemaRequest v2 = new RegisterSchemaRequest();
+    v2.setSchema("{\"type\":\"record\",\"name\":\"TopRecord\",\"namespace\":\"chainns\","
+        + "\"fields\":[{\"name\":\"mid\",\"type\":\"chainns.MiddleRecord\"}]}");
+    v2.setReferences(Collections.singletonList(
+        new SchemaReference("chainns.MiddleRecord", middleSubject, 1)));
+
+    try {
+      restApp.restClient.registerSchema(v2, ownedSubject, false);
+      fail("A topic-owned subject's reference behind a soft-deleted hop should still be "
+          + "walked transitively and rejected with "
+          + Errors.TOPIC_OWNED_SUBJECT_REFERENCE_ERROR_CODE);
+    } catch (RestClientException rce) {
+      assertEquals(
+          Errors.TOPIC_OWNED_SUBJECT_REFERENCE_ERROR_CODE,
+          rce.getErrorCode(),
+          "A soft-deleted intermediate reference must not let an out-of-context leak through");
+    }
+  }
+
+  @Test
+  public void testTopicOwnedSubjectCannotReferenceAnotherTopicOwnedSubjectEvenInSameContext()
+      throws Exception {
+    List<String> schemas = TestUtils.getAvroSchemaWithReferences();
+    String resourceNamespace = "lkc-bothowned";
+    String ownedSubject = ":." + resourceNamespace + ":owned-topic-bothowned-value";
+    String otherOwnedSubject =
+        ":." + resourceNamespace + ":other-owned-topic-bothowned-value";
+
+    RegisterSchemaRequest otherOwnedSchema = new RegisterSchemaRequest();
+    otherOwnedSchema.setSchema(schemas.get(0));
+    AssociationCreateOrUpdateRequest otherOwnedRequest = new AssociationCreateOrUpdateRequest(
+        "other-owned-topic-bothowned", resourceNamespace,
+        "other-owned-topic-bothowned-id", "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            otherOwnedSubject, "value", LifecyclePolicy.STRONG, true, otherOwnedSchema, null)));
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, otherOwnedRequest);
+
+    createTopicOwnedSubject(resourceNamespace, "owned-topic-bothowned", ownedSubject);
+
+    RegisterSchemaRequest v2 = new RegisterSchemaRequest();
+    v2.setSchema(schemas.get(1));
+    v2.setReferences(Collections.singletonList(
+        new SchemaReference("otherns.Subrecord", otherOwnedSubject, 1)));
+
+    try {
+      restApp.restClient.registerSchema(v2, ownedSubject, false);
+      fail("Referencing any topic-owned subject is rejected regardless of context, so this "
+          + "must fail with " + Errors.TOPIC_OWNED_SUBJECT_REFERENCE_ERROR_CODE);
+    } catch (RestClientException rce) {
+      assertEquals(
+          Errors.TOPIC_OWNED_SUBJECT_REFERENCE_ERROR_CODE,
+          rce.getErrorCode(),
+          "Rule #1 rejects referencing a topic-owned subject even when it's in the same "
+              + "context as the referrer");
     }
   }
 


### PR DESCRIPTION
## Summary
- A schema cannot reference a topic-owned subject: its lifecycle follows its topic, so the reference would block it from being deleted when the topic is deleted. Detected by name (context matches the reserved cluster-context pattern, subject ends in `-key`/`-value`), not by an association-store lookup.
- A topic-owned subject's own schema references must all resolve to subjects in the same context as itself, checked transitively across the whole reference chain (not just direct references) — otherwise an indirect reference could leak the topic's schema graph outside its context even when the direct reference is in-context.
- New `TopicOwnedSubjectReferenceException` / `RestTopicOwnedSubjectReferenceException`, error code `42213`.

## Known limitations (by design, not fixed here)
- **Both rules are exempted for `Mode.IMPORT`**, consistent with how this file already exempts IMPORT-mode subjects from other topic/association lifecycle invariants (replication/migration recreates already-established state).
- **A narrow association-creation-side gap is not guarded**: creating a STRONG association is rejected on a subject with existing schema history, *except* when that subject has exactly one version (v1) that exactly matches the schema supplied in the same association-creation request. In that case, a subject can become topic-owned while something else is already referencing it (e.g. subject B's v1 is registered independently, subject A references B v1, then B's topic is later created supplying that same v1 schema inline). This is a real, narrow edge case that isn't guarded against.
- **`MockSchemaRegistryClient` is out of scope for this PR** — it currently does zero reference validation, so both rules only exist server-side for now. A second PR will bring these rules to the mock client.
- The name-pattern detection (`matchesTopicOwnedSubjectName`) duplicates logic from #4489 (DGS-25010, still open) — expect a rebase/dedupe once that merges.

## Test plan
- [x] `RestApiAssociationTest`: 76/76 pass (68 pre-existing + 8 new: 3 for the reference-rejection rule including a cross-context qualification test, 5 for the same-context rule including a same-context allow case, a direct-reference rejection, a transitive-reference rejection, a soft-deleted-intermediate-hop rejection, and a same-context-but-still-topic-owned rejection)
- [x] Full `compile`/`test-compile` + `checkstyle:check` on the `core` module: clean