### PR TITLE
DGS-25088 Bump httpclient5 to 5.6.4 to fix CVE-2026-71290

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <commons.validator.version>1.9.0</commons.validator.version>
         <snappy.version>1.1.10.5</snappy.version>
         <log4j.version>2.25.4</log4j.version>
-        <apache.httpclient5.version>5.5</apache.httpclient5.version>
+        <apache.httpclient5.version>5.6.4</apache.httpclient5.version>
         <spotless.maven.plugin.version>2.45.0</spotless.maven.plugin.version>
     </properties>
 


### PR DESCRIPTION
## Summary
- Bumps `apache.httpclient5.version` from 5.5 to 5.6.4 to address CVE-2026-71290 per DGS-25088.

## Test plan
- [x] `mvn dependency:tree -Dincludes=org.apache.httpcomponents.client5:httpclient5` confirms resolved version is 5.6.4

https://confluentinc.atlassian.net/browse/DGS-25088