### PR TITLE
DGS-25088 Bump httpclient5 to 5.6.4 to fix CVE-2026-71290 (cherry-pick #4510 to 8.3.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <commons.validator.version>1.9.0</commons.validator.version>
         <snappy.version>1.1.10.5</snappy.version>
         <log4j.version>2.25.4</log4j.version>
-        <apache.httpclient5.version>5.5</apache.httpclient5.version>
+        <apache.httpclient5.version>5.6.4</apache.httpclient5.version>
         <spotless.maven.plugin.version>2.45.0</spotless.maven.plugin.version>
     </properties>
 


### PR DESCRIPTION
## Summary
- Cherry-pick of #4510 (merged to 8.0.x) onto the 8.3.2 RC branch to fix CVE-2026-71290 (httpclient5 TLS hostname verification bypass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)