### PR TITLE
DGS-25037 Fix CEL rules on unsigned/enum Protobuf fields

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/rules/RuleContext.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/rules/RuleContext.java
@@ -187,6 +187,12 @@ public class RuleContext {
 
   public FieldContext enterField(Object containingMessage,
       String fullName, String name, RuleContext.Type type, Set<String> tags) {
+    return enterField(containingMessage, fullName, name, type, tags, null);
+  }
+
+  public FieldContext enterField(Object containingMessage,
+      String fullName, String name, RuleContext.Type type, Set<String> tags,
+      Object fieldDescriptor) {
     Set<String> metadataTags = getTags(fullName);
     if (!metadataTags.isEmpty()) {
       tags = new HashSet<>(tags);
@@ -194,7 +200,8 @@ public class RuleContext {
     }
     Set<String> ruleTags = rule().getTags();
     if (!type.isPrimitive() || ruleTags.isEmpty() || !disjoint(tags, ruleTags)) {
-      return new FieldContext(containingMessage, fullName, name, type, tags);
+      return new FieldContext(containingMessage, fullName, name, type, tags,
+          fieldDescriptor);
     } else {
       return null;
     }
@@ -220,15 +227,22 @@ public class RuleContext {
     private Type type;
     private boolean inCombined;
     private final Set<String> tags;
+    private final Object fieldDescriptor;
 
     public FieldContext(Object containingMessage, String fullName,
         String name, Type type, Set<String> tags) {
+      this(containingMessage, fullName, name, type, tags, null);
+    }
+
+    public FieldContext(Object containingMessage, String fullName,
+        String name, Type type, Set<String> tags, Object fieldDescriptor) {
       this.containingMessage = containingMessage;
       this.fullName = fullName;
       this.name = name;
       this.type = type;
       this.inCombined = type == Type.COMBINED;
       this.tags = tags;
+      this.fieldDescriptor = fieldDescriptor;
       fieldContexts.addLast(this);
     }
 
@@ -242,6 +256,22 @@ public class RuleContext {
 
     public String getName() {
       return name;
+    }
+
+    /**
+     * The producer's own handle on the field, for formats that have one: a protobuf
+     * {@code FieldDescriptor}. Null for Avro and JSON Schema, whose walks carry no such
+     * object.
+     *
+     * <p>{@link #getName()} and {@link #getFullName()} are the <em>registered schema's</em>
+     * names for the field, which can differ from the producer's under a compatible rename,
+     * and {@link Type} collapses distinctions the format makes — a {@code uint64} and an
+     * {@code int64} both arrive as {@link Type#LONG}, and Java has no unsigned primitive to
+     * carry the difference in the value either. An executor that has to present the value
+     * faithfully therefore goes through this rather than re-deriving the field from a name.
+     */
+    public Object getFieldDescriptor() {
+      return fieldDescriptor;
     }
 
     public Type getType() {

--- a/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
+++ b/protobuf-provider/src/main/java/io/confluent/kafka/schemaregistry/protobuf/ProtobufSchema.java
@@ -2969,7 +2969,9 @@ public class ProtobufSchema implements ParsedSchema {
         }
         try (FieldContext fc = ctx.enterField(
             message, schemaFd.getFullName(), schemaFd.getName(), getType(fd),
-            getInlineTags(schemaFd))
+            // The producer's own field: the value below is read through it, so it is what
+            // says how the value should be presented to a rule.
+            getInlineTags(schemaFd), fd)
         ) {
           // Skip-on-null, as in the validation walk: a field with explicit presence that
           // is unset has no value to transform, and writing one back would materialize
@@ -3282,14 +3284,16 @@ public class ProtobufSchema implements ParsedSchema {
         // already happened, so there is nothing to gain from narrowing this further.
         Object schemaFieldValue = schemaMsg == null ? null : schemaMsg.getField(schemaFd);
         // Field-level rules: this = the field value as the schema presents it. Hint is the
-        // field's own message descriptor for nested messages, or the containing-type
-        // descriptor for primitives — taken from the schema's field, since that is where
-        // the value being bound comes from.
+        // field's own message descriptor for nested messages, and the field itself for
+        // everything else — the declared type is what an executor needs to present the
+        // value faithfully, and Java's boxes lose it: a uint64 and an int64 both arrive
+        // as Long. Both come from the schema's field, since that is where the value being
+        // bound comes from.
         if (schemaFd.getOptions().hasExtension(MetaProto.fieldMeta)) {
           Meta meta = schemaFd.getOptions().getExtension(MetaProto.fieldMeta);
-          Descriptor hint = (schemaFd.getJavaType() == FieldDescriptor.JavaType.MESSAGE)
+          Object hint = (schemaFd.getJavaType() == FieldDescriptor.JavaType.MESSAGE)
               ? schemaFd.getMessageType()
-              : schemaFd.getContainingType();
+              : schemaFd;
           Object thisValue = schemaFieldValue != null ? schemaFieldValue : fieldValue;
           for (MetaProto.Rule rule : meta.getRulesList()) {
             evaluateOne(rule, hint, thisValue, childPath, executor, out);

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelExecutor.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelExecutor.java
@@ -48,6 +48,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -71,6 +72,53 @@ public class CelExecutor implements RuleExecutor {
    * unconfigured falls back to {@link RegexEngine#DEFAULT}.
    */
   public static final String CEL_REGEX_ENGINE = "cel.regex.engine";
+
+  /**
+   * How an unsigned protobuf field is presented to a {@code CEL_FIELD} rule — {@code "int"}
+   * or {@code "uint"}, see {@link UnsignedFieldType}.
+   */
+  public static final String CEL_UNSIGNED_FIELD_TYPE = "cel.unsigned.field.type";
+
+  /**
+   * How a protobuf unsigned integer field is presented to CEL by {@link CelFieldExecutor},
+   * selected by {@link #CEL_UNSIGNED_FIELD_TYPE}.
+   *
+   * <ul>
+   *   <li>{@link #INT} — the field binds as a signed CEL {@code int} carrying the
+   *       {@code Long} or {@code Integer} protobuf reflection hands back. A rule written
+   *       with a plain integer literal ({@code value == 25}) compiles and one written
+   *       against the field's declared type ({@code value == 25u}) does not, and a value
+   *       above {@link Long#MAX_VALUE} compares as negative. This is what domain rules
+   *       shipped with, so it stays the default.</li>
+   *   <li>{@link #UINT} — the field binds as a CEL {@code uint} carrying an
+   *       {@link com.google.common.primitives.UnsignedLong}. That is what protobuf's own
+   *       type says, what the Go and Python clients and protovalidate-java do, and what
+   *       {@link CelValidator} does unconditionally for inline validation rules. Unsigned
+   *       literals work and large values compare correctly; equality and arithmetic
+   *       against a plain integer literal stop type-checking, because CEL declares no
+   *       mixed {@code uint}/{@code int} overloads for them. Ordering keeps working
+   *       either way, through heterogeneous numeric comparisons.</li>
+   * </ul>
+   */
+  public enum UnsignedFieldType {
+    INT,
+    UINT;
+
+    /** The mode when none is declared. Unsigned fields stay signed, as they always have. */
+    public static final UnsignedFieldType DEFAULT = INT;
+
+    public static UnsignedFieldType fromString(String s) {
+      if (s == null || s.isEmpty()) {
+        return DEFAULT;
+      }
+      try {
+        return UnsignedFieldType.valueOf(s.trim().toUpperCase(Locale.ROOT));
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException(
+            "Unknown cel.unsigned.field.type value: " + s + " (expected 'int' or 'uint')");
+      }
+    }
+  }
 
   private static final ObjectMapper JSON_MAPPER = JacksonMapper.newObjectMapper()
       .registerModule(new ProtobufModule());
@@ -135,6 +183,23 @@ public class CelExecutor implements RuleExecutor {
       }
     }
     return defaultRegexEngine;
+  }
+
+  /**
+   * Resolve how unsigned protobuf fields are presented for {@code ctx}, from the setting
+   * the schema declares beside the rule. Used by {@link CelFieldExecutor} to decide how to
+   * bind {@code value}.
+   *
+   * <p>Deliberately not readable from the executor config, unlike the regex engine: which
+   * literals a rule may use is a property of the rule's own text, not of the client running
+   * it, and the same rule evaluated by two differently-configured clients has to agree.
+   */
+  UnsignedFieldType resolveUnsignedFieldType(RuleContext ctx) throws RuleException {
+    try {
+      return UnsignedFieldType.fromString(ctx.getParameter(CEL_UNSIGNED_FIELD_TYPE));
+    } catch (IllegalArgumentException e) {
+      throw new RuleException(ctx.rule(), e);
+    }
   }
 
   @Override

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelFieldExecutor.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelFieldExecutor.java
@@ -83,8 +83,14 @@ public class CelFieldExecutor extends FieldRuleExecutor {
       // answers wrongly above Long.MAX_VALUE. The field's own value stays untouched — only
       // what CEL is handed changes, so a transform that writes the result back, or an
       // executor that encrypts it, still sees the type protobuf uses.
+      //
+      // Presenting a uint as CEL's uint is what protobuf's own type says, but it is not what
+      // this executor has always done, and an existing rule comparing such a field to a plain
+      // integer literal only compiles under the signed reading. Which one applies is therefore
+      // declared per rule, defaulting to the historical signed one.
       Object celFieldValue =
-          fieldCtx.getFieldDescriptor() instanceof FieldDescriptor
+          celExecutor.resolveUnsignedFieldType(ctx) == CelExecutor.UnsignedFieldType.UINT
+              && fieldCtx.getFieldDescriptor() instanceof FieldDescriptor
               ? CelUtils.toCelValueForProtobufField(
                   (FieldDescriptor) fieldCtx.getFieldDescriptor(), fieldValue)
               : fieldValue;

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelFieldExecutor.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelFieldExecutor.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.hubspot.jackson.datatype.protobuf.ProtobufModule;
 import dev.cel.common.values.CelByteString;
 import io.confluent.kafka.schemaregistry.rules.FieldRuleExecutor;
@@ -75,9 +76,21 @@ public class CelFieldExecutor extends FieldRuleExecutor {
       } else {
         inputMessage = message;
       }
+      // Present the value the way the field's declared type implies, through the same
+      // mapping the validator uses. Java has no unsigned primitive, so a uint64 arrives as
+      // a Long exactly as an int64 does: read as a signed int, a rule written against the
+      // field's own type (`value % 10u == 5u`) has no matching overload, and `value > 0`
+      // answers wrongly above Long.MAX_VALUE. The field's own value stays untouched — only
+      // what CEL is handed changes, so a transform that writes the result back, or an
+      // executor that encrypts it, still sees the type protobuf uses.
+      Object celFieldValue =
+          fieldCtx.getFieldDescriptor() instanceof FieldDescriptor
+              ? CelUtils.toCelValueForProtobufField(
+                  (FieldDescriptor) fieldCtx.getFieldDescriptor(), fieldValue)
+              : fieldValue;
       Object result = celExecutor.execute(ctx, fieldValue, new HashMap<String, Object>() {
             {
-              put("value", fieldValue != null ? fieldValue : NULL_VALUE);
+              put("value", celFieldValue != null ? celFieldValue : NULL_VALUE);
               put("fullName", fieldCtx.getFullName());
               put("name", fieldCtx.getName());
               put("typeName", fieldCtx.getType().name());

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelUtils.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelUtils.java
@@ -22,9 +22,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.primitives.UnsignedLong;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.EnumValueDescriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Message;
 import com.google.protobuf.NullValue;
@@ -57,6 +60,7 @@ import io.confluent.kafka.schemaregistry.rules.cel.builtin.BuiltinLibrary;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -227,6 +231,118 @@ public final class CelUtils {
     }
   }
 
+  /**
+   * Heterogeneous numeric comparisons let a rule compare across the numeric types, so
+   * {@code this > 0} holds for an unsigned field and not only {@code this > 0u}. Unsigned
+   * protobuf fields are bound as CEL uints (see {@link CelValidator}), and without this an
+   * existing rule written with a plain integer literal would stop compiling; with it,
+   * cel-java answers the same way cel-go does for the same schema.
+   */
+  private static final CelOptions CEL_OPTIONS =
+      CelOptions.DEFAULT.toBuilder().enableHeterogeneousNumericComparisons(true).build();
+
+  /**
+   * Map a protobuf field's declared type to a {@link CelType}.
+   *
+   * <p>Taking the type from the schema rather than from the value's Java class is what keeps
+   * the two in step: Java has no unsigned primitive, so a {@code uint64} and an {@code int64}
+   * both arrive as {@code Long}, and an enum arrives as an {@code EnumValueDescriptor} that
+   * no Java class mapping recognizes. Mirrors protovalidate-java's DescriptorMappings.
+   */
+  public static CelType findCelTypeForProtobufField(FieldDescriptor field) {
+    CelType type = protoKindToCelType(field.getType());
+    return field.isRepeated() ? ListType.create(type) : type;
+  }
+
+  private static CelType protoKindToCelType(FieldDescriptor.Type kind) {
+    switch (kind) {
+      case FLOAT:
+      case DOUBLE:
+        return SimpleType.DOUBLE;
+      case INT32:
+      case INT64:
+      case SINT32:
+      case SINT64:
+      case SFIXED32:
+      case SFIXED64:
+      case ENUM:
+        return SimpleType.INT;
+      case UINT32:
+      case UINT64:
+      case FIXED32:
+      case FIXED64:
+        return SimpleType.UINT;
+      case BOOL:
+        return SimpleType.BOOL;
+      case STRING:
+        return SimpleType.STRING;
+      case BYTES:
+        return SimpleType.BYTES;
+      default:
+        // MESSAGE and GROUP never reach here: the walker hands those to the executor under
+        // their own message descriptor, not their field. DYN lets the runtime dispatch on
+        // whatever the value turns out to be.
+        return SimpleType.DYN;
+    }
+  }
+
+  /**
+   * The value a protobuf field should be bound to, in the terms its declared type implies:
+   * an unsigned integer as an {@link UnsignedLong}, an enum as its number. Everything else
+   * is already what CEL expects, or is normalized by {@link #toCelValue}.
+   *
+   * <p>Only what CEL is handed changes — the caller keeps the value protobuf gave it, so a
+   * field transform that writes a result back still works in protobuf's own terms.
+   */
+  public static Object toCelValueForProtobufField(FieldDescriptor field, Object value) {
+    if (value instanceof List) {
+      List<?> values = (List<?>) value;
+      List<Object> converted = new ArrayList<>(values.size());
+      for (Object element : values) {
+        converted.add(toCelValueForProtobufField(field, element));
+      }
+      return converted;
+    }
+    switch (field.getType()) {
+      case UINT32:
+      case UINT64:
+      case FIXED32:
+      case FIXED64:
+        return toCelUnsigned(value);
+      case ENUM:
+        return value instanceof EnumValueDescriptor
+            ? (long) ((EnumValueDescriptor) value).getNumber()
+            : value;
+      default:
+        return value;
+    }
+  }
+
+  /**
+   * The value as CEL wants an unsigned integer: an {@link UnsignedLong}, which is what
+   * cel-java's uint overloads dispatch on. 32-bit unsigned values widen losslessly. A
+   * repeated field binds the whole list, so every element is converted.
+   *
+   * <p>Only what CEL is handed changes — the caller keeps the value protobuf gave it, so a
+   * field transform that writes a result back still works in protobuf's own terms.
+   */
+  public static Object toCelUnsigned(Object value) {
+    if (value instanceof List) {
+      List<Object> converted = new ArrayList<>(((List<?>) value).size());
+      for (Object element : (List<?>) value) {
+        converted.add(toCelUnsigned(element));
+      }
+      return converted;
+    }
+    if (value instanceof Long) {
+      return UnsignedLong.fromLongBits((Long) value);
+    }
+    if (value instanceof Integer) {
+      return UnsignedLong.fromLongBits(Integer.toUnsignedLong((Integer) value));
+    }
+    return value;
+  }
+
   private static CompiledRule doBuildProgram(
       ScriptType type, String expr, Object schemaHint, List<CelVarDecl> varDecls,
       RegexEngine regexEngine)
@@ -239,19 +355,19 @@ public final class CelUtils {
     // exists_one/map/filter); they have to be wired in explicitly. Without
     // them, expressions like `tags.exists_one(x, x == 'PII')` fail to compile.
     CelCompilerBuilder compilerBuilder = CelCompilerFactory.standardCelCompilerBuilder()
-        .setOptions(CelOptions.DEFAULT)
+        .setOptions(CEL_OPTIONS)
         .setStandardMacros(CelStandardMacro.STANDARD_MACROS)
         .addLibraries(
             new BuiltinLibrary(),
             CelExtensions.strings(),
-            CelExtensions.math(CelOptions.DEFAULT))
+            CelExtensions.math(CEL_OPTIONS))
         .addVarDeclarations(varDecls);
     CelRuntimeBuilder runtimeBuilder = CelRuntimeFactory.standardCelRuntimeBuilder()
-        .setOptions(CelOptions.DEFAULT)
+        .setOptions(CEL_OPTIONS)
         .addLibraries(
             new BuiltinLibrary(),
             CelExtensions.strings(),
-            CelExtensions.math(CelOptions.DEFAULT));
+            CelExtensions.math(CEL_OPTIONS));
 
     if (regexEngine == RegexEngine.PCRE) {
       // Replace stdlib RE2-backed matches with java.util.regex. Despite what

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelUtils.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelUtils.java
@@ -584,6 +584,8 @@ public final class CelUtils {
   public static CelType findCelTypeForClass(Class<?> type) {
     if (type == boolean.class || type == Boolean.class) {
       return SimpleType.BOOL;
+    } else if (type == UnsignedLong.class) {
+      return SimpleType.UINT;
     } else if (type == long.class
         || type == Long.class
         || type == int.class

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidator.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidator.java
@@ -21,6 +21,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.hubspot.jackson.datatype.protobuf.ProtobufModule;
@@ -127,6 +128,19 @@ public final class CelValidator implements ValidationRuleExecutor {
       } else {
         thisType = CelUtils.findCelTypeForClass(value.getClass());
       }
+    } else if (schema instanceof FieldDescriptor) {
+      scriptType = ScriptType.PROTOBUF;
+      FieldDescriptor field = (FieldDescriptor) schema;
+      // Both the declared type and the value come from the field, not from the value's Java
+      // class. Java's boxes do not carry protobuf's distinctions: a uint64 and an int64 are
+      // both Long, and an enum is an EnumValueDescriptor that no class mapping recognizes.
+      // The walker hands message-valued fields over under their own message descriptor, so
+      // only scalars and enums - singular or repeated - reach here.
+      thisType = CelUtils.findCelTypeForProtobufField(field);
+      value = CelUtils.toCelValueForProtobufField(field, value);
+      // The containing message is what identifies the program in the cache; the field
+      // itself has served its purpose above.
+      schema = field.getContainingType();
     } else if (schema instanceof Schema) {
       scriptType = ScriptType.AVRO;
       // Mirror the protobuf path: use the value's own schema for type registration so

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelFieldExecutorUnsignedTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelFieldExecutorUnsignedTest.java
@@ -1,16 +1,17 @@
 /*
  * Copyright 2026 Confluent Inc.
  *
- * Licensed under the Confluent Community License (the "License"); you may not use
- * this file except in compliance with the License.  You may obtain a copy of the
- * License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.confluent.io/confluent-community-license
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package io.confluent.kafka.schemaregistry.rules.cel;

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelFieldExecutorUnsignedTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelFieldExecutorUnsignedTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rules.cel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.DynamicMessage;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Rule;
+import io.confluent.kafka.schemaregistry.client.rest.entities.RuleKind;
+import io.confluent.kafka.schemaregistry.client.rest.entities.RuleMode;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.kafka.schemaregistry.rules.FieldTransform;
+import io.confluent.kafka.schemaregistry.rules.RuleContext;
+import io.confluent.kafka.schemaregistry.rules.RuleContext.FieldContext;
+import io.confluent.kafka.schemaregistry.rules.RuleContext.Type;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A domain rule (CEL_FIELD) on an unsigned protobuf field. Java has no unsigned primitive,
+ * so a {@code uint64} reaches the transform as a {@code Long} exactly as an {@code int64}
+ * does; the field context carries the distinction so the executor can present it to CEL as
+ * unsigned without changing the value the field itself holds.
+ */
+public class CelFieldExecutorUnsignedTest {
+
+  private static final String SCHEMA =
+      "syntax = \"proto3\"; package test; "
+          + "message U { uint64 serial = 1; int64 signed = 2; }";
+
+  private static Object transform(String expr, String fieldName, long value)
+      throws Exception {
+    Rule rule = new Rule("myRule", null, RuleKind.TRANSFORM, RuleMode.WRITE,
+        CelFieldExecutor.TYPE, null, null, expr, null, null, false);
+    Map<String, Object> configs = Collections.emptyMap();
+    // enterField reads metadata tags off the target schema, so it cannot be left unset,
+    // and the containing message is bound to the rule as `message`.
+    ParsedSchema target = new ProtobufSchema(SCHEMA);
+    Descriptor desc = ((ProtobufSchema) target).toDescriptor("test.U");
+    DynamicMessage message = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName(fieldName), value).build();
+    RuleContext ctx = new RuleContext(configs, null, null, target, "topic-value", "topic",
+        null, null, null, false, RuleMode.WRITE, rule, 0, Collections.singletonList(rule));
+    FieldTransform fieldTransform = new CelFieldExecutor().newTransform(ctx);
+    try (FieldContext fc = ctx.enterField(message, "test.U." + fieldName, fieldName,
+        Type.LONG, Collections.emptySet(), desc.findFieldByName(fieldName))) {
+      return fieldTransform.transform(ctx, fc, value);
+    }
+  }
+
+  @Test
+  public void unsignedFieldIsPresentedToCelAsUnsigned() throws Exception {
+    // 25 % 10 == 5, so the rule hands the value back. Read as a signed int the expression
+    // has no matching overload at all and the rule fails instead.
+    assertEquals(25L, transform("value % 10u == 5u ? value : 0u", "serial", 25L));
+  }
+
+  @Test
+  public void unsignedFieldComparesCorrectlyAboveLongMaxValue() throws Exception {
+    // 2^64 - 5 is positive as an unsigned value but negative as a signed long, so a signed
+    // reading would take the other branch. The value handed back is protobuf's own
+    // representation, ready to be written back to the field.
+    assertEquals(-5L, transform("value > 0u ? value : 0u", "serial", -5L));
+  }
+
+  @Test
+  public void signedFieldIsUnaffected() throws Exception {
+    // An int64 field declares itself signed, so nothing about its handling changes.
+    assertEquals(7L, transform("value > 0 ? value : 0", "signed", 7L));
+  }
+}

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelFieldExecutorUnsignedTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelFieldExecutorUnsignedTest.java
@@ -38,6 +38,10 @@ import org.junit.jupiter.api.Test;
  * so a {@code uint64} reaches the transform as a {@code Long} exactly as an {@code int64}
  * does; the field context carries the distinction so the executor can present it to CEL as
  * unsigned without changing the value the field itself holds.
+ *
+ * <p>That reading is not the one this executor has always used, so it is asked for by rule
+ * parameter — {@code cel.unsigned.field.type: "uint"} — and rules that do not ask keep the
+ * signed reading they were written against. Both are exercised here.
  */
 public class CelFieldExecutorUnsignedTest {
 
@@ -45,10 +49,23 @@ public class CelFieldExecutorUnsignedTest {
       "syntax = \"proto3\"; package test; "
           + "message U { uint64 serial = 1; int64 signed = 2; }";
 
+  private static final Map<String, String> UINT_MODE =
+      Collections.singletonMap(CelExecutor.CEL_UNSIGNED_FIELD_TYPE, "uint");
+
   private static Object transform(String expr, String fieldName, long value)
       throws Exception {
+    return transform(expr, fieldName, value, UINT_MODE);
+  }
+
+  private static Object transform(String expr, String fieldName, long value,
+      Map<String, String> params) throws Exception {
+    return transform(new CelFieldExecutor(), expr, fieldName, value, params);
+  }
+
+  private static Object transform(CelFieldExecutor executor, String expr, String fieldName,
+      long value, Map<String, String> params) throws Exception {
     Rule rule = new Rule("myRule", null, RuleKind.TRANSFORM, RuleMode.WRITE,
-        CelFieldExecutor.TYPE, null, null, expr, null, null, false);
+        CelFieldExecutor.TYPE, null, params, expr, null, null, false);
     Map<String, Object> configs = Collections.emptyMap();
     // enterField reads metadata tags off the target schema, so it cannot be left unset,
     // and the containing message is bound to the rule as `message`.
@@ -58,7 +75,7 @@ public class CelFieldExecutorUnsignedTest {
         .setField(desc.findFieldByName(fieldName), value).build();
     RuleContext ctx = new RuleContext(configs, null, null, target, "topic-value", "topic",
         null, null, null, false, RuleMode.WRITE, rule, 0, Collections.singletonList(rule));
-    FieldTransform fieldTransform = new CelFieldExecutor().newTransform(ctx);
+    FieldTransform fieldTransform = executor.newTransform(ctx);
     try (FieldContext fc = ctx.enterField(message, "test.U." + fieldName, fieldName,
         Type.LONG, Collections.emptySet(), desc.findFieldByName(fieldName))) {
       return fieldTransform.transform(ctx, fc, value);
@@ -84,5 +101,18 @@ public class CelFieldExecutorUnsignedTest {
   public void signedFieldIsUnaffected() throws Exception {
     // An int64 field declares itself signed, so nothing about its handling changes.
     assertEquals(7L, transform("value > 0 ? value : 0", "signed", 7L));
+  }
+
+  @Test
+  public void aRuleThatAsksForNothingKeepsTheSignedReading() throws Exception {
+    // The same bit pattern, read the way rules written before the mode existed read it:
+    // 2^64 - 5 is a negative long, so a comparison against a signed literal is false, where
+    // under the unsigned reading the very same expression is true.
+    // One executor answers both, so the two rules must not collide in its compiled-rule
+    // cache even though they agree on expression, schema, and field. They don't, because
+    // the declared type of `value` is part of the key and is exactly what the mode changes.
+    CelFieldExecutor executor = new CelFieldExecutor();
+    assertEquals(false, transform(executor, "value > 0", "serial", -5L, null));
+    assertEquals(true, transform(executor, "value > 0", "serial", -5L, UINT_MODE));
   }
 }

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelUtilsTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelUtilsTest.java
@@ -19,6 +19,7 @@ package io.confluent.kafka.schemaregistry.rules.cel;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
+import com.google.common.primitives.UnsignedLong;
 import dev.cel.common.CelValidationException;
 import dev.cel.common.CelVarDecl;
 import dev.cel.common.types.MapType;
@@ -39,6 +40,17 @@ public class CelUtilsTest {
   @Test
   public void stringClass_mapsToString() {
     assertEquals(SimpleType.STRING, CelUtils.findCelTypeForClass(String.class));
+  }
+
+  @Test
+  public void unsignedLong_mapsToUint() {
+    // The transform path types each rule argument from its Java class, and CelFieldExecutor
+    // hands it an UnsignedLong for an unsigned protobuf field. Declaring DYN here would
+    // still evaluate correctly - cel-java dispatches uint overloads on the value itself -
+    // but the same expression on the same field would be compile-checked as uint through
+    // the validator and not checked at all through a transform.
+    assertEquals(SimpleType.UINT, CelUtils.findCelTypeForClass(UnsignedLong.class));
+    assertEquals(SimpleType.UINT, CelUtils.findCelType(UnsignedLong.fromLongBits(25L)));
   }
 
   @Test

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorUnsignedTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorUnsignedTest.java
@@ -1,16 +1,17 @@
 /*
  * Copyright 2026 Confluent Inc.
  *
- * Licensed under the Confluent Community License (the "License"); you may not use
- * this file except in compliance with the License.  You may obtain a copy of the
- * License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.confluent.io/confluent-community-license
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package io.confluent.kafka.schemaregistry.rules.cel;

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorUnsignedTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorUnsignedTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rules.cel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.DynamicMessage;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.kafka.schemaregistry.rules.ValidationRuleError;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Java's boxes do not carry protobuf's type distinctions: a {@code uint64} arrives from
+ * reflection as a {@code Long} exactly as an {@code int64} does, and an enum arrives as an
+ * {@code EnumValueDescriptor} rather than a number. The validator has to take the type and
+ * the value from the field's declaration instead, or a rule written against the field's own
+ * type cannot compile, and one written with a signed literal answers wrongly for values
+ * above {@link Long#MAX_VALUE}.
+ */
+public class CelValidatorUnsignedTest {
+
+  private static final String SCHEMA = "syntax = \"proto3\";\n"
+      + "package test;\n"
+      + "import \"confluent/meta.proto\";\n"
+      + "message U {\n"
+      + "  uint64 serial = 1 [(confluent.field_meta) = {\n"
+      + "    rules: [{name: \"mod\", expr: \"this % 10u == 5u\"},\n"
+      + "            {name: \"unsignedCmp\", expr: \"this > 0u\"},\n"
+      + "            {name: \"signedCmp\", expr: \"this > 0\"}]\n"
+      + "  }];\n"
+      + "  uint32 small = 2 [(confluent.field_meta) = {\n"
+      + "    rules: [{name: \"small\", expr: \"this > 0u\"}]\n"
+      + "  }];\n"
+      + "  repeated uint64 serials = 3 [(confluent.field_meta) = {\n"
+      + "    rules: [{name: \"each\", expr: \"this.all(v, v > 0u)\"}]\n"
+      + "  }];\n"
+      + "}\n";
+
+  private static List<String> firedRules(List<ValidationRuleError> errors) {
+    List<String> out = new ArrayList<>();
+    for (ValidationRuleError e : errors) {
+      out.add(e.getRule().getName() + "@" + e.getFieldPath());
+    }
+    return out;
+  }
+
+  private static List<String> validate(long serial) {
+    ProtobufSchema schema = new ProtobufSchema(SCHEMA);
+    Descriptor desc = schema.toDescriptor("test.U");
+    DynamicMessage msg = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName("serial"), serial)
+        .setField(desc.findFieldByName("small"), 7)
+        .addRepeatedField(desc.findFieldByName("serials"), 5L)
+        .addRepeatedField(desc.findFieldByName("serials"), 15L)
+        .build();
+    return firedRules(schema.validateMessage(new CelValidator(), msg));
+  }
+
+  @Test
+  public void enumFieldIsComparedByItsNumber() {
+    // Protobuf reflection hands back an EnumValueDescriptor, which no Java class mapping
+    // recognizes — the rule is left comparing a descriptor object against an integer.
+    String schemaStr = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "enum Color { RED = 0; GREEN = 1; }\n"
+        + "message M {\n"
+        + "  test.Color color = 1 [(confluent.field_meta) = {\n"
+        + "    rules: [{name: \"isGreen\", expr: \"this == 1\"}]\n"
+        + "  }];\n"
+        + "}\n";
+    ProtobufSchema schema = new ProtobufSchema(schemaStr);
+    Descriptor desc = schema.toDescriptor("test.M");
+    FieldDescriptor color = desc.findFieldByName("color");
+    DynamicMessage msg = DynamicMessage.newBuilder(desc)
+        .setField(color, color.getEnumType().findValueByNumber(1)).build();
+
+    assertEquals(Collections.emptyList(),
+        firedRules(schema.validateMessage(new CelValidator(), msg)));
+  }
+
+  @Test
+  public void unsignedRulesHoldForAValueThatFitsInALong() {
+    // 25 % 10 == 5, and every rule here is true of it. Without the field's declared type,
+    // the two rules written with unsigned literals do not compile at all.
+    assertEquals(Collections.emptyList(), validate(25L));
+  }
+
+  @Test
+  public void unsignedRulesHoldAboveLongMaxValue() {
+    // 2^64 - 5 is positive as an unsigned value but negative as a signed long, and its
+    // remainder mod 10 is 1 rather than the 5 a signed reading would give.
+    List<String> fired = validate(-5L);
+    assertEquals(Collections.singletonList("mod@serial"), fired);
+  }
+}


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Rules typed a protobuf field value from its Java class, which loses what the schema                                                                                               
  declares:                                                                                                                                                                         
                                                                                                                                                                                    
  - `uint64`/`uint32` arrive as `Long`/`Integer`, so `this % 10u == 5u` failed to compile                                                                                           
    ("no matching overload for `_%_` applied to `(int, uint)`"), and `this > 0` answered                                                                                            
    wrongly for values above `Long.MAX_VALUE`, which as a signed long is negative.                                                                                                  
  - Enum fields arrive as an `EnumValueDescriptor`, which no class mapping recognizes, so                                                                                           
    `this == 1` never matched.                                                                                                                                                      
                                                                                                                                                                                    
  Both affected inline validation rules and CEL_FIELD domain rules. Message-level rules were                                                                                        
  already correct — cel-java resolves fields of a bound message through its own proto adapter.                                                                                      
                                                                                                                                                                                    
  The type and the value now come from the field descriptor, the way protovalidate-java does                                                                                        
  it (`DescriptorMappings.protoKindToCELType` + `ProtoAdapter`):                                                                                                                    
                                                                                                                                                                                    
  - `CelUtils.findCelTypeForProtobufField` / `toCelValueForProtobufField` — uint fields bind                                                                                        
    as `UnsignedLong` under `SimpleType.UINT`, enums as their number.                                                                                                               
  - `ProtobufSchema`'s validation walk passes the field itself as the rule's schema hint                                                                                            
    instead of the containing message, so the executor can read the declared type.                                                                                                  
  - `RuleContext.FieldContext` carries the field so `CelFieldExecutor` can use the same                                                                                             
    mapping. Only what CEL is handed changes — the field's own value is untouched, so field                                                                                         
    transforms and encryption still see protobuf's representation.                                                                                                                  
  - Heterogeneous numeric comparisons are enabled on the shared CEL options. Declaring `uint`                                                                                       
    otherwise breaks an existing `this > 0` on an unsigned field; with this, cel-java accepts                                                                                       
    it exactly as cel-go already does.   
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
