### PR TITLE
DGS-24205 Add association-level metrics for batchGet/batchMutate

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/metrics/MetricsContainer.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/metrics/MetricsContainer.java
@@ -60,6 +60,14 @@ public class MetricsContainer {
   public static final String METRIC_NAME_CUSTOM_SCHEMA_PROVIDER = "custom-schema-provider-count";
   public static final String METRIC_NAME_API_SUCCESS_COUNT = "api-success-count";
   public static final String METRIC_NAME_API_FAILURE_COUNT = "api-failure-count";
+  public static final String METRIC_NAME_ASSOCIATION_BATCH_GET_SUCCESS_COUNT =
+      "association-batch-get-success-count";
+  public static final String METRIC_NAME_ASSOCIATION_BATCH_GET_FAILURE_COUNT =
+      "association-batch-get-failure-count";
+  public static final String METRIC_NAME_ASSOCIATION_BATCH_MUTATE_SUCCESS_COUNT =
+      "association-batch-mutate-success-count";
+  public static final String METRIC_NAME_ASSOCIATION_BATCH_MUTATE_FAILURE_COUNT =
+      "association-batch-mutate-failure-count";
   public static final String METRIC_NAME_REGISTERED_COUNT = "registered-count";
   public static final String METRIC_NAME_DELETED_COUNT = "deleted-count";
   public static final String METRIC_NAME_AVRO_SCHEMAS_CREATED = "avro-schemas-created";
@@ -82,6 +90,11 @@ public class MetricsContainer {
   private final SchemaRegistryMetric customSchemaProviders;
   private final SchemaRegistryMetric apiCallsSuccess;
   private final SchemaRegistryMetric apiCallsFailure;
+
+  private final SchemaRegistryMetric associationBatchGetSuccess;
+  private final SchemaRegistryMetric associationBatchGetFailure;
+  private final SchemaRegistryMetric associationBatchMutateSuccess;
+  private final SchemaRegistryMetric associationBatchMutateFailure;
 
   private final SchemaRegistryMetric avroSchemasCreated;
   private final SchemaRegistryMetric jsonSchemasCreated;
@@ -128,6 +141,17 @@ public class MetricsContainer {
             "Number of successful API calls", new CumulativeCount());
     this.apiCallsFailure = createMetric(METRIC_NAME_API_FAILURE_COUNT,
             "Number of failed API calls", new CumulativeCount());
+
+    this.associationBatchGetSuccess = createMetric(METRIC_NAME_ASSOCIATION_BATCH_GET_SUCCESS_COUNT,
+            "Number of successful associations within batchGet calls", new CumulativeCount());
+    this.associationBatchGetFailure = createMetric(METRIC_NAME_ASSOCIATION_BATCH_GET_FAILURE_COUNT,
+            "Number of failed associations within batchGet calls", new CumulativeCount());
+    this.associationBatchMutateSuccess = createMetric(
+            METRIC_NAME_ASSOCIATION_BATCH_MUTATE_SUCCESS_COUNT,
+            "Number of successful associations within batchMutate calls", new CumulativeCount());
+    this.associationBatchMutateFailure = createMetric(
+            METRIC_NAME_ASSOCIATION_BATCH_MUTATE_FAILURE_COUNT,
+            "Number of failed associations within batchMutate calls", new CumulativeCount());
 
     this.customSchemaProviders = createMetric(METRIC_NAME_CUSTOM_SCHEMA_PROVIDER,
             "Number of custom schema providers", new Value());
@@ -212,6 +236,22 @@ public class MetricsContainer {
 
   public SchemaRegistryMetric getApiCallsFailure() {
     return apiCallsFailure;
+  }
+
+  public SchemaRegistryMetric getAssociationBatchGetSuccess() {
+    return associationBatchGetSuccess;
+  }
+
+  public SchemaRegistryMetric getAssociationBatchGetFailure() {
+    return associationBatchGetFailure;
+  }
+
+  public SchemaRegistryMetric getAssociationBatchMutateSuccess() {
+    return associationBatchMutateSuccess;
+  }
+
+  public SchemaRegistryMetric getAssociationBatchMutateFailure() {
+    return associationBatchMutateFailure;
   }
 
   public SchemaRegistryMetric getCustomSchemaProviderCount() {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -74,6 +74,7 @@ import io.confluent.kafka.schemaregistry.exceptions.InvalidSchemaException;
 import io.confluent.kafka.schemaregistry.exceptions.InvalidVersionException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
 import io.confluent.kafka.schemaregistry.metrics.MetricsContainer;
+import io.confluent.kafka.schemaregistry.metrics.SchemaRegistryMetric;
 import io.confluent.kafka.schemaregistry.rest.SchemaRegistryConfig;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.rest.VersionId;
@@ -2544,7 +2545,23 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
         results.add(new AssociationResult(errMsg, null));
       }
     }
+    recordAssociationBatchMetrics(results,
+        metricsContainer.getAssociationBatchGetSuccess(),
+        metricsContainer.getAssociationBatchGetFailure());
     return new AssociationBatchResponse(results);
+  }
+
+  private void recordAssociationBatchMetrics(
+      List<AssociationResult> results,
+      SchemaRegistryMetric successMetric,
+      SchemaRegistryMetric failureMetric) {
+    for (AssociationResult result : results) {
+      if (result.getError() != null) {
+        failureMetric.record();
+      } else {
+        successMetric.record();
+      }
+    }
   }
 
   public AssociationBatchResponse mutateAssociations(
@@ -2669,6 +2686,9 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
         lock.unlock();
       }
     }
+    recordAssociationBatchMetrics(results,
+        metricsContainer.getAssociationBatchMutateSuccess(),
+        metricsContainer.getAssociationBatchMutateFailure());
     return new AssociationBatchResponse(results);
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/metrics/MetricsTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/metrics/MetricsTest.java
@@ -15,19 +15,33 @@
 
 package io.confluent.kafka.schemaregistry.metrics;
 
+import com.google.common.collect.ImmutableList;
 import io.confluent.kafka.schemaregistry.ClusterTestHarness;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
+import io.confluent.kafka.schemaregistry.client.rest.entities.LifecyclePolicy;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationBatchGetRequest;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationBatchRequest;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationCreateOp;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationCreateOrUpdateInfo;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationCreateOrUpdateRequest;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationGetRequest;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationOpRequest;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.utils.TestUtils;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_NAME_API_FAILURE_COUNT;
 import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_NAME_API_SUCCESS_COUNT;
+import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_NAME_ASSOCIATION_BATCH_GET_FAILURE_COUNT;
+import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_NAME_ASSOCIATION_BATCH_GET_SUCCESS_COUNT;
+import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_NAME_ASSOCIATION_BATCH_MUTATE_FAILURE_COUNT;
+import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_NAME_ASSOCIATION_BATCH_MUTATE_SUCCESS_COUNT;
 import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_NAME_AVRO_SCHEMAS_CREATED;
 import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_NAME_AVRO_SCHEMAS_DELETED;
 import static io.confluent.kafka.schemaregistry.metrics.MetricsContainer.METRIC_NAME_DELETED_COUNT;
@@ -120,5 +134,91 @@ public class MetricsTest extends ClusterTestHarness {
     } catch (RestClientException rce) {
       assertEquals(1.0, mBeanServer.getAttribute(apiFailure, METRIC_NAME_API_FAILURE_COUNT));
     }
+  }
+
+  @Test
+  public void testAssociationBatchGetMetrics() throws Exception {
+    MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+    ObjectName batchGetSuccess = new ObjectName(
+        "kafka.schema.registry:type=" + METRIC_NAME_ASSOCIATION_BATCH_GET_SUCCESS_COUNT);
+    ObjectName batchGetFailure = new ObjectName(
+        "kafka.schema.registry:type=" + METRIC_NAME_ASSOCIATION_BATCH_GET_FAILURE_COUNT);
+
+    // batchGet has no per-item validation failure path today (an unknown resource ID
+    // still returns a successful, empty result) -- so both a known and an unknown
+    // resource ID count as association-level successes.
+    String subject = "metricsBatchGetSubject";
+    String resourceName = "metricsBatchGetTopic";
+    String resourceNamespace = "default";
+    String resourceId = "metrics-batch-get-id";
+    restApp.restClient.registerSchema(
+        TestUtils.getRandomCanonicalAvroString(1).get(0), subject);
+    AssociationCreateOrUpdateRequest createRequest = new AssociationCreateOrUpdateRequest(
+        resourceName, resourceNamespace, resourceId, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            subject, "value", LifecyclePolicy.WEAK, false, null, null)));
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, createRequest);
+
+    AssociationBatchGetRequest batchGetRequest = new AssociationBatchGetRequest(
+        ImmutableList.of(
+            new AssociationGetRequest(resourceId, "topic", null, null),
+            new AssociationGetRequest("unknown-metrics-id", "topic", null, null)
+        ));
+    restApp.restClient.batchGetAssociations(
+        RestService.DEFAULT_REQUEST_PROPERTIES, false, batchGetRequest);
+
+    assertEquals(2.0, mBeanServer.getAttribute(batchGetSuccess,
+        METRIC_NAME_ASSOCIATION_BATCH_GET_SUCCESS_COUNT));
+    assertEquals(0.0, mBeanServer.getAttribute(batchGetFailure,
+        METRIC_NAME_ASSOCIATION_BATCH_GET_FAILURE_COUNT));
+  }
+
+  @Test
+  public void testAssociationBatchMutateMetrics() throws Exception {
+    MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+    ObjectName batchMutateSuccess = new ObjectName(
+        "kafka.schema.registry:type=" + METRIC_NAME_ASSOCIATION_BATCH_MUTATE_SUCCESS_COUNT);
+    ObjectName batchMutateFailure = new ObjectName(
+        "kafka.schema.registry:type=" + METRIC_NAME_ASSOCIATION_BATCH_MUTATE_FAILURE_COUNT);
+
+    String subject1 = "metricsMutateSubject1";
+    String subject2 = "metricsMutateSubject2";
+    String resourceName1 = "metricsMutateTopic1";
+    String resourceName2 = "metricsMutateTopic2";
+    String resourceNamespace = "default";
+    String resourceId1 = "metrics-mutate-id-1";
+    String resourceId2 = "metrics-mutate-id-2";
+    List<String> schemas = TestUtils.getRandomCanonicalAvroString(2);
+    restApp.restClient.registerSchema(schemas.get(0), subject1);
+    restApp.restClient.registerSchema(schemas.get(1), subject2);
+
+    // Pre-create an association for resourceId1 so a second create for the same
+    // resource/association-type conflicts, forcing a per-item failure in the batch below.
+    AssociationCreateOrUpdateRequest existingRequest = new AssociationCreateOrUpdateRequest(
+        resourceName1, resourceNamespace, resourceId1, "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            subject1, "key", LifecyclePolicy.WEAK, false, null, null)));
+    restApp.restClient.createAssociation(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false, existingRequest);
+
+    List<AssociationOpRequest> requests = new ArrayList<>();
+    requests.add(new AssociationOpRequest(
+        resourceName1, resourceNamespace, resourceId1, "topic",
+        ImmutableList.of(new AssociationCreateOp(
+            subject1, "key", LifecyclePolicy.STRONG, false, null, null))));
+    requests.add(new AssociationOpRequest(
+        resourceName2, resourceNamespace, resourceId2, "topic",
+        ImmutableList.of(new AssociationCreateOp(
+            subject2, "value", LifecyclePolicy.WEAK, false, null, null))));
+
+    restApp.restClient.mutateAssociations(
+        RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
+        new AssociationBatchRequest(requests));
+
+    assertEquals(1.0, mBeanServer.getAttribute(batchMutateSuccess,
+        METRIC_NAME_ASSOCIATION_BATCH_MUTATE_SUCCESS_COUNT));
+    assertEquals(1.0, mBeanServer.getAttribute(batchMutateFailure,
+        METRIC_NAME_ASSOCIATION_BATCH_MUTATE_FAILURE_COUNT));
   }
 }


### PR DESCRIPTION
What
----
The Jersey layer's generic `api-success-count`/`api-failure-count` metrics only count
a failure when the batch endpoint itself returns a non-2xx response code. `POST
/associations:batchGet` and `POST /associations:batchMutate` always return `207`, so
per-item failures inside a batch were invisible to metrics -- a batch where every
single association failed would still register as one successful API call.

Both `batchGetAssociations` and `mutateAssociations` already build a
`List<AssociationResult>` where each item independently carries either an `error` or
a `result`. This adds four new cumulative-count JMX metrics
(`association-batch-get-success-count`, `association-batch-get-failure-count`,
`association-batch-mutate-success-count`, `association-batch-mutate-failure-count`)
and records one per `AssociationResult`, giving association-level visibility instead
of request-level visibility.

References
----------
JIRA: https://confluentinc.atlassian.net/browse/DGS-24205

Test & Review
-------------
Added `testAssociationBatchGetMetrics` and `testAssociationBatchMutateMetrics` to
`MetricsTest`, following the existing JMX-assertion pattern used by
`testApiCallMetrics`/`testSchemaCreatedCount`. The mutate test drives a genuine
partial-failure batch (one duplicate-association conflict, one successful create) to
prove per-item, not per-request, counting.

These are `ClusterTestHarness` integration tests gated behind failsafe. I could not
get a clean local run (all four tests in the class, including the two pre-existing
ones I didn't touch, fail locally with a connect timeout -- a local sandbox network
restriction, not a code issue), so these need to be verified in CI.

Manual testing: 
[DGS-24205-manual-verification.md](https://github.com/user-attachments/files/31159242/DGS-24205-manual-verification.md)


Checklist
------------------
- [ ] Contains customer facing changes? Including API/behavior changes -- adds new
      internal JMX metrics only, no API/wire format change.
- [ ] Is this change gated behind feature flag(s)?
- [x] Did you add sufficient unit test and/or integration test coverage for this PR?
- [ ] Does this change require modifying existing system tests or adding new system tests?