### PR TITLE
Enforce mutual exclusion of schema references and strong associations

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/exceptions/SubjectIsReferencedException.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/exceptions/SubjectIsReferencedException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.exceptions;
+
+public class SubjectIsReferencedException extends SchemaRegistryException {
+
+  public SubjectIsReferencedException(String name, Throwable cause) {
+    super(name, cause);
+  }
+
+  public SubjectIsReferencedException(String name) {
+    super(name);
+  }
+
+  public SubjectIsReferencedException(Throwable cause) {
+    super(cause);
+  }
+
+  public SubjectIsReferencedException() {
+    super();
+  }
+}

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/Errors.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/exceptions/Errors.java
@@ -63,6 +63,9 @@ public class Errors {
   public static final String STRONG_ASSOCIATION_FOR_SUBJECT_EXISTS_MESSAGE_FORMAT =
       "A strong association already exists for subject '%s'";
   public static final int STRONG_ASSOCIATION_FOR_SUBJECT_EXISTS_ERROR_CODE = 40905;
+  public static final String SUBJECT_IS_REFERENCED_MESSAGE_FORMAT =
+      "Subject '%s' is referenced by one or more schemas";
+  public static final int SUBJECT_IS_REFERENCED_ERROR_CODE = 40906;
   public static final String NO_ACTIVE_SUBJECT_VERSION_EXISTS_MESSAGE_FORMAT =
       "No active (non-deleted) version exists for subject '%s'";
   public static final int NO_ACTIVE_SUBJECT_VERSION_EXISTS_ERROR_CODE = 40907;
@@ -254,6 +257,12 @@ public class Errors {
     return new RestConflictException(
         String.format(STRONG_ASSOCIATION_FOR_SUBJECT_EXISTS_MESSAGE_FORMAT, subject),
         STRONG_ASSOCIATION_FOR_SUBJECT_EXISTS_ERROR_CODE);
+  }
+
+  public static RestException subjectIsReferencedException(String subject) {
+    return new RestConflictException(
+        String.format(SUBJECT_IS_REFERENCED_MESSAGE_FORMAT, subject),
+        SUBJECT_IS_REFERENCED_ERROR_CODE);
   }
 
   public static RestException tooManyAssociationsException(int max) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/AssociationsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/AssociationsResource.java
@@ -38,6 +38,7 @@ import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryTimeoutExcepti
 import io.confluent.kafka.schemaregistry.exceptions.SchemaTooLargeException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaVersionNotSoftDeletedException;
 import io.confluent.kafka.schemaregistry.exceptions.StrongAssociationForSubjectExistsException;
+import io.confluent.kafka.schemaregistry.exceptions.SubjectIsReferencedException;
 import io.confluent.kafka.schemaregistry.exceptions.UnknownLeaderException;
 import io.confluent.kafka.schemaregistry.rest.exceptions.Errors;
 import io.confluent.kafka.schemaregistry.exceptions.AssociationForResourceExistsException;
@@ -277,6 +278,8 @@ public class AssociationsResource {
       throw Errors.noActiveSubjectVersionExistsException(e.getMessage());
     } catch (StrongAssociationForSubjectExistsException e) {
       throw Errors.strongAssociationExistsException(e.getMessage());
+    } catch (SubjectIsReferencedException e) {
+      throw Errors.subjectIsReferencedException(e.getMessage());
     } catch (TooManyAssociationsException e) {
       // TODO RAY max
       //throw Errors.tooManyAssociationsException(schemaRegistry.config().maxKeys());
@@ -367,6 +370,8 @@ public class AssociationsResource {
       throw Errors.noActiveSubjectVersionExistsException(e.getMessage());
     } catch (StrongAssociationForSubjectExistsException e) {
       throw Errors.strongAssociationExistsException(e.getMessage());
+    } catch (SubjectIsReferencedException e) {
+      throw Errors.subjectIsReferencedException(e.getMessage());
     } catch (TooManyAssociationsException e) {
       // TODO RAY max
       //throw Errors.tooManyAssociationsException(schemaRegistry.config().maxKeys());

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -1647,9 +1647,11 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
 
   /**
    * Whether any version of the subject is a reference target of another schema, counting soft-
-   * deleted versions and referrers since a soft delete can be restored.  Called only after the
-   * frozen-association guard in {@link #createOrUpdateAssociation} has capped the subject at one
-   * active version, so this iterates a single version in the common case.
+   * deleted versions and referrers since a soft delete can be restored.  Despite the loop this is
+   * an O(1) check in practice, not O(N): the only caller runs it after the frozen-association
+   * guard in {@link #createOrUpdateAssociation}, which allows a STRONG association only when the
+   * subject has a single (version 1) active schema.  Only soft-deleted history can push the count
+   * past one, which is rare -- and iterating it is exactly what keeps the check correct.
    */
   protected boolean isSubjectReferenced(String subject) throws SchemaRegistryException {
     try {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -1646,14 +1646,19 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
   }
 
   /**
-   * Whether version 1 of the subject is a reference target of another schema, counting referrers
-   * that are soft-deleted since a soft delete can be restored.  Only version 1 is relevant to the
-   * STRONG-association restriction: such an association can only be created when the subject's sole
-   * version is 1.
+   * Whether any version of the subject is a reference target of another schema, counting soft-
+   * deleted versions and referrers since a soft delete can be restored.  Called only after the
+   * frozen-association guard in {@link #createOrUpdateAssociation} has capped the subject at one
+   * active version, so this iterates a single version in the common case.
    */
-  protected boolean isFirstVersionReferenced(String subject) throws SchemaRegistryException {
+  protected boolean isSubjectReferenced(String subject) throws SchemaRegistryException {
     try {
-      return !getReferencedBy(new SchemaKey(subject, MIN_VERSION), true).isEmpty();
+      for (SchemaKey key : getAllSchemaKeysDescending(subject)) {
+        if (!getReferencedBy(key, true).isEmpty()) {
+          return true;
+        }
+      }
+      return false;
     } catch (StoreException e) {
       throw new SchemaRegistryStoreException(
           "Error while checking references for subject " + subject, e);
@@ -2292,10 +2297,12 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
             throw new AssociationForSubjectExistsException(unqualifiedSubject);
           }
           // A STRONG association and a schema reference are mutually exclusive: a referenced
-          // subject cannot be claimed as topic-owned. IMPORT is exempt so cluster linking can
-          // replicate a subject that legitimately carries both states on the source.
+          // subject cannot be claimed as topic-owned. This runs after the frozen guard above,
+          // which has already rejected subjects with more than one active version. IMPORT is
+          // exempt so cluster linking can replicate a subject that carries both states on the
+          // source.
           if (getModeInScope(qualifiedSubject) != Mode.IMPORT
-              && isFirstVersionReferenced(qualifiedSubject)) {
+              && isSubjectReferenced(qualifiedSubject)) {
             throw new SubjectIsReferencedException(unqualifiedSubject);
           }
           break;

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -66,6 +66,7 @@ import io.confluent.kafka.schemaregistry.exceptions.OperationNotPermittedExcepti
 import io.confluent.kafka.schemaregistry.exceptions.SchemaRegistryStoreException;
 import io.confluent.kafka.schemaregistry.exceptions.SchemaTooLargeException;
 import io.confluent.kafka.schemaregistry.exceptions.StrongAssociationForSubjectExistsException;
+import io.confluent.kafka.schemaregistry.exceptions.SubjectIsReferencedException;
 import io.confluent.kafka.schemaregistry.exceptions.TooManyAssociationsException;
 import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
@@ -132,6 +133,8 @@ import static io.confluent.kafka.schemaregistry.rest.exceptions.Errors.NO_ACTIVE
 import static io.confluent.kafka.schemaregistry.rest.exceptions.Errors.SCHEMA_TOO_LARGE_ERROR_CODE;
 import static io.confluent.kafka.schemaregistry.rest.exceptions.Errors.STRONG_ASSOCIATION_FOR_SUBJECT_EXISTS_ERROR_CODE;
 import static io.confluent.kafka.schemaregistry.rest.exceptions.Errors.STRONG_ASSOCIATION_FOR_SUBJECT_EXISTS_MESSAGE_FORMAT;
+import static io.confluent.kafka.schemaregistry.rest.exceptions.Errors.SUBJECT_IS_REFERENCED_ERROR_CODE;
+import static io.confluent.kafka.schemaregistry.rest.exceptions.Errors.SUBJECT_IS_REFERENCED_MESSAGE_FORMAT;
 import static io.confluent.kafka.schemaregistry.rest.exceptions.RestInvalidAssociationException.INVALID_ASSOCIATION_MESSAGE_FORMAT;
 
 import static io.confluent.kafka.schemaregistry.client.rest.entities.Metadata.mergeMetadata;
@@ -1642,6 +1645,21 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
     return subjects;
   }
 
+  /**
+   * Whether version 1 of the subject is a reference target of another schema, counting referrers
+   * that are soft-deleted since a soft delete can be restored.  Only version 1 is relevant to the
+   * STRONG-association restriction: such an association can only be created when the subject's sole
+   * version is 1.
+   */
+  protected boolean isFirstVersionReferenced(String subject) throws SchemaRegistryException {
+    try {
+      return !getReferencedBy(new SchemaKey(subject, MIN_VERSION), true).isEmpty();
+    } catch (StoreException e) {
+      throw new SchemaRegistryStoreException(
+          "Error while checking references for subject " + subject, e);
+    }
+  }
+
   @Override
   public List<ContextId> listIdsForGuid(String guid)
           throws SchemaRegistryException {
@@ -2273,6 +2291,13 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
           if (!assocsBySubject.isEmpty()) {
             throw new AssociationForSubjectExistsException(unqualifiedSubject);
           }
+          // A STRONG association and a schema reference are mutually exclusive: a referenced
+          // subject cannot be claimed as topic-owned. IMPORT is exempt so cluster linking can
+          // replicate a subject that legitimately carries both states on the source.
+          if (getModeInScope(qualifiedSubject) != Mode.IMPORT
+              && isFirstVersionReferenced(qualifiedSubject)) {
+            throw new SubjectIsReferencedException(unqualifiedSubject);
+          }
           break;
         case WEAK:
           if (Boolean.TRUE.equals(info.getFrozen())) {
@@ -2669,6 +2694,11 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
         ErrorMessage errMsg = new ErrorMessage(
             STRONG_ASSOCIATION_FOR_SUBJECT_EXISTS_ERROR_CODE,
             String.format(STRONG_ASSOCIATION_FOR_SUBJECT_EXISTS_MESSAGE_FORMAT, e.getMessage()));
+        results.add(new AssociationResult(errMsg, null));
+      } catch (SubjectIsReferencedException e) {
+        ErrorMessage errMsg = new ErrorMessage(
+            SUBJECT_IS_REFERENCED_ERROR_CODE,
+            String.format(SUBJECT_IS_REFERENCED_MESSAGE_FORMAT, e.getMessage()));
         results.add(new AssociationResult(errMsg, null));
       } catch (TooManyAssociationsException e) {
         // TODO maxKeys

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -25,7 +25,9 @@ import io.confluent.kafka.schemaregistry.ParsedSchemaHolder;
 import io.confluent.kafka.schemaregistry.client.rest.RestService;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Association;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Config;
+import io.confluent.kafka.schemaregistry.client.rest.entities.LifecyclePolicy;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaString;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationBatchRequest;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationBatchResponse;
@@ -478,6 +480,21 @@ public class KafkaSchemaRegistry extends AbstractSchemaRegistry implements
       int schemaId = schema.getId();
       boolean doValidation = schemaId < 0 && isSchemaNewSchemaValidationEnabled(config);
       ParsedSchema parsedSchema = canonicalizeSchema(schema, config, doValidation, normalize);
+
+      // A schema reference and a STRONG (topic-owned) association are mutually exclusive: a
+      // subject claimed by its topic cannot be a reference target. IMPORT is exempt so cluster
+      // linking can replicate a schema that legitimately references such a subject on the source.
+      if (parsedSchema != null && mode != Mode.IMPORT) {
+        for (SchemaReference ref : schema.getReferences()) {
+          QualifiedSubject refSubject = QualifiedSubject.qualifySubjectWithParent(
+              tenant(), subject, ref.getSubject());
+          if (refSubject != null && !getAssociationsBySubject(
+              refSubject.toQualifiedSubject(), null, null, LifecyclePolicy.STRONG).isEmpty()) {
+            throw new OperationNotPermittedException("Subject '" + ref.getSubject()
+                + "' has a strong association and cannot be referenced");
+          }
+        }
+      }
 
       if (parsedSchema != null) {
         // see if the schema to be registered already exists

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
@@ -4017,5 +4017,54 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertEquals(Errors.SUBJECT_IS_REFERENCED_ERROR_CODE, e.getErrorCode());
   }
 
+  @Test
+  public void testReferenceToStrongAssociationSubjectAllowedInImportMode() throws Exception {
+    String strongSubject = ":.default:topic-imp-1-key";
+
+    // Claim the target with a STRONG association (normal mode).
+    restApp.restClient.createAssociation(RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
+        strongKeyAssociation("topic-imp-1", "default", "imp-strong-1", ORDER_SCHEMA));
+
+    // A referrer subject in IMPORT mode is exempt (cluster-link replication): the reference is
+    // allowed even though the target carries a strong association.
+    String referrerSubject = "import-payment-value";
+    restApp.restClient.setMode("IMPORT", referrerSubject);
+    RegisterSchemaRequest referrer = new RegisterSchemaRequest();
+    referrer.setSchema(PAYMENT_REFERENCING_ORDER);
+    referrer.setReferences(
+        ImmutableList.of(new SchemaReference("Order", strongSubject, 1)));
+    referrer.setId(100);
+    referrer.setVersion(1);
+    // Must not throw despite the target's strong association.
+    restApp.restClient.registerSchema(referrer, referrerSubject, false);
+  }
+
+  @Test
+  public void testCreateStrongAssociationOnReferencedSubjectAllowedInImportMode() throws Exception {
+    String strongSubject = ":.default:topic-imp-2-key";
+
+    // Register the subject and reference it (normal mode) -> the subject is a reference target.
+    RegisterSchemaRequest orderRequest = new RegisterSchemaRequest();
+    orderRequest.setSchema(ORDER_SCHEMA);
+    restApp.restClient.registerSchema(orderRequest, strongSubject, false);
+
+    RegisterSchemaRequest referrer = new RegisterSchemaRequest();
+    referrer.setSchema(PAYMENT_REFERENCING_ORDER);
+    referrer.setReferences(
+        ImmutableList.of(new SchemaReference("Order", strongSubject, 1)));
+    restApp.restClient.registerSchema(referrer, "import-payment-2-value", false);
+
+    // In IMPORT mode the subject is exempt: cluster linking replicates a strong association that
+    // was already established on the source. The association carries no schema in IMPORT mode.
+    restApp.restClient.setMode("IMPORT", strongSubject, true);
+    AssociationCreateOrUpdateRequest request = new AssociationCreateOrUpdateRequest(
+        "topic-imp-2", "default", "imp-strong-2", "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            null, "key", LifecyclePolicy.STRONG, true, null, null)));
+    // Must not throw despite the subject being referenced.
+    restApp.restClient.createAssociation(RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
+        request);
+  }
+
 }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
@@ -3911,6 +3911,11 @@ public class RestApiAssociationTest extends ClusterTestHarness {
   private static final String ORDER_SCHEMA =
       "{\"type\":\"record\",\"name\":\"Order\","
           + "\"fields\":[{\"name\":\"id\",\"type\":\"string\"}]}";
+  // Backward-compatible successor of ORDER_SCHEMA (adds a defaulted field), so it registers as v2.
+  private static final String ORDER_SCHEMA_V2 =
+      "{\"type\":\"record\",\"name\":\"Order\","
+          + "\"fields\":[{\"name\":\"id\",\"type\":\"string\"},"
+          + "{\"name\":\"note\",\"type\":\"string\",\"default\":\"\"}]}";
   private static final String PAYMENT_REFERENCING_ORDER =
       "{\"type\":\"record\",\"name\":\"Payment\","
           + "\"fields\":[{\"name\":\"order\",\"type\":\"Order\"}]}";
@@ -4014,6 +4019,39 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     RestClientException e = assertThrows(RestClientException.class, () ->
         restApp.restClient.createAssociation(RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
             strongKeyAssociation("topic-ref-3", "default", "strong-ref-3", ORDER_SCHEMA)));
+    assertEquals(Errors.SUBJECT_IS_REFERENCED_ERROR_CODE, e.getErrorCode());
+  }
+
+  @Test
+  public void testCreateStrongAssociationRejectedWhenSoftDeletedHigherVersionIsReferenced()
+      throws Exception {
+    String strongSubject = ":.default:topic-ref-4-key";
+
+    // Two versions; a referrer targets v2 specifically.
+    RegisterSchemaRequest v1 = new RegisterSchemaRequest();
+    v1.setSchema(ORDER_SCHEMA);
+    restApp.restClient.registerSchema(v1, strongSubject, false);
+    RegisterSchemaRequest v2 = new RegisterSchemaRequest();
+    v2.setSchema(ORDER_SCHEMA_V2);
+    restApp.restClient.registerSchema(v2, strongSubject, false);
+
+    RegisterSchemaRequest referrer = new RegisterSchemaRequest();
+    referrer.setSchema(PAYMENT_REFERENCING_ORDER);
+    referrer.setReferences(
+        ImmutableList.of(new SchemaReference("Order", strongSubject, 2)));
+    restApp.restClient.registerSchema(referrer, "payment-4-value", false);
+
+    // Soft-delete the referrer, then v2 (allowed now that its only referrer is soft-deleted).
+    // v1 is the sole active version, so the frozen guard would let the association through --
+    // but v2 is still a reference target and must keep blocking it.
+    restApp.restClient.deleteSchemaVersion(
+        RestService.DEFAULT_REQUEST_PROPERTIES, "payment-4-value", "1", false);
+    restApp.restClient.deleteSchemaVersion(
+        RestService.DEFAULT_REQUEST_PROPERTIES, strongSubject, "2", false);
+
+    RestClientException e = assertThrows(RestClientException.class, () ->
+        restApp.restClient.createAssociation(RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
+            strongKeyAssociation("topic-ref-4", "default", "strong-ref-4", ORDER_SCHEMA)));
     assertEquals(Errors.SUBJECT_IS_REFERENCED_ERROR_CODE, e.getErrorCode());
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
@@ -4135,5 +4135,22 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertEquals(Errors.OPERATION_NOT_PERMITTED_ERROR_CODE, e.getErrorCode());
   }
 
+  @Test
+  public void testReferenceToStrongAssociationSubjectResolvesByReferrerContext() throws Exception {
+    // Strong-associate a subject that lives in the non-default context "myctx".
+    restApp.restClient.createAssociation(RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
+        strongKeyAssociation("topic-ref-6", "myctx", "strong-ref-6", ORDER_SCHEMA));
+
+    // A referrer in the same context references the target by its bare name. Qualification must
+    // resolve the bare name into the referrer's context, where the strong association blocks it.
+    RegisterSchemaRequest referrer = new RegisterSchemaRequest();
+    referrer.setSchema(PAYMENT_REFERENCING_ORDER);
+    referrer.setReferences(
+        ImmutableList.of(new SchemaReference("Order", "topic-ref-6-key", 1)));
+    RestClientException e = assertThrows(RestClientException.class, () ->
+        restApp.restClient.registerSchema(referrer, ":.myctx:payment-6-value", false));
+    assertEquals(Errors.OPERATION_NOT_PERMITTED_ERROR_CODE, e.getErrorCode());
+  }
+
 }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
@@ -3919,6 +3919,14 @@ public class RestApiAssociationTest extends ClusterTestHarness {
   private static final String PAYMENT_REFERENCING_ORDER =
       "{\"type\":\"record\",\"name\":\"Payment\","
           + "\"fields\":[{\"name\":\"order\",\"type\":\"Order\"}]}";
+  private static final String COMMON_SCHEMA =
+      "{\"type\":\"record\",\"name\":\"Common\","
+          + "\"fields\":[{\"name\":\"c\",\"type\":\"string\"}]}";
+  // References Common first, Order second, so the STRONG target is not the first reference.
+  private static final String PAYMENT_REFERENCING_COMMON_AND_ORDER =
+      "{\"type\":\"record\",\"name\":\"Payment\","
+          + "\"fields\":[{\"name\":\"common\",\"type\":\"Common\"},"
+          + "{\"name\":\"order\",\"type\":\"Order\"}]}";
 
   private AssociationCreateOrUpdateRequest strongKeyAssociation(
       String resourceName, String resourceNamespace, String resourceId, String schema) {
@@ -4102,6 +4110,29 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     // Must not throw despite the subject being referenced.
     restApp.restClient.createAssociation(RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
         request);
+  }
+
+  @Test
+  public void testMultiReferenceRejectedWhenAnyTargetHasStrongAssociation() throws Exception {
+    String strongSubject = ":.default:topic-ref-5-key";
+
+    // An ordinary subject to reference first, and a STRONG-associated subject to reference second.
+    RegisterSchemaRequest common = new RegisterSchemaRequest();
+    common.setSchema(COMMON_SCHEMA);
+    restApp.restClient.registerSchema(common, "common-value", false);
+
+    restApp.restClient.createAssociation(RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
+        strongKeyAssociation("topic-ref-5", "default", "strong-ref-5", ORDER_SCHEMA));
+
+    // The STRONG target is the second reference, so the check must inspect every reference.
+    RegisterSchemaRequest referrer = new RegisterSchemaRequest();
+    referrer.setSchema(PAYMENT_REFERENCING_COMMON_AND_ORDER);
+    referrer.setReferences(ImmutableList.of(
+        new SchemaReference("Common", "common-value", 1),
+        new SchemaReference("Order", strongSubject, 1)));
+    RestClientException e = assertThrows(RestClientException.class, () ->
+        restApp.restClient.registerSchema(referrer, "payment-5-value", false));
+    assertEquals(Errors.OPERATION_NOT_PERMITTED_ERROR_CODE, e.getErrorCode());
   }
 
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
@@ -34,6 +34,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.LifecyclePolicyFil
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity.EntityType;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaTags;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationBatchGetRequest;
 import io.confluent.kafka.schemaregistry.client.rest.entities.requests.AssociationBatchRequest;
@@ -3905,6 +3906,69 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     } finally {
       conn.disconnect();
     }
+  }
+
+  private static final String ORDER_SCHEMA =
+      "{\"type\":\"record\",\"name\":\"Order\","
+          + "\"fields\":[{\"name\":\"id\",\"type\":\"string\"}]}";
+  private static final String PAYMENT_REFERENCING_ORDER =
+      "{\"type\":\"record\",\"name\":\"Payment\","
+          + "\"fields\":[{\"name\":\"order\",\"type\":\"Order\"}]}";
+
+  private AssociationCreateOrUpdateRequest strongKeyAssociation(
+      String resourceName, String resourceNamespace, String resourceId, String schema) {
+    RegisterSchemaRequest keyRequest = new RegisterSchemaRequest();
+    keyRequest.setSchema(schema);
+    return new AssociationCreateOrUpdateRequest(
+        resourceName,
+        resourceNamespace,
+        resourceId,
+        "topic",
+        ImmutableList.of(
+            new AssociationCreateOrUpdateInfo(
+                null, "key", LifecyclePolicy.STRONG, true, keyRequest, null)));
+  }
+
+  @Test
+  public void testRegisterReferenceToStrongAssociationSubjectIsRejected() throws Exception {
+    String resourceNamespace = "default";
+    String strongSubject = ":." + resourceNamespace + ":topic-ref-1-key";
+
+    // Claim the subject with a STRONG (topic-owned) association.
+    restApp.restClient.createAssociation(RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
+        strongKeyAssociation("topic-ref-1", resourceNamespace, "ref-strong-1", ORDER_SCHEMA));
+
+    // Referencing a strongly-associated subject is not permitted.
+    RegisterSchemaRequest referrer = new RegisterSchemaRequest();
+    referrer.setSchema(PAYMENT_REFERENCING_ORDER);
+    referrer.setReferences(
+        ImmutableList.of(new SchemaReference("Order", strongSubject, 1)));
+    RestClientException e = assertThrows(RestClientException.class, () ->
+        restApp.restClient.registerSchema(referrer, "payment-1-value", false));
+    assertEquals(Errors.OPERATION_NOT_PERMITTED_ERROR_CODE, e.getErrorCode());
+  }
+
+  @Test
+  public void testCreateStrongAssociationOnReferencedSubjectIsRejected() throws Exception {
+    String resourceNamespace = "default";
+    String strongSubject = ":." + resourceNamespace + ":topic-ref-2-key";
+
+    // Register the subject directly, then reference it from another schema.
+    RegisterSchemaRequest orderRequest = new RegisterSchemaRequest();
+    orderRequest.setSchema(ORDER_SCHEMA);
+    restApp.restClient.registerSchema(orderRequest, strongSubject, false);
+
+    RegisterSchemaRequest referrer = new RegisterSchemaRequest();
+    referrer.setSchema(PAYMENT_REFERENCING_ORDER);
+    referrer.setReferences(
+        ImmutableList.of(new SchemaReference("Order", strongSubject, 1)));
+    restApp.restClient.registerSchema(referrer, "payment-2-value", false);
+
+    // The subject is now a reference target, so it cannot be claimed by a STRONG association.
+    RestClientException e = assertThrows(RestClientException.class, () ->
+        restApp.restClient.createAssociation(RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
+            strongKeyAssociation("topic-ref-2", resourceNamespace, "strong-ref-2", ORDER_SCHEMA)));
+    assertEquals(Errors.SUBJECT_IS_REFERENCED_ERROR_CODE, e.getErrorCode());
   }
 
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/RestApiAssociationTest.java
@@ -3971,5 +3971,51 @@ public class RestApiAssociationTest extends ClusterTestHarness {
     assertEquals(Errors.SUBJECT_IS_REFERENCED_ERROR_CODE, e.getErrorCode());
   }
 
+  @Test
+  public void testReferenceToWeaklyAssociatedSubjectIsAllowed() throws Exception {
+    // Only a STRONG association blocks referencing; a WEAK association does not.
+    RegisterSchemaRequest orderRequest = new RegisterSchemaRequest();
+    orderRequest.setSchema(ORDER_SCHEMA);
+    restApp.restClient.registerSchema(orderRequest, "weak-order-value", false);
+
+    AssociationCreateOrUpdateRequest weak = new AssociationCreateOrUpdateRequest(
+        "weak-topic", "default", "weak-1", "topic",
+        ImmutableList.of(new AssociationCreateOrUpdateInfo(
+            "weak-order-value", "value", LifecyclePolicy.WEAK, false, null, null)));
+    restApp.restClient.createAssociation(RestService.DEFAULT_REQUEST_PROPERTIES, null, false, weak);
+
+    RegisterSchemaRequest referrer = new RegisterSchemaRequest();
+    referrer.setSchema(PAYMENT_REFERENCING_ORDER);
+    referrer.setReferences(
+        ImmutableList.of(new SchemaReference("Order", "weak-order-value", 1)));
+    // Registering the referencing schema must succeed; a throw here fails the test.
+    restApp.restClient.registerSchema(referrer, "weak-payment-value", false);
+  }
+
+  @Test
+  public void testCreateStrongAssociationOnSubjectWithSoftDeletedReferrerIsRejected()
+      throws Exception {
+    String strongSubject = ":.default:topic-ref-3-key";
+
+    RegisterSchemaRequest orderRequest = new RegisterSchemaRequest();
+    orderRequest.setSchema(ORDER_SCHEMA);
+    restApp.restClient.registerSchema(orderRequest, strongSubject, false);
+
+    RegisterSchemaRequest referrer = new RegisterSchemaRequest();
+    referrer.setSchema(PAYMENT_REFERENCING_ORDER);
+    referrer.setReferences(
+        ImmutableList.of(new SchemaReference("Order", strongSubject, 1)));
+    restApp.restClient.registerSchema(referrer, "payment-3-value", false);
+
+    // Soft-delete the referrer; it still counts, since a soft delete can be restored.
+    restApp.restClient.deleteSchemaVersion(
+        RestService.DEFAULT_REQUEST_PROPERTIES, "payment-3-value", "1", false);
+
+    RestClientException e = assertThrows(RestClientException.class, () ->
+        restApp.restClient.createAssociation(RestService.DEFAULT_REQUEST_PROPERTIES, null, false,
+            strongKeyAssociation("topic-ref-3", "default", "strong-ref-3", ORDER_SCHEMA)));
+    assertEquals(Errors.SUBJECT_IS_REFERENCED_ERROR_CODE, e.getErrorCode());
+  }
+
 }
 


### PR DESCRIPTION
## Summary

Enforces a two-way mutual exclusion between schema references and STRONG (topic-owned) associations, so a subject can never be both a reference target and topic-owned at the same time.

- **Register side** (`KafkaSchemaRegistry.register`): registering a schema whose reference targets a subject that has a STRONG association is rejected with `OPERATION_NOT_PERMITTED` (42205).
- **Association side** (`AbstractSchemaRegistry.createOrUpdateAssociation`): creating a STRONG association on a subject that is already a reference target is rejected with a new `SUBJECT_IS_REFERENCED` conflict (40906).

Both checks exempt `IMPORT` mode so cluster linking can replicate a subject that legitimately carries both states on the source.

## Details

- The association-side check is O(1): a STRONG association can only be created when the subject's sole version is 1 (enforced by the existing frozen-existence guard), so only version 1 needs to be checked for referrers.
- Referrers on soft-deleted schema versions still count — a soft delete can be restored, which would otherwise reintroduce the forbidden state after the frozen association is created.
- New error code/message/exception mirror the existing `StrongAssociationForSubjectExists` plumbing; the single-create resource and the batch translation loop both surface it.

## Testing

Two integration tests in `RestApiAssociationTest`, both green:
- `testRegisterReferenceToStrongAssociationSubjectIsRejected` — referencing a strongly-associated subject → 42205.
- `testCreateStrongAssociationOnReferencedSubjectIsRejected` — claiming a referenced subject as STRONG → 40906.
