### PR TITLE
DGS-23963 Hook up Logical Types to SR endpoints

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/AbstractSchemaProvider.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/AbstractSchemaProvider.java
@@ -57,21 +57,45 @@ public abstract class AbstractSchemaProvider implements SchemaProvider {
   }
 
   protected Map<String, String> resolveReferences(Schema schema, boolean validateAsNew) {
-    List<SchemaReference> references = schema.getReferences();
+    return resolveReferences(
+        schemaVersionFetcher(), schema.getSubject(), schema.getReferences(),
+        validateAsNew, referenceVersionsStrict);
+  }
+
+  /**
+   * Recursively resolves a schema's references into a map of reference name to schema text,
+   * matching the behavior of the instance-level resolution: each unqualified reference subject is
+   * qualified relative to {@code subject}'s parent context, and each referenced schema's own
+   * references are resolved before it is added, so the map contains the full transitive closure.
+   *
+   * @param fetcher                 used to look up referenced schemas by subject and version
+   * @param subject                 the referencing schema's subject, the parent for qualification
+   * @param references              the referencing schema's references, or {@code null} for none
+   * @param validateAsNew           when true, deleted referenced versions are not looked up
+   * @param referenceVersionsStrict when true, a reference name bound to two different versions
+   *                                across the graph is an error rather than being ignored
+   */
+  public static Map<String, String> resolveReferences(
+      SchemaVersionFetcher fetcher, String subject, List<SchemaReference> references,
+      boolean validateAsNew, boolean referenceVersionsStrict) {
     if (references == null) {
       return Collections.emptyMap();
     }
     Map<String, String> result = new LinkedHashMap<>();
     Map<String, Integer> visited = new HashMap<>();
-    resolveReferences(schema, result, visited, validateAsNew);
+    resolveReferences(
+        fetcher, subject, references, result, visited, validateAsNew, referenceVersionsStrict);
     return result;
   }
 
-  private void resolveReferences(
-      Schema schema, Map<String, String> schemas, Map<String, Integer> visited,
-      boolean validateAsNew) {
+  private static void resolveReferences(
+      SchemaVersionFetcher fetcher, String subject, List<SchemaReference> references,
+      Map<String, String> schemas, Map<String, Integer> visited,
+      boolean validateAsNew, boolean referenceVersionsStrict) {
     boolean lookupDeletedSchema = !validateAsNew;
-    List<SchemaReference> references = schema.getReferences();
+    if (references == null) {
+      return;
+    }
     for (SchemaReference reference : references) {
       if (reference.getName() == null
           || reference.getSubject() == null
@@ -79,8 +103,8 @@ public abstract class AbstractSchemaProvider implements SchemaProvider {
         throw new IllegalArgumentException("Invalid reference: " + reference);
       }
       QualifiedSubject refSubject = QualifiedSubject.qualifySubjectWithParent(
-              schemaVersionFetcher().tenant(), schema.getSubject(), reference.getSubject());
-      Schema s = schemaVersionFetcher().getByVersion(refSubject.toQualifiedSubject(),
+              fetcher.tenant(), subject, reference.getSubject());
+      Schema s = fetcher.getByVersion(refSubject.toQualifiedSubject(),
               reference.getVersion(), lookupDeletedSchema);
       if (s == null) {
         throw new IllegalArgumentException("No schema reference found for subject \""
@@ -107,7 +131,8 @@ public abstract class AbstractSchemaProvider implements SchemaProvider {
         visited.put(reference.getName(), reference.getVersion());
       }
       if (!schemas.containsKey(reference.getName())) {
-        resolveReferences(s, schemas, visited, validateAsNew);
+        resolveReferences(fetcher, s.getSubject(), s.getReferences(), schemas, visited,
+            validateAsNew, referenceVersionsStrict);
         schemas.put(reference.getName(), s.getSchema());
       }
     }

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/CompatibilityPolicy.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/CompatibilityPolicy.java
@@ -17,6 +17,7 @@
 package io.confluent.kafka.schemaregistry;
 
 public enum CompatibilityPolicy {
+  LOGICAL,
   STRICT,
   LENIENT;
 
@@ -32,7 +33,9 @@ public enum CompatibilityPolicy {
     }
 
     name = name.toUpperCase();
-    if (STRICT.name.equals(name)) {
+    if (LOGICAL.name.equals(name)) {
+      return LOGICAL;
+    } else if (STRICT.name.equals(name)) {
       return STRICT;
     } else if (LENIENT.name.equals(name)) {
       return LENIENT;

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -882,8 +882,22 @@ public class RestService implements Closeable, Configurable {
                                                boolean normalize,
                                                String format)
       throws IOException, RestClientException {
+    return registerSchema(
+        requestProperties, registerSchemaRequest, subject, normalize, false, format);
+  }
+
+  public RegisterSchemaResponse registerSchema(Map<String, String> requestProperties,
+                                               RegisterSchemaRequest registerSchemaRequest,
+                                               String subject,
+                                               boolean normalize,
+                                               boolean force,
+                                               String format)
+      throws IOException, RestClientException {
     UriBuilder builder = UriBuilder.fromPath("/subjects/{subject}/versions")
         .queryParam("normalize", normalize);
+    if (force) {
+      builder.queryParam("force", true);
+    }
     if (format != null) {
       builder.queryParam("format", format);
     }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -31,6 +31,37 @@
             <version>${io.confluent.schema-registry.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-registry-logical-types</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-protobuf-serializer</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-protobuf-serializer</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-json-schema-serializer</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-rules</artifactId>
+            <version>${io.confluent.schema-registry.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${kafka.scala.version}</artifactId>
         </dependency>

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
@@ -15,6 +15,7 @@
 
 package io.confluent.kafka.schemaregistry.rest.resources;
 
+import io.confluent.kafka.schemaregistry.AbstractSchemaProvider;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
@@ -37,7 +38,6 @@ import io.confluent.kafka.schemaregistry.type.logical.json.LogicalTypeToJsonConv
 import io.confluent.kafka.schemaregistry.type.logical.protobuf.LogicalTypeToProtoConverter;
 import io.confluent.kafka.schemaregistry.type.logical.protobuf.ProtoToLogicalTypeConverter;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -76,6 +76,9 @@ final class LogicalFormat {
     }
 
     LogicalType parsed;
+    if (request.getSchema() == null || request.getSchema().trim().isEmpty()) {
+      throw new InvalidSchemaException("Schema is required when format=logical");
+    }
     try {
       LogicalTypesSchemaVisitor visitor = new LogicalTypesSchemaVisitor();
       visitor.visit(LogicalTypesParserFactory.parse(request.getSchema()));
@@ -85,7 +88,7 @@ final class LogicalFormat {
     }
 
     LogicalType logicalType =
-        attachReferences(schemaRegistry, parsed, request.getReferences());
+        attachReferences(schemaRegistry, subject, parsed, request.getReferences());
     String rowName = rowNameFor(subject);
 
     ParsedSchema nativeSchema;
@@ -110,6 +113,7 @@ final class LogicalFormat {
           "Logical type schema cannot be represented as " + schemaType + ": "
               + e.getMessage(), e);
     }
+    request.setSchemaType(nativeSchema.schemaType());
     request.setSchema(nativeSchema.canonicalString());
   }
 
@@ -144,27 +148,34 @@ final class LogicalFormat {
    * Logical Type carries external-type bindings (name/alias to URI) but never SR coordinates, see
    * {@link LogicalType#getExternalImports()}. If the parsed type references anything external,
    * this resolves it against the caller-declared {@code references} the same way a native
-   * registration would: fetching each referenced subject/version's stored schema text and keying
-   * the result by the reference's own name, matching the convention every native format's
-   * {@code resolvedReferences} map already follows.
+   * registration would -- reusing {@link AbstractSchemaProvider#resolveReferences} so
+   * parent-context qualification and transitive resolution match native registration exactly, and
+   * keying the result by each reference's own name, the convention every native
+   * {@code resolvedReferences}
+   * map already follows.
    */
   private static LogicalType attachReferences(
       final SchemaRegistry schemaRegistry,
+      final String subject,
       final LogicalType parsed,
       final List<SchemaReference> references)
       throws SchemaRegistryException {
     if (references == null || references.isEmpty()) {
       return parsed;
     }
-    Map<String, String> resolvedReferences = new HashMap<>();
-    for (SchemaReference ref : references) {
-      Schema referenced = schemaRegistry.get(ref.getSubject(), ref.getVersion(), false);
-      if (referenced == null) {
-        throw new InvalidSchemaException(
-            "Could not resolve reference '" + ref.getName() + "' to subject '"
-                + ref.getSubject() + "' version " + ref.getVersion());
-      }
-      resolvedReferences.put(ref.getName(), referenced.getSchema());
+    // validateAsNew=true: this is a new registration, so references to deleted versions must not
+    // resolve, matching what the native register path does via canonicalizeSchema.
+    // referenceVersionsStrict defaults to false: it is a per-provider setting configured on the
+    // native SchemaProvider instances, which the logical registration path does not reach.
+    Map<String, String> resolvedReferences;
+    try {
+      resolvedReferences = AbstractSchemaProvider.resolveReferences(
+          schemaRegistry, subject, references, true, false);
+    } catch (Exception e) {
+      // resolveReferences throws IllegalArgument/IllegalState on a missing or conflicting
+      // reference; surface it as a clean InvalidSchemaException (422), the same way the native
+      // register path wraps it in AbstractSchemaRegistry.loadSchema.
+      throw new InvalidSchemaException("Could not resolve schema references: " + e.getMessage(), e);
     }
     return new LogicalType(
         parsed.getNamespace(),

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
@@ -171,7 +171,7 @@ final class LogicalFormat {
     try {
       resolvedReferences = AbstractSchemaProvider.resolveReferences(
           schemaRegistry, subject, references, true, false);
-    } catch (Exception e) {
+    } catch (IllegalArgumentException | IllegalStateException e) {
       // resolveReferences throws IllegalArgument/IllegalState on a missing or conflicting
       // reference; surface it as a clean InvalidSchemaException (422), the same way the native
       // register path wraps it in AbstractSchemaRegistry.loadSchema.

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
@@ -17,26 +17,21 @@ package io.confluent.kafka.schemaregistry.rest.resources;
 
 import io.confluent.kafka.schemaregistry.AbstractSchemaProvider;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
-import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
 import io.confluent.kafka.schemaregistry.exceptions.InvalidSchemaException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
-import io.confluent.kafka.schemaregistry.json.JsonSchema;
-import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.kafka.schemaregistry.storage.LogicalPolicyChecker;
 import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
 import io.confluent.kafka.schemaregistry.type.logical.LogicalType;
 import io.confluent.kafka.schemaregistry.type.logical.LogicalTypeToDdlConverter;
 import io.confluent.kafka.schemaregistry.type.logical.LogicalTypesParserFactory;
 import io.confluent.kafka.schemaregistry.type.logical.LogicalTypesSchemaVisitor;
 import io.confluent.kafka.schemaregistry.type.logical.ValidationException;
-import io.confluent.kafka.schemaregistry.type.logical.avro.AvroToLogicalTypeConverter;
 import io.confluent.kafka.schemaregistry.type.logical.avro.LogicalTypeToAvroConverter;
-import io.confluent.kafka.schemaregistry.type.logical.json.JsonToLogicalTypeConverter;
 import io.confluent.kafka.schemaregistry.type.logical.json.LogicalTypeToJsonConverter;
 import io.confluent.kafka.schemaregistry.type.logical.protobuf.LogicalTypeToProtoConverter;
-import io.confluent.kafka.schemaregistry.type.logical.protobuf.ProtoToLogicalTypeConverter;
 
 import java.util.List;
 import java.util.Locale;
@@ -124,20 +119,10 @@ final class LogicalFormat {
   static String convertToLogical(final SchemaRegistry schemaRegistry, final Schema schema)
       throws InvalidSchemaException {
     ParsedSchema parsedSchema = schemaRegistry.parseSchema(schema, false, false);
-    String schemaType = schema.getSchemaType();
     LogicalType logicalType;
     try {
-      if (schemaType == null || "AVRO".equalsIgnoreCase(schemaType)) {
-        logicalType = AvroToLogicalTypeConverter.toLogicalType((AvroSchema) parsedSchema);
-      } else if ("JSON".equalsIgnoreCase(schemaType)) {
-        logicalType = JsonToLogicalTypeConverter.toLogicalType((JsonSchema) parsedSchema);
-      } else if ("PROTOBUF".equalsIgnoreCase(schemaType)) {
-        logicalType = ProtoToLogicalTypeConverter.toLogicalType((ProtobufSchema) parsedSchema);
-      } else {
-        throw new InvalidSchemaException(
-            "format=logical is not supported for schema type '" + schemaType + "'");
-      }
-    } catch (ValidationException e) {
+      logicalType = LogicalPolicyChecker.toLogicalType(parsedSchema);
+    } catch (ValidationException | IllegalArgumentException e) {
       throw new InvalidSchemaException(
           "Stored schema cannot be represented as a logical type: " + e.getMessage(), e);
     }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rest.resources;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
+import io.confluent.kafka.schemaregistry.exceptions.InvalidSchemaException;
+import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryException;
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
+import io.confluent.kafka.schemaregistry.type.logical.LogicalType;
+import io.confluent.kafka.schemaregistry.type.logical.LogicalTypeToDdlConverter;
+import io.confluent.kafka.schemaregistry.type.logical.LogicalTypesParserFactory;
+import io.confluent.kafka.schemaregistry.type.logical.LogicalTypesSchemaVisitor;
+import io.confluent.kafka.schemaregistry.type.logical.ValidationException;
+import io.confluent.kafka.schemaregistry.type.logical.avro.AvroToLogicalTypeConverter;
+import io.confluent.kafka.schemaregistry.type.logical.avro.LogicalTypeToAvroConverter;
+import io.confluent.kafka.schemaregistry.type.logical.json.JsonToLogicalTypeConverter;
+import io.confluent.kafka.schemaregistry.type.logical.json.LogicalTypeToJsonConverter;
+import io.confluent.kafka.schemaregistry.type.logical.protobuf.LogicalTypeToProtoConverter;
+import io.confluent.kafka.schemaregistry.type.logical.protobuf.ProtoToLogicalTypeConverter;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Converts between Logical Type format and the native Avro/JSON/Protobuf formats.
+ */
+final class LogicalFormat {
+
+  static final String FORMAT_LOGICAL = "logical";
+
+  private LogicalFormat() {
+  }
+
+  static boolean isLogical(String format) {
+    return FORMAT_LOGICAL.equalsIgnoreCase(format);
+  }
+
+  /**
+   * Converts the Logical Type in {@code request}'s schema field into {@code request}'s declared
+   * {@code schemaType}, replacing it in place.
+   *
+   * <p>{@code schemaType} is required here. Unlike a native registration, the request body under
+   * {@code format=logical} never implies a target format, so there is no default to fall back to.
+   */
+  static void convertToNative(
+      final SchemaRegistry schemaRegistry,
+      final String subject,
+      final RegisterSchemaRequest request)
+      throws SchemaRegistryException {
+    String schemaType = request.getSchemaType();
+    if (schemaType == null || schemaType.trim().isEmpty()) {
+      throw new InvalidSchemaException(
+          "schemaType is required when format=logical, and must be one of "
+              + "AVRO, JSON, PROTOBUF");
+    }
+
+    LogicalType parsed;
+    try {
+      LogicalTypesSchemaVisitor visitor = new LogicalTypesSchemaVisitor();
+      visitor.visit(LogicalTypesParserFactory.parse(request.getSchema()));
+      parsed = visitor.toLogicalType();
+    } catch (ValidationException e) {
+      throw new InvalidSchemaException("Invalid logical type schema: " + e.getMessage(), e);
+    }
+
+    LogicalType logicalType =
+        attachReferences(schemaRegistry, parsed, request.getReferences());
+    String rowName = rowNameFor(subject);
+
+    ParsedSchema nativeSchema;
+    try {
+      switch (schemaType.toUpperCase(Locale.ROOT)) {
+        case "AVRO":
+          nativeSchema = LogicalTypeToAvroConverter.fromLogicalType(logicalType, rowName);
+          break;
+        case "JSON":
+          nativeSchema = LogicalTypeToJsonConverter.fromLogicalType(logicalType, rowName);
+          break;
+        case "PROTOBUF":
+          nativeSchema = LogicalTypeToProtoConverter.fromLogicalType(logicalType, rowName);
+          break;
+        default:
+          throw new InvalidSchemaException(
+              "Unsupported schemaType '" + schemaType + "' for format=logical; "
+                  + "must be one of AVRO, JSON, PROTOBUF");
+      }
+    } catch (ValidationException e) {
+      throw new InvalidSchemaException(
+          "Logical type schema cannot be represented as " + schemaType + ": "
+              + e.getMessage(), e);
+    }
+    request.setSchema(nativeSchema.canonicalString());
+  }
+
+  /**
+   * Converts the native schema in {@code schema} to Logical Type, based on its stored
+   * {@code schemaType}.
+   */
+  static String convertToLogical(final SchemaRegistry schemaRegistry, final Schema schema)
+      throws InvalidSchemaException {
+    ParsedSchema parsedSchema = schemaRegistry.parseSchema(schema, false, false);
+    String schemaType = schema.getSchemaType();
+    LogicalType logicalType;
+    try {
+      if (schemaType == null || "AVRO".equalsIgnoreCase(schemaType)) {
+        logicalType = AvroToLogicalTypeConverter.toLogicalType((AvroSchema) parsedSchema);
+      } else if ("JSON".equalsIgnoreCase(schemaType)) {
+        logicalType = JsonToLogicalTypeConverter.toLogicalType((JsonSchema) parsedSchema);
+      } else if ("PROTOBUF".equalsIgnoreCase(schemaType)) {
+        logicalType = ProtoToLogicalTypeConverter.toLogicalType((ProtobufSchema) parsedSchema);
+      } else {
+        throw new InvalidSchemaException(
+            "format=logical is not supported for schema type '" + schemaType + "'");
+      }
+    } catch (ValidationException e) {
+      throw new InvalidSchemaException(
+          "Stored schema cannot be represented as a logical type: " + e.getMessage(), e);
+    }
+    return LogicalTypeToDdlConverter.toDdl(logicalType);
+  }
+
+  /**
+   * Logical Type carries external-type bindings (name/alias to URI) but never SR coordinates, see
+   * {@link LogicalType#getExternalImports()}. If the parsed type references anything external,
+   * this resolves it against the caller-declared {@code references} the same way a native
+   * registration would: fetching each referenced subject/version's stored schema text and keying
+   * the result by the reference's own name, matching the convention every native format's
+   * {@code resolvedReferences} map already follows.
+   */
+  private static LogicalType attachReferences(
+      final SchemaRegistry schemaRegistry,
+      final LogicalType parsed,
+      final List<SchemaReference> references)
+      throws SchemaRegistryException {
+    if (references == null || references.isEmpty()) {
+      return parsed;
+    }
+    Map<String, String> resolvedReferences = new HashMap<>();
+    for (SchemaReference ref : references) {
+      Schema referenced = schemaRegistry.get(ref.getSubject(), ref.getVersion(), false);
+      if (referenced == null) {
+        throw new InvalidSchemaException(
+            "Could not resolve reference '" + ref.getName() + "' to subject '"
+                + ref.getSubject() + "' version " + ref.getVersion());
+      }
+      resolvedReferences.put(ref.getName(), referenced.getSchema());
+    }
+    return new LogicalType(
+        parsed.getNamespace(),
+        parsed.getRootSchema(),
+        parsed.getNamedTypes(),
+        parsed.getExternalTypes(),
+        parsed.getExternalImports(),
+        references,
+        resolvedReferences,
+        parsed.getDefaultValues());
+  }
+
+  private static String rowNameFor(final String subject) {
+    String sanitized = subject == null ? "" : subject.replaceAll("[^A-Za-z0-9_]", "_");
+    if (sanitized.isEmpty() || Character.isDigit(sanitized.charAt(0))) {
+      sanitized = "Envelope" + sanitized;
+    }
+    return sanitized;
+  }
+}

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -176,9 +176,13 @@ public class SubjectVersionsResource {
         schemaRegistry.extractSchemaTags(schema, tags);
       }
       if (format != null && !format.trim().isEmpty()) {
-        ParsedSchema parsedSchema = schemaRegistry.parseSchema(schema, false, false);
         String originalGuid = schema.getGuid();
-        schema.setSchema(parsedSchema.formattedString(format));
+        if (LogicalFormat.isLogical(format)) {
+          schema.setSchema(LogicalFormat.convertToLogical(schemaRegistry, schema));
+        } else {
+          ParsedSchema parsedSchema = schemaRegistry.parseSchema(schema, false, false);
+          schema.setSchema(parsedSchema.formattedString(format));
+        }
         schema.setGuid(originalGuid);
       }
       QualifiedSubject qs = QualifiedSubject.create(schemaRegistry.tenant(), schema.getSubject());
@@ -487,12 +491,18 @@ public class SubjectVersionsResource {
 
     RegisterSchemaResponse registerSchemaResponse;
     try {
+      if (LogicalFormat.isLogical(format)) {
+        LogicalFormat.convertToNative(schemaRegistry, subjectName, request);
+      }
       if (!normalize) {
         normalize = Boolean.TRUE.equals(schemaRegistry.getConfigInScope(subjectName).isNormalize());
       }
       Schema result =
           schemaRegistry.registerOrForward(subjectName, request, normalize, headerProperties);
-      if (result.getSchema() != null && format != null && !format.trim().isEmpty()) {
+      // format=logical governs how the request body is interpreted, not how the response is
+      // rendered -- the response always reflects the stored native schema.
+      if (result.getSchema() != null && format != null && !format.trim().isEmpty()
+          && !LogicalFormat.isLogical(format)) {
         ParsedSchema parsedSchema = schemaRegistry.parseSchema(result, false, false);
         String originalGuid = result.getGuid();
         result.setSchema(parsedSchema.formattedString(format));

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -456,6 +456,8 @@ public class SubjectVersionsResource {
       @QueryParam("normalize") boolean normalize,
       @Parameter(description = "Desired output format, dependent on schema type")
       @DefaultValue("") @QueryParam("format") String format,
+      @Parameter(description = "Whether to skip compatibility checks when registering the schema")
+      @QueryParam("force") boolean force,
       @Parameter(description = "Schema", required = true)
       @NotNull RegisterSchemaRequest request) {
     log.info("Registering new schema: subject {}, version {}, id {}, type {}, schema size {}",
@@ -497,8 +499,8 @@ public class SubjectVersionsResource {
       if (!normalize) {
         normalize = Boolean.TRUE.equals(schemaRegistry.getConfigInScope(subjectName).isNormalize());
       }
-      Schema result =
-          schemaRegistry.registerOrForward(subjectName, request, normalize, headerProperties);
+      Schema result = schemaRegistry.registerOrForward(
+          subjectName, request, normalize, force, headerProperties);
       // format=logical governs how the request body is interpreted, not how the response is
       // rendered -- the response always reflects the stored native schema.
       if (result.getSchema() != null && format != null && !format.trim().isEmpty()

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -1253,6 +1253,12 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
     }
     errorMessages.addAll(
             parsedSchema.isCompatible(compatibility, compatibilityPolicy, previousSchemas));
+    if (compatibilityPolicy == CompatibilityPolicy.LOGICAL) {
+      // Additive: the native check above still runs; LOGICAL layers the Flink/Iceberg logical-type
+      // validity and compatibility checks on top, so it can only make registration stricter.
+      errorMessages.addAll(
+              LogicalPolicyChecker.check(parsedSchema, previousSchemas, compatibility));
+    }
     if (!errorMessages.isEmpty()) {
       try {
         errorMessages.add(String.format("{validateFields: '%b', compatibility: '%s'}",

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -379,9 +379,14 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
 
   public Schema register(String subject, RegisterSchemaRequest request, boolean normalize)
           throws SchemaRegistryException {
+    return register(subject, request, normalize, false);
+  }
+
+  public Schema register(String subject, RegisterSchemaRequest request, boolean normalize,
+          boolean force) throws SchemaRegistryException {
     try {
       Schema schema = toSchemaWithTags(subject, request);
-      return register(subject, schema, normalize, request.doPropagateSchemaTags());
+      return register(subject, schema, normalize, force, request.doPropagateSchemaTags());
     } catch (IllegalArgumentException e) {
       throw new InvalidSchemaException(e);
     }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -435,6 +435,7 @@ public class KafkaSchemaRegistry extends AbstractSchemaRegistry implements
   public Schema register(String subject,
                          Schema schema,
                          boolean normalize,
+                         boolean force,
                          boolean propagateSchemaTags)
       throws SchemaRegistryException {
     try {
@@ -513,7 +514,9 @@ public class KafkaSchemaRegistry extends AbstractSchemaRegistry implements
 
       boolean isCompatible = true;
       List<String> compatibilityErrorLogs = new ArrayList<>();
-      if (mode != Mode.IMPORT) {
+      // force skips the compatibility checks (both the native format-specific check and the
+      // logical check) even outside IMPORT mode, the same way IMPORT mode skips them.
+      if (mode != Mode.IMPORT && !force) {
         // sort undeleted in ascending
         Collections.reverse(undeletedVersions);
         compatibilityErrorLogs.addAll(isCompatibleWithPrevious(config,
@@ -609,6 +612,7 @@ public class KafkaSchemaRegistry extends AbstractSchemaRegistry implements
   public Schema registerOrForward(String subject,
                                   RegisterSchemaRequest request,
                                   boolean normalize,
+                                  boolean force,
                                   Map<String, String> headerProperties)
       throws SchemaRegistryException {
     Schema schema = new Schema(subject, request);
@@ -646,11 +650,12 @@ public class KafkaSchemaRegistry extends AbstractSchemaRegistry implements
     kafkaStore.lockFor(subject).lock();
     try {
       if (isLeader()) {
-        return register(subject, request, normalize);
+        return register(subject, request, normalize, force);
       } else {
         // forward registering request to the leader
         if (leaderIdentity != null) {
-          return forwardRegisterRequestToLeader(subject, request, normalize, headerProperties);
+          return forwardRegisterRequestToLeader(
+              subject, request, normalize, force, headerProperties);
         } else {
           throw new UnknownLeaderException("Register schema request failed since leader is "
                                            + "unknown");
@@ -1066,14 +1071,14 @@ public class KafkaSchemaRegistry extends AbstractSchemaRegistry implements
 
   private Schema forwardRegisterRequestToLeader(
       String subject, RegisterSchemaRequest registerSchemaRequest, boolean normalize,
-      Map<String, String> headerProperties)
+      boolean force, Map<String, String> headerProperties)
       throws SchemaRegistryRequestForwardingException {
     final UrlList baseUrl = leaderRestService.getBaseUrls();
 
     log.debug("Forwarding registering schema request to {}", baseUrl);
     try {
       RegisterSchemaResponse response = leaderRestService.registerSchema(
-          headerProperties, registerSchemaRequest, subject, normalize);
+          headerProperties, registerSchemaRequest, subject, normalize, force, null);
       return new Schema(subject, response);
     } catch (IOException e) {
       throw new SchemaRegistryRequestForwardingException(

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LogicalPolicyChecker.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LogicalPolicyChecker.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.storage;
+
+import io.confluent.kafka.schemaregistry.CompatibilityLevel;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.ParsedSchemaHolder;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.kafka.schemaregistry.type.logical.LogicalType;
+import io.confluent.kafka.schemaregistry.type.logical.avro.AvroToLogicalTypeConverter;
+import io.confluent.kafka.schemaregistry.type.logical.json.JsonToLogicalTypeConverter;
+import io.confluent.kafka.schemaregistry.type.logical.policy.CompatibilityResult;
+import io.confluent.kafka.schemaregistry.type.logical.policy.LogicalTypeChecker;
+import io.confluent.kafka.schemaregistry.type.logical.policy.LogicalTypeChecker.Mode;
+import io.confluent.kafka.schemaregistry.type.logical.policy.ValidityResult;
+import io.confluent.kafka.schemaregistry.type.logical.protobuf.ProtoToLogicalTypeConverter;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs the {@link LogicalTypeChecker} validity and compatibility checks that
+ * {@code CompatibilityPolicy.LOGICAL} adds on top of a schema's native compatibility check.
+ *
+ * <p>These checks are <b>additive</b>: the native Avro/JSON/Protobuf compatibility check still runs
+ * unchanged, and any findings here are appended to the same error list, so {@code LOGICAL} can only
+ * ever make a registration stricter, never more permissive.
+ *
+ * <p>The checks run in {@link Mode#FLINK} and {@link Mode#ICEBERG_V2} -- the union of downstream
+ * consumers currently gated, excluding {@code ICEBERG_V3}, which has no way yet to know a subject's
+ * target Iceberg format version.
+ */
+public final class LogicalPolicyChecker {
+
+  private static final Logger log = LoggerFactory.getLogger(LogicalPolicyChecker.class);
+
+  private static final Mode[] MODES = {Mode.FLINK, Mode.ICEBERG_V2};
+
+  private LogicalPolicyChecker() {
+  }
+
+  /**
+   * Converts a native parsed schema into a {@link LogicalType} by dispatching on its schema type.
+   *
+   * @throws IllegalArgumentException if the schema type has no logical-type converter
+   */
+  public static LogicalType toLogicalType(ParsedSchema parsedSchema) {
+    String schemaType = parsedSchema.schemaType();
+    if (schemaType == null || AvroSchema.TYPE.equalsIgnoreCase(schemaType)) {
+      return AvroToLogicalTypeConverter.toLogicalType((AvroSchema) parsedSchema);
+    } else if (JsonSchema.TYPE.equalsIgnoreCase(schemaType)) {
+      return JsonToLogicalTypeConverter.toLogicalType((JsonSchema) parsedSchema);
+    } else if (ProtobufSchema.TYPE.equalsIgnoreCase(schemaType)) {
+      return ProtoToLogicalTypeConverter.toLogicalType((ProtobufSchema) parsedSchema);
+    }
+    throw new IllegalArgumentException(
+        "format=logical is not supported for schema type '" + schemaType + "'");
+  }
+
+  /**
+   * Runs the logical validity and compatibility checks for {@code newSchema} and returns any
+   * findings as human-readable error strings (empty if all pass).
+   *
+   * <p>Validity runs on {@code newSchema} regardless of compatibility level, since it is a property
+   * of the schema itself, not of a change. Compatibility runs against previous versions selected by
+   * {@code level}: transitive levels compare against every previous version, non-transitive levels
+   * against the latest only, and {@code NONE} skips comparison entirely. Direction follows the
+   * level -- backward levels require the new schema to read the old, forward levels the reverse,
+   * full levels both.
+   *
+   * <p>If {@code newSchema} cannot be converted to a logical type the registration is rejected (a
+   * finding is returned). If a <i>previous</i> schema cannot be converted, that comparison is
+   * skipped rather than failing the registration -- an old version being unconvertible must not
+   * block a new one (per design decision).
+   *
+   * @param newSchema       the schema being registered
+   * @param previousSchemas prior versions, ascending (oldest first, latest last)
+   * @param level           the configured compatibility level, or {@code null} (treated as NONE)
+   */
+  static List<String> check(
+      ParsedSchema newSchema,
+      List<ParsedSchemaHolder> previousSchemas,
+      CompatibilityLevel level) {
+    List<String> errors = new ArrayList<>();
+
+    LogicalType newLogical;
+    try {
+      newLogical = toLogicalType(newSchema);
+    } catch (RuntimeException e) {
+      errors.add("Schema cannot be represented as a logical type: " + e.getMessage());
+      return errors;
+    }
+
+    // Validity: a property of the new schema itself, independent of any previous version.
+    for (Mode mode : MODES) {
+      ValidityResult validity = LogicalTypeChecker.validate(mode, newLogical);
+      if (!validity.isValid()) {
+        errors.add("Logical validity (" + mode + "): " + validity.describe());
+      }
+    }
+
+    List<ParsedSchemaHolder> toCompare = selectForComparison(previousSchemas, level);
+    boolean checksBackward = checksBackward(level);
+    boolean checksForward = checksForward(level);
+    for (ParsedSchemaHolder holder : toCompare) {
+      LogicalType previousLogical;
+      try {
+        previousLogical = toLogicalType(holder.schema());
+      } catch (RuntimeException e) {
+        // Skip an unconvertible previous version rather than blocking this registration.
+        log.warn("Skipping logical compatibility against a previous version that could not be "
+            + "converted to a logical type: {}", e.getMessage());
+        continue;
+      }
+      if (checksBackward) {
+        // BACKWARD: the new schema must read data written with the previous schema.
+        addCompareErrors(errors, "backward", previousLogical, newLogical);
+      }
+      if (checksForward) {
+        // FORWARD: the previous schema must read data written with the new schema.
+        addCompareErrors(errors, "forward", newLogical, previousLogical);
+      }
+    }
+    return errors;
+  }
+
+  private static void addCompareErrors(
+      List<String> errors, String direction, LogicalType original, LogicalType update) {
+    for (Mode mode : MODES) {
+      CompatibilityResult result = LogicalTypeChecker.compare(mode, original, update);
+      if (!result.isCompatible()) {
+        errors.add(
+            "Logical compatibility (" + mode + ", " + direction + "): " + result.describe());
+      }
+    }
+  }
+
+  private static List<ParsedSchemaHolder> selectForComparison(
+      List<ParsedSchemaHolder> previousSchemas, CompatibilityLevel level) {
+    if (previousSchemas.isEmpty() || level == null || level == CompatibilityLevel.NONE) {
+      return List.of();
+    }
+    if (isTransitive(level)) {
+      return previousSchemas;
+    }
+    // Non-transitive: latest version only, which is the last element (ascending order).
+    return List.of(previousSchemas.get(previousSchemas.size() - 1));
+  }
+
+  private static boolean isTransitive(CompatibilityLevel level) {
+    return level == CompatibilityLevel.BACKWARD_TRANSITIVE
+        || level == CompatibilityLevel.FORWARD_TRANSITIVE
+        || level == CompatibilityLevel.FULL_TRANSITIVE;
+  }
+
+  private static boolean checksBackward(CompatibilityLevel level) {
+    return level == CompatibilityLevel.BACKWARD
+        || level == CompatibilityLevel.BACKWARD_TRANSITIVE
+        || level == CompatibilityLevel.FULL
+        || level == CompatibilityLevel.FULL_TRANSITIVE;
+  }
+
+  private static boolean checksForward(CompatibilityLevel level) {
+    return level == CompatibilityLevel.FORWARD
+        || level == CompatibilityLevel.FORWARD_TRANSITIVE
+        || level == CompatibilityLevel.FULL
+        || level == CompatibilityLevel.FULL_TRANSITIVE;
+  }
+}

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java
@@ -94,8 +94,13 @@ public interface SchemaRegistry extends SchemaVersionFetcher {
     return register(subject, schema, normalize, false);
   }
 
-  Schema register(String subject, Schema schema, boolean normalize, boolean propagateSchemaTags)
-      throws SchemaRegistryException;
+  default Schema register(String subject, Schema schema, boolean normalize,
+      boolean propagateSchemaTags) throws SchemaRegistryException {
+    return register(subject, schema, normalize, false, propagateSchemaTags);
+  }
+
+  Schema register(String subject, Schema schema, boolean normalize, boolean force,
+      boolean propagateSchemaTags) throws SchemaRegistryException;
 
   default Schema getByVersion(String subject, int version, boolean returnDeletedSchema) {
     try {
@@ -342,6 +347,13 @@ public interface SchemaRegistry extends SchemaVersionFetcher {
 
   default Schema registerOrForward(String subject, RegisterSchemaRequest request,
                                    boolean normalize, Map<String, String> headerProperties) throws
+          SchemaRegistryException {
+    return registerOrForward(subject, request, normalize, false, headerProperties);
+  }
+
+  default Schema registerOrForward(String subject, RegisterSchemaRequest request,
+                                   boolean normalize, boolean force,
+                                   Map<String, String> headerProperties) throws
           SchemaRegistryException {
     return null;
   }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/protobuf/rest/RestApiSerializerTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/protobuf/rest/RestApiSerializerTest.java
@@ -1,17 +1,16 @@
 /*
  * Copyright 2020 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.kafka.schemaregistry.protobuf.rest;

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiCompatibilityTest.java
@@ -133,6 +133,41 @@ public abstract class RestApiCompatibilityTest {
   }
 
   @Test
+  public void testForceSkipsCompatibilityCheck() throws Exception {
+    String subject = "testForceSubject";
+
+    String schemaString1 = AvroUtils.parseSchema("{\"type\":\"record\","
+        + "\"name\":\"myrecord\","
+        + "\"fields\":"
+        + "[{\"type\":\"string\",\"name\":\"f1\"}]}").canonicalString();
+    restApp.restClient.registerSchema(schemaString1, subject);
+
+    // An added required field is not backward-compatible.
+    String incompatibleSchemaString = AvroUtils.parseSchema("{\"type\":\"record\","
+        + "\"name\":\"myrecord\","
+        + "\"fields\":"
+        + "[{\"type\":\"string\",\"name\":\"f1\"},"
+        + " {\"type\":\"string\",\"name\":\"f2\"}]}").canonicalString();
+
+    // Without force, registration is rejected by the compatibility check.
+    try {
+      restApp.restClient.registerSchema(incompatibleSchemaString, subject);
+      fail("Registering an incompatible schema should fail without force");
+    } catch (RestClientException e) {
+      assertEquals(
+          RestIncompatibleSchemaException.DEFAULT_ERROR_CODE, e.getStatus(),
+          "Should get a conflict status");
+    }
+
+    // With force=true, the compatibility check is skipped and the schema registers.
+    RegisterSchemaRequest request = new RegisterSchemaRequest();
+    request.setSchema(incompatibleSchemaString);
+    RegisterSchemaResponse response = restApp.restClient.registerSchema(
+        Collections.emptyMap(), request, subject, false, true, null);
+    assertTrue(response.getId() > 0, "Forced registration of an incompatible schema should succeed");
+  }
+
+  @Test
   public void testCompatibilityLevelChangeToNone() throws Exception {
     String subject = "testSubject";
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiCompatibilityTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiCompatibilityTest.java
@@ -163,7 +163,7 @@ public abstract class RestApiCompatibilityTest {
     RegisterSchemaRequest request = new RegisterSchemaRequest();
     request.setSchema(incompatibleSchemaString);
     RegisterSchemaResponse response = restApp.restClient.registerSchema(
-        Collections.emptyMap(), request, subject, false, true, null);
+        RestService.DEFAULT_REQUEST_PROPERTIES, request, subject, false, true, null);
     assertTrue(response.getId() > 0, "Forced registration of an incompatible schema should succeed");
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormatTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormatTest.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rest.resources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
+import io.confluent.kafka.schemaregistry.client.rest.entities.requests.RegisterSchemaRequest;
+import io.confluent.kafka.schemaregistry.exceptions.InvalidSchemaException;
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@code format=logical} conversion helper. No live cluster is needed: both
+ * directions are pure conversions over a mocked {@link SchemaRegistry}.
+ */
+class LogicalFormatTest {
+
+  private static final String STRUCT_DDL = "STRUCT Widget (id INT NOT NULL, name VARCHAR NOT NULL)";
+
+  // -- isLogical --------------------------------------------------------------------------------
+
+  @Test
+  void isLogicalIsCaseInsensitive() {
+    assertTrue(LogicalFormat.isLogical("logical"));
+    assertTrue(LogicalFormat.isLogical("LOGICAL"));
+    assertTrue(LogicalFormat.isLogical("Logical"));
+  }
+
+  @Test
+  void isLogicalRejectsEverythingElse() {
+    assertEquals(false, LogicalFormat.isLogical("resolved"));
+    assertEquals(false, LogicalFormat.isLogical(""));
+    assertEquals(false, LogicalFormat.isLogical(null));
+  }
+
+  // -- convertToNative: happy path, one per schemaType -------------------------------------------
+
+  @Test
+  void convertToNativeProducesAvro() throws Exception {
+    RegisterSchemaRequest request = requestFor("AVRO", STRUCT_DDL);
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+
+    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
+
+    AvroSchema avroSchema = new AvroSchema(request.getSchema());
+    assertNotNull(avroSchema.rawSchema().getField("id"));
+    assertNotNull(avroSchema.rawSchema().getField("name"));
+    assertEquals(2, avroSchema.rawSchema().getFields().size());
+  }
+
+  @Test
+  void convertToNativeProducesJson() throws Exception {
+    RegisterSchemaRequest request = requestFor("JSON", STRUCT_DDL);
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+
+    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
+
+    JsonSchema jsonSchema = new JsonSchema(request.getSchema());
+    assertNotNull(jsonSchema.rawSchema());
+    assertTrue(request.getSchema().contains("id"));
+    assertTrue(request.getSchema().contains("name"));
+  }
+
+  @Test
+  void convertToNativeProducesProtobuf() throws Exception {
+    RegisterSchemaRequest request = requestFor("PROTOBUF", STRUCT_DDL);
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+
+    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
+
+    ProtobufSchema protobufSchema = new ProtobufSchema(request.getSchema());
+    assertNotNull(protobufSchema.toDescriptor().findFieldByName("id"));
+    assertNotNull(protobufSchema.toDescriptor().findFieldByName("name"));
+  }
+
+  @Test
+  void convertToNativeIsCaseInsensitiveOnSchemaType() throws Exception {
+    RegisterSchemaRequest request = requestFor("avro", STRUCT_DDL);
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+
+    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
+
+    assertEquals(2, new AvroSchema(request.getSchema()).rawSchema().getFields().size());
+  }
+
+  // -- convertToNative: rejections ---------------------------------------------------------------
+
+  @Test
+  void convertToNativeRequiresSchemaType() {
+    RegisterSchemaRequest request = requestFor(null, STRUCT_DDL);
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+
+    InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
+    assertTrue(e.getMessage().contains("schemaType is required"));
+  }
+
+  @Test
+  void convertToNativeRejectsBlankSchemaType() {
+    RegisterSchemaRequest request = requestFor("   ", STRUCT_DDL);
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+
+    InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
+    assertTrue(e.getMessage().contains("schemaType is required"));
+  }
+
+  @Test
+  void convertToNativeRejectsUnsupportedSchemaType() {
+    RegisterSchemaRequest request = requestFor("XML", STRUCT_DDL);
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+
+    InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
+    assertTrue(e.getMessage().contains("Unsupported schemaType"));
+  }
+
+  @Test
+  void convertToNativeRejectsMalformedDdl() {
+    // Syntactically valid DDL, structurally invalid: a struct may not declare the same field
+    // name twice. Distinct from convertToNativeRejectsUnparsableDdl below, which is a syntax
+    // error instead.
+    RegisterSchemaRequest request = requestFor(
+        "AVRO", "STRUCT Widget (id INT NOT NULL, id VARCHAR NOT NULL)");
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+
+    InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
+    assertTrue(e.getMessage().contains("Invalid logical type schema"));
+  }
+
+  @Test
+  void convertToNativeRejectsUnparsableDdl() {
+    RegisterSchemaRequest request = requestFor("AVRO", "not valid ddl at all {{{");
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+
+    InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
+    assertTrue(e.getMessage().contains("Invalid logical type schema"));
+  }
+
+  // -- convertToNative: external references --------------------------------------------------
+
+  @Test
+  void convertToNativeResolvesExternalReferences() throws Exception {
+    // Bare external reference (FQN used directly, no USING TYPE) -- the Avro-compatible shape.
+    // USING TYPE populates externalImports, which LogicalTypeToAvroConverter rejects outright as
+    // a JSON-only mechanism (see its own validation), so it isn't a valid fixture for AVRO here.
+    String ddl = "STRUCT Widget (id INT NOT NULL, addr com.example.Address NOT NULL)";
+    RegisterSchemaRequest request = requestFor("AVRO", ddl);
+    request.setReferences(List.of(
+        new SchemaReference("com.example.Address", "address-value", 1)));
+
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    String addressSchema =
+        "{\"type\":\"record\",\"name\":\"Address\",\"namespace\":\"com.example\","
+            + "\"fields\":[{\"name\":\"street\",\"type\":\"string\"}]}";
+    when(schemaRegistry.get("address-value", 1, false))
+        .thenReturn(schemaEntityFor("AVRO", addressSchema));
+
+    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
+
+    // The emitted schema legitimately leaves "addr" as a cross-schema pointer to
+    // com.example.Address rather than inlining it -- matching how Avro schema references work in
+    // general, so it must be re-parsed the same way the real registration pipeline would: with
+    // request.getReferences() and the resolved external body supplied alongside it.
+    AvroSchema avroSchema = new AvroSchema(
+        request.getSchema(),
+        request.getReferences(),
+        java.util.Map.of("com.example.Address", addressSchema),
+        null, null, null, false);
+    assertNotNull(avroSchema.rawSchema().getField("addr"));
+  }
+
+  @Test
+  void convertToNativeFailsWhenReferenceCannotBeResolved() throws Exception {
+    String ddl = "STRUCT Widget (id INT NOT NULL, addr com.example.Address NOT NULL)";
+    RegisterSchemaRequest request = requestFor("AVRO", ddl);
+    request.setReferences(List.of(
+        new SchemaReference("com.example.Address", "address-value", 1)));
+
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    when(schemaRegistry.get("address-value", 1, false)).thenReturn(null);
+
+    InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
+    assertTrue(e.getMessage().contains("Could not resolve reference"));
+  }
+
+  // -- convertToLogicalDdl: happy path, one per schemaType -------------------------------------
+
+  @Test
+  void convertToLogicalDdlFromAvro() throws Exception {
+    String avroSchemaString =
+        "{\"type\":\"record\",\"name\":\"Row\","
+            + "\"fields\":[{\"name\":\"id\",\"type\":\"int\"},"
+            + "{\"name\":\"name\",\"type\":\"string\"}]}";
+    Schema schema = schemaEntityFor("AVRO", avroSchemaString);
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    when(schemaRegistry.parseSchema(schema, false, false))
+        .thenReturn(new AvroSchema(avroSchemaString));
+
+    String ddl = LogicalFormat.convertToLogical(schemaRegistry, schema);
+
+    assertTrue(ddl.contains("id"));
+    assertTrue(ddl.contains("name"));
+  }
+
+  @Test
+  void convertToLogicalDdlFromJson() throws Exception {
+    String jsonSchemaString =
+        "{\"$schema\":\"http://json-schema.org/draft-07/schema#\","
+            + "\"type\":\"object\",\"properties\":{"
+            + "\"id\":{\"type\":\"integer\"},\"name\":{\"type\":\"string\"}},"
+            + "\"required\":[\"id\",\"name\"]}";
+    Schema schema = schemaEntityFor("JSON", jsonSchemaString);
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    when(schemaRegistry.parseSchema(schema, false, false))
+        .thenReturn(new JsonSchema(jsonSchemaString));
+
+    String ddl = LogicalFormat.convertToLogical(schemaRegistry, schema);
+
+    assertTrue(ddl.contains("id"));
+    assertTrue(ddl.contains("name"));
+  }
+
+  @Test
+  void convertToLogicalDdlFromProtobuf() throws Exception {
+    String protoSchemaString =
+        "syntax = \"proto3\";\n"
+            + "message Widget {\n"
+            + "  int32 id = 1;\n"
+            + "  string name = 2;\n"
+            + "}\n";
+    Schema schema = schemaEntityFor("PROTOBUF", protoSchemaString);
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    when(schemaRegistry.parseSchema(schema, false, false))
+        .thenReturn(new ProtobufSchema(protoSchemaString));
+
+    String ddl = LogicalFormat.convertToLogical(schemaRegistry, schema);
+
+    assertTrue(ddl.contains("id"));
+    assertTrue(ddl.contains("name"));
+  }
+
+  @Test
+  void convertToLogicalDdlRejectsUnsupportedSchemaType() throws Exception {
+    Schema schema = schemaEntityFor("XML", "<not-a-real-schema/>");
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    when(schemaRegistry.parseSchema(any(Schema.class), anyBoolean(), anyBoolean()))
+        .thenThrow(new InvalidSchemaException("unsupported"));
+
+    assertThrows(InvalidSchemaException.class, () ->
+        LogicalFormat.convertToLogical(schemaRegistry, schema));
+  }
+
+  // -- helpers ------------------------------------------------------------------------------
+
+  private static RegisterSchemaRequest requestFor(String schemaType, String ddl) {
+    RegisterSchemaRequest request = new RegisterSchemaRequest();
+    request.setSchemaType(schemaType);
+    request.setSchema(ddl);
+    return request;
+  }
+
+  private static Schema schemaEntityFor(String schemaType, String schemaString) {
+    return new Schema(
+        "widgets-value", 1, 1, null, schemaType, Collections.emptyList(), null, null,
+        schemaString);
+  }
+}

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormatTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormatTest.java
@@ -32,6 +32,7 @@ import io.confluent.kafka.schemaregistry.exceptions.InvalidSchemaException;
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
+import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -179,10 +180,14 @@ class LogicalFormatTest {
         new SchemaReference("com.example.Address", "address-value", 1)));
 
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    when(schemaRegistry.tenant()).thenReturn(QualifiedSubject.DEFAULT_TENANT);
     String addressSchema =
         "{\"type\":\"record\",\"name\":\"Address\",\"namespace\":\"com.example\","
             + "\"fields\":[{\"name\":\"street\",\"type\":\"string\"}]}";
-    when(schemaRegistry.get("address-value", 1, false))
+    // Reference resolution now routes through AbstractSchemaProvider.resolveReferences, which
+    // qualifies the subject against the parent context and fetches via getByVersion with
+    // lookupDeletedSchema=false (validateAsNew=true for a new registration).
+    when(schemaRegistry.getByVersion("address-value", 1, false))
         .thenReturn(schemaEntityFor("AVRO", addressSchema));
 
     LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
@@ -207,11 +212,12 @@ class LogicalFormatTest {
         new SchemaReference("com.example.Address", "address-value", 1)));
 
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
-    when(schemaRegistry.get("address-value", 1, false)).thenReturn(null);
+    when(schemaRegistry.tenant()).thenReturn(QualifiedSubject.DEFAULT_TENANT);
+    when(schemaRegistry.getByVersion("address-value", 1, false)).thenReturn(null);
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
         LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
-    assertTrue(e.getMessage().contains("Could not resolve reference"));
+    assertTrue(e.getMessage().contains("Could not resolve schema references"));
   }
 
   // -- convertToLogicalDdl: happy path, one per schemaType -------------------------------------

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResourceLogicalFormatTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResourceLogicalFormatTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rest.resources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.storage.SchemaRegistry;
+import io.confluent.kafka.schemaregistry.utils.QualifiedSubject;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Confirms the {@code format=logical} wiring inside {@link SubjectVersionsResource} itself --
+ * that {@code getSchemaByVersion} dispatches to {@link LogicalFormat} rather than the
+ * ordinary {@code formattedString} path, and only when asked to. {@link LogicalFormatTest}
+ * covers the conversion logic itself; this covers the call site.
+ */
+class SubjectVersionsResourceLogicalFormatTest {
+
+  private static final String AVRO_SCHEMA_STRING =
+      "{\"type\":\"record\",\"name\":\"Widget\","
+          + "\"fields\":[{\"name\":\"id\",\"type\":\"int\"},"
+          + "{\"name\":\"name\",\"type\":\"string\"}]}";
+
+  @Test
+  void getSchemaByVersionConvertsToLogicalDdlWhenRequested() throws Exception {
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    when(schemaRegistry.tenant()).thenReturn(QualifiedSubject.DEFAULT_TENANT);
+    Schema schema = schemaEntity();
+    when(schemaRegistry.getUsingContexts("widgets-value", 1, false)).thenReturn(schema);
+    when(schemaRegistry.parseSchema(schema, false, false))
+        .thenReturn(new AvroSchema(AVRO_SCHEMA_STRING));
+
+    SubjectVersionsResource resource = new SubjectVersionsResource(schemaRegistry);
+    Schema result = resource.getSchemaByVersion(
+        "widgets-value", "1", "logical", "", false, null);
+
+    assertTrue(result.getSchema().contains("id"));
+    assertTrue(result.getSchema().contains("name"));
+    // Not the raw Avro string any more -- it went through the DDL converter.
+    assertTrue(!result.getSchema().contains("\"type\":\"record\""));
+  }
+
+  @Test
+  void getSchemaByVersionLeavesSchemaAloneWithNoFormat() throws Exception {
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    when(schemaRegistry.tenant()).thenReturn(QualifiedSubject.DEFAULT_TENANT);
+    Schema schema = schemaEntity();
+    when(schemaRegistry.getUsingContexts("widgets-value", 1, false)).thenReturn(schema);
+
+    SubjectVersionsResource resource = new SubjectVersionsResource(schemaRegistry);
+    Schema result = resource.getSchemaByVersion(
+        "widgets-value", "1", "", "", false, null);
+
+    assertEquals(AVRO_SCHEMA_STRING, result.getSchema());
+    // format=logical's conversion path must not run at all when format is empty.
+    verify(schemaRegistry, never()).parseSchema(eq(schema), anyBoolean(), anyBoolean());
+  }
+
+  @Test
+  void getSchemaByVersionStillHonorsExistingFormatValues() throws Exception {
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    when(schemaRegistry.tenant()).thenReturn(QualifiedSubject.DEFAULT_TENANT);
+    Schema schema = schemaEntity();
+    when(schemaRegistry.getUsingContexts("widgets-value", 1, false)).thenReturn(schema);
+    ParsedSchema parsedSchema = new AvroSchema(AVRO_SCHEMA_STRING);
+    when(schemaRegistry.parseSchema(schema, false, false)).thenReturn(parsedSchema);
+
+    SubjectVersionsResource resource = new SubjectVersionsResource(schemaRegistry);
+    Schema result = resource.getSchemaByVersion(
+        "widgets-value", "1", "resolved", "", false, null);
+
+    // Existing format values still go through the ordinary formattedString path, unaffected by
+    // the new branch -- "resolved" isn't a recognized Avro format value, so it falls back to
+    // canonicalString(), same as before this change.
+    assertEquals(parsedSchema.canonicalString(), result.getSchema());
+    verify(schemaRegistry, times(1)).parseSchema(schema, false, false);
+  }
+
+  private static Schema schemaEntity() {
+    return new Schema(
+        "widgets-value", 1, 1, null, "AVRO", Collections.emptyList(), null, null,
+        AVRO_SCHEMA_STRING);
+  }
+}

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelExecutorIntegrationTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelExecutorIntegrationTest.java
@@ -1,17 +1,16 @@
 /*
  * Copyright 2023 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.kafka.schemaregistry.rules.cel;

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rules/jsonata/JsonataExecutorIntegrationTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rules/jsonata/JsonataExecutorIntegrationTest.java
@@ -1,17 +1,16 @@
 /*
  * Copyright 2023 Confluent Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.confluent.io/confluent-community-license
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 
 package io.confluent.kafka.schemaregistry.rules.jsonata;

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistryLogicalPolicyTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistryLogicalPolicyTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.storage;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.ParsedSchemaHolder;
+import io.confluent.kafka.schemaregistry.SimpleParsedSchemaHolder;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Config;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the {@code CompatibilityPolicy.LOGICAL} branch inside
+ * {@link AbstractSchemaRegistry#isCompatibleWithPrevious} -- that the logical checks run only under
+ * that policy and are layered additively on top of the native compatibility check.
+ *
+ * <p>Uses {@code CALLS_REAL_METHODS} to exercise the real method body while bypassing the registry
+ * constructor, the pattern established by {@code AbstractSchemaRegistryNullEncoderTest}.
+ */
+class AbstractSchemaRegistryLogicalPolicyTest {
+
+  // old has a field that new drops. Native Avro treats a field removal as backward-compatible,
+  // but the logical Iceberg check rejects FIELD_DELETED -- so this pair isolates the additive
+  // logical behavior from the native check.
+  private static final String RECORD_A_B =
+      "{\"type\":\"record\",\"name\":\"R\",\"fields\":["
+          + "{\"name\":\"a\",\"type\":\"int\"},"
+          + "{\"name\":\"b\",\"type\":\"int\"}]}";
+  private static final String RECORD_A =
+      "{\"type\":\"record\",\"name\":\"R\",\"fields\":["
+          + "{\"name\":\"a\",\"type\":\"int\"}]}";
+
+  private static List<String> check(String policy, ParsedSchema newSchema,
+      List<ParsedSchemaHolder> previous) {
+    AbstractSchemaRegistry registry = mock(AbstractSchemaRegistry.class, CALLS_REAL_METHODS);
+    Config config = new Config();
+    config.setCompatibilityLevel("BACKWARD");
+    config.setCompatibilityPolicy(policy);
+    return registry.isCompatibleWithPrevious(config, newSchema, previous);
+  }
+
+  @Test
+  void logicalPolicyRunsTheLogicalChecks() {
+    List<String> errors = check(
+        "LOGICAL",
+        new AvroSchema(RECORD_A),
+        List.of(new SimpleParsedSchemaHolder(new AvroSchema(RECORD_A_B))));
+    assertTrue(errors.stream().anyMatch(e -> e.contains("Logical")),
+        "expected a logical finding under LOGICAL policy: " + errors);
+  }
+
+  @Test
+  void nonLogicalPolicyDoesNotRunTheLogicalChecks() {
+    List<String> errors = check(
+        "STRICT",
+        new AvroSchema(RECORD_A),
+        List.of(new SimpleParsedSchemaHolder(new AvroSchema(RECORD_A_B))));
+    assertTrue(errors.stream().noneMatch(e -> e.contains("Logical")),
+        "logical checks must not run unless policy is LOGICAL: " + errors);
+  }
+
+  @Test
+  void logicalPolicyPassesAValidCompatibleSchema() {
+    // Identical schema, so both native and logical see no change.
+    List<String> errors = check(
+        "LOGICAL",
+        new AvroSchema(RECORD_A_B),
+        List.of(new SimpleParsedSchemaHolder(new AvroSchema(RECORD_A_B))));
+    assertFalse(errors.stream().anyMatch(e -> e.contains("Logical")), errors.toString());
+  }
+}

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/LogicalPolicyCheckerTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/LogicalPolicyCheckerTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.confluent.kafka.schemaregistry.CompatibilityLevel;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.ParsedSchemaHolder;
+import io.confluent.kafka.schemaregistry.SimpleParsedSchemaHolder;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LogicalPolicyCheckerTest {
+
+  // A struct with one field.
+  private static final String RECORD_A =
+      "{\"type\":\"record\",\"name\":\"R\",\"fields\":["
+          + "{\"name\":\"a\",\"type\":\"int\"}]}";
+
+  // Adds a second required field (no default) relative to RECORD_A -> REQUIRED_FIELD_ADDED.
+  private static final String RECORD_A_B =
+      "{\"type\":\"record\",\"name\":\"R\",\"fields\":["
+          + "{\"name\":\"a\",\"type\":\"int\"},"
+          + "{\"name\":\"b\",\"type\":\"int\"}]}";
+
+  // An empty record -> derives to an empty struct, which is invalid under Iceberg (EMPTY_STRUCT).
+  private static final String EMPTY_RECORD =
+      "{\"type\":\"record\",\"name\":\"E\",\"fields\":[]}";
+
+  private static ParsedSchemaHolder holder(String avro) {
+    return new SimpleParsedSchemaHolder(new AvroSchema(avro));
+  }
+
+  // -- toLogicalType ------------------------------------------------------------------------------
+
+  @Test
+  void toLogicalTypeConvertsAvro() {
+    assertTrue(LogicalPolicyChecker.toLogicalType(new AvroSchema(RECORD_A)) != null);
+  }
+
+  @Test
+  void toLogicalTypeRejectsUnknownSchemaType() {
+    ParsedSchema unknown = mock(ParsedSchema.class);
+    when(unknown.schemaType()).thenReturn("XML");
+    assertThrows(IllegalArgumentException.class,
+        () -> LogicalPolicyChecker.toLogicalType(unknown));
+  }
+
+  // -- validity runs regardless of level / previous versions -------------------------------------
+
+  @Test
+  void validityRunsOnFirstRegistrationWithNoPreviousVersions() {
+    List<String> errors = LogicalPolicyChecker.check(
+        new AvroSchema(EMPTY_RECORD), List.of(), CompatibilityLevel.NONE);
+    assertFalse(errors.isEmpty(), "empty struct should fail Iceberg validity even with no previous");
+    assertTrue(errors.stream().anyMatch(e -> e.contains("validity")));
+  }
+
+  @Test
+  void validSchemaWithNoPreviousPasses() {
+    List<String> errors = LogicalPolicyChecker.check(
+        new AvroSchema(RECORD_A), List.of(), CompatibilityLevel.NONE);
+    assertTrue(errors.isEmpty(), errors.toString());
+  }
+
+  // -- compatibility ------------------------------------------------------------------------------
+
+  @Test
+  void backwardReportsRequiredFieldAdded() {
+    List<String> errors = LogicalPolicyChecker.check(
+        new AvroSchema(RECORD_A_B), List.of(holder(RECORD_A)), CompatibilityLevel.BACKWARD);
+    assertFalse(errors.isEmpty());
+    assertTrue(errors.stream().anyMatch(e -> e.contains("compatibility") && e.contains("backward")),
+        errors.toString());
+  }
+
+  @Test
+  void noneSkipsCompatibilityButKeepsValidity() {
+    // Same incompatible pair, but level NONE -> no compatibility error, and RECORD_A_B is valid.
+    List<String> errors = LogicalPolicyChecker.check(
+        new AvroSchema(RECORD_A_B), List.of(holder(RECORD_A)), CompatibilityLevel.NONE);
+    assertTrue(errors.isEmpty(), errors.toString());
+  }
+
+  @Test
+  void backwardLabelsDirectionBackward() {
+    List<String> errors = LogicalPolicyChecker.check(
+        new AvroSchema(RECORD_A_B), List.of(holder(RECORD_A)), CompatibilityLevel.BACKWARD);
+    assertTrue(errors.stream().allMatch(e -> !e.contains("forward")), errors.toString());
+    assertTrue(errors.stream().anyMatch(e -> e.contains("backward")), errors.toString());
+  }
+
+  @Test
+  void forwardLabelsDirectionForward() {
+    List<String> errors = LogicalPolicyChecker.check(
+        new AvroSchema(RECORD_A_B), List.of(holder(RECORD_A)), CompatibilityLevel.FORWARD);
+    assertTrue(errors.stream().anyMatch(e -> e.contains("forward")), errors.toString());
+  }
+
+  @Test
+  void fullChecksBothDirections() {
+    List<String> errors = LogicalPolicyChecker.check(
+        new AvroSchema(RECORD_A_B), List.of(holder(RECORD_A)), CompatibilityLevel.FULL);
+    assertTrue(errors.stream().anyMatch(e -> e.contains("backward")), errors.toString());
+    assertTrue(errors.stream().anyMatch(e -> e.contains("forward")), errors.toString());
+  }
+
+  // -- transitivity: which previous versions are compared ----------------------------------------
+
+  @Test
+  void nonTransitiveComparesLatestOnly() {
+    // old (index 0) lacks b; latest (index 1) already has b, as does new -> compatible with latest.
+    // Non-transitive should only compare against latest and find nothing.
+    List<ParsedSchemaHolder> previous = List.of(holder(RECORD_A), holder(RECORD_A_B));
+    List<String> errors = LogicalPolicyChecker.check(
+        new AvroSchema(RECORD_A_B), previous, CompatibilityLevel.BACKWARD);
+    assertTrue(errors.isEmpty(), errors.toString());
+  }
+
+  @Test
+  void transitiveComparesAllPreviousVersions() {
+    // Same lists, but transitive should also compare against the older version (index 0), which is
+    // missing b -> REQUIRED_FIELD_ADDED.
+    List<ParsedSchemaHolder> previous = List.of(holder(RECORD_A), holder(RECORD_A_B));
+    List<String> errors = LogicalPolicyChecker.check(
+        new AvroSchema(RECORD_A_B), previous, CompatibilityLevel.BACKWARD_TRANSITIVE);
+    assertFalse(errors.isEmpty());
+    assertTrue(errors.stream().anyMatch(e -> e.contains("compatibility")), errors.toString());
+  }
+
+  // -- conversion failures ------------------------------------------------------------------------
+
+  @Test
+  void unconvertibleNewSchemaIsRejected() {
+    ParsedSchema unconvertible = mock(ParsedSchema.class);
+    when(unconvertible.schemaType()).thenReturn("XML");
+    List<String> errors = LogicalPolicyChecker.check(
+        unconvertible, List.of(), CompatibilityLevel.BACKWARD);
+    assertEquals(1, errors.size());
+    assertTrue(errors.get(0).contains("cannot be represented as a logical type"), errors.toString());
+  }
+
+  @Test
+  void unconvertiblePreviousSchemaIsSkippedNotFatal() {
+    ParsedSchema unconvertiblePrev = mock(ParsedSchema.class);
+    when(unconvertiblePrev.schemaType()).thenReturn("XML");
+    // New schema is valid; the only previous version can't be converted -> its comparison is
+    // skipped, so nothing is reported.
+    List<String> errors = LogicalPolicyChecker.check(
+        new AvroSchema(RECORD_A),
+        List.of(new SimpleParsedSchemaHolder(unconvertiblePrev)),
+        CompatibilityLevel.BACKWARD);
+    assertTrue(errors.isEmpty(), errors.toString());
+  }
+}

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
@@ -637,11 +637,15 @@ public class AvroToLogicalTypeConverter {
   }
 
   /**
-   * The {@code flink.precision} annotation, if the schema carries one.
+   * The {@code flink.precision} annotation, if the schema carries one and it is a JSON number.
+   * A non-numeric value (e.g. hand-authored as a string) is treated as absent rather than
+   * throwing {@link ClassCastException}.
    */
   private static Optional<Integer> annotatedPrecision(final org.apache.avro.Schema avroSchema) {
-    return Optional.ofNullable(avroSchema.getObjectProp(CommonConstants.FLINK_PRECISION))
-        .map(i -> (Integer) i);
+    final Object annotated = avroSchema.getObjectProp(CommonConstants.FLINK_PRECISION);
+    return annotated instanceof Number
+        ? Optional.of(((Number) annotated).intValue())
+        : Optional.empty();
   }
 
   /**
@@ -695,10 +699,7 @@ public class AvroToLogicalTypeConverter {
       org.apache.avro.Schema avroSchema, boolean isNullable) {
     // Unguarded: this is the widest TIME carrier, so the writer has to use it for any precision
     // above 6. See resolvePrecision.
-    final int precision =
-        Optional.ofNullable(avroSchema.getObjectProp(CommonConstants.FLINK_PRECISION))
-            .map(i -> (Integer) i)
-            .orElse(6);
+    final int precision = annotatedPrecision(avroSchema).orElse(6);
     return Schema.createTime(precision).setNullable(isNullable);
   }
 

--- a/protobuf-serializer/pom.xml
+++ b/protobuf-serializer/pom.xml
@@ -60,19 +60,6 @@
             <version>${io.confluent.schema-registry.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-schema-registry</artifactId>
-            <version>${io.confluent.schema-registry.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-schema-registry</artifactId>
-            <version>${io.confluent.schema-registry.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
             <scope>provided</scope>

--- a/schema-rules/pom.xml
+++ b/schema-rules/pom.xml
@@ -68,19 +68,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-schema-registry</artifactId>
-            <version>${io.confluent.schema-registry.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>kafka-schema-registry</artifactId>
-            <version>${io.confluent.schema-registry.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${kafka.scala.version}</artifactId>
             <classifier>test</classifier>
@@ -159,6 +146,19 @@
             <plugin>
                 <groupId>io.github.ascopes</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <phase>test-compile</phase>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Builds on #4469 (which added `LogicalTypeChecker`) to wire logical types into the registration path. Three user-facing capabilities:                                              
                                                                                                                                                                                    
  1. **`?format=logical`** on register/lookup — register a schema authored as a logical-type (converted to native Avro/Protobuf/JSON before storage) and retrieve any stored      
  native schema rendered back as a logical type. Storage stays native; the conversion is a boundary transform, so a subject's history can freely mix logical- and native-registered    
  versions.                                

**UPDATE**: `?format=logical` no longer used for input on register. See https://github.com/confluentinc/schema-registry/pull/4543
                                                                                                                                         
  2. **`CompatibilityPolicy.LOGICAL`** — when a subject's policy is `LOGICAL`, registration additionally runs the Flink and Iceberg (`Mode.FLINK` + `Mode.ICEBERG_V2`) logical      
  validity and compatibility checks. These are **additive**: the native format-specific check still runs, so `LOGICAL` can only make registration stricter.                         
  3. **`?force=true`** on register — skips the compatibility checks (both native and logical) outside IMPORT mode, mirroring how IMPORT already bypasses them.                      
                                                                                                                                                                                    
  ## Brief change log                                                                                                                                                               
                                                                                                                                                                                    
  - **`LogicalFormat`** (new) — converts between logical types and native schemas for `format=logical`; reuses the extracted `AbstractSchemaProvider.resolveReferences` so            
  parent-context qualification and transitive reference resolution match native registration exactly.                                                                               
  - **`LogicalPolicyChecker`** (new) — runs `LogicalTypeChecker` validity/compatibility for `LOGICAL` policy; validity runs on every registration (including the first),            
  compatibility respects the configured level's transitivity and direction. An unconvertible *previous* version is skipped; an unconvertible *new* schema is rejected.              
  - **`AbstractSchemaRegistry.isCompatibleWithPrevious`** — appends logical findings to the existing error list under `LOGICAL` policy, flowing into the existing                   
  `IncompatibleSchemaException`.                                                                                                                                                    
  - **`force`** threaded through `SubjectVersionsResource` → `SchemaRegistry`/`AbstractSchemaRegistry`/`KafkaSchemaRegistry` → `RestService` (for leader-forwarding), guarding the  
  compatibility block. Public interface and `RestService` changes are additive overloads (`force=false` defaults).                                                                  
  - **`AbstractSchemaProvider.resolveReferences`** refactored to a reusable `static` method (also fixes reference resolution for `format=logical` to include parent-context         
  qualification and the full transitive closure).                                                                                                                                   
  - **Dependency restructure** — `core` now depends on `logical-types`. To break the resulting reactor cycle (`core → logical-types → kafka-schema-rules → core`), three            
  `ClusterTestHarness` integration tests moved from `schema-rules`/`protobuf-serializer` into `core` (their only cross-module dependency), with corresponding pom changes.          
  - **Bug fix** — `AvroToLogicalTypeConverter` no longer throws `ClassCastException` when `flink.precision` is authored as a non-integer JSON value; falls back to the default      
  precision.                                                                                                                                                                        
                
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[Y]** Is this change gated behind config(s)?
    - `PUT /config` with `{ "compatibilityPolicy": "LOGICAL" }`
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
