### PR TITLE
Throttle leader-elector poll-loop ERROR logging on persistent failure

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/KafkaGroupLeaderElector.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/KafkaGroupLeaderElector.java
@@ -65,6 +65,9 @@ public class KafkaGroupLeaderElector implements LeaderElector, SchemaRegistryReb
   private static final AtomicInteger SR_CLIENT_ID_SEQUENCE = new AtomicInteger(1);
   private static final String JMX_PREFIX = "kafka.schema.registry";
 
+  // Re-log a persistent poll failure at most once per this window (see runPollLoop).
+  private static final long ERROR_LOG_THROTTLE_MS = 30_000L;
+
   private final int initTimeout;
   private final String clientId;
   private final ConsumerNetworkClient client;
@@ -238,7 +241,12 @@ public class KafkaGroupLeaderElector implements LeaderElector, SchemaRegistryReb
    * error code: 50002"} until a JVM restart. See upstream issues #1696, #2492, #3135,
    * #3910.
    *
-   * <p>Package-private and static so it can be exercised in isolation by unit tests.
+   * <p>The ERROR is throttled to avoid ~10 lines/s at the default {@code retry.backoff.ms=100}:
+   * the first failure logs immediately, then re-logs at most once per {@code errorLogThrottleMs};
+   * a successful poll logs one INFO recovery line and resets.
+   *
+   * <p>Package-private/static for unit testing; the {@code errorLogThrottleMs} overload drives
+   * the throttle deterministically.
    */
   static void runPollLoop(
       Runnable pollOnce,
@@ -246,16 +254,48 @@ public class KafkaGroupLeaderElector implements LeaderElector, SchemaRegistryReb
       long retryBackoffMs,
       Logger log
   ) {
+    runPollLoop(pollOnce, stopped, retryBackoffMs, ERROR_LOG_THROTTLE_MS, log);
+  }
+
+  static void runPollLoop(
+      Runnable pollOnce,
+      AtomicBoolean stopped,
+      long retryBackoffMs,
+      long errorLogThrottleMs,
+      Logger log
+  ) {
+    long consecutiveFailures = 0;
+    long firstFailureNanos = 0;
+    long lastErrorLogNanos = 0;
     while (!stopped.get()) {
       try {
         pollOnce.run();
+        if (consecutiveFailures > 0) {
+          log.info(
+              "Schema registry group processing thread recovered after {} consecutive failure(s)",
+              consecutiveFailures);
+          consecutiveFailures = 0;
+        }
       } catch (WakeupException we) {
         // do nothing because the thread is closing -- see stop()
         return;
       } catch (Throwable t) {
-        log.error(
-            "Unexpected exception in schema registry group processing thread; "
-            + "will retry after backoff", t);
+        consecutiveFailures++;
+        long now = System.nanoTime();
+        if (consecutiveFailures == 1) {
+          firstFailureNanos = now;
+          lastErrorLogNanos = now;
+          log.error(
+              "Unexpected exception in schema registry group processing thread; "
+              + "will retry after backoff", t);
+        } else if (now - lastErrorLogNanos >= TimeUnit.MILLISECONDS.toNanos(errorLogThrottleMs)) {
+          lastErrorLogNanos = now;
+          long elapsedMs = TimeUnit.NANOSECONDS.toMillis(now - firstFailureNanos);
+          log.error(
+              "Schema registry group processing thread still failing after {} consecutive "
+              + "attempts over {} ms; will keep retrying after backoff",
+              consecutiveFailures, elapsedMs, t);
+        }
         try {
           Thread.sleep(retryBackoffMs);
         } catch (InterruptedException ie) {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/KafkaGroupLeaderElectorPollLoopTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/leaderelector/kafka/KafkaGroupLeaderElectorPollLoopTest.java
@@ -17,6 +17,7 @@ package io.confluent.kafka.schemaregistry.leaderelector.kafka;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -24,6 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.kafka.common.errors.WakeupException;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -156,5 +158,112 @@ public class KafkaGroupLeaderElectorPollLoopTest {
     t.join(2_000);
     assertFalse(t.isAlive());
     assertTrue("loop should have made progress before being stopped", calls.get() > 0);
+  }
+
+  /** Persistent failure logs ERROR once while within the throttle window (flood guard). */
+  @Test(timeout = 10_000)
+  public void throttlesRepeatedErrorLogsOnPersistentFailure() throws Exception {
+    Logger mockLog = mock(Logger.class);
+    AtomicInteger calls = new AtomicInteger();
+
+    Runnable alwaysThrows = () -> {
+      calls.incrementAndGet();
+      throw new IllegalStateException("simulated persistent failure");
+    };
+
+    AtomicBoolean stopped = new AtomicBoolean(false);
+    Thread t = new Thread(() -> KafkaGroupLeaderElector.runPollLoop(
+        alwaysThrows, stopped, /* retryBackoffMs */ 20L,
+        /* errorLogThrottleMs */ 30_000L, mockLog), "test-poll-loop-throttle");
+    t.setDaemon(true);
+    t.start();
+
+    Thread.sleep(400);
+    stopped.set(true);
+    t.join(2_000);
+    assertFalse(t.isAlive());
+
+    assertTrue("loop should have retried many times, got " + calls.get(), calls.get() >= 3);
+    assertEqualsLong("only the first failure should log ERROR within the throttle window",
+        1L, countCalls(mockLog, "error"));
+  }
+
+  /** Past the throttle window, ERROR re-emits as a heartbeat, but far below one per retry. */
+  @Test(timeout = 10_000)
+  public void emitsErrorHeartbeatAfterThrottleWindow() throws Exception {
+    Logger mockLog = mock(Logger.class);
+    AtomicInteger calls = new AtomicInteger();
+
+    Runnable alwaysThrows = () -> {
+      calls.incrementAndGet();
+      throw new IllegalStateException("simulated persistent failure");
+    };
+
+    AtomicBoolean stopped = new AtomicBoolean(false);
+    Thread t = new Thread(() -> KafkaGroupLeaderElector.runPollLoop(
+        alwaysThrows, stopped, /* retryBackoffMs */ 10L,
+        /* errorLogThrottleMs */ 50L, mockLog), "test-poll-loop-heartbeat");
+    t.setDaemon(true);
+    t.start();
+
+    Thread.sleep(400);
+    stopped.set(true);
+    t.join(2_000);
+    assertFalse(t.isAlive());
+
+    long errors = countCalls(mockLog, "error");
+    assertTrue("expected more than one ERROR (heartbeat), got " + errors, errors >= 2);
+    assertTrue("ERROR logs (" + errors + ") should stay well below retry count ("
+        + calls.get() + ")", errors < calls.get());
+  }
+
+  /** Recovery logs one INFO and resets, so a later failure episode logs a fresh ERROR. */
+  @Test(timeout = 10_000)
+  public void logsRecoveryAndResetsFailureCountOnSuccess() throws Exception {
+    Logger mockLog = mock(Logger.class);
+    AtomicInteger calls = new AtomicInteger();
+    CountDownLatch reachedSeventhCall = new CountDownLatch(7);
+
+    Runnable pollOnce = () -> {
+      int n = calls.incrementAndGet();
+      reachedSeventhCall.countDown();
+      // Two single-failure episodes (n==1, n==5), each immediately recovered.
+      if (n == 1 || n == 5) {
+        throw new IllegalStateException("simulated transient failure");
+      }
+      try {
+        Thread.sleep(5);
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+      }
+    };
+
+    AtomicBoolean stopped = new AtomicBoolean(false);
+    Thread t = new Thread(() -> KafkaGroupLeaderElector.runPollLoop(
+        pollOnce, stopped, /* retryBackoffMs */ 10L,
+        /* errorLogThrottleMs */ 30_000L, mockLog), "test-poll-loop-recovery");
+    t.setDaemon(true);
+    t.start();
+
+    assertTrue("loop should reach the second failure episode and recover",
+        reachedSeventhCall.await(5, TimeUnit.SECONDS));
+    stopped.set(true);
+    t.join(2_000);
+    assertFalse(t.isAlive());
+
+    assertEqualsLong("each failure episode should log exactly one ERROR",
+        2L, countCalls(mockLog, "error"));
+    assertEqualsLong("each recovery should log exactly one INFO",
+        2L, countCalls(mockLog, "info"));
+  }
+
+  private static long countCalls(Logger log, String method) {
+    return Mockito.mockingDetails(log).getInvocations().stream()
+        .filter(inv -> inv.getMethod().getName().equals(method))
+        .count();
+  }
+
+  private static void assertEqualsLong(String message, long expected, long actual) {
+    assertTrue(message + " (expected " + expected + ", got " + actual + ")", expected == actual);
   }
 }


### PR DESCRIPTION
## What

Throttle the ERROR logging in `KafkaGroupLeaderElector.runPollLoop` so a persistently failing elector no longer floods the log.

## Why

`runPollLoop` (added in #4478 so the elector survives a transient `poll` exception instead of dying) catches `Throwable`, logs at ERROR, and sleeps `retryBackoffMs` before retrying. `retryBackoffMs` is `retry.backoff.ms`, default **100 ms**, so a persistently failing `coordinator.poll` emits roughly **10 ERROR lines per second per pod — ~600/min — indefinitely**. The survival fix is correct and stays; only the log volume is the problem.

## What changed

Time-based ERROR throttle with a recovery signal (all state is loop-local; the loop's survival behavior is unchanged):

- **First failure of an episode** → ERROR immediately, with the full stack trace (the wedge is still announced loudly the moment it starts).
- **While it keeps failing** → re-log ERROR **at most once per 30 s** as a heartbeat that carries the consecutive-failure count and elapsed time — so an "up but can't elect a leader" pod stays visible/alertable, at ~2 ERROR/min instead of ~600/min.
- **On recovery** (a `poll` succeeds) → one INFO recovery line, and the episode resets so a later failure re-alarms immediately.

A package-private `errorLogThrottleMs` overload is added so tests can drive the throttle window deterministically; the production caller uses the 30 s default.

This reaches every SR deployment (including on-prem), same as #4478. No config flag — it is a strict log-volume reduction with no behavioral change to election.

## Testing

`KafkaGroupLeaderElectorPollLoopTest` — 3 new tests (written test-first, watched fail, then pass), alongside the 4 existing ones:

- `throttlesRepeatedErrorLogsOnPersistentFailure` — persistent failure over the run emits exactly **one** ERROR within the throttle window (regression guard for the flood).
- `emitsErrorHeartbeatAfterThrottleWindow` — with a small window, ERRORs re-emit (> 1) yet stay well below one-per-retry.
- `logsRecoveryAndResetsFailureCountOnSuccess` — two failure episodes each log one ERROR and one recovery INFO, proving the reset.

```
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
```

`mvn -pl core checkstyle:check` passes.

## Notes

- Base branch is `7.8.x` to match #4478 and ride the forward-merge to newer branches.
- Out of scope (unchanged from #4478, matching the review thread): the retry backoff itself, any attempt cap, and `catch (Throwable)` still catching `Error`. A metric/counter for dashboard alerting can be a separate follow-up; the 30 s heartbeat keeps it log-alertable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
