### PR TITLE
Add config to control fetching external refs for JSON Schema

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -191,8 +191,8 @@ public class SchemaRegistryConfig extends RestConfig {
       "Determines whether the JSON Schema provider may fetch remote schema references over "
       + "HTTP/HTTPS. If false, a newly registered JSON Schema must resolve its references from the "
       + "registered references, the classpath, or the prepopulated meta-schemas, and any attempt "
-      + "to fetch an http/https URL is rejected. The check applies only to new schema "
-      + "registrations; already-stored schemas are never affected.";
+      + "to fetch an http/https URL is rejected. The check applies to all schema parsing, "
+      + "including validation against already-stored schemas.";
 
   /**
    * <code>schema.cache.size</code>

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -184,6 +184,16 @@ public class SchemaRegistryConfig extends RestConfig {
   public static final String SCHEMA_VALIDATE_FIELDS_CONFIG = "schema.validate.fields";
   public static final boolean SCHEMA_VALIDATE_FIELDS_DEFAULT = false;
 
+  public static final String SCHEMA_PROVIDERS_JSON_FETCH_REMOTE_REFS_CONFIG =
+      "schema.providers.json.fetch.remote.schemas";
+  public static final boolean SCHEMA_PROVIDERS_JSON_FETCH_REMOTE_REFS_DEFAULT = true;
+  protected static final String SCHEMA_PROVIDERS_JSON_FETCH_REMOTE_REFS_DOC =
+      "Determines whether the JSON Schema provider may fetch remote schema references over "
+      + "HTTP/HTTPS. If false, a newly registered JSON Schema must resolve its references from the "
+      + "registered references, the classpath, or the prepopulated meta-schemas, and any attempt "
+      + "to fetch an http/https URL is rejected. The check applies only to new schema "
+      + "registrations; already-stored schemas are never affected.";
+
   /**
    * <code>schema.cache.size</code>
    */
@@ -572,6 +582,10 @@ public class SchemaRegistryConfig extends RestConfig {
     )
     .define(SCHEMA_VALIDATE_FIELDS_CONFIG, ConfigDef.Type.BOOLEAN, SCHEMA_VALIDATE_FIELDS_DEFAULT,
         ConfigDef.Importance.LOW, VALIDATE_FIELDS_DOC
+    )
+    .define(SCHEMA_PROVIDERS_JSON_FETCH_REMOTE_REFS_CONFIG, ConfigDef.Type.BOOLEAN,
+        SCHEMA_PROVIDERS_JSON_FETCH_REMOTE_REFS_DEFAULT,
+        ConfigDef.Importance.LOW, SCHEMA_PROVIDERS_JSON_FETCH_REMOTE_REFS_DOC
     )
     .define(SCHEMA_CACHE_SIZE_CONFIG, ConfigDef.Type.INT, SCHEMA_CACHE_SIZE_DEFAULT,
         ConfigDef.Importance.LOW, SCHEMA_CACHE_SIZE_DOC

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -252,6 +252,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     Map<String, Object> schemaProviderConfigs =
         config.originalsWithPrefix(SchemaRegistryConfig.SCHEMA_PROVIDERS_CONFIG + ".");
     schemaProviderConfigs.put(SchemaProvider.SCHEMA_VERSION_FETCHER_CONFIG, this);
+    schemaProviderConfigs.put(JsonSchemaProvider.FETCH_REMOTE_REFS,
+        config.getBoolean(SchemaRegistryConfig.SCHEMA_PROVIDERS_JSON_FETCH_REMOTE_REFS_CONFIG));
     List<SchemaProvider> defaultSchemaProviders = Arrays.asList(
         new AvroSchemaProvider(), new JsonSchemaProvider(), new ProtobufSchemaProvider()
     );
@@ -1449,9 +1451,11 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     try {
       if (getModeInScope(schema.getSubject()) != Mode.IMPORT) {
         parsedSchema.validate(isSchemaFieldValidationEnabled(config));
-        if (normalize) {
-          parsedSchema = parsedSchema.normalize();
-        }
+      } else {
+        enforceRemoteRefBlockOnImport(parsedSchema);
+      }
+      if (normalize) {
+        parsedSchema = parsedSchema.normalize();
       }
     } catch (Exception e) {
       String errMsg = "Invalid schema " + schema + ", details: " + e.getMessage();
@@ -1462,6 +1466,35 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     schema.setSchema(parsedSchema.canonicalString());
     schema.setReferences(parsedSchema.references());
     return parsedSchema;
+  }
+
+  // IMPORT skips validation, so force $ref resolution to fire the block; other parse failures are
+  // swallowed to preserve IMPORT's leniency for storing quirky schemas.
+  private void enforceRemoteRefBlockOnImport(ParsedSchema parsedSchema)
+          throws InvalidSchemaException {
+    if (!"JSON".equals(parsedSchema.schemaType())
+        || config.getBoolean(
+            SchemaRegistryConfig.SCHEMA_PROVIDERS_JSON_FETCH_REMOTE_REFS_CONFIG)) {
+      return;
+    }
+    try {
+      parsedSchema.rawSchema();
+    } catch (RuntimeException e) {
+      if (isBlockedRemoteRef(e)) {
+        throw new InvalidSchemaException("Invalid schema of type " + parsedSchema.schemaType()
+            + ", details: " + e.getMessage(), e);
+      }
+    }
+  }
+
+  private static boolean isBlockedRemoteRef(Throwable t) {
+    for (Throwable c = t; c != null; c = c.getCause()) {
+      if (c.getMessage() != null
+          && c.getMessage().contains("Remote schema reference fetching over HTTP(S) is disabled")) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public ParsedSchema parseSchema(Schema schema) throws InvalidSchemaException {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -1451,11 +1451,11 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
     try {
       if (getModeInScope(schema.getSubject()) != Mode.IMPORT) {
         parsedSchema.validate(isSchemaFieldValidationEnabled(config));
+        if (normalize) {
+          parsedSchema = parsedSchema.normalize();
+        }
       } else {
         enforceRemoteRefBlockOnImport(parsedSchema);
-      }
-      if (normalize) {
-        parsedSchema = parsedSchema.normalize();
       }
     } catch (Exception e) {
       String errMsg = "Invalid schema " + schema + ", details: " + e.getMessage();

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -66,6 +66,7 @@ import io.confluent.kafka.schemaregistry.exceptions.SubjectNotSoftDeletedExcepti
 import io.confluent.kafka.schemaregistry.exceptions.UnknownLeaderException;
 import io.confluent.kafka.schemaregistry.id.IdGenerator;
 import io.confluent.kafka.schemaregistry.id.IncrementalIdGenerator;
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
 import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
 import io.confluent.kafka.schemaregistry.leaderelector.kafka.KafkaGroupLeaderElector;
 import io.confluent.kafka.schemaregistry.metrics.MetricsContainer;
@@ -1490,7 +1491,7 @@ public class KafkaSchemaRegistry implements SchemaRegistry, LeaderAwareSchemaReg
   private static boolean isBlockedRemoteRef(Throwable t) {
     for (Throwable c = t; c != null; c = c.getCause()) {
       if (c.getMessage() != null
-          && c.getMessage().contains("Remote schema reference fetching over HTTP(S) is disabled")) {
+          && c.getMessage().contains(JsonSchema.REMOTE_REF_DISABLED_MESSAGE)) {
         return true;
       }
     }

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -482,13 +482,13 @@ public class JsonSchema implements ParsedSchema {
       String scheme = url == null ? null : URI.create(url.trim()).getScheme();
       if (isHttpScheme(scheme)) {
         throw new UncheckedIOException(new IOException(
-            "Remote schema reference fetching over HTTP(S) is disabled: " + url));
+            REMOTE_REF_DISABLED_MESSAGE + ": " + url));
       }
       return delegate.get(url);
     }
   }
 
-  static final String REMOTE_REF_DISABLED_MESSAGE =
+  public static final String REMOTE_REF_DISABLED_MESSAGE =
       "Remote schema reference fetching over HTTP(S) is disabled";
 
   static boolean isRemoteRefBlocked(Throwable t) {

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -54,6 +54,8 @@ import io.confluent.kafka.schemaregistry.rules.RuleContext.Type;
 import io.confluent.kafka.schemaregistry.rules.RuleException;
 import io.confluent.kafka.schemaregistry.utils.BoundedConcurrentHashMap;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
@@ -121,6 +123,11 @@ public class JsonSchema implements ParsedSchema {
 
   private final RuleSet ruleSet;
 
+  // When true, remote HTTP/HTTPS schema-reference fetching is blocked while loading this schema.
+  // Set only for a new schema registration when remote fetching is disabled; carried across
+  // copy()/normalize() so it is not lost before the schema is loaded/validated.
+  private final boolean blockRemoteRefs;
+
   private transient volatile String canonicalString;
 
   private transient volatile int hashCode = NO_HASHCODE;
@@ -156,6 +163,7 @@ public class JsonSchema implements ParsedSchema {
     this.resolvedReferences = Collections.unmodifiableMap(resolvedReferences);
     this.metadata = null;
     this.ruleSet = null;
+    this.blockRemoteRefs = false;
   }
 
   public JsonSchema(
@@ -181,6 +189,7 @@ public class JsonSchema implements ParsedSchema {
     this.metadata = metadata;
     this.ruleSet = ruleSet;
     this.version = version;
+    this.blockRemoteRefs = false;
   }
 
   public JsonSchema(
@@ -198,8 +207,31 @@ public class JsonSchema implements ParsedSchema {
       this.resolvedReferences = Collections.unmodifiableMap(resolvedReferences);
       this.metadata = metadata;
       this.ruleSet = ruleSet;
+      this.blockRemoteRefs = false;
     } catch (IOException e) {
-      throw new IllegalArgumentException("Invalid JSON " + schemaString, e);
+      throw new IllegalArgumentException("Invalid JSON schema", e);
+    }
+  }
+
+  public JsonSchema(
+      String schemaString,
+      List<SchemaReference> references,
+      Map<String, String> resolvedReferences,
+      Metadata metadata,
+      RuleSet ruleSet,
+      Integer version,
+      boolean blockRemoteRefs
+  ) {
+    try {
+      this.jsonNode = schemaString != null ? objectMapper.readTree(schemaString) : null;
+      this.version = version;
+      this.references = Collections.unmodifiableList(references);
+      this.resolvedReferences = Collections.unmodifiableMap(resolvedReferences);
+      this.metadata = metadata;
+      this.ruleSet = ruleSet;
+      this.blockRemoteRefs = blockRemoteRefs;
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Invalid JSON schema", e);
     }
   }
 
@@ -216,6 +248,7 @@ public class JsonSchema implements ParsedSchema {
       this.resolvedReferences = Collections.emptyMap();
       this.metadata = null;
       this.ruleSet = null;
+      this.blockRemoteRefs = false;
     } catch (IOException e) {
       throw new IllegalArgumentException("Invalid JSON " + schemaObj, e);
     }
@@ -229,7 +262,8 @@ public class JsonSchema implements ParsedSchema {
       Map<String, String> resolvedReferences,
       Metadata metadata,
       RuleSet ruleSet,
-      String canonicalString
+      String canonicalString,
+      boolean blockRemoteRefs
   ) {
     this.jsonNode = jsonNode;
     this.schemaObj = schemaObj;
@@ -239,6 +273,7 @@ public class JsonSchema implements ParsedSchema {
     this.metadata = metadata;
     this.ruleSet = ruleSet;
     this.canonicalString = canonicalString;
+    this.blockRemoteRefs = blockRemoteRefs;
   }
 
   @Override
@@ -251,7 +286,8 @@ public class JsonSchema implements ParsedSchema {
         this.resolvedReferences,
         this.metadata,
         this.ruleSet,
-        this.canonicalString
+        this.canonicalString,
+        this.blockRemoteRefs
     );
   }
 
@@ -265,7 +301,8 @@ public class JsonSchema implements ParsedSchema {
         this.resolvedReferences,
         this.metadata,
         this.ruleSet,
-        this.canonicalString
+        this.canonicalString,
+        this.blockRemoteRefs
     );
   }
 
@@ -279,7 +316,8 @@ public class JsonSchema implements ParsedSchema {
         this.resolvedReferences,
         metadata,
         ruleSet,
-        this.canonicalString
+        this.canonicalString,
+        this.blockRemoteRefs
     );
   }
 
@@ -289,12 +327,16 @@ public class JsonSchema implements ParsedSchema {
     JsonSchema schemaCopy = this.copy();
     JsonNode original = schemaCopy.toJsonNode().deepCopy();
     modifySchemaTags(original, tagsToAdd, tagsToRemove);
-    return new JsonSchema(original.toString(),
+    return new JsonSchema(
+      original,
+      null,
+      schemaCopy.version(),
       schemaCopy.references(),
       schemaCopy.resolvedReferences(),
       schemaCopy.metadata(),
       schemaCopy.ruleSet(),
-      schemaCopy.version());
+      null,
+      this.blockRemoteRefs);
   }
 
   public JsonNode toJsonNode() {
@@ -330,11 +372,27 @@ public class JsonSchema implements ParsedSchema {
             }
             SchemaLoader.SchemaLoaderBuilder builder = SchemaLoader.builder()
                 .useDefaults(true).draftV7Support();
-            for (Map.Entry<String, String> dep : resolvedReferences.entrySet()) {
-              URI child = ReferenceResolver.resolve(idUri, dep.getKey());
-              builder.registerSchemaByURI(child, new JSONObject(dep.getValue()));
+            if (blockRemoteRefs) {
+              // Block remote HTTP(S) ref fetching; classpath and registered refs still resolve.
+              builder.schemaClient(new NoHttpSchemaClient());
             }
-            JSONObject jsonObject = objectMapper.treeToValue(jsonNode, JSONObject.class);
+            for (Map.Entry<String, String> dep : resolvedReferences.entrySet()) {
+              // Bridge top-level `definitions` into `$defs` so a `$ref: "#/$defs/X"`
+              // resolves via Everit's literal JSON Pointer fallback even when the
+              // schema author placed the body under draft-7's native `definitions`
+              // bucket. The asymmetric direction (definitions → $defs, not the
+              // reverse) makes `$defs` the canonical "forgiving" ref form across both
+              // drafts: a `$ref: "#/$defs/X"` always finds its target, regardless of
+              // which bucket the body actually lives in. The original content in
+              // resolvedReferences is left untouched; only the in-memory copy passed
+              // to the loader is augmented.
+              String content = mergeDefBuckets(dep.getValue(), "definitions", "$defs");
+              URI child = ReferenceResolver.resolve(idUri, dep.getKey());
+              builder.registerSchemaByURI(child, new JSONObject(content));
+            }
+            String rootJson = mergeDefBuckets(
+                objectMapper.writeValueAsString(jsonNode), "definitions", "$defs");
+            JSONObject jsonObject = new JSONObject(rootJson);
             builder.schemaJson(jsonObject);
             SchemaLoader loader = builder.build();
             schemaObj = loader.load().build();
@@ -345,6 +403,101 @@ public class JsonSchema implements ParsedSchema {
       }
     }
     return schemaObj;
+  }
+
+  /**
+   * Copies any top-level entries under {@code fromKey} into {@code toKey}.
+   *
+   * <p>Used by both load paths to bridge {@code definitions} entries into {@code $defs} so
+   * that {@code $ref: "#/$defs/X"} resolves regardless of which bucket the body lives in.
+   * The keys are parameterized to keep the helper algorithmically symmetric and easy to test
+   * in isolation; in production both call sites pass {@code ("definitions", "$defs")}.
+   *
+   * <p>Existing {@code toKey} entries take precedence on key collision (the target keyword
+   * wins). Returns the original string when:
+   * <ul>
+   *   <li>{@code json} is null or empty,</li>
+   *   <li>{@code json} parses to a non-object (e.g. a boolean schema),</li>
+   *   <li>{@code fromKey} is absent, its value is not an object, or its value is empty,</li>
+   *   <li>{@code toKey} is present but not an object (preserved rather than overwritten),</li>
+   *   <li>parsing fails (best-effort fallback).</li>
+   * </ul>
+   *
+   * <p>Top-level only — nested {@code definitions}/{@code $defs} inside subschemas are not
+   * bridged.
+   */
+  static String mergeDefBuckets(String json, String fromKey, String toKey) {
+    if (json == null || json.isEmpty()) {
+      return json;
+    }
+    try {
+      JsonNode root = objectMapper.readTree(json);
+      if (!root.isObject()) {
+        return json;
+      }
+      JsonNode source = root.get(fromKey);
+      if (source == null || !source.isObject() || source.size() == 0) {
+        // Nothing to copy — return as-is to avoid creating a stray empty target.
+        return json;
+      }
+      // Preserve a non-object target unchanged rather than overwriting it.
+      JsonNode existingTarget = root.get(toKey);
+      if (existingTarget != null && !existingTarget.isObject()) {
+        return json;
+      }
+      ObjectNode mut = (ObjectNode) root;
+      ObjectNode target = existingTarget != null
+          ? (ObjectNode) existingTarget
+          : mut.putObject(toKey);
+      java.util.Iterator<Map.Entry<String, JsonNode>> it = source.fields();
+      while (it.hasNext()) {
+        Map.Entry<String, JsonNode> entry = it.next();
+        if (!target.has(entry.getKey())) {
+          target.set(entry.getKey(), entry.getValue());
+        }
+      }
+      return objectMapper.writeValueAsString(mut);
+    } catch (IOException e) {
+      return json;
+    }
+  }
+
+  private static boolean isHttpScheme(String scheme) {
+    return "http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme);
+  }
+
+  /**
+   * An Everit {@link org.everit.json.schema.loader.SchemaClient} that refuses to fetch
+   * {@code http}/{@code https} URLs, while delegating all other (e.g. {@code classpath})
+   * lookups to the default classpath-aware client.
+   */
+  private static final class NoHttpSchemaClient
+      implements org.everit.json.schema.loader.SchemaClient {
+
+    private final org.everit.json.schema.loader.SchemaClient delegate =
+        org.everit.json.schema.loader.SchemaClient.classPathAwareClient();
+
+    @Override
+    public InputStream get(String url) {
+      String scheme = url == null ? null : URI.create(url.trim()).getScheme();
+      if (isHttpScheme(scheme)) {
+        throw new UncheckedIOException(new IOException(
+            "Remote schema reference fetching over HTTP(S) is disabled: " + url));
+      }
+      return delegate.get(url);
+    }
+  }
+
+  static final String REMOTE_REF_DISABLED_MESSAGE =
+      "Remote schema reference fetching over HTTP(S) is disabled";
+
+  static boolean isRemoteRefBlocked(Throwable t) {
+    for (Throwable c = t; c != null; c = c.getCause()) {
+      if (c.getMessage() != null && c.getMessage().contains(REMOTE_REF_DISABLED_MESSAGE)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override
@@ -438,11 +591,15 @@ public class JsonSchema implements ParsedSchema {
       JsonNode jsonNode = objectMapperWithOrderedProps.readTree(canonical);
       return new JsonSchema(
           jsonNode,
-          this.references.stream().sorted().distinct().collect(Collectors.toList()),
+          null,
+          this.version,
+          Collections.unmodifiableList(
+              this.references.stream().sorted().distinct().collect(Collectors.toList())),
           this.resolvedReferences,
           this.metadata,
           this.ruleSet,
-          this.version
+          null,
+          this.blockRemoteRefs
       );
     } catch (IOException e) {
       throw new IllegalArgumentException("Invalid JSON", e);
@@ -520,8 +677,19 @@ public class JsonSchema implements ParsedSchema {
     if (!schemaType().equals(previousSchema.schemaType())) {
       return Lists.newArrayList("Incompatible because of different schema type");
     }
-    final List<Difference> differences =
-            SchemaDiff.compare(((JsonSchema) previousSchema).rawSchema(), rawSchema());
+    final List<Difference> differences;
+    try {
+      differences =
+              SchemaDiff.compare(((JsonSchema) previousSchema).rawSchema(), rawSchema());
+    } catch (RuntimeException e) {
+      if (isRemoteRefBlocked(e)) {
+        // mutable: the FULL compatibility check appends to the returned list
+        List<String> errors = new ArrayList<>();
+        errors.add("A previous schema version contains an unsupported external reference");
+        return errors;
+      }
+      throw e;
+    }
     final List<Difference> incompatibleDiffs = differences.stream()
         .filter(diff -> !SchemaDiff.COMPATIBLE_CHANGES.contains(diff.getType()))
         .collect(Collectors.toList());

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaProvider.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaProvider.java
@@ -16,6 +16,7 @@
 package io.confluent.kafka.schemaregistry.json;
 
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,9 +27,38 @@ public class JsonSchemaProvider extends AbstractSchemaProvider {
 
   private static final Logger log = LoggerFactory.getLogger(JsonSchemaProvider.class);
 
+  /**
+   * Config key (within the {@code schema.providers.} provider config map) controlling whether
+   * remote HTTP(S) schema references may be fetched. The typed value is injected by the schema
+   * registry from {@code schema.providers.json.fetch.remote.schemas} (defaults to true).
+   */
+  public static final String FETCH_REMOTE_REFS = "fetchRemoteRefs";
+
+  private boolean fetchRemoteRefs = true;
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    super.configure(configs);
+    Object value = configs.get(FETCH_REMOTE_REFS);
+    if (value instanceof Boolean) {
+      fetchRemoteRefs = (Boolean) value;
+    } else if (value != null) {
+      fetchRemoteRefs = Boolean.parseBoolean(value.toString());
+    }
+  }
+
   @Override
   public String schemaType() {
     return JsonSchema.TYPE;
+  }
+
+  /**
+   * Determines whether remote HTTP(S) schema-reference fetching should be blocked while loading
+   * the given schema. Subclasses may override to apply a narrower policy (e.g. only blocking
+   * new schema registrations) than the default of blocking all fetches once disabled.
+   */
+  protected boolean shouldBlockRemoteRefs(Schema schema, boolean fetchRemoteRefs) {
+    return !fetchRemoteRefs;
   }
 
   @Override
@@ -40,7 +70,8 @@ public class JsonSchemaProvider extends AbstractSchemaProvider {
               resolveReferences(schema, isNew),
               schema.getMetadata(),
               schema.getRuleSet(),
-              null
+              null,
+              shouldBlockRemoteRefs(schema, fetchRemoteRefs)
       );
     } catch (Exception e) {
       log.error("Could not parse JSON schema", e);

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaProvider.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaProvider.java
@@ -54,8 +54,8 @@ public class JsonSchemaProvider extends AbstractSchemaProvider {
 
   /**
    * Determines whether remote HTTP(S) schema-reference fetching should be blocked while loading
-   * the given schema. Subclasses may override to apply a narrower policy (e.g. only blocking
-   * new schema registrations) than the default of blocking all fetches once disabled.
+   * the given schema. Applies uniformly to all parses (new registrations and already-stored
+   * schemas alike); subclasses may override for a different policy.
    */
   protected boolean shouldBlockRemoteRefs(Schema schema, boolean fetchRemoteRefs) {
     return !fetchRemoteRefs;

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaRemoteRefTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaRemoteRefTest.java
@@ -32,9 +32,6 @@ import org.junit.Test;
  */
 public class JsonSchemaRemoteRefTest {
 
-  private static final String DISABLED_MESSAGE =
-      "Remote schema reference fetching over HTTP(S) is disabled";
-
   private static JsonSchema schema(
       String schemaString,
       Map<String, String> resolvedReferences,
@@ -50,22 +47,17 @@ public class JsonSchemaRemoteRefTest {
   }
 
   private static void assertBlocked(Throwable t) {
-    for (Throwable c = t; c != null; c = c.getCause()) {
-      if (c.getMessage() != null && c.getMessage().contains(DISABLED_MESSAGE)) {
-        return;
-      }
+    if (!JsonSchema.isRemoteRefBlocked(t)) {
+      throw new AssertionError("Expected a 'remote fetch disabled' cause but was: " + t, t);
     }
-    throw new AssertionError("Expected a 'remote fetch disabled' cause but was: " + t, t);
   }
 
   private static void assertNotBlocked(JsonSchema schema) {
     try {
       schema.rawSchema();
     } catch (RuntimeException e) {
-      for (Throwable c = e; c != null; c = c.getCause()) {
-        if (c.getMessage() != null && c.getMessage().contains(DISABLED_MESSAGE)) {
-          throw new AssertionError("Schema must not be blocked, but it was: " + e, e);
-        }
+      if (JsonSchema.isRemoteRefBlocked(e)) {
+        throw new AssertionError("Schema must not be blocked, but it was: " + e, e);
       }
     }
   }

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaRemoteRefTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaRemoteRefTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * Tests for the {@code blockRemoteRefs} behavior of {@link JsonSchema}: when set, a
+ * {@code $ref} to an unregistered http/https document is rejected rather than fetched over
+ * the network.
+ */
+public class JsonSchemaRemoteRefTest {
+
+  private static final String DISABLED_MESSAGE =
+      "Remote schema reference fetching over HTTP(S) is disabled";
+
+  private static JsonSchema schema(
+      String schemaString,
+      Map<String, String> resolvedReferences,
+      boolean blockRemoteRefs) {
+    return new JsonSchema(
+        schemaString,
+        Collections.emptyList(),
+        resolvedReferences,
+        null,
+        null,
+        null,
+        blockRemoteRefs);
+  }
+
+  private static void assertBlocked(Throwable t) {
+    for (Throwable c = t; c != null; c = c.getCause()) {
+      if (c.getMessage() != null && c.getMessage().contains(DISABLED_MESSAGE)) {
+        return;
+      }
+    }
+    throw new AssertionError("Expected a 'remote fetch disabled' cause but was: " + t, t);
+  }
+
+  private static void assertNotBlocked(JsonSchema schema) {
+    try {
+      schema.rawSchema();
+    } catch (RuntimeException e) {
+      for (Throwable c = e; c != null; c = c.getCause()) {
+        if (c.getMessage() != null && c.getMessage().contains(DISABLED_MESSAGE)) {
+          throw new AssertionError("Schema must not be blocked, but it was: " + e, e);
+        }
+      }
+    }
+  }
+
+  private static void assertRefRejected(String schemaString) {
+    try {
+      schema(schemaString, Collections.emptyMap(), true).rawSchema();
+      fail("Expected loading to fail because the remote $ref fetch is disabled");
+    } catch (RuntimeException e) {
+      assertBlocked(e);
+    }
+  }
+
+  @Test
+  public void localSchemaLoadsWhenBlocked_latestDraft() {
+    String s = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\",\"properties\":{\"a\":{\"type\":\"string\"}}}";
+    assertNotNull(schema(s, Collections.emptyMap(), true).rawSchema());
+  }
+
+  @Test
+  public void localSchemaLoadsWhenBlocked_draft7() {
+    String s = "{\"$schema\":\"http://json-schema.org/draft-07/schema#\","
+        + "\"type\":\"object\",\"properties\":{\"a\":{\"type\":\"string\"}}}";
+    assertNotNull(schema(s, Collections.emptyMap(), true).rawSchema());
+  }
+
+  @Test
+  public void httpRefRejectedWhenBlocked_latestDraft() {
+    assertRefRejected("{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\",\"properties\":{\"a\":{\"$ref\":\"http://example.com/r.json\"}}}");
+  }
+
+  @Test
+  public void httpsRefRejectedWhenBlocked_draft7() {
+    assertRefRejected("{\"$schema\":\"http://json-schema.org/draft-07/schema#\","
+        + "\"type\":\"object\",\"properties\":{\"a\":{\"$ref\":\"https://example.com/r.json\"}}}");
+  }
+
+  @Test
+  public void registeredHttpRefNotBlocked_latestDraft() {
+    String ref = "http://acme.com/widget.json";
+    String s = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\",\"properties\":{\"a\":{\"$ref\":\"" + ref + "\"}}}";
+    Map<String, String> resolvedRefs = Collections.singletonMap(
+        ref, "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"type\":\"string\"}");
+    // A registered reference resolves from the in-memory mappings, not the network.
+    assertNotNull(schema(s, resolvedRefs, true).rawSchema());
+  }
+
+  @Test
+  public void registeredHttpRefNotBlocked_draft7() {
+    String ref = "http://acme.com/widget.json";
+    String s = "{\"$schema\":\"http://json-schema.org/draft-07/schema#\","
+        + "\"type\":\"object\",\"properties\":{\"a\":{\"$ref\":\"" + ref + "\"}}}";
+    Map<String, String> resolvedRefs = Collections.singletonMap(ref, "{\"type\":\"string\"}");
+    assertNotNull(schema(s, resolvedRefs, true).rawSchema());
+  }
+
+  @Test
+  public void notBlockedWhenBlockRemoteRefsFalse() {
+    String s = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\","
+        + "\"properties\":{\"a\":{\"$ref\":\"http://nonexistent.invalid/r.json\"}}}";
+    assertNotBlocked(schema(s, Collections.emptyMap(), false));
+  }
+
+  // The registration pipeline copies/normalizes the parsed schema before it is loaded, so the
+  // block must survive those operations.
+
+  @Test
+  public void blockSurvivesCopyWithVersion() {
+    String s = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\",\"properties\":{\"a\":{\"$ref\":\"http://example.com/r.json\"}}}";
+    JsonSchema copy = schema(s, Collections.emptyMap(), true).copy(0);
+    assertTrue(copy instanceof JsonSchema);
+    try {
+      copy.rawSchema();
+      fail("Expected the copy to still block the remote $ref fetch");
+    } catch (RuntimeException e) {
+      assertBlocked(e);
+    }
+  }
+
+  @Test
+  public void blockSurvivesNormalize() {
+    String s = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\",\"properties\":{\"a\":{\"$ref\":\"http://example.com/r.json\"}}}";
+    JsonSchema normalized = schema(s, Collections.emptyMap(), true).normalize();
+    try {
+      normalized.rawSchema();
+      fail("Expected the normalized copy to still block the remote $ref fetch");
+    } catch (RuntimeException e) {
+      assertBlocked(e);
+    }
+  }
+
+  @Test
+  public void blockedPreviousSurfacesAsIncompatibilityNotError() {
+    String previous = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\",\"properties\":{\"a\":{\"$ref\":\"http://example.com/r.json\"}}}";
+    String current = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\",\"properties\":{\"a\":{\"type\":\"string\"}}}";
+    List<String> errors = schema(current, Collections.emptyMap(), true)
+        .isBackwardCompatible(schema(previous, Collections.emptyMap(), true));
+    assertFalse(errors.isEmpty());
+    assertTrue(errors.get(0).contains("unsupported external reference"));
+  }
+}


### PR DESCRIPTION
What
----
Adds `schema.providers.json.fetch.remote.schemas` (default `true`). When `false`, a newly registered JSON Schema must resolve `$ref`s from registered references, the classpath, or bundled meta-schemas — any `http`/`https` fetch is rejected instead of the server making an outbound call.

Everit-only loader branch: block implemented via a custom `SchemaClient` on `SchemaLoader.builder()`. Draft 4/6/7 meta-schemas are pre-registered so refs to them resolve locally. IMPORT mode skips normal validation, so the block is force-checked separately there.

This diverges slightly from the original source patch: the patch predates PR #4434 ("skip normalize in IMPORT mode"), so applying it literally would have silently reintroduced normalize-in-IMPORT. Fixed to compose with #4434 instead. See confluentinc/packaging#2667, confluentinc/packaging#2666, confluentinc/packaging#2662 for the patch-generation history.

Checklist
------------------
- [x] Customer facing / behavior change: new config, defaults `true` (no-op unless disabled)
- [x] Tests: `JsonSchemaRemoteRefTest`

References
----------
JIRA: DGS-24482