### PR TITLE
Record per-field FAILED status when a kek is unavailable on read

### DIFF
--- a/client-encryption/src/main/java/io/confluent/kafka/schemaregistry/encryption/EncryptionExecutor.java
+++ b/client-encryption/src/main/java/io/confluent/kafka/schemaregistry/encryption/EncryptionExecutor.java
@@ -190,7 +190,11 @@ public class EncryptionExecutor implements RuleExecutor {
   @Override
   public Object transform(RuleContext ctx, Object message) throws RuleException {
     EncryptionExecutorTransform transform = newTransform(ctx);
-    return transform.transform(ctx, Type.BYTES, message);
+    Object result = transform.transform(ctx, Type.BYTES, message);
+    // Payload-level transforms have no field walk to complete, so surface any
+    // deferred kek failure here rather than returning the ciphertext as a success.
+    transform.checkDeferredFailure();
+    return result;
   }
 
   public EncryptionExecutorTransform newTransform(RuleContext ctx) throws RuleException {
@@ -302,15 +306,42 @@ public class EncryptionExecutor implements RuleExecutor {
     private Kek kek;
     private int dekExpiryDays;
     private boolean passthroughOnRead;
+    private RuleException deferredKekFailure;
 
     public void init(RuleContext ctx) throws RuleException {
       cryptor = getCryptor(ctx);
       kekName = getKekName(ctx);
-      kek = getOrCreateKek(ctx);
+      try {
+        kek = getOrCreateKek(ctx);
+      } catch (RuleException e) {
+        if (ctx.ruleMode() != RuleMode.READ || !ctx.includeRuleResults()) {
+          // On write a missing kek means we cannot encrypt, so fail before any field
+          // is visited rather than risk emitting plaintext. Without rule-result
+          // collection the deferred walk would record nothing, so fail early there too
+          // - the rule ends up failing with this same exception either way.
+          throw e;
+        }
+        // On read, defer so the field walk still visits every field targeted by the
+        // rule and records a FAILED status for each; checkDeferredFailure() then
+        // rethrows so the rule itself still fails and its onFailure action runs.
+        deferredKekFailure = e;
+        return;
+      }
       dekExpiryDays = getDekExpiryDays(ctx);
       passthroughOnRead = nonsharedKekPassthrough
           && !kek.isShared()
           && ctx.ruleMode() == RuleMode.READ;
+    }
+
+    /**
+     * Rethrows a kek lookup failure that {@link #init(RuleContext)} deferred so the
+     * field walk could record per-field metadata. Must be called once the walk is
+     * done, before its result is used.
+     */
+    public void checkDeferredFailure() throws RuleException {
+      if (deferredKekFailure != null) {
+        throw deferredKekFailure;
+      }
     }
 
     public boolean isDekRotated() {
@@ -567,6 +598,13 @@ public class EncryptionExecutor implements RuleExecutor {
       try {
         if (value == null) {
           return null;
+        }
+        if (deferredKekFailure != null) {
+          // No kek, so nothing can be decrypted. Record why for this field and leave
+          // the ciphertext in place; the walk continues so every targeted field is
+          // reported, and checkDeferredFailure() fails the rule once it completes.
+          recordResult(ctx, Status.FAILED, null, deferredKekFailure.getMessage());
+          return value;
         }
         if (passthroughOnRead) {
           recordResult(ctx, Status.PASSTHROUGH, null, null);

--- a/client-encryption/src/main/java/io/confluent/kafka/schemaregistry/encryption/FieldEncryptionExecutor.java
+++ b/client-encryption/src/main/java/io/confluent/kafka/schemaregistry/encryption/FieldEncryptionExecutor.java
@@ -105,6 +105,14 @@ public class FieldEncryptionExecutor extends FieldRuleExecutor {
         throws RuleException {
       return transform.transform(ctx, fieldCtx.getType(), fieldValue);
     }
+
+    @Override
+    public void close() throws RuleException {
+      // Called by FieldRuleExecutor once the field walk is done. If the kek could not
+      // be resolved, every targeted field has now recorded a FAILED status, so fail
+      // the rule; throwing here discards the walk's result, leaving the message as is.
+      transform.checkDeferredFailure();
+    }
   }
 }
 

--- a/client-encryption/src/test/java/io/confluent/kafka/schemaregistry/encryption/FieldEncryptionExecutorTest.java
+++ b/client-encryption/src/test/java/io/confluent/kafka/schemaregistry/encryption/FieldEncryptionExecutorTest.java
@@ -2389,6 +2389,114 @@ public abstract class FieldEncryptionExecutorTest {
   }
 
   @Test
+  public void testRuleResultsFailedForEveryFieldWhenKekMissing() throws Exception {
+    IndexedRecord avroRecord = createUserRecord();
+    AvroSchema avroSchema = new AvroSchema(createUserSchema());
+    // Tag both string fields so we can check that a missing kek is reported for every
+    // field the rule targets, not just the first one visited. NONE,NONE on the read
+    // side so the record still deserializes.
+    Rule rule = new Rule("rule1", null, null, null,
+        FieldEncryptionExecutor.TYPE, ImmutableSortedSet.of("PII", "PII2"),
+        null, null, null, "NONE,NONE", false);
+    RuleSet ruleSet = new RuleSet(Collections.emptyList(), ImmutableList.of(rule));
+    Metadata metadata = getMetadata("kek1");
+    avroSchema = avroSchema.copy(metadata, ruleSet);
+    schemaRegistry.register(topic + "-value", avroSchema);
+
+    RecordHeaders headers = new RecordHeaders();
+    byte[] bytes = avroSerializer.serialize(topic, headers, avroRecord);
+
+    // Simulate the kek being removed between produce and consume.
+    dekRegistry.deleteKek("kek1", false);
+    dekRegistry.deleteKek("kek1", true);
+
+    GenericContainerWithVersion wrapper =
+        avroDeserializer.deserializeWithSchema(topic, headers, bytes, null, true);
+    assertNotNull(wrapper);
+    GenericRecord record = (GenericRecord) wrapper.getValue();
+
+    // Nothing could be decrypted, so both tagged fields stay as ciphertext while the
+    // untagged field is returned untouched.
+    assertNotEquals("testUser", record.get("name").toString());
+    assertNotEquals("testUser2", record.get("name2").toString());
+    assertEquals(18, record.get("age"));
+
+    // The rule itself still fails - the per-field metadata is additional detail, not a
+    // replacement for the rule-level failure.
+    RuleResult rr = findEncryptRuleResult(wrapper);
+    assertNotNull("expected an ENCRYPT RuleResult", rr);
+    assertEquals(RuleResult.Result.FAILURE, rr.result());
+    assertNotNull("expected a rule-level error message", rr.errorMessage());
+
+    // Both targeted fields are reported, neither of which is the untagged one.
+    assertEquals(2, rr.fieldMetadata().size());
+    for (Map.Entry<String, Map<String, String>> entry : rr.fieldMetadata().entrySet()) {
+      assertNotEquals("example.avro.User.age", entry.getKey());
+      Map<String, String> meta = entry.getValue();
+      assertEquals(EncryptionExecutor.Status.FAILED.name(),
+          meta.get(EncryptionExecutor.META_STATUS));
+      assertEquals("kek1", meta.get(EncryptionExecutor.META_KEK_NAME));
+      assertNotNull("expected the kek lookup failure to be reported",
+          meta.get(EncryptionExecutor.META_ERROR_MESSAGE));
+    }
+  }
+
+  @Test
+  public void testMissingKekWithErrorActionFailsWholeRecord() throws Exception {
+    IndexedRecord avroRecord = createUserRecord();
+    AvroSchema avroSchema = new AvroSchema(createUserSchema());
+    // Deferring the kek failure to the field walk must not make the failure any more
+    // tolerable: with the default (ERROR) action the whole record still fails.
+    Rule rule = new Rule("rule1", null, null, null,
+        FieldEncryptionExecutor.TYPE, ImmutableSortedSet.of("PII"),
+        null, null, null, null, false);
+    RuleSet ruleSet = new RuleSet(Collections.emptyList(), ImmutableList.of(rule));
+    Metadata metadata = getMetadata("kek1");
+    avroSchema = avroSchema.copy(metadata, ruleSet);
+    schemaRegistry.register(topic + "-value", avroSchema);
+
+    RecordHeaders headers = new RecordHeaders();
+    byte[] bytes = avroSerializer.serialize(topic, headers, avroRecord);
+
+    dekRegistry.deleteKek("kek1", false);
+    dekRegistry.deleteKek("kek1", true);
+
+    try {
+      avroDeserializer.deserializeWithSchema(topic, headers, bytes, null, true);
+      fail("Expected deserialization to fail when the kek is missing");
+    } catch (SerializationException expected) {
+      // Expected: the missing kek fails the record rather than being tolerated.
+    }
+  }
+
+  @Test
+  public void testMissingKekWithoutRuleResultsStillFails() throws Exception {
+    IndexedRecord avroRecord = createUserRecord();
+    AvroSchema avroSchema = new AvroSchema(createUserSchema());
+    Rule rule = new Rule("rule1", null, null, null,
+        FieldEncryptionExecutor.TYPE, ImmutableSortedSet.of("PII"),
+        null, null, null, "NONE,NONE", false);
+    RuleSet ruleSet = new RuleSet(Collections.emptyList(), ImmutableList.of(rule));
+    Metadata metadata = getMetadata("kek1");
+    avroSchema = avroSchema.copy(metadata, ruleSet);
+    schemaRegistry.register(topic + "-value", avroSchema);
+
+    RecordHeaders headers = new RecordHeaders();
+    byte[] bytes = avroSerializer.serialize(topic, headers, avroRecord);
+
+    dekRegistry.deleteKek("kek1", false);
+    dekRegistry.deleteKek("kek1", true);
+
+    // Without rule-result collection there is no metadata to gather, so the kek failure
+    // is raised up front. The outcome is the same as when it is deferred: NONE swallows
+    // it and the record comes back with the tagged field left as ciphertext.
+    Object value = avroDeserializer.deserialize(topic, headers, bytes);
+    GenericRecord record = (GenericRecord) value;
+    assertNotEquals("testUser", record.get("name").toString());
+    assertEquals("testUser2", record.get("name2").toString());
+  }
+
+  @Test
   public void testRuleResultsEmptyWhenNoRules() throws Exception {
     IndexedRecord avroRecord = createUserRecord();
     AvroSchema avroSchema = new AvroSchema(createUserSchema());

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/rules/RuleContext.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/rules/RuleContext.java
@@ -155,6 +155,15 @@ public class RuleContext {
   }
 
   /**
+   * Whether the enclosing call opted into rule-result collection. When false,
+   * {@link #putMessageMetadata} and {@link #putFieldMetadata} discard their input,
+   * so executors can skip work whose only purpose is to produce that metadata.
+   */
+  public boolean includeRuleResults() {
+    return includeRuleResults;
+  }
+
+  /**
    * Record a message-level metadata key/value for this rule's execution.
    * When the enclosing deserialize call did not opt into rule-result
    * collection, or when {@code value} is null, the key is not stored.

--- a/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
+++ b/protobuf-provider/src/test/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchemaTest.java
@@ -3320,7 +3320,7 @@ public class ProtobufSchemaTest {
         null, null, null, null, null, false);
     return new RuleContext(Collections.emptyMap(), null, null, schema,
         "topic-value", "topic", null, null, null, false,
-        RuleMode.WRITE, rule, 0, Collections.singletonList(rule));
+        RuleMode.WRITE, rule, 0, Collections.singletonList(rule), false);
   }
 
   /**
@@ -3521,7 +3521,7 @@ public class ProtobufSchemaTest {
         Collections.singleton("PII"), null, null, null, null, false);
     RuleContext ctx = new RuleContext(Collections.emptyMap(), null, null, schema,
         "topic-value", "topic", null, null, null, false,
-        RuleMode.WRITE, rule, 0, Collections.singletonList(rule));
+        RuleMode.WRITE, rule, 0, Collections.singletonList(rule), false);
     RecordingTransform recorder = new RecordingTransform();
 
     Message result = (Message) schema.transformMessage(ctx, recorder, msg);


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
When a field-encryption rule's kek is unavailable (deleted, inaccessible, or otherwise
unresolvable), `EncryptionExecutor.EncryptionExecutorTransform#init` threw before the
per-field transform loop started. `recordResult` is only called from inside the per-field
`transform()`, so `RuleResult.fieldMetadata()` came back empty — the rule reported a
failure, but with no indication of which fields were affected.

This PR defers the kek failure instead of aborting on it. On `READ`, when the caller opted
into rule-result collection, `init()` stashes the `RuleException` and lets the field walk
proceed. Each field targeted by the rule records `Status.FAILED` (with `kekName` and the
underlying error message) and is returned as ciphertext. Once the walk completes,
`checkDeferredFailure()` rethrows from `FieldEncryptionExecutorTransform#close()` —
`FieldRuleExecutor` already runs the walk under try-with-resources, so throwing from
`close()` discards the walk's result and leaves the message untouched.

Consequences of doing it this way:
- The rule still ends in `RuleResult.Result.FAILURE` with the original error message. The
  per-field entries are added detail, not a replacement for the rule-level failure.
- `onFailure` handling is unchanged and is not consulted by the executor: `ERROR` still
  fails the record, `DLQ` still produces to the dlq topic, `NONE` still returns the record
  with the targeted fields left as ciphertext.
- `WRITE` still fails eagerly — a missing kek there means we cannot encrypt, and no field
  should be visited.
- Without rule-result collection there is no metadata to gather, so the failure is raised
  up front as before and the walk is skipped entirely.

`EncryptionExecutor#transform(RuleContext, Object)` (payload-level) has no field walk, so it
calls `checkDeferredFailure()` directly rather than returning ciphertext as a success.
`RuleContext` gains an `includeRuleResults()` accessor for the field it already held.
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[Y]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
