### PR TITLE
DGS-25105 Harden the Variant/CEL reference for cross-language parity 

### DIFF
--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/VariantPath.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/VariantPath.java
@@ -49,33 +49,30 @@ import java.util.List;
  * accepting the syntax with degenerate semantics is a trap for users importing
  * expectations from those dialects.
  *
- * <p><b>Quoted-key escape behavior:</b> inside a quoted key, a backslash
- * followed by any character X decodes to the literal character X. The useful
- * cases are a doubled backslash (embed a literal backslash) and backslash +
- * quote (embed the same quote character used to enclose the key). This is
- * intentionally narrower than RFC 9535 — escape sequences denoting newline,
- * tab, carriage return, or Unicode codepoints (the RFC 9535 escape table) are
- * NOT interpreted; backslash + n decodes to the literal letter n, backslash +
- * t to literal t, and so on. Variant object keys in practice are simple
+ * <p><b>Quoted-key escape behavior:</b> inside a quoted key only two escapes
+ * are recognized — a doubled backslash for a literal backslash, and backslash
+ * followed by the enclosing quote for a literal quote character. Any other
+ * escape sequence is a parse error rather than being silently decoded. This is
+ * intentionally narrower than RFC 9535: escape sequences denoting newline, tab,
+ * carriage return, or Unicode codepoints (the RFC 9535 escape table) are not
+ * interpreted and are rejected. Variant object keys in practice are simple
  * identifiers, so this minimal model covers realistic needs without an
  * RFC 9535 escape table.
  *
- * <p><b>Silent-mistranslation hazard for Unicode escapes.</b> A would-be
- * Unicode escape like a backslash followed by {@code u00e9} decodes as 5
- * literal characters: the backslash consumes the {@code u}, and {@code 00e9}
- * are appended literally one by one. So {@code $["café"]} resolves to
- * the 8-character key {@code cafu00e9}, NOT the 4-character key {@code café}.
- * Users coming from JSON or RFC 9535 JSONPath should be aware that this path
- * grammar cannot express non-ASCII keys via escape sequences. For keys that
- * actually contain non-ASCII characters, use {@link
+ * <p><b>Non-ASCII and special keys.</b> Because the escape table is minimal,
+ * this path grammar cannot express non-ASCII keys via escape sequences: a
+ * would-be Unicode escape (a backslash followed by {@code u00e9}) is not
+ * interpreted, and rather than silently resolving {@code $["café"]} to a wrong
+ * key it throws with an "unsupported escape" message. For keys that actually
+ * contain non-ASCII characters — or any character outside the two recognized
+ * escapes — use {@link
  * io.confluent.kafka.schemaregistry.rules.cel.builtin.BuiltinOverload
  * variants.field(v, "café")} directly — the key argument is a regular CEL
  * string and handles Unicode through CEL's own escape semantics.
  *
- * <p>A trailing backslash at end-of-input (e.g., {@code $["foo} followed by a
- * stray backslash) is not consumed as an escape because there is no following
- * character; it is treated as a literal backslash, the key remains open, and
- * parsing throws as an unterminated quoted key.
+ * <p>A backslash at end-of-input (e.g., {@code $["foo} followed by a stray
+ * backslash) has no following character to escape and is reported as a parse
+ * error.
  */
 final class VariantPath {
 
@@ -216,13 +213,26 @@ final class VariantPath {
     StringBuilder sb = new StringBuilder();
     while (c.hasMore()) {
       char ch = c.next();
-      if (ch == '\\' && c.hasMore()) {
-        // Minimal-escape: backslash consumes exactly one following character
-        // and emits it literally. Intentionally not RFC 9535: a backslash-u
-        // sequence decodes to a literal 'u' (and the following hex digits
-        // continue as literals). See the class-level Javadoc for the Unicode
-        // silent-mistranslation hazard and the recommended workaround.
-        sb.append(c.next());
+      if (ch == '\\') {
+        // Only two escapes are recognized: a doubled backslash for a literal
+        // backslash, and backslash + the enclosing quote for a literal quote.
+        // Any other escape — including a would-be Unicode escape like
+        // backslash-u00e9 — is a parse error rather than being silently decoded
+        // to the wrong key. For keys needing characters outside this set, use
+        // variants.field(v, key) with a regular CEL string. See the class-level
+        // Javadoc.
+        if (!c.hasMore()) {
+          throw new IllegalArgumentException(
+              "unterminated escape at end of quoted key in variant path: " + path);
+        }
+        char esc = c.next();
+        if (esc == '\\' || esc == quote) {
+          sb.append(esc);
+        } else {
+          throw new IllegalArgumentException(
+              "unsupported escape '\\" + esc + "' in quoted key of variant path "
+                  + "(only '\\\\' and '\\" + quote + "' are allowed): " + path);
+        }
       } else if (ch == quote) {
         return sb.toString();
       } else {

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/VariantPath.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/VariantPath.java
@@ -59,13 +59,11 @@ import java.util.List;
  * identifiers, so this minimal model covers realistic needs without an
  * RFC 9535 escape table.
  *
- * <p><b>Non-ASCII and special keys.</b> Because the escape table is minimal,
- * this path grammar cannot express non-ASCII keys via escape sequences: a
- * would-be Unicode escape (a backslash followed by {@code u00e9}) is not
- * interpreted, and rather than silently resolving {@code $["café"]} to a wrong
- * key it throws with an "unsupported escape" message. For keys that actually
- * contain non-ASCII characters — or any character outside the two recognized
- * escapes — use {@link
+ * <p><b>Unicode escape notation.</b> This path grammar does not interpret
+ * Unicode escape sequences. A backslash followed by {@code u00e9}, for example,
+ * is rejected with an "unsupported escape" message rather than silently
+ * resolving to the wrong key. Non-ASCII characters can still be written
+ * literally in a quoted key, as in {@code $["café"]}. Alternatively, use {@link
  * io.confluent.kafka.schemaregistry.rules.cel.builtin.BuiltinOverload
  * variants.field(v, "café")} directly — the key argument is a regular CEL
  * string and handles Unicode through CEL's own escape semantics.
@@ -218,9 +216,8 @@ final class VariantPath {
         // backslash, and backslash + the enclosing quote for a literal quote.
         // Any other escape — including a would-be Unicode escape like
         // backslash-u00e9 — is a parse error rather than being silently decoded
-        // to the wrong key. For keys needing characters outside this set, use
-        // variants.field(v, key) with a regular CEL string. See the class-level
-        // Javadoc.
+        // to the wrong key. Literal characters (including non-ASCII) need no
+        // escaping and pass through as-is. See the class-level Javadoc.
         if (!c.hasMore()) {
           throw new IllegalArgumentException(
               "unterminated escape at end of quoted key in variant path: " + path);

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/VariantPathTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/VariantPathTest.java
@@ -191,10 +191,27 @@ public class VariantPathTest {
 
   @Test
   void quotedKey_trailingBackslashAtEnd_throws() {
-    // $["foo\   — the trailing '\' consumes EOF as its escape target, then the
-    // loop exits with the key still open and throws as unterminated.
+    // $["foo\   — the trailing '\' has no following character to escape, so it
+    // is reported as a parse error (unterminated escape).
     assertThrows(IllegalArgumentException.class,
         () -> VariantPath.parse("$[\"foo\\"));
+  }
+
+  @Test
+  void quotedKey_unsupportedEscape_throws() {
+    // Only \\ and \" (the enclosing quote) are valid escapes. Any other escape
+    // is a parse error rather than being silently decoded to a wrong key.
+    // \n would previously have decoded to a literal 'n'.
+    IllegalArgumentException e1 = assertThrows(IllegalArgumentException.class,
+        () -> VariantPath.parse("$[\"a\\nb\"]"));
+    assertTrue(e1.getMessage().contains("unsupported escape"),
+        "message was: " + e1.getMessage());
+
+    // The motivating case: a would-be Unicode escape ($["café"]) throws
+    // instead of silently resolving to the wrong key "café". Use
+    // variants.field(v, "café") for keys with non-ASCII characters.
+    assertThrows(IllegalArgumentException.class,
+        () -> VariantPath.parse("$[\"caf\\u00e9\"]"));
   }
 
   @Test

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/VariantPathTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/VariantPathTest.java
@@ -207,11 +207,20 @@ public class VariantPathTest {
     assertTrue(e1.getMessage().contains("unsupported escape"),
         "message was: " + e1.getMessage());
 
-    // The motivating case: a would-be Unicode escape ($["café"]) throws
-    // instead of silently resolving to the wrong key "café". Use
-    // variants.field(v, "café") for keys with non-ASCII characters.
+    // The motivating case: a would-be Unicode escape (a backslash followed by
+    // u00e9) throws instead of silently resolving to the wrong key "cafu00e9".
+    // A literal non-ASCII key such as "café" remains valid.
     assertThrows(IllegalArgumentException.class,
         () -> VariantPath.parse("$[\"caf\\u00e9\"]"));
+  }
+
+  @Test
+  void quotedKey_literalNonAscii_parses() {
+    // A literal non-ASCII character needs no escaping; it passes through as-is.
+    // Only the backslash-u escape spelling is rejected (see above).
+    List<Segment> segs = VariantPath.parse("$[\"café\"]");
+    assertEquals(1, segs.size());
+    assertEquals("café", ((FieldSegment) segs.get(0)).key);
   }
 
   @Test

--- a/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantUtils.java
+++ b/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantUtils.java
@@ -16,7 +16,11 @@
 
 package io.confluent.kafka.schemaregistry.type;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -42,6 +46,14 @@ public class VariantUtils {
    * @return a Variant containing the encoded metadata and value
    */
   private static final JsonNodeFactory FACTORY = JsonNodeFactory.instance;
+
+  /**
+   * Serializer for {@link #toJsonString}. WRITE_BIGDECIMAL_AS_PLAIN renders decimals in
+   * fixed-point form (never scientific), the cross-language contract for variant JSON.
+   */
+  private static final ObjectMapper JSON_MAPPER = JsonMapper.builder()
+      .enable(JsonWriteFeature.WRITE_BIGDECIMAL_AS_PLAIN)
+      .build();
 
   /**
    * Converts a Variant into a Jackson JsonNode.
@@ -82,28 +94,15 @@ public class VariantUtils {
       case TIMESTAMP_TZ:
         return FACTORY.textNode(
             Instant.ofEpochSecond(0, variant.getLong() * 1000).toString());
-      case TIMESTAMP_NTZ: {
-        long micros = variant.getLong();
-        return FACTORY.textNode(
-            LocalDateTime.ofEpochSecond(
-                Math.floorDiv(micros, 1_000_000L),
-                (int) Math.floorMod(micros, 1_000_000L) * 1000,
-                ZoneOffset.UTC).toString());
-      }
+      case TIMESTAMP_NTZ:
+        return FACTORY.textNode(formatLocalDateTimeMicros(variant.getLong()));
       case TIMESTAMP_NANOS_TZ:
         return FACTORY.textNode(
             Instant.ofEpochSecond(0, variant.getLong()).toString());
-      case TIMESTAMP_NANOS_NTZ: {
-        long nanos = variant.getLong();
-        return FACTORY.textNode(
-            LocalDateTime.ofEpochSecond(
-                Math.floorDiv(nanos, 1_000_000_000L),
-                (int) Math.floorMod(nanos, 1_000_000_000L),
-                ZoneOffset.UTC).toString());
-      }
+      case TIMESTAMP_NANOS_NTZ:
+        return FACTORY.textNode(formatLocalDateTimeNanos(variant.getLong()));
       case TIME:
-        return FACTORY.textNode(
-            LocalTime.ofNanoOfDay(variant.getLong() * 1000).toString());
+        return FACTORY.textNode(formatLocalTime(variant.getLong()));
       case BINARY:
         ByteBuffer bin = variant.getBinary();
         byte[] binBytes = new byte[bin.remaining()];
@@ -140,7 +139,54 @@ public class VariantUtils {
    * @return the JSON string representation
    */
   public static String toJsonString(Variant variant) {
-    return toJsonNode(variant).toString();
+    try {
+      return JSON_MAPPER.writeValueAsString(toJsonNode(variant));
+    } catch (JsonProcessingException e) {
+      // toJsonNode only produces standard scalar/container nodes, so this is not reachable.
+      throw new IllegalStateException("Failed to serialize variant to JSON", e);
+    }
+  }
+
+  // Formats an NTZ timestamp / time to ISO-8601 with the seconds field ALWAYS present. This
+  // is the cross-language contract: it deviates from LocalDateTime/LocalTime.toString(),
+  // which omit the seconds field when both seconds and fraction are zero, so that the NTZ
+  // form stays consistent with the TZ (Instant) form. The fractional-second field uses the
+  // same 0/3/6/9-digit grouping as Instant.toString().
+  private static String formatLocalDateTimeMicros(long micros) {
+    return formatLocalDateTime(
+        Math.floorDiv(micros, 1_000_000L), (int) Math.floorMod(micros, 1_000_000L) * 1000);
+  }
+
+  private static String formatLocalDateTimeNanos(long nanos) {
+    return formatLocalDateTime(
+        Math.floorDiv(nanos, 1_000_000_000L), (int) Math.floorMod(nanos, 1_000_000_000L));
+  }
+
+  private static String formatLocalDateTime(long epochSecond, int nanoOfSecond) {
+    LocalDateTime dt = LocalDateTime.ofEpochSecond(epochSecond, nanoOfSecond, ZoneOffset.UTC);
+    return String.format("%04d-%02d-%02dT%02d:%02d:%02d%s",
+        dt.getYear(), dt.getMonthValue(), dt.getDayOfMonth(),
+        dt.getHour(), dt.getMinute(), dt.getSecond(), fractionOfSecond(dt.getNano()));
+  }
+
+  private static String formatLocalTime(long micros) {
+    LocalTime time = LocalTime.ofNanoOfDay(micros * 1000);
+    return String.format("%02d:%02d:%02d%s",
+        time.getHour(), time.getMinute(), time.getSecond(), fractionOfSecond(time.getNano()));
+  }
+
+  // Fractional-second suffix using Instant.toString()'s 0/3/6/9-digit grouping (empty for 0).
+  private static String fractionOfSecond(int nano) {
+    if (nano == 0) {
+      return "";
+    }
+    if (nano % 1_000_000 == 0) {
+      return String.format(".%03d", nano / 1_000_000);
+    }
+    if (nano % 1_000 == 0) {
+      return String.format(".%06d", nano / 1_000);
+    }
+    return String.format(".%09d", nano);
   }
 
   /**

--- a/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantUtils.java
+++ b/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantUtils.java
@@ -16,11 +16,10 @@
 
 package io.confluent.kafka.schemaregistry.type;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -32,6 +31,7 @@ import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.Base64;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -51,12 +51,16 @@ public class VariantUtils {
    * Serializer for {@link #toJsonString}. WRITE_BIGDECIMAL_AS_PLAIN renders decimals in
    * fixed-point form (never scientific), the cross-language contract for variant JSON.
    */
-  private static final ObjectMapper JSON_MAPPER = JsonMapper.builder()
-      .enable(JsonWriteFeature.WRITE_BIGDECIMAL_AS_PLAIN)
-      .build();
+  private static final ObjectMapper JSON_MAPPER = new ObjectMapper()
+      .configure(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN, true);
 
   /**
    * Converts a Variant into a Jackson JsonNode.
+   *
+   * <p>Decimals are returned as a {@link com.fasterxml.jackson.databind.node.DecimalNode},
+   * so their serialized text depends on the caller's generator: a default generator may emit
+   * scientific notation for small-magnitude decimals. {@link #toJsonString} is the canonical
+   * string form and always renders decimals in fixed-point.
    *
    * @param variant the Variant to convert
    * @return a JsonNode representing the variant value
@@ -133,7 +137,9 @@ public class VariantUtils {
   }
 
   /**
-   * Converts a Variant into a JSON string.
+   * Converts a Variant into a JSON string. This is the canonical cross-language form:
+   * decimals are fixed-point (never scientific) and temporal types are ISO-8601 with the
+   * seconds field always present.
    *
    * @param variant the Variant to convert
    * @return the JSON string representation
@@ -164,14 +170,16 @@ public class VariantUtils {
 
   private static String formatLocalDateTime(long epochSecond, int nanoOfSecond) {
     LocalDateTime dt = LocalDateTime.ofEpochSecond(epochSecond, nanoOfSecond, ZoneOffset.UTC);
-    return String.format("%04d-%02d-%02dT%02d:%02d:%02d%s",
+    // Locale.ROOT: %d must emit ASCII digits regardless of the JVM's default locale
+    // (a locale with non-ASCII native digits would otherwise corrupt the ISO-8601 output).
+    return String.format(Locale.ROOT, "%04d-%02d-%02dT%02d:%02d:%02d%s",
         dt.getYear(), dt.getMonthValue(), dt.getDayOfMonth(),
         dt.getHour(), dt.getMinute(), dt.getSecond(), fractionOfSecond(dt.getNano()));
   }
 
   private static String formatLocalTime(long micros) {
     LocalTime time = LocalTime.ofNanoOfDay(micros * 1000);
-    return String.format("%02d:%02d:%02d%s",
+    return String.format(Locale.ROOT, "%02d:%02d:%02d%s",
         time.getHour(), time.getMinute(), time.getSecond(), fractionOfSecond(time.getNano()));
   }
 
@@ -181,12 +189,12 @@ public class VariantUtils {
       return "";
     }
     if (nano % 1_000_000 == 0) {
-      return String.format(".%03d", nano / 1_000_000);
+      return String.format(Locale.ROOT, ".%03d", nano / 1_000_000);
     }
     if (nano % 1_000 == 0) {
-      return String.format(".%06d", nano / 1_000);
+      return String.format(Locale.ROOT, ".%06d", nano / 1_000);
     }
-    return String.format(".%09d", nano);
+    return String.format(Locale.ROOT, ".%09d", nano);
   }
 
   /**

--- a/schema-types/src/test/java/io/confluent/kafka/schemaregistry/type/TestVariantJsonConverter.java
+++ b/schema-types/src/test/java/io/confluent/kafka/schemaregistry/type/TestVariantJsonConverter.java
@@ -25,6 +25,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
+import java.util.Locale;
 import java.util.UUID;
 import org.junit.Assert;
 import org.junit.Test;
@@ -348,6 +349,24 @@ public class TestVariantJsonConverter {
     VariantBuilder builder = new VariantBuilder();
     builder.appendDecimal(new BigDecimal("0.0000001"));
     Assert.assertEquals("0.0000001", VariantUtils.toJsonString(builder.build()));
+  }
+
+  @Test
+  public void testToJsonTemporalUsesAsciiDigitsRegardlessOfLocale() {
+    // The temporal formatters must emit ASCII digits even when the default locale uses
+    // non-ASCII native digits (here Arabic-Indic, forced via the -u-nu-arab extension).
+    Locale previous = Locale.getDefault();
+    try {
+      Locale.setDefault(Locale.forLanguageTag("ar-EG-u-nu-arab"));
+      VariantBuilder builder = new VariantBuilder();
+      long micros =
+          LocalDateTime.of(2020, 1, 2, 3, 4, 5).toEpochSecond(ZoneOffset.UTC) * 1_000_000;
+      builder.appendTimestampNtz(micros);
+      Assert.assertEquals(
+          "2020-01-02T03:04:05", VariantUtils.toJsonNode(builder.build()).textValue());
+    } finally {
+      Locale.setDefault(previous);
+    }
   }
 
   @Test

--- a/schema-types/src/test/java/io/confluent/kafka/schemaregistry/type/TestVariantJsonConverter.java
+++ b/schema-types/src/test/java/io/confluent/kafka/schemaregistry/type/TestVariantJsonConverter.java
@@ -178,7 +178,8 @@ public class TestVariantJsonConverter {
     long micros = LocalTime.of(14, 30, 0).toNanoOfDay() / 1000;
     builder.appendTime(micros);
     JsonNode node = VariantUtils.toJsonNode(builder.build());
-    Assert.assertEquals("14:30", node.textValue());
+    // Seconds are always emitted (cross-language contract), unlike LocalTime.toString().
+    Assert.assertEquals("14:30:00", node.textValue());
   }
 
   // -- toJsonNode: binary and UUID --
@@ -339,6 +340,25 @@ public class TestVariantJsonConverter {
     builder.endObject();
     String json = VariantUtils.toJsonString(builder.build());
     Assert.assertEquals("{\"a\":1}", json);
+  }
+
+  @Test
+  public void testToJsonStringDecimalIsPlain() {
+    // Decimals render in fixed-point (toPlainString) form, never scientific notation.
+    VariantBuilder builder = new VariantBuilder();
+    builder.appendDecimal(new BigDecimal("0.0000001"));
+    Assert.assertEquals("0.0000001", VariantUtils.toJsonString(builder.build()));
+  }
+
+  @Test
+  public void testToJsonTimestampNtzAlwaysEmitsSeconds() {
+    // Midnight NTZ still shows the :00 seconds field (cross-language contract), unlike
+    // LocalDateTime.toString() which would omit it.
+    VariantBuilder builder = new VariantBuilder();
+    long micros = LocalDateTime.of(2020, 1, 1, 0, 0, 0).toEpochSecond(ZoneOffset.UTC) * 1_000_000;
+    builder.appendTimestampNtz(micros);
+    Assert.assertEquals(
+        "2020-01-01T00:00:00", VariantUtils.toJsonNode(builder.build()).textValue());
   }
 
   // -- round-trip: JsonNode → Variant → JsonNode --


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
  Tightens the Java Variant CEL surface — the reference implementation the other Schema                                                                                             
  Registry clients are ported from — so its observable behavior is a clean, portable                                                                                                
  cross-language contract. Two areas: `variants.path` quoted-key escapes, and                                                                                                       
  `variants.toJson` temporal/decimal rendering. No functional additions; behavior changes                                                                                           
  are confined to edge cases in brand-new (unreleased) functions.

**`schema-rules` — `VariantPath` (quoted-key escapes):**                                                                                                                          
  - Recognize only `\\` and `\<enclosing-quote>` inside a quoted key; **any other escape is a                                                                                       
    parse error** instead of being silently decoded to the wrong key (previously `\X` → `X`                                                                                         
    for any `X`, so `$["caf\u00e9"]` silently became `cafu00e9`). A trailing backslash reports                                                                                      
    "unterminated escape".                                                                                                                                                          
  - Clarified the Javadoc/comments: literal non-ASCII keys (e.g. `$["café"]`) parse fine; only                                                                                      
    the escape *spelling* is rejected. Non-escapable keys use `variants.field(v, key)`.                                                                                             
                                                                                                                                                                                    
  **`schema-types` — `VariantUtils.toJsonNode`/`toJsonString`:**                                                                                                                    
  - **Temporal: always emit the seconds field.** `TIMESTAMP_NTZ`, `TIMESTAMP_NANOS_NTZ`, and                                                                                        
    `TIME` previously omitted `:SS` when zero (via `LocalDateTime`/`LocalTime.toString()`), so                                                                                      
    the same wall-clock time rendered differently depending on tz-ness. Now uses an explicit                                                                                        
    formatter (0/3/6/9-digit fractional grouping, matching `Instant.toString()`) so NTZ is                                                                                          
    consistent with the TZ (`Instant`) form: midnight NTZ → `2020-01-01T00:00:00`, time →                                                                                           
    `12:34:00`.                                                                                                                                                                     
  - **Decimal: fixed-point rendering.** `toJsonString` now writes decimals via                                                                                                      
    `WRITE_BIGDECIMAL_AS_PLAIN` (e.g. `0.0000001`) instead of `BigDecimal.toString()`                                                                                               
    scientific notation (`1E-7`) — deterministic and reproducible from unscaled+scale in every                                                                                      
    client.           

<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
