### PR TITLE
DGS-25033 Use names from registered Protobuf schema for validation

### DIFF
--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -1152,17 +1152,19 @@ public class JsonSchema implements ParsedSchema {
    *       each subschema and walk into matching ones.</li>
    *   <li>{@link ArraySchema} — recurse on each element with {@code [i]}
    *       path.</li>
-   *   <li>{@link ObjectSchema} — evaluate object-level rules with
-   *       {@code this = message}; iterate properties, evaluate
-   *       property-level rules (with skip-on-null), then recurse on each
+   *   <li>{@link ObjectSchema} — iterate properties and recurse on each
    *       property value.</li>
    *   <li>{@link ReferenceSchema} — resolve to the referred schema and
    *       recurse.</li>
    *   <li>{@link ConditionalSchema}, {@link EmptySchema},
    *       {@link FalseSchema}, {@link NotSchema} — no-op (return).</li>
-   *   <li>otherwise (primitive) — no-op; property-level rules were
-   *       already evaluated by the parent {@code ObjectSchema} case.</li>
+   *   <li>otherwise (primitive) — no-op.</li>
    * </ul>
+   *
+   * <p>Rules are evaluated once per location the walk reaches, before the
+   * dispatch below, so that a schema declaring rules is charged exactly
+   * once whether it is reached as the root, as a property value, or as an
+   * array element.
    */
   private void toValidatedMessage(
       Schema schema, String path, Object message,
@@ -1172,6 +1174,22 @@ public class JsonSchema implements ParsedSchema {
       return;
     }
     message = getValue(message);
+    // Skip-on-null: an absent or null value does not invoke the executor,
+    // and there is nothing below it to walk.
+    if (message == null) {
+      return;
+    }
+    // Rules declared at this level: this = the value at this location, hint
+    // = its class. This is the only place rules are read: a property's
+    // schema and the schema the walk recurses into for that property are
+    // the same Schema, so evaluating them in the property loop as well
+    // would charge every rule on an object-valued property twice.
+    for (ValidationRule rule : readRulesProp(schema)) {
+      evaluateOne(rule, message.getClass(), message, path, executor, out);
+      if (failFast && !out.isEmpty()) {
+        return;
+      }
+    }
     if (schema instanceof CombinedSchema) {
       CombinedSchema combinedSchema = (CombinedSchema) schema;
       CombinedSchema.ValidationCriterion criterion = combinedSchema.getCriterion();
@@ -1228,16 +1246,6 @@ public class JsonSchema implements ParsedSchema {
       }
       return;
     } else if (schema instanceof ObjectSchema) {
-      if (message == null) {
-        return;
-      }
-      // Object-level rules: this = the object value, hint = its class.
-      for (ValidationRule rule : readRulesProp(schema)) {
-        evaluateOne(rule, message.getClass(), message, path, executor, out);
-        if (failFast && !out.isEmpty()) {
-          return;
-        }
-      }
       Map<String, Schema> propertySchemas = ((ObjectSchema) schema).getPropertySchemas();
       for (Map.Entry<String, Schema> entry : propertySchemas.entrySet()) {
         String propertyName = entry.getKey();
@@ -1249,20 +1257,9 @@ public class JsonSchema implements ParsedSchema {
         if (propertyAccessor == null) {
           continue;
         }
-        Object propertyValue = getValue(propertyAccessor.getPropertyValue());
-        // Skip-on-null for property-level rules: when the property value
-        // is null (or the property is absent), don't evaluate. The
-        // recursion still happens but lands at branches that no-op for
-        // null values.
-        if (propertyValue != null) {
-          for (ValidationRule rule : readRulesProp(propertySchema)) {
-            evaluateOne(rule, propertyValue.getClass(), propertyValue,
-                fullName, executor, out);
-            if (failFast && !out.isEmpty()) {
-              return;
-            }
-          }
-        }
+        // The recursive call normalizes the value and skips a null one, so a
+        // property that is absent or null invokes no rules.
+        Object propertyValue = propertyAccessor.getPropertyValue();
         toValidatedMessage(propertySchema, fullName, propertyValue, executor, failFast, out);
         if (failFast && !out.isEmpty()) {
           return;
@@ -1270,9 +1267,6 @@ public class JsonSchema implements ParsedSchema {
       }
       return;
     } else if (schema instanceof ReferenceSchema) {
-      if (message == null) {
-        return;
-      }
       toValidatedMessage(((ReferenceSchema) schema).getReferredSchema(),
           path, message, executor, failFast, out);
       return;
@@ -1282,15 +1276,17 @@ public class JsonSchema implements ParsedSchema {
         || schema instanceof NotSchema) {
       return;
     }
-    // Primitive leaf — no rules at this level (property-level rules
-    // were evaluated by the parent ObjectSchema case).
+    // Primitive leaf — nothing below it to walk; its own rules were
+    // evaluated above.
   }
 
   /**
    * Read the {@code confluent:rules} property off a schema's unprocessed
    * properties map. Empty / missing / malformed entries return an empty
-   * list. Used for both object-level (the {@link ObjectSchema} itself)
-   * and property-level (each property's schema) rule reads.
+   * list. The loader attaches the keyword to exactly one {@link Schema} per
+   * JSON node — for a {@code "type"} array, to the enclosing
+   * {@link CombinedSchema} rather than to the synthesized members — so a
+   * single read per location covers every declaration site.
    */
   private static List<ValidationRule> readRulesProp(Schema schema) {
     Map<String, Object> unprocessed = schema.getUnprocessedProperties();

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaValidateMessageTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaValidateMessageTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
  * return {@code false} so every walker invocation surfaces as a {@link ValidationRuleError};
  * the test asserts on (rule name, path) pairs to verify the walker's dispatch (recursion
  * into nested objects, array iteration, CombinedSchema/oneOf semantics, ReferenceSchema
- * resolution, skip-on-null).
+ * resolution, skip-on-null) and that each rule is evaluated once per location reached.
  */
 public class JsonSchemaValidateMessageTest {
 
@@ -152,6 +152,71 @@ public class JsonSchemaValidateMessageTest {
 
     List<ValidationRuleError> errors = schema.validateMessage(ALWAYS_FAIL, outer);
     assertEquals(Collections.singletonList("r@$.inner.x"), firedRules(errors));
+  }
+
+  @Test
+  public void objectValuedProperty_firesItsRuleOnce() throws Exception {
+    // A property's schema and the schema the walk recurses into for that property are the
+    // same everit Schema. Reading confluent:rules in the property loop as well as at the
+    // object being walked charged an object-valued property's rules twice, at one path.
+    String schemaStr = "{"
+        + "\"type\":\"object\","
+        + "\"confluent:rules\":[{\"name\":\"root\",\"expr\":\"true\"}],"
+        + "\"properties\":{"
+        + "  \"inner\":{\"type\":\"object\","
+        + "    \"confluent:rules\":[{\"name\":\"obj\",\"expr\":\"true\"}],"
+        + "    \"properties\":{\"x\":{\"type\":\"integer\","
+        + "      \"confluent:rules\":[{\"name\":\"leaf\",\"expr\":\"true\"}]}}}"
+        + "}}";
+    JsonSchema schema = new JsonSchema(schemaStr);
+    ObjectNode inner = MAPPER.createObjectNode().put("x", 5);
+    ObjectNode outer = MAPPER.createObjectNode().set("inner", inner);
+
+    List<ValidationRuleError> errors = schema.validateMessage(ALWAYS_FAIL, outer);
+    assertEquals(Arrays.asList("root@$", "obj@$.inner", "leaf@$.inner.x"), firedRules(errors));
+  }
+
+  @Test
+  public void arrayItems_firesTheItemSchemaRuleOnEachElement() throws Exception {
+    // Items are not properties, so a rule on a scalar items subschema has no parent
+    // property loop to evaluate it: it is only reached by the walk landing on the element.
+    String schemaStr = "{"
+        + "\"type\":\"object\","
+        + "\"properties\":{"
+        + "  \"tags\":{\"type\":\"array\","
+        + "    \"confluent:rules\":[{\"name\":\"arr\",\"expr\":\"true\"}],"
+        + "    \"items\":{\"type\":\"string\","
+        + "      \"confluent:rules\":[{\"name\":\"item\",\"expr\":\"true\"}]}}"
+        + "}}";
+    JsonSchema schema = new JsonSchema(schemaStr);
+    ArrayNode tags = MAPPER.createArrayNode();
+    tags.add("a");
+    tags.add("b");
+    ObjectNode outer = MAPPER.createObjectNode().set("tags", tags);
+
+    List<ValidationRuleError> errors = schema.validateMessage(ALWAYS_FAIL, outer);
+    assertEquals(Arrays.asList("arr@$.tags", "item@$.tags[0]", "item@$.tags[1]"),
+        firedRules(errors));
+  }
+
+  @Test
+  public void nullableObjectProperty_firesItsRuleOnce() throws Exception {
+    // A "type" array makes the loader synthesize an anyOf whose members do not carry the
+    // keyword, so the rule is declared on the enclosing CombinedSchema alone. The walk
+    // descends into the matching member, which must not re-read it.
+    String schemaStr = "{"
+        + "\"type\":\"object\","
+        + "\"properties\":{"
+        + "  \"inner\":{\"type\":[\"object\",\"null\"],"
+        + "    \"confluent:rules\":[{\"name\":\"obj\",\"expr\":\"true\"}],"
+        + "    \"properties\":{\"x\":{\"type\":\"integer\"}}}"
+        + "}}";
+    JsonSchema schema = new JsonSchema(schemaStr);
+    ObjectNode inner = MAPPER.createObjectNode().put("x", 5);
+    ObjectNode outer = MAPPER.createObjectNode().set("inner", inner);
+
+    List<ValidationRuleError> errors = schema.validateMessage(ALWAYS_FAIL, outer);
+    assertEquals(Collections.singletonList("obj@$.inner"), firedRules(errors));
   }
 
   @Test

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -3134,7 +3134,7 @@ public class ProtobufSchema implements ParsedSchema {
    */
   private static boolean presentsSameValues(
       Descriptor desc, Descriptor runtimeDesc, Set<String> visited) {
-    if (!visited.add(desc.getFullName() + ' ' + runtimeDesc.getFullName())) {
+    if (!visited.add(desc.getFullName() + '\0' + runtimeDesc.getFullName())) {
       // Already compared on another path, or cycling back to it. Either way this pair
       // contributes no new disagreement.
       return true;
@@ -3252,20 +3252,20 @@ public class ProtobufSchema implements ParsedSchema {
         String childPath = path.isEmpty()
             ? schemaFd.getName()
             : path + "." + schemaFd.getName();
-        // Only a message-valued field needs the schema's view of its value: a scalar, or a
-        // list of scalars, carries no field names for a rule to resolve.
-        Object schemaFieldValue = null;
-        if (schemaMsg != null
-            && fd.getJavaType() == FieldDescriptor.JavaType.MESSAGE
-            && schemaFd.getJavaType() == FieldDescriptor.JavaType.MESSAGE) {
-          schemaFieldValue = schemaMsg.getField(schemaFd);
-        }
-        // Field-level rules: this = fieldValue. Hint is the field's own
-        // message descriptor for nested messages, or the containing-type
-        // descriptor for primitives.
+        // Where a schema view exists, every value comes from it, not just message-valued
+        // ones: the two descriptors can disagree about representation as well as naming.
+        // bytes and string are interchangeable at the same number — a compatible change —
+        // and a rule authored as `this == 'hello'` cannot match a ByteString. The same goes
+        // for a renamed enum value. Reading the field is cheap next to the re-read that
+        // already happened, so there is nothing to gain from narrowing this further.
+        Object schemaFieldValue = schemaMsg == null ? null : schemaMsg.getField(schemaFd);
+        // Field-level rules: this = the field value as the schema presents it. Hint is the
+        // field's own message descriptor for nested messages, or the containing-type
+        // descriptor for primitives — taken from the schema's field, since that is where
+        // the value being bound comes from.
         if (schemaFd.getOptions().hasExtension(MetaProto.fieldMeta)) {
           Meta meta = schemaFd.getOptions().getExtension(MetaProto.fieldMeta);
-          Descriptor hint = (fd.getJavaType() == FieldDescriptor.JavaType.MESSAGE)
+          Descriptor hint = (schemaFd.getJavaType() == FieldDescriptor.JavaType.MESSAGE)
               ? schemaFd.getMessageType()
               : schemaFd.getContainingType();
           Object thisValue = schemaFieldValue != null ? schemaFieldValue : fieldValue;

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -3126,8 +3126,13 @@ public class ProtobufSchema implements ParsedSchema {
   /**
    * Whether {@code desc} and {@code runtimeDesc} present every field they share — paired by
    * number, which is how protobuf identifies a field — under the same name, type and label,
-   * recursively through message-valued fields. Fields only one of them declares are ignored:
-   * the walk visits the intersection either way.
+   * recursively through message-valued fields.
+   *
+   * <p>A field the registered schema declares and the caller's does not counts as a
+   * difference: adding a field is a compatible change, and a message-level rule may reference
+   * the added field expecting the schema's default for it, which only a message read through
+   * the schema can supply. Fields only the caller declares are ignored — no rule can name
+   * them, and the walk skips them.
    *
    * <p>{@code visited} holds the descriptor pairs already compared, so a self-referential
    * message type terminates.
@@ -3138,6 +3143,11 @@ public class ProtobufSchema implements ParsedSchema {
       // Already compared on another path, or cycling back to it. Either way this pair
       // contributes no new disagreement.
       return true;
+    }
+    for (FieldDescriptor schemaFd : desc.getFields()) {
+      if (runtimeDesc.findFieldByNumber(schemaFd.getNumber()) == null) {
+        return false;
+      }
     }
     for (FieldDescriptor runtimeFd : runtimeDesc.getFields()) {
       FieldDescriptor schemaFd = desc.findFieldByNumber(runtimeFd.getNumber());

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -74,11 +74,11 @@ import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.Descriptors.GenericDescriptor;
 import com.google.protobuf.DurationProto;
 import com.google.protobuf.DynamicMessage;
-import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.EmptyProto;
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.FieldMaskProto;
 import com.google.protobuf.GeneratedMessage.ExtendableMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.SourceContextProto;
 import com.google.protobuf.StructProto;
@@ -167,6 +167,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import kotlin.Pair;
@@ -428,6 +429,11 @@ public class ProtobufSchema implements ParsedSchema {
   private transient volatile Descriptor descriptor;
 
   private transient volatile int hashCode = NO_HASHCODE;
+
+  // Keyed by the runtime descriptor of a message passed to validateMessage: whether that
+  // message has to be re-read through this schema's descriptor before rules can bind `this`
+  // to it. Identity-keyed, and a serializer sees a small fixed set of message types.
+  private final transient Map<Descriptor, Boolean> schemaViewNeeded = new ConcurrentHashMap<>();
 
   private static final int NO_HASHCODE = Integer.MIN_VALUE;
 
@@ -3040,6 +3046,11 @@ public class ProtobufSchema implements ParsedSchema {
    * are appended to the returned list with their dotted-path location
    * (e.g. {@code addr.zip}, {@code tags[3]}). The walk continues after
    * each failure so callers see the full set rather than only the first.
+   *
+   * @throws org.apache.kafka.common.errors.SerializationException if the
+   *     message cannot be read through this schema at all, which no rule
+   *     result can express — the walk reads it through the registered
+   *     descriptor so that rules see the schema's field names.
    */
   @Override
   public List<ValidationRuleError> validateMessage(
@@ -3061,29 +3072,101 @@ public class ProtobufSchema implements ParsedSchema {
     if (desc == null) {
       return violations;
     }
-    // Re-read the message through that descriptor. Protobuf pairs fields by number on the
-    // wire, so this carries every value across a rename, and it means a message-level rule
-    // binds `this` to a message whose fields the rule's own environment - built from the
-    // same schema - can resolve. Without it, `this.renamed` reads a missing field and a
-    // valid message is rejected. The runtime descriptor is still what bounds the walk, so
-    // both walks visit the same fields.
-    Descriptor runtimeDesc = msg.getDescriptorForType();
-    if (runtimeDesc != desc) {
+    // The walk is driven by the caller's message throughout: it decides which fields exist,
+    // which are absent, and what the values are. A rule that binds `this` to a message needs
+    // one more thing, though — a view of that message in the schema's terms, since a rule's
+    // CEL environment is built from the schema and `this.renamed` cannot read a field the
+    // caller's class calls something else. Protobuf pairs fields by number on the wire, so
+    // re-reading the message through the registered descriptor produces exactly that view.
+    //
+    // Re-reading is only worth its cost when the two descriptors actually present values
+    // differently, which is decided once per runtime descriptor (see needsSchemaView) rather
+    // than per record: for the common case of a generated class that matches the registered
+    // schema, the two descriptors are distinct objects but describe the same fields, so no
+    // re-read happens at all.
+    Message schemaMsg = null;
+    if (needsSchemaView(desc, msg.getDescriptorForType())) {
       try {
-        msg = DynamicMessage.parseFrom(desc, msg.toByteString());
+        schemaMsg = DynamicMessage.parseFrom(desc, msg.toByteString());
       } catch (InvalidProtocolBufferException e) {
-        throw new IllegalArgumentException(
-            "Could not read the message through the registered schema", e);
+        // The bytes the producer is about to write cannot be read through the registered
+        // schema, so a consumer reading with that schema could not read them either — a
+        // bytes field carrying non-UTF-8 data against a schema that declares a string, for
+        // instance, which is a compatible change. Fail in the channel the caller already
+        // handles rather than returning silently, and name the type so it is searchable.
+        throw new SerializationException(
+            "Could not read message " + desc.getFullName()
+                + " through the registered schema", e);
       }
     }
-    toValidatedMessage(desc, runtimeDesc, msg, "", executor, failFast, violations);
+    toValidatedMessage(desc, msg, schemaMsg, "", executor, failFast, violations);
     return violations;
   }
 
   /**
+   * Whether validating a message whose runtime descriptor is {@code runtimeDesc} has to
+   * re-read it through {@code desc} — true when the two disagree about any field a rule
+   * could observe: its name, its type, or whether it is repeated, at any depth.
+   *
+   * <p>Presence deliberately does not count. Whether an unset field is absent is decided by
+   * the producer's field on the producer's message, which the walk reads directly, so a
+   * schema that only moved a field into or out of a oneof needs no re-read.
+   *
+   * <p>Memoized per runtime descriptor: both descriptors are stable for the lifetime of a
+   * serializer, so this is one map lookup per record rather than a tree comparison.
+   */
+  private boolean needsSchemaView(Descriptor desc, Descriptor runtimeDesc) {
+    if (desc == runtimeDesc) {
+      return false;
+    }
+    return schemaViewNeeded.computeIfAbsent(runtimeDesc,
+        rd -> !presentsSameValues(desc, rd, new HashSet<>()));
+  }
+
+  /**
+   * Whether {@code desc} and {@code runtimeDesc} present every field they share — paired by
+   * number, which is how protobuf identifies a field — under the same name, type and label,
+   * recursively through message-valued fields. Fields only one of them declares are ignored:
+   * the walk visits the intersection either way.
+   *
+   * <p>{@code visited} holds the descriptor pairs already compared, so a self-referential
+   * message type terminates.
+   */
+  private static boolean presentsSameValues(
+      Descriptor desc, Descriptor runtimeDesc, Set<String> visited) {
+    if (!visited.add(desc.getFullName() + ' ' + runtimeDesc.getFullName())) {
+      // Already compared on another path, or cycling back to it. Either way this pair
+      // contributes no new disagreement.
+      return true;
+    }
+    for (FieldDescriptor runtimeFd : runtimeDesc.getFields()) {
+      FieldDescriptor schemaFd = desc.findFieldByNumber(runtimeFd.getNumber());
+      if (schemaFd == null) {
+        continue;
+      }
+      if (!schemaFd.getName().equals(runtimeFd.getName())
+          || schemaFd.getType() != runtimeFd.getType()
+          || schemaFd.isRepeated() != runtimeFd.isRepeated()) {
+        return false;
+      }
+      if (schemaFd.getType() == Type.MESSAGE
+          && !presentsSameValues(schemaFd.getMessageType(), runtimeFd.getMessageType(),
+              visited)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
    * Mirrors {@link #toTransformedMessage}'s value-driven dispatch shape.
-   * Each call receives a {@code (descriptor, value)} pair and dispatches
-   * on the value type:
+   * Each call receives a {@code (descriptor, value)} pair — the registered
+   * schema's descriptor and the caller's value — plus {@code schemaValue},
+   * the same value read through that descriptor, or {@code null} when the
+   * two descriptors present it identically and the caller's value already
+   * reads as the schema does. The caller's value drives the walk; the
+   * schema's view is used only where a rule binds {@code this} to a
+   * message. Dispatch is on the value type:
    * <ul>
    *   <li>{@code List} — repeated field or proto3 map (which arrives as a
    *       {@code List<MapEntry>}); recurse on each element with the same
@@ -3100,15 +3183,19 @@ public class ProtobufSchema implements ParsedSchema {
    * </ul>
    */
   private static void toValidatedMessage(
-      Descriptor desc, Descriptor runtimeDesc, Object value, String path,
+      Descriptor desc, Object value, Object schemaValue, String path,
       ValidationRuleExecutor executor, boolean failFast, List<ValidationRuleError> out) {
     if (desc == null) {
       return;
     }
     if (value instanceof List) {
+      List<?> schemaElements = schemaValue instanceof List ? (List<?>) schemaValue : null;
       int i = 0;
       for (Object element : (List<?>) value) {
-        toValidatedMessage(desc, runtimeDesc, element, path + "[" + i + "]", executor,
+        // Both lists came from the same bytes, so they line up; the guard is for safety.
+        Object schemaElement =
+            schemaElements != null && i < schemaElements.size() ? schemaElements.get(i) : null;
+        toValidatedMessage(desc, element, schemaElement, path + "[" + i + "]", executor,
             failFast, out);
         if (failFast && !out.isEmpty()) {
           return;
@@ -3121,23 +3208,28 @@ public class ProtobufSchema implements ParsedSchema {
       return;
     } else if (value instanceof Message) {
       Message msg = (Message) value;
-      // Message-level rules: this = msg, type hint = desc.
+      // The same message in the registered schema's terms, when the two descriptors present
+      // fields differently; null when they agree and `msg` already reads as the schema does.
+      Message schemaMsg = schemaValue instanceof Message ? (Message) schemaValue : null;
+      // Message-level rules: this = msg, type hint = desc. `this` is a message, so it has to
+      // read as the schema names it.
       if (desc.getOptions().hasExtension(MetaProto.messageMeta)) {
         Meta meta = desc.getOptions().getExtension(MetaProto.messageMeta);
+        Object thisValue = schemaMsg != null ? schemaMsg : msg;
         for (MetaProto.Rule rule : meta.getRulesList()) {
-          evaluateOne(rule, desc, msg, path, executor, out);
+          evaluateOne(rule, desc, thisValue, path, executor, out);
           if (failFast && !out.isEmpty()) {
             return;
           }
         }
       }
-      // Iterate fields — same shape as toTransformedMessage's field loop. The message is in
-      // the schema's terms, so these are the schema's fields; runtimeDesc bounds the walk to
-      // the fields the caller's message class declares, which is the set the transform walk
-      // visits too.
+      // Iterate the caller's own fields — same shape as toTransformedMessage's field loop —
+      // and pair each to the registered schema by number, which is how protobuf identifies a
+      // field. Fields the schema does not declare are skipped, so the walk visits the
+      // intersection, which is the set the transform walk visits too.
       for (FieldDescriptor fd : msg.getDescriptorForType().getFields()) {
-        FieldDescriptor schemaFd = fd;
-        if (runtimeDesc != null && runtimeDesc.findFieldByNumber(fd.getNumber()) == null) {
+        FieldDescriptor schemaFd = desc.findFieldByNumber(fd.getNumber());
+        if (schemaFd == null) {
           continue;
         }
         // Skip-on-null per proto3 presence: hasPresence() returns true for
@@ -3147,15 +3239,27 @@ public class ProtobufSchema implements ParsedSchema {
         // Repeated/map fields are never null in proto3; the collection
         // itself is bound to `this` (per the design's "empty == null"
         // convention for collection IS NULL).
+        //
+        // Both halves are read from the caller's message: whether an unset field counts as
+        // absent is decided by the class that wrote it, not by the registered schema, and the
+        // two can disagree — moving a field into or out of a oneof is a compatible change.
         if (fd.hasPresence() && !msg.hasField(fd)) {
           continue;
         }
         Object fieldValue = msg.getField(fd);
         // The path names the field as the registered schema does, which is what a rule
-        // refers to; the value is still read through the runtime field.
+        // refers to; the value is still read through the caller's field.
         String childPath = path.isEmpty()
             ? schemaFd.getName()
             : path + "." + schemaFd.getName();
+        // Only a message-valued field needs the schema's view of its value: a scalar, or a
+        // list of scalars, carries no field names for a rule to resolve.
+        Object schemaFieldValue = null;
+        if (schemaMsg != null
+            && fd.getJavaType() == FieldDescriptor.JavaType.MESSAGE
+            && schemaFd.getJavaType() == FieldDescriptor.JavaType.MESSAGE) {
+          schemaFieldValue = schemaMsg.getField(schemaFd);
+        }
         // Field-level rules: this = fieldValue. Hint is the field's own
         // message descriptor for nested messages, or the containing-type
         // descriptor for primitives.
@@ -3164,8 +3268,9 @@ public class ProtobufSchema implements ParsedSchema {
           Descriptor hint = (fd.getJavaType() == FieldDescriptor.JavaType.MESSAGE)
               ? schemaFd.getMessageType()
               : schemaFd.getContainingType();
+          Object thisValue = schemaFieldValue != null ? schemaFieldValue : fieldValue;
           for (MetaProto.Rule rule : meta.getRulesList()) {
-            evaluateOne(rule, hint, fieldValue, childPath, executor, out);
+            evaluateOne(rule, hint, thisValue, childPath, executor, out);
             if (failFast && !out.isEmpty()) {
               return;
             }
@@ -3178,13 +3283,7 @@ public class ProtobufSchema implements ParsedSchema {
         Descriptor childDesc = (schemaFd.getType() == Type.MESSAGE)
             ? schemaFd.getMessageType()
             : desc;
-        FieldDescriptor runtimeFd =
-            runtimeDesc == null ? null : runtimeDesc.findFieldByNumber(fd.getNumber());
-        Descriptor childRuntimeDesc =
-            runtimeFd != null && runtimeFd.getType() == Type.MESSAGE
-                ? runtimeFd.getMessageType()
-                : runtimeDesc;
-        toValidatedMessage(childDesc, childRuntimeDesc, fieldValue, childPath, executor,
+        toValidatedMessage(childDesc, fieldValue, schemaFieldValue, childPath, executor,
             failFast, out);
         if (failFast && !out.isEmpty()) {
           return;

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -432,7 +432,9 @@ public class ProtobufSchema implements ParsedSchema {
 
   // Keyed by the runtime descriptor of a message passed to validateMessage: whether that
   // message has to be re-read through this schema's descriptor before rules can bind `this`
-  // to it. Identity-keyed, and a serializer sees a small fixed set of message types.
+  // to it. Identity-keyed, and a serializer sees a small fixed set of message types. The
+  // answer is no only for a class that describes the same fields as the registered schema;
+  // a class that has fallen behind it re-reads every record. See needsSchemaView.
   private final transient Map<Descriptor, Boolean> schemaViewNeeded = new ConcurrentHashMap<>();
 
   private static final int NO_HASHCODE = Integer.MIN_VALUE;
@@ -3079,11 +3081,13 @@ public class ProtobufSchema implements ParsedSchema {
     // caller's class calls something else. Protobuf pairs fields by number on the wire, so
     // re-reading the message through the registered descriptor produces exactly that view.
     //
-    // Re-reading is only worth its cost when the two descriptors actually present values
-    // differently, which is decided once per runtime descriptor (see needsSchemaView) rather
-    // than per record: for the common case of a generated class that matches the registered
-    // schema, the two descriptors are distinct objects but describe the same fields, so no
-    // re-read happens at all.
+    // Whether that is needed is decided once per runtime descriptor (see needsSchemaView)
+    // rather than per record. A generated class describing the same fields as the registered
+    // schema skips it entirely, even though the two descriptors are distinct objects. A class
+    // that has fallen behind the schema does not: under use.latest.version the schema may
+    // declare a field the class has never heard of, and a rule that binds `this` can read the
+    // schema's default for it, so those producers re-read every record. That cost is the
+    // price of evaluating rules in the schema's terms, not an accident.
     Message schemaMsg = null;
     if (needsSchemaView(desc, msg.getDescriptorForType())) {
       try {
@@ -3111,6 +3115,14 @@ public class ProtobufSchema implements ParsedSchema {
    * <p>Presence deliberately does not count. Whether an unset field is absent is decided by
    * the producer's field on the producer's message, which the walk reads directly, so a
    * schema that only moved a field into or out of a oneof needs no re-read.
+   *
+   * <p>A field the schema declares and the caller's class does not <em>does</em> count, which
+   * means a class running behind the registered schema — the {@code use.latest.version} case
+   * — re-reads every record. Only an exact match skips the re-read. Narrowing that to the
+   * rules that could actually observe the added field is possible but not simple: a rule
+   * binding {@code this} at any ancestor can traverse into the field, and a field-level rule
+   * on a message-valued field binds {@code this} to a type that need not declare rules of its
+   * own, so a per-descriptor test for message-level rules would be wrong in both directions.
    *
    * <p>Memoized per runtime descriptor: both descriptors are stable for the lifetime of a
    * serializer, so this is one map lookup per record rather than a tree comparison.

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -74,6 +74,7 @@ import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.Descriptors.GenericDescriptor;
 import com.google.protobuf.DurationProto;
 import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.EmptyProto;
 import com.google.protobuf.ExtensionRegistry;
 import com.google.protobuf.FieldMaskProto;
@@ -3060,7 +3061,22 @@ public class ProtobufSchema implements ParsedSchema {
     if (desc == null) {
       return violations;
     }
-    toValidatedMessage(desc, msg, "", executor, failFast, violations);
+    // Re-read the message through that descriptor. Protobuf pairs fields by number on the
+    // wire, so this carries every value across a rename, and it means a message-level rule
+    // binds `this` to a message whose fields the rule's own environment - built from the
+    // same schema - can resolve. Without it, `this.renamed` reads a missing field and a
+    // valid message is rejected. The runtime descriptor is still what bounds the walk, so
+    // both walks visit the same fields.
+    Descriptor runtimeDesc = msg.getDescriptorForType();
+    if (runtimeDesc != desc) {
+      try {
+        msg = DynamicMessage.parseFrom(desc, msg.toByteString());
+      } catch (InvalidProtocolBufferException e) {
+        throw new IllegalArgumentException(
+            "Could not read the message through the registered schema", e);
+      }
+    }
+    toValidatedMessage(desc, runtimeDesc, msg, "", executor, failFast, violations);
     return violations;
   }
 
@@ -3084,7 +3100,7 @@ public class ProtobufSchema implements ParsedSchema {
    * </ul>
    */
   private static void toValidatedMessage(
-      Descriptor desc, Object value, String path,
+      Descriptor desc, Descriptor runtimeDesc, Object value, String path,
       ValidationRuleExecutor executor, boolean failFast, List<ValidationRuleError> out) {
     if (desc == null) {
       return;
@@ -3092,7 +3108,8 @@ public class ProtobufSchema implements ParsedSchema {
     if (value instanceof List) {
       int i = 0;
       for (Object element : (List<?>) value) {
-        toValidatedMessage(desc, element, path + "[" + i + "]", executor, failFast, out);
+        toValidatedMessage(desc, runtimeDesc, element, path + "[" + i + "]", executor,
+            failFast, out);
         if (failFast && !out.isEmpty()) {
           return;
         }
@@ -3114,14 +3131,13 @@ public class ProtobufSchema implements ParsedSchema {
           }
         }
       }
-      // Iterate fields — same shape as toTransformedMessage's field loop.
+      // Iterate fields — same shape as toTransformedMessage's field loop. The message is in
+      // the schema's terms, so these are the schema's fields; runtimeDesc bounds the walk to
+      // the fields the caller's message class declares, which is the set the transform walk
+      // visits too.
       for (FieldDescriptor fd : msg.getDescriptorForType().getFields()) {
-        // Resolve by number, as the transform walk does: protobuf identifies a field by
-        // its number, and renaming a field at the same number is a compatible change (see
-        // SchemaDiff.COMPATIBLE_CHANGES), so with use.latest.version the registered
-        // schema's name for a field can differ from the message's.
-        FieldDescriptor schemaFd = desc.findFieldByNumber(fd.getNumber());
-        if (schemaFd == null) {
+        FieldDescriptor schemaFd = fd;
+        if (runtimeDesc != null && runtimeDesc.findFieldByNumber(fd.getNumber()) == null) {
           continue;
         }
         // Skip-on-null per proto3 presence: hasPresence() returns true for
@@ -3162,7 +3178,14 @@ public class ProtobufSchema implements ParsedSchema {
         Descriptor childDesc = (schemaFd.getType() == Type.MESSAGE)
             ? schemaFd.getMessageType()
             : desc;
-        toValidatedMessage(childDesc, fieldValue, childPath, executor, failFast, out);
+        FieldDescriptor runtimeFd =
+            runtimeDesc == null ? null : runtimeDesc.findFieldByNumber(fd.getNumber());
+        Descriptor childRuntimeDesc =
+            runtimeFd != null && runtimeFd.getType() == Type.MESSAGE
+                ? runtimeFd.getMessageType()
+                : runtimeDesc;
+        toValidatedMessage(childDesc, childRuntimeDesc, fieldValue, childPath, executor,
+            failFast, out);
         if (failFast && !out.isEmpty()) {
           return;
         }

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -48,6 +48,7 @@ import io.confluent.kafka.schemaregistry.rules.FieldTransform;
 import io.confluent.kafka.schemaregistry.rules.RuleContext;
 import io.confluent.kafka.schemaregistry.rules.RuleContext.FieldContext;
 import io.confluent.kafka.schemaregistry.rules.ValidationRuleError;
+import io.confluent.kafka.schemaregistry.rules.ValidationRuleExecutor;
 import io.confluent.protobuf.MetaProto;
 import io.confluent.protobuf.MetaProto.Meta;
 import java.io.IOException;
@@ -3778,5 +3779,44 @@ public class ProtobufSchemaTest {
     MessageIndexes localIdx = top.toMessageIndexes("com.Local");
     assertEquals(Collections.singletonList(0), localIdx.indexes());
     assertEquals("com.Local", top.toMessageName(localIdx));
+  }
+
+  /**
+   * A message-level rule binds {@code this} to the message and its CEL environment is built
+   * from the registered schema, so the message it evaluates has to be in the schema's terms
+   * too. Otherwise a rule written against a renamed field reads a missing field and rejects a
+   * valid message.
+   */
+  @Test
+  public void testValidateMessageEvaluatesMessageRulesInSchemaTerms() {
+    String registered = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "message Outer {\n"
+        + "  option (confluent.message_meta) = {\n"
+        + "    rules: [{name: \"m\", expr: \"this.renamed == 'hello'\"}]\n"
+        + "  };\n"
+        + "  string renamed = 1;\n"
+        + "}\n";
+    String runtime = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "message Outer { string original = 1; }\n";
+    ProtobufSchema schema = new ProtobufSchema(registered);
+    Descriptor runtimeDesc = new ProtobufSchema(runtime).toDescriptor("test.Outer");
+    DynamicMessage msg = DynamicMessage.newBuilder(runtimeDesc)
+        .setField(runtimeDesc.findFieldByName("original"), "hello").build();
+
+    // Stands in for a CEL environment built from the registered schema: the rule can only
+    // read the value if the message it is handed is in the schema's terms.
+    ValidationRuleExecutor executor = (rule, sch, value) -> {
+      Message evaluated = (Message) value;
+      FieldDescriptor fd = evaluated.getDescriptorForType().findFieldByName("renamed");
+      return fd != null && "hello".equals(evaluated.getField(fd));
+    };
+
+    List<ValidationRuleError> errors = schema.validateMessage(executor, msg);
+
+    assertEquals("the rule was evaluated against the wrong names: " + errors,
+        Collections.emptyList(), errors);
   }
 }

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaValidateMessageTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaValidateMessageTest.java
@@ -371,6 +371,44 @@ public class ProtobufSchemaValidateMessageTest {
   }
 
   @Test
+  public void fieldOnlyTheSchemaDeclares_isVisibleToMessageRules() {
+    // Adding a field is the most ordinary compatible change there is, so the registered schema
+    // can declare one the producer's class has never heard of — and a message-level rule can
+    // reference it, expecting the schema's default. The rule's environment comes from the
+    // value it is handed, so that only works if the message is read through the schema: a
+    // field with no counterpart is itself a reason to re-read, even when every shared field
+    // agrees.
+    String registered = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "message M {\n"
+        + "  option (confluent.message_meta) = {\n"
+        + "    rules: [{name: \"m\", expr: \"this.added == ''\"}]\n"
+        + "  };\n"
+        + "  string kept = 1;\n"
+        + "  string added = 2;\n"
+        + "}\n";
+    String producer = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "message M { string kept = 1; }\n";
+    ProtobufSchema schema = new ProtobufSchema(registered);
+    Descriptor producerDesc = new ProtobufSchema(producer).toDescriptor("test.M");
+    DynamicMessage msg = DynamicMessage.newBuilder(producerDesc)
+        .setField(producerDesc.findFieldByName("kept"), "here").build();
+
+    // Stands in for the CEL rule above: it can only read the added field if the message it is
+    // handed declares it.
+    ValidationRuleExecutor readsAdded = (rule, sch, value) -> {
+      Message evaluated = (Message) value;
+      FieldDescriptor fd = evaluated.getDescriptorForType().findFieldByName("added");
+      return fd != null && "".equals(evaluated.getField(fd));
+    };
+
+    assertEquals(Collections.emptyList(),
+        firedRules(schema.validateMessage(readsAdded, msg)));
+  }
+
+  @Test
   public void descriptorsThatAgree_areNotReReadThroughTheSchema() {
     // A generated class's descriptor is never the same object as the one built from the
     // registered schema text, so an identity check alone would re-read every record. When

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaValidateMessageTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaValidateMessageTest.java
@@ -301,6 +301,76 @@ public class ProtobufSchemaValidateMessageTest {
   }
 
   @Test
+  public void scalarFieldRule_seesTheSchemasRepresentationNotTheProducers() {
+    // bytes and string are interchangeable at the same number — a compatible change — so a
+    // producer can write bytes against a schema that declares a string. The rule is authored
+    // against the schema, so `this == 'hello'` has to be handed the string: CEL's byte
+    // strings only compare equal to other byte strings, so the producer's ByteString would
+    // reject a valid message. Naming is not the only thing the schema's view fixes.
+    String registered = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "message M {\n"
+        + "  string payload = 1 [(confluent.field_meta) = {\n"
+        + "    rules: [{name: \"r\", expr: \"this == 'hello'\"}]\n"
+        + "  }];\n"
+        + "}\n";
+    String producer = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "message M { bytes payload = 1; }\n";
+    ProtobufSchema schema = new ProtobufSchema(registered);
+    Descriptor producerDesc = new ProtobufSchema(producer).toDescriptor("test.M");
+    DynamicMessage msg = DynamicMessage.newBuilder(producerDesc)
+        .setField(producerDesc.findFieldByName("payload"), ByteString.copyFromUtf8("hello"))
+        .build();
+
+    // Stands in for the CEL rule above: it can only match if it is handed the schema's
+    // representation of the value.
+    ValidationRuleExecutor stringValued = (rule, sch, value) -> "hello".equals(value);
+
+    assertEquals(Collections.emptyList(),
+        firedRules(schema.validateMessage(stringValued, msg)));
+  }
+
+  @Test
+  public void mapEntries_arePairedToTheirOwnSchemaView() {
+    // Map entries reach the walk as a list of entry messages, and the schema's view of that
+    // list comes from re-reading the same bytes — so the two lists carry the entries in the
+    // order the producer serialized them, and pair up positionally.
+    String registered = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "message Outer { map<string, test.Inner> labels = 1; }\n"
+        + "message Inner {\n"
+        + "  option (confluent.message_meta) = {\n"
+        + "    rules: [{name: \"m\", expr: \"this.renamed == 'x'\"}]\n"
+        + "  };\n"
+        + "  string renamed = 1;\n"
+        + "}\n";
+    String producer = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "message Outer { map<string, test.Inner> labels = 1; }\n"
+        + "message Inner { string original = 1; }\n";
+    ProtobufSchema schema = new ProtobufSchema(registered);
+    ProtobufSchema producerSchema = new ProtobufSchema(producer);
+    Descriptor outerDesc = producerSchema.toDescriptor("test.Outer");
+    Descriptor innerDesc = producerSchema.toDescriptor("test.Inner");
+    FieldDescriptor labels = outerDesc.findFieldByName("labels");
+    Descriptor entryDesc = labels.getMessageType();
+    DynamicMessage.Builder builder = DynamicMessage.newBuilder(outerDesc);
+    for (String[] entry : new String[][] {{"a", "x"}, {"b", "wrong"}, {"c", "x"}}) {
+      builder.addRepeatedField(labels, DynamicMessage.newBuilder(entryDesc)
+          .setField(entryDesc.findFieldByName("key"), entry[0])
+          .setField(entryDesc.findFieldByName("value"), DynamicMessage.newBuilder(innerDesc)
+              .setField(innerDesc.findFieldByName("original"), entry[1]).build())
+          .build());
+    }
+
+    assertEquals(Collections.singletonList("m@labels[1].value"),
+        firedRules(schema.validateMessage(SCHEMA_NAMED, builder.build())));
+  }
+
+  @Test
   public void descriptorsThatAgree_areNotReReadThroughTheSchema() {
     // A generated class's descriptor is never the same object as the one built from the
     // registered schema text, so an identity check alone would re-read every record. When

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaValidateMessageTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaValidateMessageTest.java
@@ -16,16 +16,21 @@
 package io.confluent.kafka.schemaregistry.protobuf;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
 import io.confluent.kafka.schemaregistry.rules.ValidationRuleError;
 import io.confluent.kafka.schemaregistry.rules.ValidationRuleExecutor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.apache.kafka.common.errors.SerializationException;
 import org.junit.Test;
 
 /**
@@ -41,6 +46,17 @@ public class ProtobufSchemaValidateMessageTest {
 
   private static final ValidationRuleExecutor ALWAYS_FAIL =
       (rule, schema, value) -> Boolean.FALSE;
+
+  /**
+   * Stands in for a CEL environment built from the registered schema: it can only read the
+   * value if the message it is handed names its fields the way the schema does. Mirrors
+   * {@code this.renamed == 'x'}.
+   */
+  private static final ValidationRuleExecutor SCHEMA_NAMED = (rule, schema, value) -> {
+    Message evaluated = (Message) value;
+    FieldDescriptor fd = evaluated.getDescriptorForType().findFieldByName("renamed");
+    return fd != null && "x".equals(evaluated.getField(fd));
+  };
 
   private static List<String> firedRules(List<ValidationRuleError> errors) {
     List<String> out = new ArrayList<>();
@@ -195,5 +211,187 @@ public class ProtobufSchemaValidateMessageTest {
 
     assertEquals(Arrays.asList("r1@x", "r2@x"),
         firedRules(schema.validateMessage(ALWAYS_FAIL, msg)));
+  }
+
+  @Test
+  public void unsetPresenceField_isSkippedEvenWhenTheSchemaDoesNotTrackPresence() {
+    // Moving a field out of a oneof is a compatible change, so the registered schema can
+    // declare a plain scalar where the producer's class still tracks presence. The walk
+    // reads the message through the registered descriptor, but whether a value is absent
+    // is the producer's question: the field was never set, so its rule must not fire on a
+    // synthesized default.
+    String registered = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "message M {\n"
+        + "  string name = 1 [(confluent.field_meta) = {\n"
+        + "    rules: [{name: \"r\", expr: \"true\"}]\n"
+        + "  }];\n"
+        + "}\n";
+    String producer = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "message M { oneof g { string name = 1; } }\n";
+    ProtobufSchema schema = new ProtobufSchema(registered);
+    Descriptor producerDesc = new ProtobufSchema(producer).toDescriptor("test.M");
+
+    DynamicMessage unset = DynamicMessage.newBuilder(producerDesc).build();
+    assertTrue("Rule must skip a field the producer left unset",
+        schema.validateMessage(ALWAYS_FAIL, unset).isEmpty());
+
+    DynamicMessage set = DynamicMessage.newBuilder(producerDesc)
+        .setField(producerDesc.findFieldByName("name"), "alice").build();
+    assertEquals(Collections.singletonList("r@name"),
+        firedRules(schema.validateMessage(ALWAYS_FAIL, set)));
+  }
+
+  @Test
+  public void defaultValuedField_stillFiresWhenOnlyTheSchemaTracksPresence() {
+    // The mirror case: the registered schema tracks presence where the producer's class
+    // does not. A plain proto3 scalar holding "" is indistinguishable from unset on the
+    // wire, but the producer's class cannot mark it absent, so the rule must still run on
+    // the value it has — taking the schema's view would silently stop enforcing it.
+    String registered = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "message M {\n"
+        + "  oneof g {\n"
+        + "    string name = 1 [(confluent.field_meta) = {\n"
+        + "      rules: [{name: \"r\", expr: \"true\"}]\n"
+        + "    }];\n"
+        + "  }\n"
+        + "}\n";
+    String producer = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "message M { string name = 1; }\n";
+    ProtobufSchema schema = new ProtobufSchema(registered);
+    Descriptor producerDesc = new ProtobufSchema(producer).toDescriptor("test.M");
+
+    DynamicMessage msg = DynamicMessage.newBuilder(producerDesc)
+        .setField(producerDesc.findFieldByName("name"), "").build();
+    assertEquals(Collections.singletonList("r@name"),
+        firedRules(schema.validateMessage(ALWAYS_FAIL, msg)));
+  }
+
+  @Test
+  public void messageUnreadableThroughTheSchema_failsInTheSerializationChannel() {
+    // bytes -> string is a compatible change, so a producer writing non-UTF-8 bytes can
+    // meet a registered schema that declares a string. Those bytes cannot be read through
+    // the registered schema — a consumer using it could not read them either — so this
+    // fails loudly, in the channel callers already handle, naming the type.
+    String registered = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "message M {\n"
+        + "  string payload = 1 [(confluent.field_meta) = {\n"
+        + "    rules: [{name: \"r\", expr: \"true\"}]\n"
+        + "  }];\n"
+        + "}\n";
+    String producer = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "message M { bytes payload = 1; }\n";
+    ProtobufSchema schema = new ProtobufSchema(registered);
+    Descriptor producerDesc = new ProtobufSchema(producer).toDescriptor("test.M");
+    DynamicMessage msg = DynamicMessage.newBuilder(producerDesc)
+        .setField(producerDesc.findFieldByName("payload"),
+            ByteString.copyFrom(new byte[] {(byte) 0xff, (byte) 0xfe})).build();
+
+    SerializationException e = assertThrows(SerializationException.class,
+        () -> schema.validateMessage(ALWAYS_FAIL, msg));
+    assertTrue(e.getMessage(), e.getMessage().contains("test.M"));
+  }
+
+  @Test
+  public void descriptorsThatAgree_areNotReReadThroughTheSchema() {
+    // A generated class's descriptor is never the same object as the one built from the
+    // registered schema text, so an identity check alone would re-read every record. When
+    // the two describe the same fields there is nothing to gain from it — and something to
+    // lose: re-reading imposes the schema's own parse checks on a message that already
+    // satisfies its class. A proto2 message built with buildPartial() shows the difference,
+    // since re-reading bytes that omit a required field fails.
+    String s = "syntax = \"proto2\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "message M {\n"
+        + "  required string a = 1;\n"
+        + "  optional string b = 2 [(confluent.field_meta) = {\n"
+        + "    rules: [{name: \"r\", expr: \"true\"}]\n"
+        + "  }];\n"
+        + "}\n";
+    ProtobufSchema schema = new ProtobufSchema(s);
+    // A separate instance, so the descriptors are distinct objects describing the same type.
+    Descriptor producerDesc = new ProtobufSchema(s).toDescriptor("test.M");
+    DynamicMessage partial = DynamicMessage.newBuilder(producerDesc)
+        .setField(producerDesc.findFieldByName("b"), "set").buildPartial();
+
+    assertEquals(Collections.singletonList("r@b"),
+        firedRules(schema.validateMessage(ALWAYS_FAIL, partial)));
+  }
+
+  @Test
+  public void nestedMessageRule_seesSchemaNamesUnderARename() {
+    // A rule that binds `this` to a nested message needs that message in the schema's terms,
+    // not just the top-level one: the rule's CEL environment comes from the schema, so
+    // `this.renamed` cannot read a field the producer's class calls something else.
+    String registered = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "message Outer { test.Inner inner = 1; }\n"
+        + "message Inner {\n"
+        + "  option (confluent.message_meta) = {\n"
+        + "    rules: [{name: \"m\", expr: \"this.renamed == 'x'\"}]\n"
+        + "  };\n"
+        + "  string renamed = 1;\n"
+        + "}\n";
+    String producer = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "message Outer { test.Inner inner = 1; }\n"
+        + "message Inner { string original = 1; }\n";
+    ProtobufSchema schema = new ProtobufSchema(registered);
+    ProtobufSchema producerSchema = new ProtobufSchema(producer);
+    Descriptor outerDesc = producerSchema.toDescriptor("test.Outer");
+    Descriptor innerDesc = producerSchema.toDescriptor("test.Inner");
+    DynamicMessage inner = DynamicMessage.newBuilder(innerDesc)
+        .setField(innerDesc.findFieldByName("original"), "x").build();
+    DynamicMessage outer = DynamicMessage.newBuilder(outerDesc)
+        .setField(outerDesc.findFieldByName("inner"), inner).build();
+
+    assertEquals(Collections.emptyList(),
+        firedRules(schema.validateMessage(SCHEMA_NAMED, outer)));
+  }
+
+  @Test
+  public void repeatedNestedMessageRule_seesSchemaNamesUnderARename() {
+    // Same requirement per element of a repeated field: the schema's view of the list has to
+    // be paired to the caller's list positionally.
+    String registered = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "message Outer { repeated test.Inner items = 1; }\n"
+        + "message Inner {\n"
+        + "  option (confluent.message_meta) = {\n"
+        + "    rules: [{name: \"m\", expr: \"this.renamed == 'x'\"}]\n"
+        + "  };\n"
+        + "  string renamed = 1;\n"
+        + "}\n";
+    String producer = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "message Outer { repeated test.Inner items = 1; }\n"
+        + "message Inner { string original = 1; }\n";
+    ProtobufSchema schema = new ProtobufSchema(registered);
+    ProtobufSchema producerSchema = new ProtobufSchema(producer);
+    Descriptor outerDesc = producerSchema.toDescriptor("test.Outer");
+    Descriptor innerDesc = producerSchema.toDescriptor("test.Inner");
+    FieldDescriptor original = innerDesc.findFieldByName("original");
+    DynamicMessage outer = DynamicMessage.newBuilder(outerDesc)
+        .addRepeatedField(outerDesc.findFieldByName("items"),
+            DynamicMessage.newBuilder(innerDesc).setField(original, "x").build())
+        .addRepeatedField(outerDesc.findFieldByName("items"),
+            DynamicMessage.newBuilder(innerDesc).setField(original, "wrong").build())
+        .build();
+
+    // Only the second element violates, which also shows each element was paired to its own
+    // position rather than all of them seeing the first.
+    assertEquals(Collections.singletonList("m@items[1]"),
+        firedRules(schema.validateMessage(SCHEMA_NAMED, outer)));
   }
 }


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
A validation rule is authored against the registered schema, but the message handed to it was
the caller's. Since a rule's CEL type comes from the value it is bound to, a schema that renames
a field at the same number (a compatible change) leaves `this.renamed` reading a missing field —
**rejecting a valid message**.

`validateMessage` now re-reads the message through the registered descriptor and binds rules to
that view. Protobuf pairs fields by number on the wire, so every value carries across.

The walk is still driven by the caller's message — it decides which fields exist, which are
absent, and what was set. Only the value bound to `this` comes from the schema's view. In
particular, **presence stays the caller's question**: whether an unset field counts as absent is
decided by the class that wrote it, not by the registered schema.

Re-reading happens only when the two descriptors actually disagree — about a field's name, type,
or label, or when the schema declares a field the caller's class does not. Decided once per
runtime descriptor, not per record.

Three cases this covers beyond the rename:
- **Representation, not just naming.** `bytes`/`string` are interchangeable at the same number, and
  a rule written as `this == 'hello'` cannot match a `ByteString`.
- **Added fields.** A message rule may reference a field the caller's class has never heard of,
  expecting the schema's default. Previously that surfaced as a CEL resolution error recorded as
  a violation.
- **Unreadable messages.** Bytes that cannot be read through the registered schema (non-UTF-8
  against a widened `string`, say) now fail as a `SerializationException` naming the type, rather
  than returning silently.

Also fixes double evaluation of rules for JSON Schema: a property's schema and the schema the walk
recurses into for that property are the same object, so rules on an object-valued property were
charged twice. Rules are now read once per location reached.

Behavior changes
----------------
- **JSON:** rules on `items` subschemas and on non-object roots now fire. They previously never
  did — only object and property schemas were read — so a declared rule that was silently dead
  will start rejecting messages.
- **Protobuf:** a field rule on a field the schema and the caller's class type differently now
  receives the schema's representation (e.g. `String` rather than `ByteString`).
- Both are behind the existing gate: they only apply when inline validation rules are enabled
  (`validation.rules.execution` not DISABLED).

<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
