### PR TITLE
Add config to control fetching external refs for JSON Schema (#4515)

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -191,6 +191,15 @@ public class SchemaRegistryConfig extends RestConfig {
   public static final String SCHEMA_VALIDATE_FIELDS_CONFIG = "schema.validate.fields";
   public static final boolean SCHEMA_VALIDATE_FIELDS_DEFAULT = false;
 
+  public static final String SCHEMA_PROVIDERS_JSON_FETCH_REMOTE_REFS_CONFIG =
+      "schema.providers.json.fetch.remote.schemas";
+  public static final boolean SCHEMA_PROVIDERS_JSON_FETCH_REMOTE_REFS_DEFAULT = true;
+  protected static final String SCHEMA_PROVIDERS_JSON_FETCH_REMOTE_REFS_DOC =
+      "Determines whether the JSON Schema provider may fetch remote schema references over "
+      + "HTTP/HTTPS. If false, a newly registered JSON Schema must resolve its references from the "
+      + "registered references, the classpath, or the prepopulated meta-schemas, and any attempt "
+      + "to fetch an http/https URL is rejected. The check applies to all schema parsing, "
+      + "including validation against already-stored schemas.";
   /**
    * <code>schema.cache.size</code>
    */
@@ -651,6 +660,10 @@ public class SchemaRegistryConfig extends RestConfig {
     )
     .define(SCHEMA_VALIDATE_FIELDS_CONFIG, ConfigDef.Type.BOOLEAN, SCHEMA_VALIDATE_FIELDS_DEFAULT,
         ConfigDef.Importance.LOW, VALIDATE_FIELDS_DOC
+    )
+    .define(SCHEMA_PROVIDERS_JSON_FETCH_REMOTE_REFS_CONFIG, ConfigDef.Type.BOOLEAN,
+        SCHEMA_PROVIDERS_JSON_FETCH_REMOTE_REFS_DEFAULT,
+        ConfigDef.Importance.LOW, SCHEMA_PROVIDERS_JSON_FETCH_REMOTE_REFS_DOC
     )
     .define(SCHEMA_CACHE_SIZE_CONFIG, ConfigDef.Type.INT, SCHEMA_CACHE_SIZE_DEFAULT,
         ConfigDef.Importance.LOW, SCHEMA_CACHE_SIZE_DOC

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -69,6 +69,7 @@ import io.confluent.kafka.schemaregistry.exceptions.SubjectNotSoftDeletedExcepti
 import io.confluent.kafka.schemaregistry.exceptions.UnknownLeaderException;
 import io.confluent.kafka.schemaregistry.id.IdGenerator;
 import io.confluent.kafka.schemaregistry.id.IncrementalIdGenerator;
+import io.confluent.kafka.schemaregistry.json.JsonSchema;
 import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
 import io.confluent.kafka.schemaregistry.leaderelector.kafka.KafkaGroupLeaderElector;
 import io.confluent.kafka.schemaregistry.metrics.MetricsContainer;
@@ -282,6 +283,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry,
     Map<String, Object> schemaProviderConfigs =
         config.originalsWithPrefix(SchemaRegistryConfig.SCHEMA_PROVIDERS_CONFIG + ".");
     schemaProviderConfigs.put(SchemaProvider.SCHEMA_VERSION_FETCHER_CONFIG, this);
+    schemaProviderConfigs.put(JsonSchemaProvider.FETCH_REMOTE_REFS,
+        config.getBoolean(SchemaRegistryConfig.SCHEMA_PROVIDERS_JSON_FETCH_REMOTE_REFS_CONFIG));
     List<SchemaProvider> defaultSchemaProviders = Arrays.asList(
         new AvroSchemaProvider(), new JsonSchemaProvider(), new ProtobufSchemaProvider()
     );
@@ -1038,12 +1041,31 @@ public class KafkaSchemaRegistry implements SchemaRegistry,
       throws SchemaRegistryException {
     ParsedSchema parsedSchema = parseSchema(schema);
     boolean isWildcard = tags.contains("*");
-    List<SchemaTags> schemaTags = parsedSchema.inlineTaggedEntities().entrySet()
-        .stream()
-        .filter(e -> isWildcard || !Collections.disjoint(tags, e.getValue()))
-        .map(e -> new SchemaTags(e.getKey(), new ArrayList<>(e.getValue())))
-        .collect(Collectors.toList());
+    List<SchemaTags> schemaTags;
+    try {
+      schemaTags = parsedSchema.inlineTaggedEntities().entrySet()
+          .stream()
+          .filter(e -> isWildcard || !Collections.disjoint(tags, e.getValue()))
+          .map(e -> new SchemaTags(e.getKey(), new ArrayList<>(e.getValue())))
+          .collect(Collectors.toList());
+    } catch (RuntimeException e) {
+      if (isBlockedRemoteRef(e)) {
+        throw new InvalidSchemaException("Invalid schema of type " + schema.getSchemaType()
+            + ", details: " + e.getMessage(), e);
+      }
+      throw e;
+    }
     schema.setSchemaTags(schemaTags);
+  }
+
+  private static boolean isBlockedRemoteRef(Throwable t) {
+    for (Throwable c = t; c != null; c = c.getCause()) {
+      if (c.getMessage() != null
+          && c.getMessage().contains(JsonSchema.REMOTE_REF_DISABLED_MESSAGE)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public Schema modifySchemaTags(String subject, Schema schema, TagSchemaRequest request)
@@ -1630,6 +1652,8 @@ public class KafkaSchemaRegistry implements SchemaRegistry,
         if (normalize) {
           parsedSchema = parsedSchema.normalize();
         }
+      } else {
+        enforceRemoteRefBlockOnImport(parsedSchema);
       }
     } catch (Exception e) {
       String errMsg = "Invalid schema " + schema + ", details: " + e.getMessage();
@@ -1640,6 +1664,25 @@ public class KafkaSchemaRegistry implements SchemaRegistry,
     schema.setSchema(parsedSchema.canonicalString());
     schema.setReferences(parsedSchema.references());
     return parsedSchema;
+  }
+
+  // IMPORT skips validation, so force $ref resolution to fire the block; other parse
+  // failures are swallowed to preserve IMPORT's leniency for storing quirky schemas.
+  private void enforceRemoteRefBlockOnImport(ParsedSchema parsedSchema)
+          throws InvalidSchemaException {
+    if (!"JSON".equals(parsedSchema.schemaType())
+        || config.getBoolean(
+            SchemaRegistryConfig.SCHEMA_PROVIDERS_JSON_FETCH_REMOTE_REFS_CONFIG)) {
+      return;
+    }
+    try {
+      parsedSchema.rawSchema();
+    } catch (RuntimeException e) {
+      if (isBlockedRemoteRef(e)) {
+        throw new InvalidSchemaException("Invalid schema of type " + parsedSchema.schemaType()
+            + ", details: " + e.getMessage(), e);
+      }
+    }
   }
 
   public ParsedSchema parseSchema(Schema schema) throws InvalidSchemaException {

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchema.java
@@ -38,6 +38,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
 import com.fasterxml.jackson.databind.ser.PropertyWriter;
+import com.github.erosb.jsonsKema.ClassPathAwareSchemaClient;
 import com.github.erosb.jsonsKema.JsonArray;
 import com.github.erosb.jsonsKema.JsonBoolean;
 import com.github.erosb.jsonsKema.JsonNull;
@@ -45,7 +46,10 @@ import com.github.erosb.jsonsKema.JsonNumber;
 import com.github.erosb.jsonsKema.JsonObject;
 import com.github.erosb.jsonsKema.JsonString;
 import com.github.erosb.jsonsKema.JsonValue;
+import com.github.erosb.jsonsKema.MemoizingSchemaClient;
+import com.github.erosb.jsonsKema.PrepopulatedSchemaClient;
 import com.github.erosb.jsonsKema.SchemaLoaderConfig;
+import com.github.erosb.jsonsKema.URLQueryingSchemaClient;
 import com.github.erosb.jsonsKema.UnknownSource;
 import com.github.erosb.jsonsKema.ValidationFailure;
 import com.github.erosb.jsonsKema.Validator;
@@ -73,6 +77,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
@@ -148,6 +153,11 @@ public class JsonSchema implements ParsedSchema {
   private final RuleSet ruleSet;
 
   private final boolean ignoreModernDialects;
+
+  // When true, remote HTTP/HTTPS schema-reference fetching is blocked while loading this schema.
+  // Set only for a new schema registration when remote fetching is disabled; carried across
+  // copy()/normalize() so it is not lost before the schema is loaded/validated.
+  private final boolean blockRemoteRefs;
 
   private transient volatile String canonicalString;
 
@@ -247,6 +257,7 @@ public class JsonSchema implements ParsedSchema {
     this.metadata = null;
     this.ruleSet = null;
     this.ignoreModernDialects = false;
+    this.blockRemoteRefs = false;
   }
 
   public JsonSchema(
@@ -273,6 +284,7 @@ public class JsonSchema implements ParsedSchema {
     this.ruleSet = ruleSet;
     this.version = version;
     this.ignoreModernDialects = false;
+    this.blockRemoteRefs = false;
   }
 
   public JsonSchema(
@@ -291,6 +303,30 @@ public class JsonSchema implements ParsedSchema {
       this.metadata = metadata;
       this.ruleSet = ruleSet;
       this.ignoreModernDialects = false;
+      this.blockRemoteRefs = false;
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Invalid JSON schema", e);
+    }
+  }
+
+  public JsonSchema(
+      String schemaString,
+      List<SchemaReference> references,
+      Map<String, String> resolvedReferences,
+      Metadata metadata,
+      RuleSet ruleSet,
+      Integer version,
+      boolean blockRemoteRefs
+  ) {
+    try {
+      this.jsonNode = schemaString != null ? objectMapper.readTree(schemaString) : null;
+      this.version = version;
+      this.references = Collections.unmodifiableList(references);
+      this.resolvedReferences = Collections.unmodifiableMap(resolvedReferences);
+      this.metadata = metadata;
+      this.ruleSet = ruleSet;
+      this.ignoreModernDialects = false;
+      this.blockRemoteRefs = blockRemoteRefs;
     } catch (IOException e) {
       throw new IllegalArgumentException("Invalid JSON " + schemaString, e);
     }
@@ -310,11 +346,13 @@ public class JsonSchema implements ParsedSchema {
       this.metadata = null;
       this.ruleSet = null;
       this.ignoreModernDialects = false;
+      this.blockRemoteRefs = false;
     } catch (IOException e) {
       throw new IllegalArgumentException("Invalid JSON " + schemaObj, e);
     }
   }
 
+  // CHECKSTYLE_RULES.OFF: ParameterNumber
   private JsonSchema(
       JsonNode jsonNode,
       com.github.erosb.jsonsKema.Schema skemaObj,
@@ -325,8 +363,10 @@ public class JsonSchema implements ParsedSchema {
       Metadata metadata,
       RuleSet ruleSet,
       boolean ignoreModernDialects,
-      String canonicalString
+      String canonicalString,
+      boolean blockRemoteRefs
   ) {
+    // CHECKSTYLE_RULES.ON: ParameterNumber
     this.jsonNode = jsonNode;
     this.skemaObj = skemaObj;
     this.schemaObj = schemaObj;
@@ -337,6 +377,7 @@ public class JsonSchema implements ParsedSchema {
     this.ruleSet = ruleSet;
     this.ignoreModernDialects = ignoreModernDialects;
     this.canonicalString = canonicalString;
+    this.blockRemoteRefs = blockRemoteRefs;
   }
 
   @Override
@@ -351,7 +392,8 @@ public class JsonSchema implements ParsedSchema {
         this.metadata,
         this.ruleSet,
         this.ignoreModernDialects,
-        this.canonicalString
+        this.canonicalString,
+        this.blockRemoteRefs
     );
   }
 
@@ -367,7 +409,8 @@ public class JsonSchema implements ParsedSchema {
         this.metadata,
         this.ruleSet,
         this.ignoreModernDialects,
-        this.canonicalString
+        this.canonicalString,
+        this.blockRemoteRefs
     );
   }
 
@@ -383,7 +426,8 @@ public class JsonSchema implements ParsedSchema {
         metadata,
         ruleSet,
         this.ignoreModernDialects,
-        this.canonicalString
+        this.canonicalString,
+        this.blockRemoteRefs
     );
   }
 
@@ -393,12 +437,18 @@ public class JsonSchema implements ParsedSchema {
     JsonSchema schemaCopy = this.copy();
     JsonNode original = schemaCopy.toJsonNode().deepCopy();
     modifySchemaTags(original, tagsToAdd, tagsToRemove);
-    return new JsonSchema(original.toString(),
+    return new JsonSchema(
+      original,
+      null,
+      null,
+      schemaCopy.version(),
       schemaCopy.references(),
       schemaCopy.resolvedReferences(),
       schemaCopy.metadata(),
       schemaCopy.ruleSet(),
-      schemaCopy.version());
+      this.ignoreModernDialects,
+      null,
+      this.blockRemoteRefs);
   }
 
   public JsonSchema copyIgnoringModernDialects() {
@@ -412,7 +462,8 @@ public class JsonSchema implements ParsedSchema {
         this.metadata,
         this.ruleSet,
         true,
-        this.canonicalString
+        this.canonicalString,
+        this.blockRemoteRefs
     );
   }
 
@@ -491,7 +542,19 @@ public class JsonSchema implements ParsedSchema {
         mappings.put(new URI("./" + dep.getKey()), dep.getValue());
       }
     }
-    SchemaLoaderConfig config = SchemaLoaderConfig.createDefaultConfig(mappings);
+    SchemaLoaderConfig config;
+    if (blockRemoteRefs) {
+      // Reproduce json-sKema's default client chain, but swap the innermost
+      // URLQueryingSchemaClient (which performs the network call) for one that refuses HTTP(S).
+      // The prepopulated meta-schemas, the registered mappings, and the classpath are tried first,
+      // so anything reaching the blocking client is a genuine remote fetch.
+      com.github.erosb.jsonsKema.SchemaClient schemaClient = new MemoizingSchemaClient(
+          new PrepopulatedSchemaClient(
+              new ClassPathAwareSchemaClient(new NoHttpSkemaClient()), mappings));
+      config = new SchemaLoaderConfig(schemaClient, URI.create(DEFAULT_BASE_URI), mappings);
+    } else {
+      config = SchemaLoaderConfig.createDefaultConfig(mappings);
+    }
     JsonValue schemaJson = objectMapper.convertValue(jsonNode, JsonObject.class);
     skemaObj = new com.github.erosb.jsonsKema.SchemaLoader(schemaJson, config).load();
     SchemaTranslator.SchemaContext ctx = skemaObj.accept(new SchemaTranslator());
@@ -536,6 +599,10 @@ public class JsonSchema implements ParsedSchema {
     for (Map.Entry<URI, String> meta : previousDraftMetaSchemas.entrySet()) {
       builder.registerSchemaByURI(meta.getKey(), new JSONObject(meta.getValue()));
     }
+    if (blockRemoteRefs) {
+      // Block remote HTTP(S) ref fetching; classpath and registered refs still resolve.
+      builder.schemaClient(new NoHttpSchemaClient());
+    }
     for (Map.Entry<String, String> dep : resolvedReferences.entrySet()) {
       URI child = ReferenceResolver.resolve(idUri, dep.getKey());
       builder.registerSchemaByURI(child, new JSONObject(dep.getValue()));
@@ -544,6 +611,72 @@ public class JsonSchema implements ParsedSchema {
     builder.schemaJson(jsonObject);
     SchemaLoader loader = builder.build();
     schemaObj = loader.load().build();
+  }
+
+  private static boolean isHttpScheme(String scheme) {
+    return "http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme);
+  }
+
+  /**
+   * An Everit {@link org.everit.json.schema.loader.SchemaClient} that refuses to fetch
+   * {@code http}/{@code https} URLs, while delegating all other (e.g. {@code classpath})
+   * lookups to the default classpath-aware client.
+   */
+  private static final class NoHttpSchemaClient
+      implements org.everit.json.schema.loader.SchemaClient {
+
+    private final org.everit.json.schema.loader.SchemaClient delegate =
+        org.everit.json.schema.loader.SchemaClient.classPathAwareClient();
+
+    @Override
+    public InputStream get(String url) {
+      String scheme = url == null ? null : URI.create(url.trim()).getScheme();
+      if (isHttpScheme(scheme)) {
+        throw new UncheckedIOException(new IOException(
+            REMOTE_REF_DISABLED_MESSAGE + ": " + url));
+      }
+      return delegate.get(url);
+    }
+  }
+
+  /**
+   * A json-sKema {@link com.github.erosb.jsonsKema.SchemaClient} that refuses to fetch
+   * {@code http}/{@code https} URIs, while delegating any other scheme to the standard
+   * URL-querying client.
+   */
+  private static final class NoHttpSkemaClient implements com.github.erosb.jsonsKema.SchemaClient {
+
+    private final com.github.erosb.jsonsKema.SchemaClient delegate = new URLQueryingSchemaClient();
+
+    @Override
+    public InputStream get(URI uri) {
+      if (isHttpScheme(uri.getScheme())) {
+        throw new UncheckedIOException(new IOException(
+            REMOTE_REF_DISABLED_MESSAGE + ": " + uri));
+      }
+      return delegate.get(uri);
+    }
+
+    @Override
+    public com.github.erosb.jsonsKema.IJsonValue getParsed(URI uri) {
+      if (isHttpScheme(uri.getScheme())) {
+        throw new UncheckedIOException(new IOException(
+            REMOTE_REF_DISABLED_MESSAGE + ": " + uri));
+      }
+      return delegate.getParsed(uri);
+    }
+  }
+
+  public static final String REMOTE_REF_DISABLED_MESSAGE =
+      "Remote schema reference fetching over HTTP(S) is disabled";
+
+  static boolean isRemoteRefBlocked(Throwable t) {
+    for (Throwable c = t; c != null; c = c.getCause()) {
+      if (c.getMessage() != null && c.getMessage().contains(REMOTE_REF_DISABLED_MESSAGE)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override
@@ -641,11 +774,17 @@ public class JsonSchema implements ParsedSchema {
       JsonNode jsonNode = objectMapperWithOrderedProps.readTree(canonical);
       return new JsonSchema(
           jsonNode,
-          this.references.stream().sorted().distinct().collect(Collectors.toList()),
+          null,
+          null,
+          this.version,
+          Collections.unmodifiableList(
+              this.references.stream().sorted().distinct().collect(Collectors.toList())),
           this.resolvedReferences,
           this.metadata,
           this.ruleSet,
-          this.version
+          this.ignoreModernDialects,
+          null,
+          this.blockRemoteRefs
       );
     } catch (IOException e) {
       throw new IllegalArgumentException("Invalid JSON", e);
@@ -766,8 +905,19 @@ public class JsonSchema implements ParsedSchema {
     if (!schemaType().equals(previousSchema.schemaType())) {
       return Lists.newArrayList("Incompatible because of different schema type");
     }
-    final List<Difference> differences =
-            SchemaDiff.compare(((JsonSchema) previousSchema).rawSchema(), rawSchema());
+    final List<Difference> differences;
+    try {
+      differences =
+              SchemaDiff.compare(((JsonSchema) previousSchema).rawSchema(), rawSchema());
+    } catch (RuntimeException e) {
+      if (isRemoteRefBlocked(e)) {
+        // mutable: the FULL compatibility check appends to the returned list
+        List<String> errors = new ArrayList<>();
+        errors.add("A previous schema version contains an unsupported external reference");
+        return errors;
+      }
+      throw e;
+    }
     final List<Difference> incompatibleDiffs = differences.stream()
         .filter(diff -> !SchemaDiff.COMPATIBLE_CHANGES.contains(diff.getType()))
         .collect(Collectors.toList());

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaProvider.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/JsonSchemaProvider.java
@@ -16,6 +16,7 @@
 package io.confluent.kafka.schemaregistry.json;
 
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,9 +27,38 @@ public class JsonSchemaProvider extends AbstractSchemaProvider {
 
   private static final Logger log = LoggerFactory.getLogger(JsonSchemaProvider.class);
 
+  /**
+   * Config key (within the {@code schema.providers.} provider config map) controlling whether
+   * remote HTTP(S) schema references may be fetched. The typed value is injected by the schema
+   * registry from {@code schema.providers.json.fetch.remote.schemas} (defaults to true).
+   */
+  public static final String FETCH_REMOTE_REFS = "fetchRemoteRefs";
+
+  private boolean fetchRemoteRefs = true;
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    super.configure(configs);
+    Object value = configs.get(FETCH_REMOTE_REFS);
+    if (value instanceof Boolean) {
+      fetchRemoteRefs = (Boolean) value;
+    } else if (value != null) {
+      fetchRemoteRefs = Boolean.parseBoolean(value.toString());
+    }
+  }
+
   @Override
   public String schemaType() {
     return JsonSchema.TYPE;
+  }
+
+  /**
+   * Determines whether remote HTTP(S) schema-reference fetching should be blocked while loading
+   * the given schema. Applies uniformly to all parses (new registrations and already-stored
+   * schemas alike); subclasses may override for a different policy.
+   */
+  protected boolean shouldBlockRemoteRefs(Schema schema, boolean fetchRemoteRefs) {
+    return !fetchRemoteRefs;
   }
 
   @Override
@@ -40,7 +70,8 @@ public class JsonSchemaProvider extends AbstractSchemaProvider {
               resolveReferences(schema, isNew),
               schema.getMetadata(),
               schema.getRuleSet(),
-              null
+              null,
+              shouldBlockRemoteRefs(schema, fetchRemoteRefs)
       );
     } catch (Exception e) {
       log.error("Could not parse JSON schema", e);

--- a/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaRemoteRefTest.java
+++ b/json-schema-provider/src/test/java/io/confluent/kafka/schemaregistry/json/JsonSchemaRemoteRefTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.json;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+/**
+ * Tests for the {@code blockRemoteRefs} behavior of {@link JsonSchema}: when set, a
+ * {@code $ref}/{@code $dynamicRef} to an unregistered http/https document is rejected rather
+ * than fetched over the network.
+ */
+public class JsonSchemaRemoteRefTest {
+
+  private static JsonSchema schema(
+      String schemaString,
+      Map<String, String> resolvedReferences,
+      boolean blockRemoteRefs) {
+    return new JsonSchema(
+        schemaString,
+        Collections.emptyList(),
+        resolvedReferences,
+        null,
+        null,
+        null,
+        blockRemoteRefs);
+  }
+
+  private static void assertBlocked(Throwable t) {
+    if (!JsonSchema.isRemoteRefBlocked(t)) {
+      throw new AssertionError("Expected a 'remote fetch disabled' cause but was: " + t, t);
+    }
+  }
+
+  private static void assertNotBlocked(JsonSchema schema) {
+    try {
+      schema.rawSchema();
+    } catch (RuntimeException e) {
+      if (JsonSchema.isRemoteRefBlocked(e)) {
+        throw new AssertionError("Schema must not be blocked, but it was: " + e, e);
+      }
+    }
+  }
+
+  private static void assertRefRejected(String schemaString) {
+    try {
+      schema(schemaString, Collections.emptyMap(), true).rawSchema();
+      fail("Expected loading to fail because the remote $ref fetch is disabled");
+    } catch (RuntimeException e) {
+      assertBlocked(e);
+    }
+  }
+
+  @Test
+  public void localSchemaLoadsWhenBlocked_latestDraft() {
+    String s = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\",\"properties\":{\"a\":{\"type\":\"string\"}}}";
+    assertNotNull(schema(s, Collections.emptyMap(), true).rawSchema());
+  }
+
+  @Test
+  public void localSchemaLoadsWhenBlocked_draft7() {
+    String s = "{\"$schema\":\"http://json-schema.org/draft-07/schema#\","
+        + "\"type\":\"object\",\"properties\":{\"a\":{\"type\":\"string\"}}}";
+    assertNotNull(schema(s, Collections.emptyMap(), true).rawSchema());
+  }
+
+  @Test
+  public void httpRefRejectedWhenBlocked_latestDraft() {
+    assertRefRejected("{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\",\"properties\":{\"a\":{\"$ref\":\"http://example.com/r.json\"}}}");
+  }
+
+  @Test
+  public void httpsRefRejectedWhenBlocked_draft7() {
+    assertRefRejected("{\"$schema\":\"http://json-schema.org/draft-07/schema#\","
+        + "\"type\":\"object\",\"properties\":{\"a\":{\"$ref\":\"https://example.com/r.json\"}}}");
+  }
+
+  @Test
+  public void dynamicRefRejectedWhenBlocked_latestDraft() {
+    assertRefRejected("{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\","
+        + "\"properties\":{\"a\":{\"$dynamicRef\":\"http://example.com/r.json#node\"}}}");
+  }
+
+  @Test
+  public void registeredHttpRefNotBlocked_latestDraft() {
+    String ref = "http://acme.com/widget.json";
+    String s = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\",\"properties\":{\"a\":{\"$ref\":\"" + ref + "\"}}}";
+    Map<String, String> resolvedRefs = Collections.singletonMap(
+        ref, "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\",\"type\":\"string\"}");
+    // A registered reference resolves from the in-memory mappings, not the network.
+    assertNotNull(schema(s, resolvedRefs, true).rawSchema());
+  }
+
+  @Test
+  public void registeredHttpRefNotBlocked_draft7() {
+    String ref = "http://acme.com/widget.json";
+    String s = "{\"$schema\":\"http://json-schema.org/draft-07/schema#\","
+        + "\"type\":\"object\",\"properties\":{\"a\":{\"$ref\":\"" + ref + "\"}}}";
+    Map<String, String> resolvedRefs = Collections.singletonMap(ref, "{\"type\":\"string\"}");
+    assertNotNull(schema(s, resolvedRefs, true).rawSchema());
+  }
+
+  @Test
+  public void notBlockedWhenBlockRemoteRefsFalse() {
+    String s = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\","
+        + "\"properties\":{\"a\":{\"$ref\":\"http://nonexistent.invalid/r.json\"}}}";
+    assertNotBlocked(schema(s, Collections.emptyMap(), false));
+  }
+
+  // The registration pipeline copies/normalizes the parsed schema before it is loaded, so the
+  // block must survive those operations.
+
+  @Test
+  public void blockSurvivesCopyWithVersion() {
+    String s = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\",\"properties\":{\"a\":{\"$ref\":\"http://example.com/r.json\"}}}";
+    JsonSchema copy = schema(s, Collections.emptyMap(), true).copy(0);
+    assertTrue(copy instanceof JsonSchema);
+    try {
+      copy.rawSchema();
+      fail("Expected the copy to still block the remote $ref fetch");
+    } catch (RuntimeException e) {
+      assertBlocked(e);
+    }
+  }
+
+  @Test
+  public void blockSurvivesNormalize() {
+    String s = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\",\"properties\":{\"a\":{\"$ref\":\"http://example.com/r.json\"}}}";
+    JsonSchema normalized = schema(s, Collections.emptyMap(), true).normalize();
+    try {
+      normalized.rawSchema();
+      fail("Expected the normalized copy to still block the remote $ref fetch");
+    } catch (RuntimeException e) {
+      assertBlocked(e);
+    }
+  }
+
+  @Test
+  public void blockedPreviousSurfacesAsIncompatibilityNotError() {
+    String previous = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\",\"properties\":{\"a\":{\"$ref\":\"http://example.com/r.json\"}}}";
+    String current = "{\"$schema\":\"https://json-schema.org/draft/2020-12/schema\","
+        + "\"type\":\"object\",\"properties\":{\"a\":{\"type\":\"string\"}}}";
+    List<String> errors = schema(current, Collections.emptyMap(), true)
+        .isBackwardCompatible(schema(previous, Collections.emptyMap(), true));
+    assertFalse(errors.isEmpty());
+    assertTrue(errors.get(0).contains("unsupported external reference"));
+  }
+}


### PR DESCRIPTION
What
----
Manual cherry-pick of #4515 to 7.8.x due to pint merge conflict

Checklist
------------------
- [x] Customer facing / behavior change: new config, defaults `true` (no-op unless disabled)
- [x] Tests: `JsonSchemaRemoteRefTest`

References
----------
JIRA: DGS-24482

Open questions / Follow-ups
--------------------------
