### PR TITLE
INIT-5113: pin kafka-connect-schema-backup-api to Java 8 bytecode target (cherry-pick #4508 to 8.3.2)

### DIFF
--- a/kafka-connect-schema-backup-api/pom.xml
+++ b/kafka-connect-schema-backup-api/pom.xml
@@ -22,6 +22,13 @@
     <packaging>jar</packaging>
     <name>kafka-connect-schema-backup-api</name>
 
+    <properties>
+        <!-- Pin bytecode to Java 8 so external Kafka Connect connectors on
+             Java 8 runtimes can load BackupWrapper. Overrides the parent
+             chain (rest-utils-parent sets java.version=17). -->
+        <java.version>8</java.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
What
----
Cherry-pick of #4508 from `8.3.x` to `8.3.2`.

Pin `kafka-connect-schema-backup-api` to Java 8 source/target so its bytecode
stays at version 52.0.

The module is consumed by external Kafka Connect connectors
(kafka-connect-storage-common, and downstream S3/GCS/ABS sinks and
object-store-source), whose build/runtime pipelines are still on Java 8.
Without this override the module inherits Java 17 bytecode from
rest-utils-parent, producing version-61.0 class files that fail with:

    class file has wrong version 61.0, should be 52.0

Only `-api` is pinned. `-core` continues to inherit the parent toolchain
because it only runs inside the SR JVM.

Checklist
------------------
- **[N]** Contains customer facing changes? Including API/behavior changes
- **[N]** Is this change gated behind config(s)?
- **[N]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - Build-config-only change; existing module tests continue to pass.
- **[N]** Does this change require modifying existing system tests or adding new system tests?
- **[Y]** Must this be released together with other change(s), either in this repo or another one?
    - Required by kafka-connect-storage-common PR #486 (INIT-5113 backup envelope)
      and downstream connector PRs (kafka-connect-storage-cloud #948,
      kafka-connect-object-store-source #776, plus ABS / GCS PRs to follow).

References
----------
JIRA: https://confluentinc.atlassian.net/browse/INIT-5113

Related PRs:
- schema-registry PR #4508 (parent, merged to 8.3.x)
- kafka-connect-storage-common PR #486
- kafka-connect-storage-cloud PR #948
- kafka-connect-object-store-source PR #776

Test & Review
------------
- Clean cherry-pick of merged commit c1f75f2e3f2 with no conflicts.
- Built the module locally on JDK 17: \`mvn -pl kafka-connect-schema-backup-api -am clean install\`.
- Verified resulting jar bytecode is version 52.0 via \`javap -v\`.
- Downstream connector builds (storage-common, storage-cloud) succeed against
  the pinned jar with a Java 8 toolchain; previous \`class file has wrong
  version 61.0\` failure is gone.