### PR TITLE
DGS-25078 Propagate Avro aliases, Protobuf field nums to logical types

### DIFF
--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/Schema.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/Schema.java
@@ -651,12 +651,16 @@ public abstract class Schema {
 
     /**
      * The field's explicit Protobuf field number, or {@code null} when it is not recorded. The
-     * Protobuf reader records {@link Schema#PROTOBUF_FIELD_NUMBER} only when the number deviates
-     * from the positional default (the field's {@code position + 1}); when they coincide it is
-     * omitted, so {@code null} means "equal to {@code position + 1}", not "unknown". Callers that
-     * need the effective number should therefore read {@code getFieldNumber()} falling back to
-     * {@code position + 1}. A stable, format-agnostic read point for the rename/identity signal;
-     * the value's origin is Protobuf-specific but any {@code Field} can be asked.
+     * Protobuf reader records {@link Schema#PROTOBUF_FIELD_NUMBER} all-or-nothing per message: it
+     * records every field's number when the message's numbering is non-trivial, and records none
+     * when the numbers are exactly the sequence the writer reproduces positionally. So {@code null}
+     * means "the message was trivially sequential", not "unknown": the number is this field's
+     * ordinal (starting at 1) in the writer's regulars-then-oneofs emission order, which the writer
+     * re-derives on its own. Do <b>not</b> reconstruct it from {@link #getPosition()} — that is
+     * unreliable for a message containing a {@code oneof} (positions are duplicated/out of order),
+     * and oneof branches have no position at all. A stable, format-agnostic read point for the
+     * rename/identity signal; the value's origin is Protobuf-specific but any {@code Field} can be
+     * asked.
      */
     public Integer getFieldNumber() {
       return parseFieldNumber(params, name);

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/Schema.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/Schema.java
@@ -641,7 +641,15 @@ public abstract class Schema {
      */
     public Integer getFieldNumber() {
       Object v = params.get(PROTOBUF_FIELD_NUMBER);
-      return v == null ? null : Integer.valueOf(v.toString());
+      if (v == null) {
+        return null;
+      }
+      try {
+        return Integer.valueOf(v.toString());
+      } catch (NumberFormatException e) {
+        throw new ValidationException("Field '" + name + "' has a non-numeric "
+            + PROTOBUF_FIELD_NUMBER + " param: '" + v + "'");
+      }
     }
 
     /**

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/Schema.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/Schema.java
@@ -17,6 +17,7 @@
 package io.confluent.kafka.schemaregistry.type.logical;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -33,6 +34,63 @@ public abstract class Schema {
   public static final int DEFAULT_DECIMAL_SCALE = 0;
   public static final int DEFAULT_TIME_PRECISION = 0;
   public static final int DEFAULT_TIMESTAMP_PRECISION = 6;
+
+  /**
+   * Reserved {@code params} key carrying a field's Protobuf field number, populated by the
+   * Protobuf reader from {@code FieldDescriptor.getNumber()}. Read via
+   * {@link Field#getFieldNumber()}. Part of the {@code protobuf.} format-native reserved namespace:
+   * it mirrors a Protobuf-native slot (the field number) that the LT type system has no home for,
+   * so it is emitted through that native slot and stripped from any generic param container. See
+   * {@link #isFormatNativeParam(String)}.
+   */
+  public static final String PROTOBUF_FIELD_NUMBER = "protobuf.field.number";
+
+  /**
+   * Reserved {@code params} key carrying a field's Avro aliases (its previous names) as a
+   * comma-delimited string, populated by the Avro reader from {@code Schema.Field.aliases()}.
+   * Read via {@link Field#getAliases()}. Avro field names cannot contain commas, so the delimiter
+   * is unambiguous. Part of the {@code avro.} format-native reserved namespace: it mirrors an
+   * Avro-native slot (aliases) that the LT type system has no home for, so it is emitted through
+   * that native slot and stripped from any generic param container. See
+   * {@link #isFormatNativeParam(String)}.
+   */
+  public static final String AVRO_ALIASES = "avro.aliases";
+
+  /**
+   * True if {@code key} belongs to a format-native reserved param namespace ({@code avro.} or
+   * {@code protobuf.}). Such params are authoritative only through their owning format's native
+   * slot (Avro aliases, Protobuf field number); in every generic param container
+   * ({@code confluent:params}, Protobuf {@code field_meta.params}) they are stripped on write and
+   * ignored on read. They enter and leave the LT param map only via the owning format's native
+   * slot or via a DDL {@code WITH} clause. This is distinct from the {@code logical.} /
+   * {@code connect.} / {@code flink.} namespaces, whose values are absorbed into the LT
+   * type/structure and never persist as LT params.
+   */
+  public static boolean isFormatNativeParam(String key) {
+    return key.startsWith("avro.") || key.startsWith("protobuf.");
+  }
+
+  /**
+   * Return {@code params} with every {@linkplain #isFormatNativeParam format-native} key removed,
+   * or the same map unchanged when it contains none. Used by the format writers/readers to keep
+   * their generic param containers ({@code confluent:params}, Protobuf {@code field_meta.params})
+   * free of keys that are authoritative only through a native slot.
+   */
+  public static Map<String, Object> stripFormatNativeParams(Map<String, Object> params) {
+    boolean any = false;
+    for (String key : params.keySet()) {
+      if (isFormatNativeParam(key)) {
+        any = true;
+        break;
+      }
+    }
+    if (!any) {
+      return params;
+    }
+    Map<String, Object> copy = new LinkedHashMap<>(params);
+    copy.keySet().removeIf(Schema::isFormatNativeParam);
+    return copy;
+  }
 
   public enum Type {
     STRUCT, ENUM, UNION, MAP, ARRAY, MULTISET,
@@ -570,6 +628,37 @@ public abstract class Schema {
 
     public Map<String, Object> getParams() {
       return params;
+    }
+
+    /**
+     * The field's explicit Protobuf field number, or {@code null} when it is not recorded. The
+     * Protobuf reader records {@link Schema#PROTOBUF_FIELD_NUMBER} only when the number deviates
+     * from the positional default (the field's {@code position + 1}); when they coincide it is
+     * omitted, so {@code null} means "equal to {@code position + 1}", not "unknown". Callers that
+     * need the effective number should therefore read {@code getFieldNumber()} falling back to
+     * {@code position + 1}. A stable, format-agnostic read point for the rename/identity signal;
+     * the value's origin is Protobuf-specific but any {@code Field} can be asked.
+     */
+    public Integer getFieldNumber() {
+      Object v = params.get(PROTOBUF_FIELD_NUMBER);
+      return v == null ? null : Integer.valueOf(v.toString());
+    }
+
+    /**
+     * The field's Avro aliases (its previous names), or an empty list if the field did not
+     * originate from an Avro schema carrying aliases (only the Avro reader populates
+     * {@link Schema#AVRO_ALIASES}). Stored comma-delimited; see {@link Schema#AVRO_ALIASES}.
+     */
+    public List<String> getAliases() {
+      Object v = params.get(AVRO_ALIASES);
+      if (v == null) {
+        return Collections.emptyList();
+      }
+      String s = v.toString();
+      if (s.isEmpty()) {
+        return Collections.emptyList();
+      }
+      return Collections.unmodifiableList(Arrays.asList(s.split(",")));
     }
 
     /**

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/Schema.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/Schema.java
@@ -92,6 +92,25 @@ public abstract class Schema {
     return copy;
   }
 
+  /**
+   * Parse the {@link #PROTOBUF_FIELD_NUMBER} param from {@code params}, or {@code null} if absent.
+   * Throws a {@link ValidationException} (not a raw {@code NumberFormatException}) on a non-numeric
+   * value, since this param is user-settable through a DDL {@code WITH} clause. {@code ownerName}
+   * names the field or branch for the error message.
+   */
+  static Integer parseFieldNumber(Map<String, Object> params, String ownerName) {
+    Object v = params.get(PROTOBUF_FIELD_NUMBER);
+    if (v == null) {
+      return null;
+    }
+    try {
+      return Integer.valueOf(v.toString());
+    } catch (NumberFormatException e) {
+      throw new ValidationException("'" + ownerName + "' has a non-numeric "
+          + PROTOBUF_FIELD_NUMBER + " param: '" + v + "'");
+    }
+  }
+
   public enum Type {
     STRUCT, ENUM, UNION, MAP, ARRAY, MULTISET,
     BOOLEAN,
@@ -640,16 +659,7 @@ public abstract class Schema {
      * the value's origin is Protobuf-specific but any {@code Field} can be asked.
      */
     public Integer getFieldNumber() {
-      Object v = params.get(PROTOBUF_FIELD_NUMBER);
-      if (v == null) {
-        return null;
-      }
-      try {
-        return Integer.valueOf(v.toString());
-      } catch (NumberFormatException e) {
-        throw new ValidationException("Field '" + name + "' has a non-numeric "
-            + PROTOBUF_FIELD_NUMBER + " param: '" + v + "'");
-      }
+      return parseFieldNumber(params, name);
     }
 
     /**
@@ -811,6 +821,15 @@ public abstract class Schema {
 
     public Map<String, Object> getParams() {
       return params;
+    }
+
+    /**
+     * The branch's explicit Protobuf field number (a oneof member is a Protobuf field), or
+     * {@code null} when not recorded. Populated by the Protobuf reader; see
+     * {@link Field#getFieldNumber()} for the recording contract.
+     */
+    public Integer getFieldNumber() {
+      return parseFieldNumber(params, name);
     }
 
     @Override

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
@@ -784,10 +784,21 @@ public class AvroToLogicalTypeConverter {
   @SuppressWarnings("unchecked")
   private static Map<String, Object> readFieldParams(org.apache.avro.Schema.Field field) {
     Object params = field.getObjectProp("confluent:params");
-    if (params instanceof Map) {
-      return new LinkedHashMap<>((Map<String, Object>) params);
+    Map<String, Object> result = params instanceof Map
+        ? new LinkedHashMap<>((Map<String, Object>) params)
+        : new LinkedHashMap<>();
+    // Format-native params are authoritative only through a native slot, never through a generic
+    // param container, so drop any that a hand-authored schema smuggled into confluent:params
+    // (both the Avro-owned avro.* and any foreign protobuf.*) before injecting the native aliases.
+    result.keySet().removeIf(Schema::isFormatNativeParam);
+    // Carry Avro field aliases as the reserved avro.aliases param, comma-delimited, so they survive
+    // into the SRLT and round-trip through DDL; the writer re-emits them as native Avro aliases.
+    // Field names cannot contain commas, so the delimiter is unambiguous.
+    Set<String> aliases = field.aliases();
+    if (aliases != null && !aliases.isEmpty()) {
+      result.put(Schema.AVRO_ALIASES, String.join(",", aliases));
     }
-    return Collections.emptyMap();
+    return result.isEmpty() ? Collections.emptyMap() : result;
   }
 
   @SuppressWarnings("unchecked")

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
@@ -534,6 +534,11 @@ public class AvroToLogicalTypeConverter {
           @SuppressWarnings("unchecked")
           Map<String, Object> hintParams = hint != null
               ? (Map<String, Object>) hint.get("params") : null;
+          // Drop any stray format-native key (e.g. a foreign protobuf.field.number) so it does not
+          // leak in through confluent:union; Avro owns no branch-level format-native concept.
+          if (hintParams != null) {
+            hintParams = Schema.stripFormatNativeParams(hintParams);
+          }
           branches.add(new UnionBranch(branchName, member.getSchema(), hintDoc, hintParams));
         }
         return Schema.createUnion(branches).setNullable(hasNull);

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/LogicalTypeToAvroConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/LogicalTypeToAvroConverter.java
@@ -306,9 +306,7 @@ public class LogicalTypeToAvroConverter {
             if (!field.getTags().isEmpty()) {
               avroField.addProp("confluent:tags", field.getTags());
             }
-            if (!field.getParams().isEmpty()) {
-              avroField.addProp("confluent:params", field.getParams());
-            }
+            addFieldAliasesAndParams(avroField, field);
             addFieldRules(avroField, field);
             if (field.getSchema().getType() == Schema.Type.UNION) {
               List<Map<String, Object>> unionMeta = new ArrayList<>();
@@ -483,9 +481,7 @@ public class LogicalTypeToAvroConverter {
         if (!field.getTags().isEmpty()) {
           avroField.addProp("confluent:tags", field.getTags());
         }
-        if (!field.getParams().isEmpty()) {
-          avroField.addProp("confluent:params", field.getParams());
-        }
+        addFieldAliasesAndParams(avroField, field);
         addFieldRules(avroField, field);
         if (fieldType.getType() == Schema.Type.UNION) {
           List<Map<String, Object>> unionMeta = new ArrayList<>();
@@ -600,6 +596,25 @@ public class LogicalTypeToAvroConverter {
   private static void addFieldRules(
       org.apache.avro.Schema.Field avroField, Field field) {
     addRulesProp(avroField::addProp, field.getRules());
+  }
+
+  /**
+   * Emit the field aliases carried in {@link Schema#AVRO_ALIASES} through the
+   * native Avro alias slot, and write the remaining user params as
+   * {@code confluent:params}. All format-native params ({@code avro.*} /
+   * {@code protobuf.*}) are stripped from the container: the Avro-owned aliases
+   * because they are emitted natively, and any foreign {@code protobuf.*} because
+   * a format-native param never belongs in a generic container.
+   */
+  private static void addFieldAliasesAndParams(
+      org.apache.avro.Schema.Field avroField, Field field) {
+    for (String alias : field.getAliases()) {
+      avroField.addAlias(alias);
+    }
+    Map<String, Object> userParams = Schema.stripFormatNativeParams(field.getParams());
+    if (!userParams.isEmpty()) {
+      avroField.addProp("confluent:params", userParams);
+    }
   }
 
   private static void addRulesProp(

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/LogicalTypeToAvroConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/LogicalTypeToAvroConverter.java
@@ -663,8 +663,11 @@ public class LogicalTypeToAvroConverter {
     if (branch.getDoc() != null) {
       entry.put("doc", branch.getDoc());
     }
-    if (!branch.getParams().isEmpty()) {
-      entry.put("params", branch.getParams());
+    // A oneof member's protobuf.field.number is format-native and has no Avro home, so keep it out
+    // of confluent:union just as regular field numbers are kept out of confluent:params.
+    Map<String, Object> branchParams = Schema.stripFormatNativeParams(branch.getParams());
+    if (!branchParams.isEmpty()) {
+      entry.put("params", branchParams);
     }
     return entry;
   }

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/JsonToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/JsonToLogicalTypeConverter.java
@@ -811,7 +811,14 @@ public class JsonToLogicalTypeConverter {
     Object params = jsonSchema.getUnprocessedProperties().get("confluent:params");
     if (params instanceof Map) {
       Map<String, Object> userParams = (Map<String, Object>) params;
-      return userParams.isEmpty() ? null : new LinkedHashMap<>(userParams);
+      if (userParams.isEmpty()) {
+        return null;
+      }
+      // JSON owns no format-native concept and has no native slot for one, so any avro./protobuf.
+      // key here is a stray in a generic container and is dropped (see Schema#isFormatNativeParam).
+      Map<String, Object> stripped =
+          Schema.stripFormatNativeParams(new LinkedHashMap<>(userParams));
+      return stripped.isEmpty() ? null : stripped;
     }
     return null;
   }

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/JsonToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/JsonToLogicalTypeConverter.java
@@ -651,6 +651,11 @@ public class JsonToLogicalTypeConverter {
         @SuppressWarnings("unchecked")
         Map<String, Object> branchParams = hint != null
             ? (Map<String, Object>) hint.get("params") : null;
+        // Drop any stray format-native key so a foreign protobuf.field.number cannot leak in
+        // through confluent:union; JSON owns no format-native concept.
+        if (branchParams != null) {
+          branchParams = Schema.stripFormatNativeParams(branchParams);
+        }
         Schema branchType = convertWithCycleDetection(
             subSchema, true, ctx, appendToList(indexPath, index));
         branches.add(new UnionBranch(branchName, branchType, branchDoc, branchParams));

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/LogicalTypeToJsonConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/LogicalTypeToJsonConverter.java
@@ -345,8 +345,11 @@ public class LogicalTypeToJsonConverter {
             if (!field.getTags().isEmpty()) {
               extendedProps.put("confluent:tags", field.getTags());
             }
-            if (!field.getParams().isEmpty()) {
-              extendedProps.put("confluent:params", field.getParams());
+            // JSON has no native slot for a format-native param, so strip avro.*/protobuf.* rather
+            // than emit them into confluent:params (see Schema#isFormatNativeParam).
+            Map<String, Object> fieldParams = Schema.stripFormatNativeParams(field.getParams());
+            if (!fieldParams.isEmpty()) {
+              extendedProps.put("confluent:params", fieldParams);
             }
             if (!field.getRules().isEmpty()) {
               extendedProps.put("confluent:rules", buildRulesWire(field.getRules()));

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/LogicalTypeToJsonConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/LogicalTypeToJsonConverter.java
@@ -410,8 +410,11 @@ public class LogicalTypeToJsonConverter {
           if (branch.getDoc() != null) {
             entry.put("doc", branch.getDoc());
           }
-          if (!branch.getParams().isEmpty()) {
-            entry.put("params", branch.getParams());
+          // JSON has no native slot for a branch's protobuf.field.number, so keep format-native
+          // keys out of confluent:union, mirroring the strip applied to regular field params.
+          Map<String, Object> branchParams = Schema.stripFormatNativeParams(branch.getParams());
+          if (!branchParams.isEmpty()) {
+            entry.put("params", branchParams);
           }
           unionMeta.add(entry);
         }

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/LogicalTypeToProtoConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/LogicalTypeToProtoConverter.java
@@ -602,12 +602,12 @@ public class LogicalTypeToProtoConverter {
     // would otherwise surface as an opaque DescriptorValidationException from FileDescriptor build.
     final Set<Integer> reservedNumbers = new LinkedHashSet<>();
     for (Field field : fields) {
-      if (field.getSchema().getType() != Schema.Type.UNION) {
-        Integer declared = field.getFieldNumber();
-        if (declared != null && !reservedNumbers.add(declared)) {
-          throw new ValidationException("Duplicate " + Schema.PROTOBUF_FIELD_NUMBER + " "
-              + declared + " in struct '" + rowName + "'");
+      if (field.getSchema().getType() == Schema.Type.UNION) {
+        for (UnionBranch branch : field.getSchema().getBranches()) {
+          reserveFieldNumber(branch.getFieldNumber(), reservedNumbers, rowName);
         }
+      } else {
+        reserveFieldNumber(field.getFieldNumber(), reservedNumbers, rowName);
       }
     }
     // Pass 2 (below) assigns numbers: an author-declared number is used as-is; an unnumbered field
@@ -628,6 +628,11 @@ public class LogicalTypeToProtoConverter {
         Schema unionSchema = field.getSchema();
         for (UnionBranch branch : unionSchema.getBranches()) {
           final FieldDescriptorProto.Builder fieldProtoBuilder;
+          // A oneof member is a Protobuf field: use its recorded number when present, else the next
+          // free number — same rule as a regular field.
+          final Integer branchDeclared = branch.getFieldNumber();
+          final int branchNumber = branchDeclared != null
+              ? branchDeclared : nextFieldNumber(numberCursor, reservedNumbers);
           // Proto3 oneof can't contain repeated/map fields. Composite branches
           // (ARRAY/MAP/MULTISET) must be wrapped in a single message field
           // regardless of nullability — fromField only wraps when nullable, so
@@ -637,7 +642,7 @@ public class LogicalTypeToProtoConverter {
                 branch.getSchema(),
                 branch.getName(),
                 branch.getDoc(),
-                nextFieldNumber(numberCursor, reservedNumbers),
+                branchNumber,
                 nestedRows,
                 dependencies,
                 ctx);
@@ -646,15 +651,17 @@ public class LogicalTypeToProtoConverter {
                 branch.getSchema(),
                 branch.getName(),
                 branch.getDoc(),
-                nextFieldNumber(numberCursor, reservedNumbers),
+                branchNumber,
                 nestedRows,
                 nestedEnums,
                 dependencies,
                 ctx);
           }
-          if (!branch.getParams().isEmpty()) {
+          // Strip the format-native number (emitted via the native slot) from the branch meta.
+          Map<String, Object> branchParams = Schema.stripFormatNativeParams(branch.getParams());
+          if (!branchParams.isEmpty()) {
             Map<String, String> stringParams = new LinkedHashMap<>();
-            branch.getParams().forEach((k, v) -> stringParams.put(k, String.valueOf(v)));
+            branchParams.forEach((k, v) -> stringParams.put(k, String.valueOf(v)));
             addMetaParams(fieldProtoBuilder, stringParams);
           }
           fieldProtoBuilder.setOneofIndex(oneofIndex);
@@ -1370,6 +1377,18 @@ public class LogicalTypeToProtoConverter {
       cursor[0]++;
     }
     return cursor[0]++;
+  }
+
+  /**
+   * Add an author-declared field number to the reserved set, rejecting a duplicate — an invalid
+   * proto that would otherwise surface as an opaque DescriptorValidationException. A {@code null}
+   * number (unnumbered field or branch) is ignored.
+   */
+  private static void reserveFieldNumber(Integer declared, Set<Integer> reserved, String rowName) {
+    if (declared != null && !reserved.add(declared)) {
+      throw new ValidationException("Duplicate " + Schema.PROTOBUF_FIELD_NUMBER + " "
+          + declared + " in struct '" + rowName + "'");
+    }
   }
 
   private static void addFieldTagsAndParams(

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/LogicalTypeToProtoConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/LogicalTypeToProtoConverter.java
@@ -54,6 +54,7 @@ import io.confluent.protobuf.type.Decimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.EnumSet;
@@ -596,7 +597,23 @@ public class LogicalTypeToProtoConverter {
     final List<DescriptorProto> nestedRows = new ArrayList<>();
     final List<EnumDescriptorProto> nestedEnums = new ArrayList<>();
     final List<Field> fields = schema.getFields();
-    int fieldNumber = 1;
+    // Pass 1: reserve every author-declared field number so unnumbered fields can be assigned
+    // around them, and reject a schema that declares the same number twice — an invalid proto that
+    // would otherwise surface as an opaque DescriptorValidationException from FileDescriptor build.
+    final Set<Integer> reservedNumbers = new LinkedHashSet<>();
+    for (Field field : fields) {
+      if (field.getSchema().getType() != Schema.Type.UNION) {
+        Integer declared = field.getFieldNumber();
+        if (declared != null && !reservedNumbers.add(declared)) {
+          throw new ValidationException("Duplicate " + Schema.PROTOBUF_FIELD_NUMBER + " "
+              + declared + " in struct '" + rowName + "'");
+        }
+      }
+    }
+    // Pass 2 (below) assigns numbers: an author-declared number is used as-is; an unnumbered field
+    // gets the next number not already reserved, so a positional fallback can never collide with an
+    // explicit number. The cursor is a 1-element array so nextFieldNumber can advance it.
+    final int[] numberCursor = {1};
 
     for (int i = 0; i < fields.size(); i++) {
       final Field field = fields.get(i);
@@ -620,7 +637,7 @@ public class LogicalTypeToProtoConverter {
                 branch.getSchema(),
                 branch.getName(),
                 branch.getDoc(),
-                fieldNumber++,
+                nextFieldNumber(numberCursor, reservedNumbers),
                 nestedRows,
                 dependencies,
                 ctx);
@@ -629,7 +646,7 @@ public class LogicalTypeToProtoConverter {
                 branch.getSchema(),
                 branch.getName(),
                 branch.getDoc(),
-                fieldNumber++,
+                nextFieldNumber(numberCursor, reservedNumbers),
                 nestedRows,
                 nestedEnums,
                 dependencies,
@@ -646,14 +663,11 @@ public class LogicalTypeToProtoConverter {
           builder.addField(fieldProtoBuilder.build());
         }
       } else {
-        // Emit the author-declared field number when present (the round-trip
-        // fidelity fix), otherwise fall back to positional numbering. The
-        // positional counter still advances per field so unnumbered fields
-        // keep today's behavior; collision handling between the two is left
-        // for a later pass.
+        // Emit the author-declared field number when present (the round-trip fidelity fix),
+        // otherwise assign the next number not reserved by an explicit one.
         final Integer declaredNumber = field.getFieldNumber();
-        final int effectiveNumber = declaredNumber != null ? declaredNumber : fieldNumber;
-        fieldNumber++;
+        final int effectiveNumber = declaredNumber != null
+            ? declaredNumber : nextFieldNumber(numberCursor, reservedNumbers);
         final FieldDescriptorProto.Builder fieldProtoBuilder =
             fromField(
                 field.getSchema(),
@@ -1343,6 +1357,19 @@ public class LogicalTypeToProtoConverter {
           .setExtension(MetaProto.enumMeta, metaBuilder.build())
           .build());
     }
+  }
+
+  /**
+   * Return the next positive field number not already reserved by an author-declared number,
+   * advancing {@code cursor} past it. Skipping reserved numbers guarantees a positional fallback
+   * never collides with an explicit number, and the monotonic cursor keeps successive fallbacks
+   * distinct.
+   */
+  private static int nextFieldNumber(int[] cursor, Set<Integer> reserved) {
+    while (reserved.contains(cursor[0])) {
+      cursor[0]++;
+    }
+    return cursor[0]++;
   }
 
   private static void addFieldTagsAndParams(

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/LogicalTypeToProtoConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/LogicalTypeToProtoConverter.java
@@ -646,12 +646,20 @@ public class LogicalTypeToProtoConverter {
           builder.addField(fieldProtoBuilder.build());
         }
       } else {
+        // Emit the author-declared field number when present (the round-trip
+        // fidelity fix), otherwise fall back to positional numbering. The
+        // positional counter still advances per field so unnumbered fields
+        // keep today's behavior; collision handling between the two is left
+        // for a later pass.
+        final Integer declaredNumber = field.getFieldNumber();
+        final int effectiveNumber = declaredNumber != null ? declaredNumber : fieldNumber;
+        fieldNumber++;
         final FieldDescriptorProto.Builder fieldProtoBuilder =
             fromField(
                 field.getSchema(),
                 field.getName(),
                 field.getDoc(),
-                fieldNumber++,
+                effectiveNumber,
                 nestedRows,
                 nestedEnums,
                 dependencies,
@@ -1339,7 +1347,11 @@ public class LogicalTypeToProtoConverter {
 
   private static void addFieldTagsAndParams(
       FieldDescriptorProto.Builder builder, Field field) {
-    if (field.getTags().isEmpty() && field.getParams().isEmpty()
+    // Format-native params are carried through native slots (the field number via
+    // FieldDescriptorProto.number), never through the field meta params, so strip them here:
+    // protobuf.* because it is emitted natively, avro.* because it is foreign to proto.
+    Map<String, Object> userParams = Schema.stripFormatNativeParams(field.getParams());
+    if (field.getTags().isEmpty() && userParams.isEmpty()
         && field.getRules().isEmpty()) {
       return;
     }
@@ -1347,9 +1359,9 @@ public class LogicalTypeToProtoConverter {
     if (!field.getTags().isEmpty()) {
       metaBuilder.addAllTags(field.getTags());
     }
-    if (!field.getParams().isEmpty()) {
+    if (!userParams.isEmpty()) {
       Map<String, String> stringParams = new LinkedHashMap<>();
-      field.getParams().forEach((k, v) -> stringParams.put(k, String.valueOf(v)));
+      userParams.forEach((k, v) -> stringParams.put(k, String.valueOf(v)));
       metaBuilder.putAllParams(stringParams);
     }
     addRulesToMeta(metaBuilder, field.getRules());

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverter.java
@@ -580,16 +580,19 @@ public class ProtoToLogicalTypeConverter {
     }
     List<String> fieldTags = getFieldTags(field);
     Map<String, Object> fieldParams = getFieldParams(field);
-    // Carry the Protobuf field number as a reserved logical param so it survives into the SRLT
-    // (and round-trips through DDL), but ONLY when it deviates from the positional default the
-    // writer would otherwise assign (index + 1). When number == index + 1 the writer re-derives
-    // the identical number positionally, so recording it is redundant and the identity is
-    // losslessly reconstructable as getFieldNumber() ?? (position + 1). Omitting the trivial case
-    // keeps sequential proto schemas free of field-number noise; the deviating case (gaps or
-    // out-of-order declaration) is what the writer would otherwise corrupt by renumbering.
-    // field.getIndex() (declaration position) is a distinct value used for the SRLT field position.
+    // Carry the Protobuf field number as a reserved param so it survives into the SRLT (and
+    // round-trips through DDL), but ONLY when it deviates from the positional default the writer
+    // would otherwise assign. That default is (ordinal + 1), where the ordinal is this field's
+    // position in the writer's regulars-then-oneofs layout — the tail of indexPath, which is
+    // aligned to that same layout (see toLogicalTypeNested). It is NOT field.getIndex(): the
+    // Protobuf descriptor index has gaps where oneof members sit, so keying off it would omit a
+    // number the writer will not reproduce (and thus corrupt it) whenever a oneof is present. When
+    // number == ordinal + 1 the writer re-derives the identical number positionally, so recording
+    // it is redundant and the identity is losslessly reconstructable as getFieldNumber() ??
+    // (ordinal + 1); omitting it keeps sequential proto schemas free of field-number noise.
+    int ordinal = indexPath.get(indexPath.size() - 1);
     Map<String, Object> effectiveParams = fieldParams;
-    if (field.getNumber() != field.getIndex() + 1) {
+    if (field.getNumber() != ordinal + 1) {
       effectiveParams = fieldParams != null
           ? new LinkedHashMap<>(fieldParams) : new LinkedHashMap<>();
       effectiveParams.put(Schema.PROTOBUF_FIELD_NUMBER, String.valueOf(field.getNumber()));

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverter.java
@@ -1141,9 +1141,12 @@ public class ProtoToLogicalTypeConverter {
     }
     for (OneofDescriptor oneof : wrapper.getRealOneofs()) {
       if (CommonConstants.FLINK_WRAPPER_FIELD_NAME.equals(oneof.getName())) {
-        // The wrapper's oneof is writer-synthesized for a nullable composite UNION; its branch
-        // numbers are regenerated on re-emission, so they are not recorded.
-        return toLogicalTypeOneof(oneof, ctx, indexPath, false);
+        // Apply the same all-or-nothing decision to the wrapper descriptor: a writer-produced
+        // wrapper numbers its branches sequentially (so nothing is recorded), but a wrapped UNION
+        // whose branches carry non-sequential numbers must record them, or the writer — which does
+        // honor branch numbers when re-synthesizing the wrapper via fromStructType — would renumber
+        // them positionally on the next round trip.
+        return toLogicalTypeOneof(oneof, ctx, indexPath, !messageNumbersAreSequential(wrapper));
       }
     }
     throw new ValidationException(

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverter.java
@@ -580,10 +580,25 @@ public class ProtoToLogicalTypeConverter {
     }
     List<String> fieldTags = getFieldTags(field);
     Map<String, Object> fieldParams = getFieldParams(field);
+    // Carry the Protobuf field number as a reserved logical param so it survives into the SRLT
+    // (and round-trips through DDL), but ONLY when it deviates from the positional default the
+    // writer would otherwise assign (index + 1). When number == index + 1 the writer re-derives
+    // the identical number positionally, so recording it is redundant and the identity is
+    // losslessly reconstructable as getFieldNumber() ?? (position + 1). Omitting the trivial case
+    // keeps sequential proto schemas free of field-number noise; the deviating case (gaps or
+    // out-of-order declaration) is what the writer would otherwise corrupt by renumbering.
+    // field.getIndex() (declaration position) is a distinct value used for the SRLT field position.
+    Map<String, Object> effectiveParams = fieldParams;
+    if (field.getNumber() != field.getIndex() + 1) {
+      effectiveParams = fieldParams != null
+          ? new LinkedHashMap<>(fieldParams) : new LinkedHashMap<>();
+      effectiveParams.put(Schema.PROTOBUF_FIELD_NUMBER, String.valueOf(field.getNumber()));
+    }
     List<io.confluent.kafka.schemaregistry.type.logical.Rule> fieldRules =
         getFieldRules(field);
     return new Field(field.getName(), fieldSchema, field.getIndex(),
-        defaultValue, hasDefault, derivedDefault, description, fieldTags, fieldParams, fieldRules);
+        defaultValue, hasDefault, derivedDefault, description, fieldTags,
+        effectiveParams, fieldRules);
   }
 
   /**
@@ -659,14 +674,17 @@ public class ProtoToLogicalTypeConverter {
    * True if a Meta.params key represents user-supplied metadata (vs. an
    * internal type-encoding marker). Internal namespaces are flink.*, connect.*,
    * and logical.* — all reserved for the converter; user `WITH params` from
-   * SQL must not collide with these prefixes. Also reserved are unprefixed
-   * keys that the proto encoding writes for specific types: {@code precision}
-   * and {@code scale} for {@code .confluent.type.Decimal} fields.
+   * SQL must not collide with these prefixes. Also reserved are the format-native
+   * namespaces {@code avro.} and {@code protobuf.} (the field number arrives via
+   * the native slot, not as a user param), and the unprefixed keys the proto
+   * encoding writes for specific types: {@code precision} and {@code scale} for
+   * {@code .confluent.type.Decimal} fields.
    */
   private static boolean isUserParam(String key) {
     if (key.startsWith("flink.")
         || key.startsWith("connect.")
-        || key.startsWith(CommonConstants.LOGICAL_PREFIX)) {
+        || key.startsWith(CommonConstants.LOGICAL_PREFIX)
+        || Schema.isFormatNativeParam(key)) {
       return false;
     }
     return !CommonConstants.PROTOBUF_PRECISION_PROP.equals(key)

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverter.java
@@ -441,17 +441,23 @@ public class ProtoToLogicalTypeConverter {
     // position in the resulting struct. Downstream consumers rely on the
     // regulars-then-oneofs layout, so we align path numbering to it rather than
     // reordering the fields.
+    // Record Protobuf field numbers all-or-nothing per message: when the numbers are exactly the
+    // sequence the writer reproduces positionally we record none (keeping ordinary schemas clean);
+    // otherwise we record every one — regular fields and oneof members alike. Recording all-or-
+    // nothing guarantees a reader/writer round-trip never mixes recorded and omitted numbers, the
+    // mix that would otherwise let the writer's positional fallback corrupt an omitted number.
+    final boolean recordNumbers = !messageNumbersAreSequential(schema);
     final List<Field> fields = new ArrayList<>();
     int index = 0;
     for (FieldDescriptor fieldDescriptor : schema.getFields()) {
       if (fieldDescriptor.getRealContainingOneof() != null) {
         continue;
       }
-      fields.add(toField(ctx, fieldDescriptor, appendToList(indexPath, index++)));
+      fields.add(toField(ctx, fieldDescriptor, appendToList(indexPath, index++), recordNumbers));
     }
     for (OneofDescriptor oneOfDescriptor : schema.getRealOneofs()) {
       Schema unionSchema = toLogicalTypeOneof(
-          oneOfDescriptor, ctx, appendToList(indexPath, index));
+          oneOfDescriptor, ctx, appendToList(indexPath, index), recordNumbers);
       fields.add(new Field(oneOfDescriptor.getName(), unionSchema, index++,
           null, false, null, null, null));
     }
@@ -470,10 +476,37 @@ public class ProtoToLogicalTypeConverter {
     return newList;
   }
 
+  /**
+   * True if the message's field numbers are exactly {@code 1..N} in the writer's emission order
+   * (regular fields first, then oneof members in declaration order) — i.e. the positional defaults
+   * the writer reproduces for free. When true no numbers need recording; when false every number
+   * is recorded (see the all-or-nothing note in {@code toLogicalTypeNested}).
+   */
+  private static boolean messageNumbersAreSequential(Descriptor schema) {
+    int expected = 1;
+    for (FieldDescriptor f : schema.getFields()) {
+      if (f.getRealContainingOneof() != null) {
+        continue;
+      }
+      if (f.getNumber() != expected++) {
+        return false;
+      }
+    }
+    for (OneofDescriptor oneof : schema.getRealOneofs()) {
+      for (FieldDescriptor f : oneof.getFields()) {
+        if (f.getNumber() != expected++) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
   private static Schema toLogicalTypeOneof(
       final OneofDescriptor oneOfDescriptor,
       final ToLogicalContext<String> ctx,
-      final List<Integer> indexPath) {
+      final List<Integer> indexPath,
+      final boolean recordNumbers) {
     List<FieldDescriptor> fieldDescriptors = oneOfDescriptor.getFields();
     final List<UnionBranch> branches = new ArrayList<>();
     for (int i = 0; i < fieldDescriptors.size(); i++) {
@@ -486,6 +519,13 @@ public class ProtoToLogicalTypeConverter {
       fieldSchema = fieldSchema.setNullable(true);
       ctx.popFieldPath();
       Map<String, Object> branchParams = getBranchParams(fieldDescriptor);
+      if (recordNumbers) {
+        // A oneof member is a Protobuf field; record its number the same way as a regular field so
+        // the writer can restore it. UnionBranch.params carries it and round-trips through DDL.
+        branchParams = branchParams != null
+            ? new LinkedHashMap<>(branchParams) : new LinkedHashMap<>();
+        branchParams.put(Schema.PROTOBUF_FIELD_NUMBER, String.valueOf(fieldDescriptor.getNumber()));
+      }
       branches.add(new UnionBranch(
           fieldDescriptor.getName(), fieldSchema, description, branchParams));
     }
@@ -495,7 +535,8 @@ public class ProtoToLogicalTypeConverter {
   private static Field toField(
       final ToLogicalContext<String> ctx,
       final FieldDescriptor field,
-      final List<Integer> indexPath) {
+      final List<Integer> indexPath,
+      final boolean recordNumber) {
     final String description = getDescription(field);
     ctx.pushFieldPath(field.getName());
     Schema fieldSchema = fieldToLogicalType(field, ctx, indexPath);
@@ -580,19 +621,11 @@ public class ProtoToLogicalTypeConverter {
     }
     List<String> fieldTags = getFieldTags(field);
     Map<String, Object> fieldParams = getFieldParams(field);
-    // Carry the Protobuf field number as a reserved param so it survives into the SRLT (and
-    // round-trips through DDL), but ONLY when it deviates from the positional default the writer
-    // would otherwise assign. That default is (ordinal + 1), where the ordinal is this field's
-    // position in the writer's regulars-then-oneofs layout — the tail of indexPath, which is
-    // aligned to that same layout (see toLogicalTypeNested). It is NOT field.getIndex(): the
-    // Protobuf descriptor index has gaps where oneof members sit, so keying off it would omit a
-    // number the writer will not reproduce (and thus corrupt it) whenever a oneof is present. When
-    // number == ordinal + 1 the writer re-derives the identical number positionally, so recording
-    // it is redundant and the identity is losslessly reconstructable as getFieldNumber() ??
-    // (ordinal + 1); omitting it keeps sequential proto schemas free of field-number noise.
-    int ordinal = indexPath.get(indexPath.size() - 1);
+    // Record the Protobuf field number when the message is not trivially sequential (the caller's
+    // all-or-nothing decision; see toLogicalTypeNested). When recorded it survives into the SRLT
+    // and round-trips through DDL, and the writer restores it via the native number slot.
     Map<String, Object> effectiveParams = fieldParams;
-    if (field.getNumber() != ordinal + 1) {
+    if (recordNumber) {
       effectiveParams = fieldParams != null
           ? new LinkedHashMap<>(fieldParams) : new LinkedHashMap<>();
       effectiveParams.put(Schema.PROTOBUF_FIELD_NUMBER, String.valueOf(field.getNumber()));
@@ -1108,7 +1141,9 @@ public class ProtoToLogicalTypeConverter {
     }
     for (OneofDescriptor oneof : wrapper.getRealOneofs()) {
       if (CommonConstants.FLINK_WRAPPER_FIELD_NAME.equals(oneof.getName())) {
-        return toLogicalTypeOneof(oneof, ctx, indexPath);
+        // The wrapper's oneof is writer-synthesized for a nullable composite UNION; its branch
+        // numbers are regenerated on re-emission, so they are not recorded.
+        return toLogicalTypeOneof(oneof, ctx, indexPath, false);
       }
     }
     throw new ValidationException(

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverterTest.java
@@ -299,4 +299,24 @@ class LogicalTypeToDdlConverterTest {
         "nullable root should emit explicit TYPE, got:\n" + ddl);
     assertRoundTrip(lt);
   }
+
+  @Test
+  void testFieldNumberAndAliasesRoundTripThroughDdlWithClause() {
+    // DDL has no native slot for either signal, so both ride opaquely through WITH(...).
+    Map<String, Object> params = new LinkedHashMap<>();
+    params.put(Schema.PROTOBUF_FIELD_NUMBER, "42");
+    params.put(Schema.AVRO_ALIASES, "a_old,a_older");
+    Schema struct = Schema.createStruct(Arrays.asList(
+        new Schema.Field("a", Schema.create(Schema.Type.INT).setNullable(false), 0,
+            null, false, null, null, params)))
+        .setNullable(false);
+    LogicalType lt = new LogicalType(struct);
+
+    assertRoundTrip(lt);
+
+    LogicalType parsed = parse(LogicalTypeToDdlConverter.toDdl(lt));
+    Schema.Field a = parsed.getRootSchema().getField("a");
+    assertEquals(Integer.valueOf(42), a.getFieldNumber());
+    assertEquals(Arrays.asList("a_old", "a_older"), a.getAliases());
+  }
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/SchemaTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/SchemaTest.java
@@ -22,7 +22,10 @@ import io.confluent.kafka.schemaregistry.type.logical.Schema.UnionBranch;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Tests for Schema model-level validation invariants. */
@@ -54,5 +57,36 @@ class SchemaTest {
             new EnumValue("RED"),
             new EnumValue("GREEN"),
             new EnumValue("RED"))));
+  }
+
+  // Field identity getters read the reserved params, typed.
+  @Test
+  void testFieldNumberAndAliasesGetters() {
+    Map<String, Object> params = new LinkedHashMap<>();
+    params.put(Schema.PROTOBUF_FIELD_NUMBER, "7");
+    params.put(Schema.AVRO_ALIASES, "old1,old2");
+    Field f = new Field("a", Schema.create(Schema.Type.INT).setNullable(false), 0,
+        null, false, null, null, params);
+
+    assertThat(f.getFieldNumber()).isEqualTo(7);
+    assertThat(f.getAliases()).containsExactly("old1", "old2");
+  }
+
+  @Test
+  void testFieldIdentityGettersDefaultWhenAbsent() {
+    Field f = new Field("a", Schema.create(Schema.Type.INT).setNullable(false), 0);
+
+    assertThat(f.getFieldNumber()).isNull();
+    assertThat(f.getAliases()).isEmpty();
+  }
+
+  @Test
+  void testSingleAliasSplitsToSingletonList() {
+    Map<String, Object> params = new LinkedHashMap<>();
+    params.put(Schema.AVRO_ALIASES, "only");
+    Field f = new Field("a", Schema.create(Schema.Type.INT).setNullable(false), 0,
+        null, false, null, null, params);
+
+    assertThat(f.getAliases()).containsExactly("only");
   }
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/SchemaTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/SchemaTest.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Tests for Schema model-level validation invariants. */
@@ -88,5 +89,15 @@ class SchemaTest {
         null, false, null, null, params);
 
     assertThat(f.getAliases()).containsExactly("only");
+  }
+
+  @Test
+  void testNonNumericFieldNumberThrows() {
+    Map<String, Object> params = new LinkedHashMap<>();
+    params.put(Schema.PROTOBUF_FIELD_NUMBER, "abc");
+    Field f = new Field("a", Schema.create(Schema.Type.INT).setNullable(false), 0,
+        null, false, null, null, params);
+
+    assertThatThrownBy(f::getFieldNumber).isInstanceOf(ValidationException.class);
   }
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverterTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.stream.Collectors;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -223,5 +224,33 @@ class AvroToLogicalTypeConverterTest {
     final AvroSchema deep = new AvroSchema(inner);
     assertThrows(ValidationException.class,
         () -> AvroToLogicalTypeConverter.toRootSchema(deep));
+  }
+
+  @Test
+  void testFieldAliasesPopulatedFromAvro() {
+    String json = "{\"type\":\"record\",\"name\":\"M\",\"fields\":["
+        + "{\"name\":\"a\",\"type\":\"int\",\"aliases\":[\"a_old\",\"a_older\"]}]}";
+    org.apache.avro.Schema parsed = new org.apache.avro.Schema.Parser().parse(json);
+
+    Schema struct = AvroToLogicalTypeConverter.toLogicalType(new AvroSchema(parsed))
+        .getNamedTypes().get("M");
+
+    assertThat(struct.getField("a").getAliases())
+        .containsExactlyInAnyOrder("a_old", "a_older");
+  }
+
+  @Test
+  void testStrayAliasParamOverriddenByNativeAliases() {
+    // A hand-authored schema that puts logical.aliases in confluent:params must not win over the
+    // authoritative native alias; the native "a_old" replaces the smuggled "stray".
+    String json = "{\"type\":\"record\",\"name\":\"M\",\"fields\":["
+        + "{\"name\":\"a\",\"type\":\"int\",\"aliases\":[\"a_old\"],"
+        + "\"confluent:params\":{\"logical.aliases\":\"stray\"}}]}";
+    org.apache.avro.Schema parsed = new org.apache.avro.Schema.Parser().parse(json);
+
+    Schema struct = AvroToLogicalTypeConverter.toLogicalType(new AvroSchema(parsed))
+        .getNamedTypes().get("M");
+
+    assertThat(struct.getField("a").getAliases()).containsExactly("a_old");
   }
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/LogicalTypeToAvroConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/LogicalTypeToAvroConverterTest.java
@@ -34,6 +34,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -2462,5 +2463,62 @@ class LogicalTypeToAvroConverterTest {
     assertEquals("Outer.Inner", innerAvro.getFullName());
     assertEquals("Outer", innerAvro.getNamespace());
     assertEquals("Inner", innerAvro.getName());
+  }
+
+  @Test
+  void testFieldAliasesEmittedNativelyAndStrippedFromParams() {
+    Map<String, Object> params = new LinkedHashMap<>();
+    params.put(Schema.AVRO_ALIASES, "a_old,a_older");
+    params.put("owner", "team-a");
+    Schema struct = Schema.createStruct(Arrays.asList(
+        new Field("a", Schema.create(Schema.Type.INT).setNullable(false), 0,
+            null, false, null, null, params)))
+        .setNullable(false);
+
+    org.apache.avro.Schema avro =
+        LogicalTypeToAvroConverter.fromLogicalType(new LogicalType(struct), "M").rawSchema();
+
+    org.apache.avro.Schema.Field a = avro.getField("a");
+    assertThat(a.aliases()).containsExactlyInAnyOrder("a_old", "a_older");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> cp = (Map<String, Object>) a.getObjectProp("confluent:params");
+    assertThat(cp)
+        .doesNotContainKey(Schema.AVRO_ALIASES)
+        .containsEntry("owner", "team-a");
+  }
+
+  @Test
+  void testFieldAliasesRoundTrip() {
+    Map<String, Object> params = new LinkedHashMap<>();
+    params.put(Schema.AVRO_ALIASES, "a_old");
+    Schema struct = Schema.createStruct(Arrays.asList(
+        new Field("a", Schema.create(Schema.Type.INT).setNullable(false), 0,
+            null, false, null, null, params)))
+        .setNullable(false);
+
+    org.apache.avro.Schema avro =
+        LogicalTypeToAvroConverter.fromLogicalType(new LogicalType(struct), "M").rawSchema();
+    Schema back = AvroToLogicalTypeConverter.toRootSchema(new AvroSchema(avro));
+
+    assertThat(back.getField("a").getAliases()).containsExactly("a_old");
+  }
+
+  @Test
+  void testForeignFieldNumberStrippedByAvro() {
+    // A format-native param is authoritative only through a native slot, and Avro has none for a
+    // field number, so protobuf.field.number is dropped rather than carried in confluent:params.
+    Map<String, Object> params = new LinkedHashMap<>();
+    params.put(Schema.PROTOBUF_FIELD_NUMBER, "42");
+    Schema struct = Schema.createStruct(Arrays.asList(
+        new Field("a", Schema.create(Schema.Type.INT).setNullable(false), 0,
+            null, false, null, null, params)))
+        .setNullable(false);
+
+    org.apache.avro.Schema avro =
+        LogicalTypeToAvroConverter.fromLogicalType(new LogicalType(struct), "M").rawSchema();
+    assertThat(avro.getField("a").getObjectProp("confluent:params")).isNull();
+    Schema back = AvroToLogicalTypeConverter.toRootSchema(new AvroSchema(avro));
+
+    assertThat(back.getField("a").getFieldNumber()).isNull();
   }
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/LogicalTypeToAvroConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/LogicalTypeToAvroConverterTest.java
@@ -2521,4 +2521,27 @@ class LogicalTypeToAvroConverterTest {
 
     assertThat(back.getField("a").getFieldNumber()).isNull();
   }
+
+  @Test
+  void testForeignBranchFieldNumberStrippedByAvro() {
+    // A oneof member's protobuf.field.number lives in UnionBranch.params; it must be kept out of
+    // confluent:union just like regular field numbers are kept out of confluent:params.
+    Map<String, Object> branchParams = new LinkedHashMap<>();
+    branchParams.put(Schema.PROTOBUF_FIELD_NUMBER, "10");
+    branchParams.put("owner", "team-a");
+    Schema union = Schema.createUnion(Arrays.asList(
+        new UnionBranch("s", Schema.createString().setNullable(true), null, branchParams),
+        new UnionBranch("i", Schema.create(Schema.Type.INT).setNullable(true))))
+        .setNullable(true);
+    Schema struct = Schema.createStruct(Arrays.asList(
+        new Field("u", union, 0))).setNullable(false);
+
+    org.apache.avro.Schema avro =
+        LogicalTypeToAvroConverter.fromLogicalType(new LogicalType(struct), "M").rawSchema();
+    Schema back = AvroToLogicalTypeConverter.toRootSchema(new AvroSchema(avro));
+
+    UnionBranch s = back.getField("u").getSchema().getBranches().get(0);
+    assertThat(s.getFieldNumber()).isNull();
+    assertThat(s.getParams()).containsEntry("owner", "team-a");
+  }
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/json/LogicalTypeToJsonConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/json/LogicalTypeToJsonConverterTest.java
@@ -38,6 +38,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -2426,5 +2427,27 @@ class LogicalTypeToJsonConverterTest {
     assertTrue(defs.has("Outer.Inner"),
         "expected `Outer.Inner` to appear as a flat $defs key, got keys: "
             + defs.keySet());
+  }
+
+  @Test
+  void testForeignBranchFieldNumberStrippedByJson() {
+    // A oneof member's protobuf.field.number lives in UnionBranch.params; JSON has no native slot
+    // for it, so it must be kept out of confluent:union just like regular field params.
+    Map<String, Object> branchParams = new LinkedHashMap<>();
+    branchParams.put(Schema.PROTOBUF_FIELD_NUMBER, "10");
+    branchParams.put("owner", "team-a");
+    Schema union = Schema.createUnion(Arrays.asList(
+        new UnionBranch("s", Schema.createString().setNullable(true), null, branchParams),
+        new UnionBranch("i", Schema.create(Schema.Type.INT).setNullable(true))))
+        .setNullable(true);
+    Schema struct = Schema.createStruct(Arrays.asList(
+        new Field("u", union, 0))).setNullable(false);
+
+    JsonSchema json = LogicalTypeToJsonConverter.fromLogicalType(new LogicalType(struct), "row");
+    Schema back = JsonToLogicalTypeConverter.toRootSchema(json);
+
+    UnionBranch s = back.getField("u").getSchema().getBranches().get(0);
+    assertThat(s.getFieldNumber()).isNull();
+    assertThat(s.getParams()).containsEntry("owner", "team-a");
   }
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/LogicalTypeToProtoConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/LogicalTypeToProtoConverterTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -2988,5 +2989,60 @@ class LogicalTypeToProtoConverterTest {
 
     assertThat(descriptor.findFieldByName("a").getNumber()).isEqualTo(1);
     assertThat(descriptor.findFieldByName("b").getNumber()).isEqualTo(2);
+  }
+
+  @Test
+  void testPositionalFallbackDoesNotCollideWithExplicitNumber() {
+    // a (unnumbered), b (explicit 3), c (unnumbered). A naive positional counter would hand c the
+    // number 3 and produce a duplicate; the writer reserves 3 first and assigns c the next free.
+    Map<String, Object> bParams = new LinkedHashMap<>();
+    bParams.put(Schema.PROTOBUF_FIELD_NUMBER, "3");
+    Schema struct = Schema.createStruct(Arrays.asList(
+        new Field("a", Schema.create(Schema.Type.INT).setNullable(false), 0),
+        new Field("b", Schema.create(Schema.Type.INT).setNullable(false), 1,
+            null, false, null, null, bParams),
+        new Field("c", Schema.create(Schema.Type.INT).setNullable(false), 2)))
+        .setNullable(false);
+
+    Descriptor descriptor = LogicalTypeToProtoConverter.fromLogicalType(
+        new LogicalType(struct), "M").toDescriptor();
+
+    assertThat(descriptor.findFieldByName("a").getNumber()).isEqualTo(1);
+    assertThat(descriptor.findFieldByName("b").getNumber()).isEqualTo(3);
+    assertThat(descriptor.findFieldByName("c").getNumber()).isEqualTo(2);
+  }
+
+  @Test
+  void testDuplicateExplicitFieldNumberRejected() {
+    Map<String, Object> p1 = new LinkedHashMap<>();
+    p1.put(Schema.PROTOBUF_FIELD_NUMBER, "5");
+    Map<String, Object> p2 = new LinkedHashMap<>();
+    p2.put(Schema.PROTOBUF_FIELD_NUMBER, "5");
+    Schema struct = Schema.createStruct(Arrays.asList(
+        new Field("a", Schema.create(Schema.Type.INT).setNullable(false), 0,
+            null, false, null, null, p1),
+        new Field("b", Schema.create(Schema.Type.INT).setNullable(false), 1,
+            null, false, null, null, p2)))
+        .setNullable(false);
+
+    assertThatThrownBy(() ->
+        LogicalTypeToProtoConverter.fromLogicalType(new LogicalType(struct), "M"))
+        .isInstanceOf(ValidationException.class);
+  }
+
+  @Test
+  void testNonNumericFieldNumberRejectedAsValidation() {
+    // A DDL-authored non-numeric protobuf.field.number must surface as a clean ValidationException,
+    // not a raw NumberFormatException, during conversion.
+    Map<String, Object> params = new LinkedHashMap<>();
+    params.put(Schema.PROTOBUF_FIELD_NUMBER, "abc");
+    Schema struct = Schema.createStruct(Arrays.asList(
+        new Field("a", Schema.create(Schema.Type.INT).setNullable(false), 0,
+            null, false, null, null, params)))
+        .setNullable(false);
+
+    assertThatThrownBy(() ->
+        LogicalTypeToProtoConverter.fromLogicalType(new LogicalType(struct), "M"))
+        .isInstanceOf(ValidationException.class);
   }
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/LogicalTypeToProtoConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/LogicalTypeToProtoConverterTest.java
@@ -3045,4 +3045,29 @@ class LogicalTypeToProtoConverterTest {
         LogicalTypeToProtoConverter.fromLogicalType(new LogicalType(struct), "M"))
         .isInstanceOf(ValidationException.class);
   }
+
+  @Test
+  void testWrappedUnionBranchNumbersRoundTrip() {
+    // An ARRAY<UNION> wraps the union in a synthesized message; non-sequential branch numbers must
+    // survive that wrapper round trip rather than being renumbered positionally.
+    Map<String, Object> b1 = new LinkedHashMap<>();
+    b1.put(Schema.PROTOBUF_FIELD_NUMBER, "5");
+    Map<String, Object> b2 = new LinkedHashMap<>();
+    b2.put(Schema.PROTOBUF_FIELD_NUMBER, "9");
+    Schema union = Schema.createUnion(Arrays.asList(
+        new UnionBranch("s", Schema.createString().setNullable(true), null, b1),
+        new UnionBranch("i", Schema.create(Schema.Type.INT).setNullable(true), null, b2)))
+        .setNullable(true);
+    Schema struct = Schema.createStruct(Arrays.asList(
+        new Field("arr", Schema.createArray(union).setNullable(false), 0)))
+        .setNullable(false);
+
+    ProtobufSchema proto =
+        LogicalTypeToProtoConverter.fromLogicalType(new LogicalType(struct), "M");
+    Schema back = ProtoToLogicalTypeConverter.toRootSchema(proto);
+
+    Schema backUnion = back.getField("arr").getSchema().getElementType();
+    assertThat(backUnion.getBranches().get(0).getFieldNumber()).isEqualTo(5);
+    assertThat(backUnion.getBranches().get(1).getFieldNumber()).isEqualTo(9);
+  }
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/LogicalTypeToProtoConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/LogicalTypeToProtoConverterTest.java
@@ -35,6 +35,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -2952,5 +2953,40 @@ class LogicalTypeToProtoConverterTest {
     assertEquals("com.Foo", rt.getRootSchema().getQualifiedName());
     assertTrue(rt.getNamedTypes().isEmpty(),
         "public-import round-trip should produce no local namedTypes");
+  }
+
+  @Test
+  void testFieldNumberEmittedNativelyAndStrippedFromParams() {
+    Map<String, Object> params = new LinkedHashMap<>();
+    params.put(Schema.PROTOBUF_FIELD_NUMBER, "42");
+    params.put("owner", "team-a");
+    Schema struct = Schema.createStruct(Arrays.asList(
+        new Field("f", Schema.create(Schema.Type.INT).setNullable(false), 0,
+            null, false, null, null, params)))
+        .setNullable(false);
+
+    Descriptor descriptor = LogicalTypeToProtoConverter.fromLogicalType(
+        new LogicalType(struct), "M").toDescriptor();
+
+    FieldDescriptor f = descriptor.findFieldByName("f");
+    assertThat(f.getNumber()).isEqualTo(42);
+    Map<String, String> emitted = f.getOptions()
+        .getExtension(io.confluent.protobuf.MetaProto.fieldMeta).getParamsMap();
+    assertThat(emitted).doesNotContainKey(Schema.PROTOBUF_FIELD_NUMBER);
+    assertThat(emitted).containsEntry("owner", "team-a");
+  }
+
+  @Test
+  void testFieldWithoutDeclaredNumberFallsBackToPositional() {
+    Schema struct = Schema.createStruct(Arrays.asList(
+        new Field("a", Schema.create(Schema.Type.INT).setNullable(false), 0),
+        new Field("b", Schema.create(Schema.Type.INT).setNullable(false), 1)))
+        .setNullable(false);
+
+    Descriptor descriptor = LogicalTypeToProtoConverter.fromLogicalType(
+        new LogicalType(struct), "M").toDescriptor();
+
+    assertThat(descriptor.findFieldByName("a").getNumber()).isEqualTo(1);
+    assertThat(descriptor.findFieldByName("b").getNumber()).isEqualTo(2);
   }
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverterTest.java
@@ -28,6 +28,7 @@ import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
 import com.google.protobuf.DescriptorProtos.EnumDescriptorProto;
 import com.google.protobuf.DescriptorProtos.EnumValueDescriptorProto;
 import com.google.protobuf.DescriptorProtos.OneofDescriptorProto;
+import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FileDescriptor;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +37,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -518,5 +520,46 @@ class ProtoToLogicalTypeConverterTest {
     // References pass through unchanged.
     assertEquals(1, lt.getReferences().size());
     assertEquals("leaf.proto", lt.getReferences().get(0).getName());
+  }
+
+  @Test
+  void testFieldNumberPopulatedFromProto() throws Exception {
+    DescriptorProto message = DescriptorProto.newBuilder()
+        .setName("M")
+        .addField(FieldDescriptorProto.newBuilder()
+            .setName("a").setNumber(3).setType(Type.TYPE_INT32))
+        .addField(FieldDescriptorProto.newBuilder()
+            .setName("b").setNumber(7).setType(Type.TYPE_INT32))
+        .build();
+
+    Schema result = ProtoToLogicalTypeConverter.toRootSchema(
+        new ProtobufSchema(buildFileDescriptor(message)));
+
+    assertThat(result.getField("a").getFieldNumber()).isEqualTo(3);
+    assertThat(result.getField("b").getFieldNumber()).isEqualTo(7);
+  }
+
+  @Test
+  void testFieldNumbersRoundTripPreservesNonSequential() throws Exception {
+    // Non-sequential, non-positional numbers: the round-trip must preserve them
+    // rather than renumbering positionally (the field-number fidelity fix).
+    DescriptorProto message = DescriptorProto.newBuilder()
+        .setName("M")
+        .addField(FieldDescriptorProto.newBuilder()
+            .setName("a").setNumber(3).setType(Type.TYPE_INT32))
+        .addField(FieldDescriptorProto.newBuilder()
+            .setName("b").setNumber(7).setType(Type.TYPE_INT32))
+        .addField(FieldDescriptorProto.newBuilder()
+            .setName("c").setNumber(100).setType(Type.TYPE_INT32))
+        .build();
+
+    Schema srlt = ProtoToLogicalTypeConverter.toRootSchema(
+        new ProtobufSchema(buildFileDescriptor(message)));
+    Descriptor out = LogicalTypeToProtoConverter.fromLogicalType(
+        new LogicalType(srlt), "M").toDescriptor();
+
+    assertThat(out.findFieldByName("a").getNumber()).isEqualTo(3);
+    assertThat(out.findFieldByName("b").getNumber()).isEqualTo(7);
+    assertThat(out.findFieldByName("c").getNumber()).isEqualTo(100);
   }
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverterTest.java
@@ -564,11 +564,12 @@ class ProtoToLogicalTypeConverterTest {
   }
 
   @Test
-  void testRegularFieldNumberPreservedWhenOneofPresent() throws Exception {
-    // A oneof makes the reader lay out regulars before oneof members, so the regular field's
-    // Protobuf descriptor index (2) differs from its writer ordinal (0). The number capture keys
-    // off the ordinal, so the regular field's number survives the round-trip even though its
-    // descriptor index would have (mis-)matched the positional default.
+  void testOneofBranchAndRegularFieldNumbersRoundTrip() throws Exception {
+    // Numbers are out of sequence (oneof members 10/20 declared before regular field 3), so the
+    // reader records all of them — regular field and oneof branches alike — and the writer restores
+    // each via the native slot. Regulars are laid out before oneof members, so the regular field's
+    // descriptor index differs from its emission position; the all-or-nothing recording is immune
+    // to that skew.
     DescriptorProto message = DescriptorProto.newBuilder()
         .setName("M")
         .addOneofDecl(OneofDescriptorProto.newBuilder().setName("o"))
@@ -589,9 +590,29 @@ class ProtoToLogicalTypeConverterTest {
     Descriptor out = LogicalTypeToProtoConverter.fromLogicalType(
         new LogicalType(srlt), "M").toDescriptor();
     assertThat(out.findFieldByName("c").getNumber()).isEqualTo(3);
-    // Known limitation: oneof branch numbers are NOT preserved (UnionBranch carries no number),
-    // so a and b are renumbered positionally rather than restored to 10/20.
-    assertThat(out.findFieldByName("a").getNumber()).isNotEqualTo(10);
-    assertThat(out.findFieldByName("b").getNumber()).isNotEqualTo(20);
+    assertThat(out.findFieldByName("a").getNumber()).isEqualTo(10);
+    assertThat(out.findFieldByName("b").getNumber()).isEqualTo(20);
+  }
+
+  @Test
+  void testOutOfOrderRegularFieldNumbersRoundTrip() throws Exception {
+    // Regression for the mixed omit/record hole: with per-field omission, b (number 2 == its
+    // position + 1) was omitted while a (5) was recorded, and the writer's positional fallback then
+    // handed b the number 1. All-or-nothing recording keeps both.
+    DescriptorProto message = DescriptorProto.newBuilder()
+        .setName("M")
+        .addField(FieldDescriptorProto.newBuilder()
+            .setName("a").setNumber(5).setType(Type.TYPE_INT32))
+        .addField(FieldDescriptorProto.newBuilder()
+            .setName("b").setNumber(2).setType(Type.TYPE_INT32))
+        .build();
+
+    Schema srlt = ProtoToLogicalTypeConverter.toRootSchema(
+        new ProtobufSchema(buildFileDescriptor(message)));
+    Descriptor out = LogicalTypeToProtoConverter.fromLogicalType(
+        new LogicalType(srlt), "M").toDescriptor();
+
+    assertThat(out.findFieldByName("a").getNumber()).isEqualTo(5);
+    assertThat(out.findFieldByName("b").getNumber()).isEqualTo(2);
   }
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverterTest.java
@@ -562,4 +562,36 @@ class ProtoToLogicalTypeConverterTest {
     assertThat(out.findFieldByName("b").getNumber()).isEqualTo(7);
     assertThat(out.findFieldByName("c").getNumber()).isEqualTo(100);
   }
+
+  @Test
+  void testRegularFieldNumberPreservedWhenOneofPresent() throws Exception {
+    // A oneof makes the reader lay out regulars before oneof members, so the regular field's
+    // Protobuf descriptor index (2) differs from its writer ordinal (0). The number capture keys
+    // off the ordinal, so the regular field's number survives the round-trip even though its
+    // descriptor index would have (mis-)matched the positional default.
+    DescriptorProto message = DescriptorProto.newBuilder()
+        .setName("M")
+        .addOneofDecl(OneofDescriptorProto.newBuilder().setName("o"))
+        .addField(FieldDescriptorProto.newBuilder()
+            .setName("a").setNumber(10).setType(Type.TYPE_INT32)
+            .setLabel(Label.LABEL_OPTIONAL).setOneofIndex(0))
+        .addField(FieldDescriptorProto.newBuilder()
+            .setName("b").setNumber(20).setType(Type.TYPE_INT32)
+            .setLabel(Label.LABEL_OPTIONAL).setOneofIndex(0))
+        .addField(FieldDescriptorProto.newBuilder()
+            .setName("c").setNumber(3).setType(Type.TYPE_INT32))
+        .build();
+
+    Schema srlt = ProtoToLogicalTypeConverter.toRootSchema(
+        new ProtobufSchema(buildFileDescriptor(message)));
+    assertThat(srlt.getField("c").getFieldNumber()).isEqualTo(3);
+
+    Descriptor out = LogicalTypeToProtoConverter.fromLogicalType(
+        new LogicalType(srlt), "M").toDescriptor();
+    assertThat(out.findFieldByName("c").getNumber()).isEqualTo(3);
+    // Known limitation: oneof branch numbers are NOT preserved (UnionBranch carries no number),
+    // so a and b are renumbered positionally rather than restored to 10/20.
+    assertThat(out.findFieldByName("a").getNumber()).isNotEqualTo(10);
+    assertThat(out.findFieldByName("b").getNumber()).isNotEqualTo(20);
+  }
 }


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Adds field-level identity signals to the Logical Type                                                                                                    
  model so a field's Avro aliases and Protobuf field number survive the                                                                                                             
  LT ↔ format conversion, and fixes a Protobuf round-trip bug that silently                                                                                                         
  renumbered fields.                                                                                                                                                                
                                                                                                                                                                                    
  `Schema.Field` gains two format-agnostic read points:                                                                                                                             
                                                                                                                                                                                    
  - `getFieldNumber()` — the field's explicit Protobuf number                                                                                                                       
  - `getAliases()` — the field's Avro aliases (previous names)                                                                                                                      
                                                                                                                                                                                    
  Both are backed by reserved `params` keys (`protobuf.field.number`,                                                                                                               
  `avro.aliases`), so they participate in `Field.equals` and round-trip through                                                                                                     
  DDL `WITH(...)` with no grammar or model-shape change.   
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
