### PR TITLE
Fix Variant, Decimal, and Timestamp correctness in CEL rules

### DIFF
--- a/avro-types/src/test/java/io/confluent/avro/type/TestVariantConversion.java
+++ b/avro-types/src/test/java/io/confluent/avro/type/TestVariantConversion.java
@@ -23,9 +23,7 @@ import io.confluent.kafka.schemaregistry.type.VariantObjectBuilder;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.avro.LogicalType;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.IndexedRecord;
 import org.junit.Assert;
 import org.junit.Test;
@@ -162,7 +160,7 @@ public class TestVariantConversion {
     Variant decoded = conversion.fromRecord(record, schema, null);
 
     Assert.assertEquals(Variant.Type.OBJECT, decoded.getType());
-    Assert.assertEquals(1, decoded.numObjectElements());
+    Assert.assertEquals(1, decoded.numObjectFields());
     Assert.assertEquals("Alice", decoded.getFieldByKey("name").getString());
   }
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchema.java
@@ -682,7 +682,7 @@ public class AvroSchema implements ParsedSchema {
           String fullName = recordSchema.getFullName() + "." + f.name();
           try (FieldContext fc = ctx.enterField(
               message, fullName, f.name(),
-              getType(originalField.schema()), getInlineTags(originalField))) {
+              getType(originalField.schema()), getInlineTags(originalField), originalField)) {
             Object value = data.getField(message, f.name(), f.pos());
             if (value instanceof Utf8) {
               value = value.toString();

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/rules/RuleContext.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/rules/RuleContext.java
@@ -260,8 +260,8 @@ public class RuleContext {
 
     /**
      * The producer's own handle on the field, for formats that have one: a protobuf
-     * {@code FieldDescriptor}. Null for Avro and JSON Schema, whose walks carry no such
-     * object.
+     * {@code FieldDescriptor}, or an Avro {@code Schema.Field}. Null for JSON Schema, whose
+     * walk carries no such object.
      *
      * <p>{@link #getName()} and {@link #getFullName()} are the <em>registered schema's</em>
      * names for the field, which can differ from the producer's under a compatible rename,

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/constraint/ConstraintEmitter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/constraint/ConstraintEmitter.java
@@ -614,7 +614,7 @@ final class ConstraintEmitter {
         }
       }
       // Non-numeric: timestamp normalization (instant-timestamp operands wrapped
-      // in timestamp.of(...); CURRENT_TIMESTAMP stays `now`) or plain native.
+      // in timestamp(...); CURRENT_TIMESTAMP stays `now`) or plain native.
       emitCompareOperandWrapped(betweens.get(0), vctx, sb);
       sb.append(' ').append(celOp).append(' ');
       emitCompareOperandWrapped(betweens.get(1), vctx, sb);
@@ -625,7 +625,7 @@ final class ConstraintEmitter {
 
   // -------------------------------------------------------------------------
   // Timestamp normalization — wrap instant-timestamp operands in
-  // timestamp.of(...) so Avro (Instant) / JSON (RFC-3339 string) values coerce
+  // timestamp(...) so Avro (Instant) / JSON (RFC-3339 string) values coerce
   // to a CEL timestamp; proto Timestamp is identity. The comparison/BETWEEN
   // operators stay native (CEL has first-class timestamp comparison).
   // CURRENT_TIMESTAMP (→ now) is already a CEL timestamp and is left unwrapped.
@@ -634,7 +634,7 @@ final class ConstraintEmitter {
   /**
    * A comparison operand. If it involves a timestamp column or a TIMESTAMP/
    * INTERVAL literal, emit it via the timestamp-value cascade (column leaves
-   * wrapped in {@code timestamp.of(...)}, literals as {@code timestamp(...)}/
+   * wrapped in {@code timestamp(...)}, literals as {@code timestamp(...)}/
    * {@code duration(...)}, operators native); otherwise emit natively.
    */
   /**
@@ -691,7 +691,7 @@ final class ConstraintEmitter {
 
   /**
    * Emit an EXTRACT receiver. Temporal receivers go through the timestamp-value
-   * cascade (so {@code ts} → {@code timestamp.of(this.ts)}); {@code now} and
+   * cascade (so {@code ts} → {@code timestamp(this.ts)}); {@code now} and
    * non-temporal receivers emit natively. Compound receivers are parenthesized
    * so the trailing {@code .getXxx()} binds to the whole receiver.
    */
@@ -752,7 +752,7 @@ final class ConstraintEmitter {
   }
 
   // ---- timestamp-value cascade: native emit, but instant-timestamp column
-  // leaves wrapped in timestamp.of(...). Reused by comparison, BETWEEN, EXTRACT,
+  // leaves wrapped in timestamp(...). Reused by comparison, BETWEEN, EXTRACT,
   // and the Phase B constructs. ----
 
   static void emitTimestampValueIn(
@@ -823,7 +823,7 @@ final class ConstraintEmitter {
           ((LogicalTypesParser.CheckColumnRefContext) ctx).columnref();
       if (ConstraintResolver.isInstantTimestamp(
           ConstraintResolver.resolveColumnRefType(cr, EMIT_VCTX.get()))) {
-        sb.append("timestamp.of(");
+        sb.append("timestamp(");
         visitColumnRef(cr, sb);
         sb.append(')');
       } else {

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/constraint/ConstraintFunctions.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/constraint/ConstraintFunctions.java
@@ -973,7 +973,7 @@ final class ConstraintFunctions {
 
   /**
    * EXTRACT(field FROM ts) → ts.getXxx(). The receiver is normalized via
-   * {@code timestamp.of(...)} when it's an instant-timestamp column so the
+   * {@code timestamp(...)} when it's an instant-timestamp column so the
    * runtime value (Instant / RFC-3339 string) coerces to a CEL timestamp;
    * {@code now} (CURRENT_TIMESTAMP) is left unwrapped.
    */

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/constraint/ConstraintResolver.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/constraint/ConstraintResolver.java
@@ -714,7 +714,7 @@ final class ConstraintResolver {
   /**
    * True if {@code s} is an instant-bearing timestamp ({@code TIMESTAMP} or
    * {@code TIMESTAMP_LTZ}). These are the temporal types the emitter normalizes
-   * with {@code timestamp.of(...)} (DATE/TIME are partial temporals and out of
+   * with {@code timestamp(...)} (DATE/TIME are partial temporals and out of
    * scope). The runtime surfaces these as Instant/proto Timestamp/RFC-3339
    * string, none of which CEL's native timestamp ops accept un-normalized.
    */
@@ -749,7 +749,7 @@ final class ConstraintResolver {
   /**
    * True if {@code node}'s subtree contains an instant-timestamp column
    * reference or a TIMESTAMP/INTERVAL literal — i.e. the expression needs the
-   * timestamp-value emit (column leaves wrapped in {@code timestamp.of(...)},
+   * timestamp-value emit (column leaves wrapped in {@code timestamp(...)},
    * literals as {@code timestamp("…")}/{@code duration("…")}).
    *
    * <p>A generic parse-tree walk rather than a per-level cascade: over-detection

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/constraint/CheckConstraintTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/constraint/CheckConstraintTest.java
@@ -1729,39 +1729,39 @@ class CheckConstraintTest {
 
   @Test
   void extractYear() {
-    // The receiver is normalized via timestamp.of(...) (ts is TIMESTAMP_LTZ).
-    assertEquals("timestamp.of(this.ts).getFullYear() == 2026",
+    // The receiver is normalized via timestamp(...) (ts is TIMESTAMP_LTZ).
+    assertEquals("timestamp(this.ts).getFullYear() == 2026",
         translateCheck("EXTRACT(YEAR FROM ts) = 2026"));
   }
 
   @Test
   void extractMonth() {
     // CEL getMonth() is 0-based; SQL MONTH is 1-based. Translator adds 1.
-    assertEquals("(timestamp.of(this.ts).getMonth() + 1) < 12",
+    assertEquals("(timestamp(this.ts).getMonth() + 1) < 12",
         translateCheck("EXTRACT(MONTH FROM ts) < 12"));
   }
 
   @Test
   void extractMonthIsOneBased() {
     // Lock in SQL semantics: January is month 1, not 0.
-    assertEquals("(timestamp.of(this.ts).getMonth() + 1) == 1",
+    assertEquals("(timestamp(this.ts).getMonth() + 1) == 1",
         translateCheck("EXTRACT(MONTH FROM ts) = 1"));
   }
 
   @Test
   void extractDay() {
-    assertEquals("timestamp.of(this.ts).getDate() <= 31",
+    assertEquals("timestamp(this.ts).getDate() <= 31",
         translateCheck("EXTRACT(DAY FROM ts) <= 31"));
   }
 
   @Test
   void extractEpoch() {
-    assertEquals("int(timestamp.of(this.ts)) > 0", translateCheck("EXTRACT(EPOCH FROM ts) > 0"));
+    assertEquals("int(timestamp(this.ts)) > 0", translateCheck("EXTRACT(EPOCH FROM ts) > 0"));
   }
 
   @Test
   void extractCaseInsensitiveField() {
-    assertEquals("timestamp.of(this.ts).getFullYear() == 2026",
+    assertEquals("timestamp(this.ts).getFullYear() == 2026",
         translateCheck("EXTRACT(year FROM ts) = 2026"));
   }
 
@@ -1936,7 +1936,7 @@ class CheckConstraintTest {
   void currentTimestamp() {
     // created_at (TIMESTAMP_LTZ) is normalized; CURRENT_TIMESTAMP (now) is
     // already a CEL timestamp and stays unwrapped.
-    assertEquals("timestamp.of(this.created_at) <= now",
+    assertEquals("timestamp(this.created_at) <= now",
         translateCheck("created_at <= CURRENT_TIMESTAMP"));
   }
 
@@ -1950,21 +1950,21 @@ class CheckConstraintTest {
   @Test
   void timestampColumnVsColumn() {
     // Both operands are TIMESTAMP_LTZ → both normalized; operator stays native.
-    assertEquals("timestamp.of(this.ts) < timestamp.of(this.created_at)",
+    assertEquals("timestamp(this.ts) < timestamp(this.created_at)",
         translateCheck("ts < created_at"));
   }
 
   @Test
   void timestampBetween() {
     assertEquals(
-        "timestamp.of(this.created_at) <= timestamp.of(this.ts) "
-            + "&& timestamp.of(this.ts) <= now",
+        "timestamp(this.created_at) <= timestamp(this.ts) "
+            + "&& timestamp(this.ts) <= now",
         translateCheck("ts BETWEEN created_at AND CURRENT_TIMESTAMP"));
   }
 
   @Test
   void extractHour() {
-    assertEquals("timestamp.of(this.ts).getHours() >= 0",
+    assertEquals("timestamp(this.ts).getHours() >= 0",
         translateCheck("EXTRACT(HOUR FROM ts) >= 0"));
   }
 
@@ -1977,14 +1977,14 @@ class CheckConstraintTest {
   @Test
   void timestampLiteralComparison() {
     assertEquals(
-        "timestamp.of(this.ts) >= timestamp(\"2020-01-01T00:00:00Z\")",
+        "timestamp(this.ts) >= timestamp(\"2020-01-01T00:00:00Z\")",
         translateCheck("ts >= TIMESTAMP '2020-01-01 00:00:00'"));
   }
 
   @Test
   void timestampLiteralWithOffsetPassesThrough() {
     assertEquals(
-        "timestamp.of(this.ts) < timestamp(\"2020-01-01T00:00:00+02:00\")",
+        "timestamp(this.ts) < timestamp(\"2020-01-01T00:00:00+02:00\")",
         translateCheck("ts < TIMESTAMP '2020-01-01T00:00:00+02:00'"));
   }
 
@@ -1992,14 +1992,14 @@ class CheckConstraintTest {
   void intervalRelativeWindow() {
     // The dominant idiom: "within the last 7 days".
     assertEquals(
-        "timestamp.of(this.created_at) > now - duration(\"604800s\")",
+        "timestamp(this.created_at) > now - duration(\"604800s\")",
         translateCheck("created_at > CURRENT_TIMESTAMP - INTERVAL '7' DAY"));
   }
 
   @Test
   void intervalPlusTimestampCommutative() {
     assertEquals(
-        "duration(\"86400s\") + timestamp.of(this.created_at) > timestamp.of(this.ts)",
+        "duration(\"86400s\") + timestamp(this.created_at) > timestamp(this.ts)",
         translateCheck("INTERVAL '1' DAY + created_at > ts"));
   }
 
@@ -2007,7 +2007,7 @@ class CheckConstraintTest {
   void intervalOnTimestampColumn() {
     // Full arithmetic: interval applied to a column (not just CURRENT_TIMESTAMP).
     assertEquals(
-        "timestamp.of(this.created_at) - duration(\"86400s\") < timestamp.of(this.ts)",
+        "timestamp(this.created_at) - duration(\"86400s\") < timestamp(this.ts)",
         translateCheck("created_at - INTERVAL '1' DAY < ts"));
   }
 
@@ -2015,15 +2015,15 @@ class CheckConstraintTest {
   void timestampMinusTimestampYieldsDuration() {
     // T - T → duration; compared against an INTERVAL (elapsed-time check).
     assertEquals(
-        "timestamp.of(this.ts) - timestamp.of(this.created_at) > duration(\"3600s\")",
+        "timestamp(this.ts) - timestamp(this.created_at) > duration(\"3600s\")",
         translateCheck("ts - created_at > INTERVAL '1' HOUR"));
   }
 
   @Test
   void intervalUnitsConvertToSeconds() {
-    assertEquals("timestamp.of(this.ts) > now - duration(\"90s\")",
+    assertEquals("timestamp(this.ts) > now - duration(\"90s\")",
         translateCheck("ts > CURRENT_TIMESTAMP - INTERVAL '90' SECOND"));
-    assertEquals("timestamp.of(this.ts) > now - duration(\"120s\")",
+    assertEquals("timestamp(this.ts) > now - duration(\"120s\")",
         translateCheck("ts > CURRENT_TIMESTAMP - INTERVAL '2' MINUTE"));
   }
 
@@ -2078,8 +2078,8 @@ class CheckConstraintTest {
   @Test
   void timestampLiteralBetween() {
     assertEquals(
-        "timestamp(\"2020-01-01T00:00:00Z\") <= timestamp.of(this.ts) "
-            + "&& timestamp.of(this.ts) <= now",
+        "timestamp(\"2020-01-01T00:00:00Z\") <= timestamp(this.ts) "
+            + "&& timestamp(this.ts) <= now",
         translateCheck("ts BETWEEN TIMESTAMP '2020-01-01 00:00:00' AND CURRENT_TIMESTAMP"));
   }
 
@@ -2088,7 +2088,7 @@ class CheckConstraintTest {
   @Test
   void timestampInValueList() {
     assertEquals(
-        "timestamp.of(this.ts) in [timestamp(\"2020-01-01T00:00:00Z\"), "
+        "timestamp(this.ts) in [timestamp(\"2020-01-01T00:00:00Z\"), "
             + "timestamp(\"2021-01-01T00:00:00Z\")]",
         translateCheck("ts IN (TIMESTAMP '2020-01-01 00:00:00', TIMESTAMP '2021-01-01 00:00:00')"));
   }
@@ -2097,7 +2097,7 @@ class CheckConstraintTest {
   void timestampGreatest() {
     String cel = translateCheck("GREATEST(ts, created_at) <= CURRENT_TIMESTAMP");
     org.junit.jupiter.api.Assertions.assertTrue(
-        cel.contains("timestamp.of(this.ts) > timestamp.of(this.created_at)")
+        cel.contains("timestamp(this.ts) > timestamp(this.created_at)")
             && cel.contains("<= now"),
         "expected timestamp GREATEST; got: " + cel);
   }
@@ -2106,8 +2106,8 @@ class CheckConstraintTest {
   void timestampCoalesce() {
     String cel = translateCheck("COALESCE(ts, created_at) <= CURRENT_TIMESTAMP");
     org.junit.jupiter.api.Assertions.assertTrue(
-        cel.contains("timestamp.of(this.ts)")
-            && cel.contains("timestamp.of(this.created_at)")
+        cel.contains("timestamp(this.ts)")
+            && cel.contains("timestamp(this.created_at)")
             && cel.contains("<= now"),
         "expected timestamp COALESCE; got: " + cel);
   }
@@ -2117,7 +2117,7 @@ class CheckConstraintTest {
     String cel = translateCheck(
         "CASE ts WHEN TIMESTAMP '2020-01-01 00:00:00' THEN 1 ELSE 0 END = 1");
     org.junit.jupiter.api.Assertions.assertTrue(
-        cel.contains("timestamp.of(this.ts) == timestamp(\"2020-01-01T00:00:00Z\")"),
+        cel.contains("timestamp(this.ts) == timestamp(\"2020-01-01T00:00:00Z\")"),
         "expected timestamp simple-CASE; got: " + cel);
   }
 
@@ -2899,10 +2899,10 @@ class CheckConstraintTest {
   @Test
   void variantGetReturningTimestamp() {
     // RETURNING TIMESTAMP resolves to a timestamp, so it composes with a
-    // timestamp column (which normalizes via timestamp.of).
+    // timestamp column (which normalizes via timestamp).
     assertEquals(
         "variants.as(variants.path(this.data, '$.ts'), \"timestamp\") "
-            + "> timestamp.of(this.created_at)",
+            + "> timestamp(this.created_at)",
         translateCheck("VARIANT_GET(data, '$.ts' RETURNING TIMESTAMP) > created_at"));
   }
 
@@ -2959,7 +2959,7 @@ class CheckConstraintTest {
         + "CHECK (ts <= CURRENT_TIMESTAMP)"
         + ");";
     Schema schema = parseScript(script).getNamedTypes().get("T");
-    assertEquals("timestamp.of(this.ts) <= now", schema.getRules().get(0).getExpr());
+    assertEquals("timestamp(this.ts) <= now", schema.getRules().get(0).getExpr());
   }
 
   // ---------------------------------------------------------------------
@@ -4514,7 +4514,7 @@ class CheckConstraintTest {
     // Confirms the deferred LOW item is a non-bug: subtreeHasTemporal not
     // flagging VARIANT_GET RETURNING TIMESTAMP / CURRENT_TIMESTAMP is harmless,
     // because both already emit CEL timestamps — the native comparison path
-    // produces correct, well-typed CEL without the timestamp.of() wrap (which
+    // produces correct, well-typed CEL without the timestamp() wrap (which
     // is only needed for timestamp COLUMNS and TIMESTAMP/INTERVAL literals).
     String cel = translateCheck(
         "VARIANT_GET(data, '$.a' RETURNING TIMESTAMP) > CURRENT_TIMESTAMP");

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/constraint/StrictCelCheckSmokeTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/constraint/StrictCelCheckSmokeTest.java
@@ -468,7 +468,7 @@ class StrictCelCheckSmokeTest {
   @Test void acceptsTimestampOf() {
     Schema intCol = Schema.create(Schema.Type.INT);
     CelValidator.assertValidStrictColumnLevel(
-        "timestamp.of(this, \"millis\") < now", "x", intCol);
+        "timestamp(this, 3) < now", "x", intCol);
   }
 
   @Test void acceptsVariantConstructorAndNavigation() {

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <alibaba.tea.sdk.version>1.3.2</alibaba.tea.sdk.version>
         <alibaba.credentials.sdk.version>1.0.4</alibaba.credentials.sdk.version>
         <caffeine.version>2.9.3</caffeine.version>
-        <cel-version>0.12.0</cel-version>
+        <cel-version>0.13.1</cel-version>
         <google.api.client.version>2.4.0</google.api.client.version>
         <google.auth.version>1.24.1</google.auth.version>
         <guice.version>5.1.0</guice.version>

--- a/protobuf-types/src/test/java/io/confluent/protobuf/type/utils/TestVariantUtils.java
+++ b/protobuf-types/src/test/java/io/confluent/protobuf/type/utils/TestVariantUtils.java
@@ -16,7 +16,6 @@
 
 package io.confluent.protobuf.type.utils;
 
-import com.google.protobuf.ByteString;
 import com.google.protobuf.ListValue;
 import com.google.protobuf.NullValue;
 import com.google.protobuf.Struct;
@@ -134,7 +133,7 @@ public class TestVariantUtils {
         .build();
     Variant variant = VariantUtils.toKafkaVariant(value);
     Assert.assertEquals(Variant.Type.OBJECT, variant.getType());
-    Assert.assertEquals(0, variant.numObjectElements());
+    Assert.assertEquals(0, variant.numObjectFields());
   }
 
   @Test

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelExecutor.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelExecutor.java
@@ -252,6 +252,9 @@ public class CelExecutor implements RuleExecutor {
     if (ctx.rule().getKind() == RuleKind.CONDITION) {
       return result;
     }
+    // Every result writer below expects a Decimal as BigDecimal, not the CelDecimal wrapper,
+    // so unwrap before AvroResultWriter or the Jackson roundtrip runs.
+    result = CelUtils.unwrapCelDecimals(result);
     if (ctx.target() instanceof AvroSchema) {
       // Avro target: walker handles every Schema.Type — records, primitives,
       // enums, bytes/fixed, logical types, unions. Sidesteps the JSON

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelFieldExecutor.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelFieldExecutor.java
@@ -105,6 +105,9 @@ public class CelFieldExecutor extends FieldRuleExecutor {
             }
           }
       );
+      // Unwrap before the narrowing chain below: a CelDecimal is not a Number, so it would
+      // silently skip it.
+      result = CelUtils.unwrapCelDecimals(result);
       if (result instanceof com.google.protobuf.NullValue
           || result instanceof dev.cel.common.values.NullValue) {
         // CEL `null` literal evaluates to dev.cel.common.values.NullValue;

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelFieldExecutor.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelFieldExecutor.java
@@ -33,6 +33,7 @@ import io.confluent.kafka.schemaregistry.utils.JacksonMapper;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.avro.Schema;
 
 public class CelFieldExecutor extends FieldRuleExecutor {
 
@@ -88,12 +89,20 @@ public class CelFieldExecutor extends FieldRuleExecutor {
       // this executor has always done, and an existing rule comparing such a field to a plain
       // integer literal only compiles under the signed reading. Which one applies is therefore
       // declared per rule, defaulting to the historical signed one.
-      Object celFieldValue =
-          celExecutor.resolveUnsignedFieldType(ctx) == CelExecutor.UnsignedFieldType.UINT
-              && fieldCtx.getFieldDescriptor() instanceof FieldDescriptor
-              ? CelUtils.toCelValueForProtobufField(
-                  (FieldDescriptor) fieldCtx.getFieldDescriptor(), fieldValue)
-              : fieldValue;
+      // For Avro the same idea applies to a logical type: a timestamp field's unit lives in
+      // the schema, so a bare epoch long has to be presented against the field's schema or a
+      // rule reading `timestamp(value)` would take it for epoch seconds.
+      Object celFieldValue;
+      if (celExecutor.resolveUnsignedFieldType(ctx) == CelExecutor.UnsignedFieldType.UINT
+          && fieldCtx.getFieldDescriptor() instanceof FieldDescriptor) {
+        celFieldValue = CelUtils.toCelValueForProtobufField(
+            (FieldDescriptor) fieldCtx.getFieldDescriptor(), fieldValue);
+      } else if (fieldCtx.getFieldDescriptor() instanceof Schema.Field) {
+        celFieldValue = CelUtils.toCelValue(
+            fieldValue, ((Schema.Field) fieldCtx.getFieldDescriptor()).schema());
+      } else {
+        celFieldValue = fieldValue;
+      }
       Object result = celExecutor.execute(ctx, fieldValue, new HashMap<String, Object>() {
             {
               put("value", celFieldValue != null ? celFieldValue : NULL_VALUE);

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelUtils.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelUtils.java
@@ -57,6 +57,7 @@ import dev.cel.runtime.CelStandardFunctions;
 import dev.cel.runtime.CelStandardFunctions.StandardFunction;
 import io.confluent.kafka.schemaregistry.rules.cel.avro.AvroCelTypeProvider;
 import io.confluent.kafka.schemaregistry.rules.cel.builtin.BuiltinLibrary;
+import io.confluent.kafka.schemaregistry.rules.cel.builtin.CelDecimal;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.ZonedDateTime;
@@ -799,6 +800,61 @@ public final class CelUtils {
     // `this.intField <= 150` won't dispatch because CEL only registers the
     // int64 overload.
     return toCelValue(mapper.convertValue(value, new TypeReference<Map<String, Object>>() {}));
+  }
+
+  /**
+   * Recursively replace every {@link CelDecimal} in a CEL evaluation result with the
+   * {@link java.math.BigDecimal} it wraps — the logical-type Java rep the result writers,
+   * Jackson and the field setters all expect. A rule may return a Decimal at top level or
+   * nested in a result map / list.
+   *
+   * <p>Returns the very same instance when nothing changed, so a decimal-free result
+   * costs one walk and no copying.
+   */
+  public static Object unwrapCelDecimals(Object value) {
+    if (value instanceof CelDecimal) {
+      return ((CelDecimal) value).value();
+    }
+    if (value instanceof Map) {
+      Map<?, ?> in = (Map<?, ?>) value;
+      Map<String, Object> out = null;
+      int index = 0;
+      for (Map.Entry<?, ?> e : in.entrySet()) {
+        Object converted = unwrapCelDecimals(e.getValue());
+        if (out == null && converted != e.getValue()) {
+          // First change: copy the entries already confirmed unchanged, in iteration order.
+          out = new LinkedHashMap<>(in.size());
+          int seen = 0;
+          for (Map.Entry<?, ?> prior : in.entrySet()) {
+            if (seen++ == index) {
+              break;
+            }
+            out.put(String.valueOf(prior.getKey()), prior.getValue());
+          }
+        }
+        if (out != null) {
+          out.put(String.valueOf(e.getKey()), converted);
+        }
+        index++;
+      }
+      return out == null ? value : out;
+    }
+    if (value instanceof List) {
+      List<?> in = (List<?>) value;
+      List<Object> out = null;
+      for (int i = 0; i < in.size(); i++) {
+        Object element = in.get(i);
+        Object converted = unwrapCelDecimals(element);
+        if (out == null && converted != element) {
+          out = new ArrayList<>(in);
+        }
+        if (out != null) {
+          out.set(i, converted);
+        }
+      }
+      return out == null ? value : out;
+    }
+    return value;
   }
 
   private static Map<String, Object> avroRecordToMap(IndexedRecord record) {

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelUtils.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelUtils.java
@@ -59,20 +59,24 @@ import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
 import io.confluent.kafka.schemaregistry.rules.cel.avro.AvroCelTypeProvider;
 import io.confluent.kafka.schemaregistry.rules.cel.builtin.BuiltinLibrary;
 import io.confluent.kafka.schemaregistry.rules.cel.builtin.CelDecimal;
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.generic.GenericData;
@@ -368,34 +372,58 @@ public final class CelUtils {
             CelExtensions.strings(),
             CelExtensions.math(CEL_OPTIONS))
         .addVarDeclarations(varDecls);
-    CelRuntimeBuilder runtimeBuilder = CelRuntimeFactory.standardCelRuntimeBuilder()
+    // plannerRuntimeBuilder, not standardCelRuntimeBuilder: cel-java promoted the
+    // ProgramPlanner runtime to the main factories in 0.13.0 ("will become the default in a
+    // future release") and 0.14.0 states the legacy runtime "will be deprecated in the next
+    // release. Callers are strongly urged to migrate to the Program Planner."
+    //
+    // setOptions(CEL_OPTIONS) after the factory call is load-bearing: plannerRuntimeBuilder
+    // seeds its own options with enableHeterogeneousNumericComparisons(true), which
+    // CelOptions.current() leaves false. Overriding here keeps cross-type numeric comparison
+    // off, matching the compiler's options and the other clients. CelUtilsTest pins this.
+    //
+    // BuiltinLibrary extends three standard function names (timestamp, string, double). On the
+    // planner runtime an overload cannot simply be added alongside the standard ones: the
+    // planner resolves a call to a single overload id at plan time and, when the checker could
+    // not narrow it that far — every call with a dyn argument, i.e. every Avro logical-typed
+    // field — falls back to a *name*-keyed dispatch entry built only from the bindings
+    // registered together under that name. So the standard functions are excluded here and
+    // re-registered by standardOverrides(), regrouped with our additions. There is exactly one
+    // setStandardFunctions call because a second one silently discards the first; the PCRE
+    // exclusion below rides along in the same set.
+    Set<StandardFunction> excludedStandardFunctions =
+        EnumSet.copyOf(BuiltinLibrary.overriddenStandardFunctions());
+    if (regexEngine == RegexEngine.PCRE) {
+      excludedStandardFunctions.add(StandardFunction.MATCHES);
+    }
+    CelRuntimeBuilder runtimeBuilder = CelRuntimeFactory.plannerRuntimeBuilder()
         .setOptions(CEL_OPTIONS)
         .addLibraries(
             new BuiltinLibrary(),
             CelExtensions.strings(),
-            CelExtensions.math(CEL_OPTIONS));
+            CelExtensions.math(CEL_OPTIONS))
+        .setStandardFunctions(
+            CelStandardFunctions.newBuilder()
+                .excludeFunctions(excludedStandardFunctions)
+                .build())
+        .addFunctionBindings(BuiltinLibrary.standardOverrides(CEL_OPTIONS));
 
     if (regexEngine == RegexEngine.PCRE) {
       // Replace stdlib RE2-backed matches with java.util.regex. Despite what
       // CelRuntimeBuilder.addFunctionBindings's javadoc says about replacing
       // duplicate overload IDs, it actually throws on duplicates unless both
       // sides are DynamicDispatchOverload (see DefaultDispatcher.Builder).
-      // Stdlib matches isn't dynamic-dispatch, so we subset the standard
-      // functions to drop MATCHES, then add our own bindings under the same
-      // overload IDs the compiler resolves to.
-      // setStandardEnvironmentEnabled(false) is required by cel-java when
-      // overriding standard function bindings (else build() throws).
-      runtimeBuilder
-          .setStandardEnvironmentEnabled(false)
-          .setStandardFunctions(
-              CelStandardFunctions.newBuilder()
-                  .excludeFunctions(StandardFunction.MATCHES)
-                  .build())
-          .addFunctionBindings(
-              CelFunctionBinding.from("matches", String.class, String.class,
-                  CelUtils::pcreMatches),
-              CelFunctionBinding.from("matches_string", String.class, String.class,
-                  CelUtils::pcreMatches));
+      // Stdlib matches isn't dynamic-dispatch, so MATCHES is dropped from the
+      // standard-function set above and our own bindings are added here under
+      // the same overload IDs the compiler resolves to.
+      // The legacy runtime additionally required setStandardEnvironmentEnabled(false) here;
+      // the planner runtime rejects that call outright ("Unsupported. Subset the environment
+      // using setStandardFunctions instead."), so the subset is the whole mechanism.
+      runtimeBuilder.addFunctionBindings(
+          CelFunctionBinding.from("matches", String.class, String.class,
+              CelUtils::pcreMatches),
+          CelFunctionBinding.from("matches_string", String.class, String.class,
+              CelUtils::pcreMatches));
     }
 
     if (type == ScriptType.PROTOBUF) {
@@ -748,7 +776,7 @@ public final class CelUtils {
    * schema is in hand; the schema-less overload cannot recover the unit.
    */
   public static Object toCelValue(Object value, Schema schema) {
-    return toCelValue(normalizeAvroTemporal(value, schema));
+    return toCelValue(normalizeAvroLogical(value, schema));
   }
 
   /**
@@ -880,27 +908,31 @@ public final class CelUtils {
   }
 
   /**
-   * Present an Avro timestamp logical type as the {@code java.time} value CEL's
-   * {@code timestamp} overloads expect, taking the unit from the schema.
+   * Present an Avro logical type as the value CEL's extension types expect, taking the unit or
+   * scale from the schema: a timestamp as the {@code java.time} value the {@code timestamp}
+   * overloads bind, a decimal as the {@link CelDecimal} the {@code decimals.*} overloads bind.
    *
    * <p>Avro's {@code use.logical.type.converters} defaults to false, so without this a
-   * {@code timestamp-millis} field reaches a rule as a bare {@code long} whose unit lives
-   * only in the schema — and CEL reads a bare int as epoch <em>seconds</em>, so
-   * {@code timestamp(this.ts)} would silently answer with a 1970 date. Converting here makes
-   * a rule read the same under either converter setting, and matches what the JS, Rust and
-   * C++ clients already do at their Avro boundary.
+   * {@code timestamp-millis} field reaches a rule as a bare {@code long} whose unit lives only
+   * in the schema — and CEL reads a bare int as epoch <em>seconds</em>, so
+   * {@code timestamp(this.ts)} would silently answer with a 1970 date — while a
+   * {@code decimal} field arrives as unscaled bytes whose scale is likewise only in the schema.
+   * Converting here makes a rule read the same under either converter setting, and matches what
+   * the JS, Rust and C++ clients already do at their Avro boundary.
    *
-   * <p>Values that already arrived as a temporal (converters on) pass through untouched, as
-   * does anything without a recognized timestamp logical type.
+   * <p>Values that already arrived in the logical representation (converters on) are passed
+   * through — wrapped, for a decimal, since a bare {@link BigDecimal} is a {@link Number} and
+   * would take the numeric-equality short-circuit that answers false for any BigDecimal pair.
+   * Anything without a recognized logical type is returned untouched.
    */
-  private static Object normalizeAvroTemporal(Object value, Schema schema) {
+  private static Object normalizeAvroLogical(Object value, Schema schema) {
     if (value == null || schema == null) {
       return value;
     }
     switch (schema.getType()) {
       case UNION: {
         Schema branch = avroUnionBranch(schema, value);
-        return branch != null ? normalizeAvroTemporal(value, branch) : value;
+        return branch != null ? normalizeAvroLogical(value, branch) : value;
       }
       case ARRAY: {
         if (!(value instanceof List)) {
@@ -909,7 +941,7 @@ public final class CelUtils {
         List<?> in = (List<?>) value;
         List<Object> out = new ArrayList<>(in.size());
         for (Object e : in) {
-          out.add(normalizeAvroTemporal(e, schema.getElementType()));
+          out.add(normalizeAvroLogical(e, schema.getElementType()));
         }
         return out;
       }
@@ -920,39 +952,87 @@ public final class CelUtils {
         Map<?, ?> in = (Map<?, ?>) value;
         Map<Object, Object> out = new LinkedHashMap<>(in.size());
         for (Map.Entry<?, ?> e : in.entrySet()) {
-          out.put(e.getKey(), normalizeAvroTemporal(e.getValue(), schema.getValueType()));
+          out.put(e.getKey(), normalizeAvroLogical(e.getValue(), schema.getValueType()));
         }
         return out;
       }
       default:
         break;
     }
-    // Only a numeric carrier needs the schema's unit; an Instant / LocalDateTime already
-    // carries it. Records fall through here too and are converted by avroRecordToMap.
-    if (!(value instanceof Long || value instanceof Integer)) {
-      return value;
-    }
     LogicalType logicalType = schema.getLogicalType();
     if (logicalType == null) {
       return value;
     }
-    long epoch = ((Number) value).longValue();
     switch (logicalType.getName()) {
+      case "decimal":
+        return normalizeAvroDecimal(value, (LogicalTypes.Decimal) logicalType);
       case "timestamp-millis":
-        return Instant.ofEpochMilli(epoch);
+        return epochOf(value, 1_000L, 1_000_000L);
       case "timestamp-micros":
-        return instantOfEpoch(epoch, 1_000_000L, 1_000L);
+        return epochOf(value, 1_000_000L, 1_000L);
       case "timestamp-nanos":
-        return instantOfEpoch(epoch, 1_000_000_000L, 1L);
+        return epochOf(value, 1_000_000_000L, 1L);
       case "local-timestamp-millis":
-        return localDateTimeOf(Instant.ofEpochMilli(epoch));
+        return localOf(value, 1_000L, 1_000_000L);
       case "local-timestamp-micros":
-        return localDateTimeOf(instantOfEpoch(epoch, 1_000_000L, 1_000L));
+        return localOf(value, 1_000_000L, 1_000L);
       case "local-timestamp-nanos":
-        return localDateTimeOf(instantOfEpoch(epoch, 1_000_000_000L, 1L));
+        return localOf(value, 1_000_000_000L, 1L);
       default:
         return value;
     }
+  }
+
+  /**
+   * A {@code decimal} logical type as a {@link CelDecimal}: unscaled bytes plus the schema's
+   * scale with the converters off, an already-scaled {@link BigDecimal} with them on.
+   */
+  private static Object normalizeAvroDecimal(Object value, LogicalTypes.Decimal logicalType) {
+    if (value instanceof BigDecimal) {
+      return CelDecimal.of((BigDecimal) value);
+    }
+    byte[] unscaled = unscaledBytes(value);
+    if (unscaled == null) {
+      return value;
+    }
+    return CelDecimal.ofUnscaled(unscaled, logicalType.getScale());
+  }
+
+  /** The bytes carrying a decimal, for the shapes Avro backs one with, else null. */
+  private static byte[] unscaledBytes(Object value) {
+    if (value instanceof ByteBuffer) {
+      // Defensive duplicate so the position-mutating read doesn't leak back to the reader.
+      ByteBuffer buf = ((ByteBuffer) value).duplicate();
+      byte[] bytes = new byte[buf.remaining()];
+      buf.get(bytes);
+      return bytes;
+    }
+    if (value instanceof byte[]) {
+      return (byte[]) value;
+    }
+    if (value instanceof GenericFixed) {
+      return ((GenericFixed) value).bytes();
+    }
+    return null;
+  }
+
+  /**
+   * An epoch value at the given unit as an {@link Instant}; a non-numeric carrier is passed on.
+   */
+  private static Object epochOf(Object value, long perSecond, long nanosPerUnit) {
+    if (!(value instanceof Long || value instanceof Integer)) {
+      // Already an Instant (converters on), or not a numeric carrier at all.
+      return value;
+    }
+    return instantOfEpoch(((Number) value).longValue(), perSecond, nanosPerUnit);
+  }
+
+  /**
+   * As {@link #epochOf} but for a {@code local-timestamp-*}, which carries no zone.
+   */
+  private static Object localOf(Object value, long perSecond, long nanosPerUnit) {
+    Object instant = epochOf(value, perSecond, nanosPerUnit);
+    return instant instanceof Instant ? localDateTimeOf((Instant) instant) : instant;
   }
 
   /**

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelUtils.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelUtils.java
@@ -60,6 +60,8 @@ import io.confluent.kafka.schemaregistry.rules.cel.builtin.BuiltinLibrary;
 import io.confluent.kafka.schemaregistry.rules.cel.builtin.CelDecimal;
 import java.nio.ByteBuffer;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -69,6 +71,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import org.apache.avro.LogicalType;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
 import org.apache.avro.generic.GenericEnumSymbol;
@@ -738,6 +741,15 @@ public final class CelUtils {
   }
 
   /**
+   * {@link #toCelValue(Object)} for a value whose Avro schema is known, so a timestamp
+   * logical type can be presented with the unit the schema declares. Use this wherever the
+   * schema is in hand; the schema-less overload cannot recover the unit.
+   */
+  public static Object toCelValue(Object value, Schema schema) {
+    return toCelValue(normalizeAvroTemporal(value, schema));
+  }
+
+  /**
    * JSON-flavored variant of {@link #toCelValue(Object)}: additionally converts
    * Jackson {@link JsonNode} and arbitrary POJOs to maps via the supplied
    * {@link ObjectMapper}. Used on the JSON validation/transform path where the
@@ -860,8 +872,117 @@ public final class CelUtils {
   private static Map<String, Object> avroRecordToMap(IndexedRecord record) {
     Map<String, Object> out = new LinkedHashMap<>();
     for (Schema.Field f : record.getSchema().getFields()) {
-      out.put(f.name(), toCelValue(record.get(f.pos())));
+      out.put(f.name(), toCelValue(record.get(f.pos()), f.schema()));
     }
     return out;
+  }
+
+  /**
+   * Present an Avro timestamp logical type as the {@code java.time} value CEL's
+   * {@code timestamp} overloads expect, taking the unit from the schema.
+   *
+   * <p>Avro's {@code use.logical.type.converters} defaults to false, so without this a
+   * {@code timestamp-millis} field reaches a rule as a bare {@code long} whose unit lives
+   * only in the schema — and CEL reads a bare int as epoch <em>seconds</em>, so
+   * {@code timestamp(this.ts)} would silently answer with a 1970 date. Converting here makes
+   * a rule read the same under either converter setting, and matches what the JS, Rust and
+   * C++ clients already do at their Avro boundary.
+   *
+   * <p>Values that already arrived as a temporal (converters on) pass through untouched, as
+   * does anything without a recognized timestamp logical type.
+   */
+  private static Object normalizeAvroTemporal(Object value, Schema schema) {
+    if (value == null || schema == null) {
+      return value;
+    }
+    switch (schema.getType()) {
+      case UNION: {
+        Schema branch = avroUnionBranch(schema);
+        return branch != null ? normalizeAvroTemporal(value, branch) : value;
+      }
+      case ARRAY: {
+        if (!(value instanceof List)) {
+          return value;
+        }
+        List<?> in = (List<?>) value;
+        List<Object> out = new ArrayList<>(in.size());
+        for (Object e : in) {
+          out.add(normalizeAvroTemporal(e, schema.getElementType()));
+        }
+        return out;
+      }
+      case MAP: {
+        if (!(value instanceof Map)) {
+          return value;
+        }
+        Map<?, ?> in = (Map<?, ?>) value;
+        Map<Object, Object> out = new LinkedHashMap<>(in.size());
+        for (Map.Entry<?, ?> e : in.entrySet()) {
+          out.put(e.getKey(), normalizeAvroTemporal(e.getValue(), schema.getValueType()));
+        }
+        return out;
+      }
+      default:
+        break;
+    }
+    // Only a numeric carrier needs the schema's unit; an Instant / LocalDateTime already
+    // carries it. Records fall through here too and are converted by avroRecordToMap.
+    if (!(value instanceof Long || value instanceof Integer)) {
+      return value;
+    }
+    LogicalType logicalType = schema.getLogicalType();
+    if (logicalType == null) {
+      return value;
+    }
+    long epoch = ((Number) value).longValue();
+    switch (logicalType.getName()) {
+      case "timestamp-millis":
+        return Instant.ofEpochMilli(epoch);
+      case "timestamp-micros":
+        return instantOfEpoch(epoch, 1_000_000L, 1_000L);
+      case "timestamp-nanos":
+        return instantOfEpoch(epoch, 1_000_000_000L, 1L);
+      case "local-timestamp-millis":
+        return localDateTimeOf(Instant.ofEpochMilli(epoch));
+      case "local-timestamp-micros":
+        return localDateTimeOf(instantOfEpoch(epoch, 1_000_000L, 1_000L));
+      case "local-timestamp-nanos":
+        return localDateTimeOf(instantOfEpoch(epoch, 1_000_000_000L, 1L));
+      default:
+        return value;
+    }
+  }
+
+  /**
+   * The branch of a union a non-null value took. Nullable {@code [null, X]} — the shape a
+   * logical-typed optional field takes — resolves to X. A multi-branch union may pick the
+   * wrong arm, which is harmless: the caller only acts on the branch when the value is a
+   * numeric carrier and the branch declares a timestamp logical type.
+   */
+  private static Schema avroUnionBranch(Schema union) {
+    for (Schema branch : union.getTypes()) {
+      if (branch.getType() != Schema.Type.NULL) {
+        return branch;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Epoch value in units of {@code perSecond} per second, each worth {@code nanosPerUnit}.
+   */
+  private static Instant instantOfEpoch(long epoch, long perSecond, long nanosPerUnit) {
+    // floorDiv/floorMod rather than / and %: a pre-epoch value is negative, and the
+    // nano-of-second adjustment must stay non-negative.
+    return Instant.ofEpochSecond(
+        Math.floorDiv(epoch, perSecond), Math.floorMod(epoch, perSecond) * nanosPerUnit);
+  }
+
+  /**
+   * A {@code local-timestamp-*} value read at UTC and stripped of the offset — what Avro's own
+   * local-timestamp conversions do, so the same wall-clock time comes out either way.
+   */
+  private static LocalDateTime localDateTimeOf(Instant instant) {
+    return LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
   }
 }

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelUtils.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelUtils.java
@@ -860,7 +860,11 @@ public final class CelUtils {
     }
     if (value instanceof Map) {
       Map<?, ?> in = (Map<?, ?>) value;
-      Map<String, Object> out = null;
+      // Keys are copied as they are, NOT through String.valueOf. A CEL map may be keyed by int,
+      // uint or bool, and stringifying would both change the key type and collapse distinct keys
+      // (1 and "1" into one entry, silently dropping a value) — and only when a Decimal happened
+      // to be somewhere in the map, since the no-change path below returns the original.
+      Map<Object, Object> out = null;
       int index = 0;
       for (Map.Entry<?, ?> e : in.entrySet()) {
         Object converted = unwrapCelDecimals(e.getValue());
@@ -872,11 +876,11 @@ public final class CelUtils {
             if (seen++ == index) {
               break;
             }
-            out.put(String.valueOf(prior.getKey()), prior.getValue());
+            out.put(prior.getKey(), prior.getValue());
           }
         }
         if (out != null) {
-          out.put(String.valueOf(e.getKey()), converted);
+          out.put(e.getKey(), converted);
         }
         index++;
       }

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelUtils.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelUtils.java
@@ -382,15 +382,17 @@ public final class CelUtils {
     // CelOptions.current() leaves false. Overriding here keeps cross-type numeric comparison
     // off, matching the compiler's options and the other clients. CelUtilsTest pins this.
     //
-    // BuiltinLibrary extends three standard function names (timestamp, string, double). On the
-    // planner runtime an overload cannot simply be added alongside the standard ones: the
-    // planner resolves a call to a single overload id at plan time and, when the checker could
-    // not narrow it that far — every call with a dyn argument, i.e. every Avro logical-typed
-    // field — falls back to a *name*-keyed dispatch entry built only from the bindings
-    // registered together under that name. So the standard functions are excluded here and
-    // re-registered by standardOverrides(), regrouped with our additions. There is exactly one
-    // setStandardFunctions call because a second one silently discards the first; the PCRE
-    // exclusion below rides along in the same set.
+    // BuiltinLibrary takes over five standard function names (timestamp, string, double, == and
+    // !=), which is why they are excluded here. On the planner runtime an overload cannot simply
+    // be added alongside the standard ones: the planner resolves a call to a single overload id
+    // at plan time and, when the checker could not narrow it that far — every call with a dyn
+    // argument, i.e. every Avro logical-typed field — falls back to a *name*-keyed dispatch entry
+    // built only from the bindings registered together under that name. The library re-registers
+    // each of the five, preserving the standard behavior (see BuiltinOverload.standardOverrides).
+    //
+    // Only the exclusion lives here, not the bindings: this is the one setStandardFunctions call,
+    // and a second one silently discards the first, so the PCRE exclusion below has to ride along
+    // in the same set.
     Set<StandardFunction> excludedStandardFunctions =
         EnumSet.copyOf(BuiltinLibrary.overriddenStandardFunctions());
     if (regexEngine == RegexEngine.PCRE) {
@@ -405,8 +407,7 @@ public final class CelUtils {
         .setStandardFunctions(
             CelStandardFunctions.newBuilder()
                 .excludeFunctions(excludedStandardFunctions)
-                .build())
-        .addFunctionBindings(BuiltinLibrary.standardOverrides(CEL_OPTIONS));
+                .build());
 
     if (regexEngine == RegexEngine.PCRE) {
       // Replace stdlib RE2-backed matches with java.util.regex. Despite what

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelUtils.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelUtils.java
@@ -55,6 +55,7 @@ import dev.cel.runtime.CelRuntimeBuilder;
 import dev.cel.runtime.CelRuntimeFactory;
 import dev.cel.runtime.CelStandardFunctions;
 import dev.cel.runtime.CelStandardFunctions.StandardFunction;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
 import io.confluent.kafka.schemaregistry.rules.cel.avro.AvroCelTypeProvider;
 import io.confluent.kafka.schemaregistry.rules.cel.builtin.BuiltinLibrary;
 import io.confluent.kafka.schemaregistry.rules.cel.builtin.CelDecimal;
@@ -74,6 +75,7 @@ import java.util.stream.Collectors;
 import org.apache.avro.LogicalType;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericContainer;
+import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericEnumSymbol;
 import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
@@ -897,7 +899,7 @@ public final class CelUtils {
     }
     switch (schema.getType()) {
       case UNION: {
-        Schema branch = avroUnionBranch(schema);
+        Schema branch = avroUnionBranch(schema, value);
         return branch != null ? normalizeAvroTemporal(value, branch) : value;
       }
       case ARRAY: {
@@ -954,18 +956,23 @@ public final class CelUtils {
   }
 
   /**
-   * The branch of a union a non-null value took. Nullable {@code [null, X]} — the shape a
-   * logical-typed optional field takes — resolves to X. A multi-branch union may pick the
-   * wrong arm, which is harmless: the caller only acts on the branch when the value is a
-   * numeric carrier and the branch declares a timestamp logical type.
+   * The branch of a union the value actually took, via Avro's own runtime resolution — the same
+   * call the walker in {@code AvroSchema} makes. Picking the first non-null branch instead would
+   * be wrong for a legal multi-branch union: given {@code [long(timestamp-millis), int]} an
+   * Integer belongs to the {@code int} arm, and the timestamp arm would convert it to an instant.
+   *
+   * <p>Returns null — meaning "leave the value alone" — when the branch is NULL or the value is
+   * not resolvable against the union at all. The latter is the ordinary case for a value that
+   * already arrived as a temporal (logical-type converters on): there is nothing to normalize.
    */
-  private static Schema avroUnionBranch(Schema union) {
-    for (Schema branch : union.getTypes()) {
-      if (branch.getType() != Schema.Type.NULL) {
-        return branch;
-      }
+  private static Schema avroUnionBranch(Schema union, Object value) {
+    try {
+      GenericData data = AvroSchemaUtils.getData(union, value, false, false);
+      Schema branch = union.getTypes().get(data.resolveUnion(union, value));
+      return branch.getType() == Schema.Type.NULL ? null : branch;
+    } catch (RuntimeException e) {
+      return null;
     }
-    return null;
   }
 
   /**

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidator.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidator.java
@@ -111,6 +111,7 @@ public final class CelValidator implements ValidationRuleExecutor {
     }
     ScriptType scriptType;
     CelType thisType;
+    Schema avroSchemaHint = null;
     if (schema instanceof Descriptor) {
       scriptType = ScriptType.PROTOBUF;
       // Walker passes the field's message-type descriptor for nested-message values and
@@ -151,7 +152,11 @@ public final class CelValidator implements ValidationRuleExecutor {
         thisType = CelUtils.findCelTypeForAvroSchema(valueSchema);
         schema = valueSchema;
       } else {
-        thisType = CelUtils.findCelTypeForAvroSchema((Schema) schema);
+        // A primitive field value: the walker's hint is the only place the field's
+        // logical type (and so a timestamp's unit) is recorded, so present the value
+        // against it. Records take the same path per field inside toCelValue.
+        avroSchemaHint = (Schema) schema;
+        thisType = CelUtils.findCelTypeForAvroSchema(avroSchemaHint);
       }
     } else if (schema instanceof Class<?>) {
       scriptType = ScriptType.JSON;
@@ -165,9 +170,13 @@ public final class CelValidator implements ValidationRuleExecutor {
     ValidationKey key = new ValidationKey(rule.getExpr(), scriptType, thisType, schema);
     Object celValue;
     try {
-      celValue = scriptType == ScriptType.JSON
-          ? CelUtils.toCelValueForJson(value, JSON_MAPPER)
-          : CelUtils.toCelValue(value);
+      if (scriptType == ScriptType.JSON) {
+        celValue = CelUtils.toCelValueForJson(value, JSON_MAPPER);
+      } else if (avroSchemaHint != null) {
+        celValue = CelUtils.toCelValue(value, avroSchemaHint);
+      } else {
+        celValue = CelUtils.toCelValue(value);
+      }
     } catch (IllegalArgumentException e) {
       throw new RuleException(
           "Could not convert value for validation rule '"

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/avro/AvroResultWriter.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/avro/AvroResultWriter.java
@@ -546,9 +546,11 @@ public final class AvroResultWriter {
         return value instanceof java.time.LocalTime;
       case "timestamp-millis":
       case "timestamp-micros":
+      case "timestamp-nanos":
         return value instanceof java.time.Instant;
       case "local-timestamp-millis":
       case "local-timestamp-micros":
+      case "local-timestamp-nanos":
         return value instanceof java.time.LocalDateTime;
       default:
         return false;

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinDeclarations.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinDeclarations.java
@@ -22,12 +22,13 @@ import dev.cel.common.CelOverloadDecl;
 import dev.cel.common.types.CelType;
 import dev.cel.common.types.OpaqueType;
 import dev.cel.common.types.SimpleType;
+import dev.cel.common.types.StructTypeReference;
 import java.util.ArrayList;
 import java.util.List;
 
 public final class BuiltinDeclarations {
 
-  private static final OpaqueType DECIMAL = CelTypeLabels.DECIMAL;
+  private static final StructTypeReference DECIMAL = CelTypeLabels.DECIMAL;
   private static final OpaqueType VARIANT = CelTypeLabels.VARIANT;
 
   private BuiltinDeclarations() {

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinDeclarations.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinDeclarations.java
@@ -182,20 +182,30 @@ public final class BuiltinDeclarations {
   // ---- Timestamp ----
 
   private static void addTimestamp(List<CelFunctionDecl> decls) {
-    // timestamp.of — two overloads (matches the decimal(...) / variant(...)
-    // pattern: (dyn) runtime-dispatch + explicit (int, string) epoch + unit).
-    // The arity check in SignaturesOverlap short-circuits, so the overlap rule
-    // doesn't trigger.
+    // Extension overloads on the *standard* `timestamp` function, rather than a
+    // `timestamp.of` namespace of our own. cel-java isolates the standard declarations in
+    // their own scope (Env.standard) and composites the scopes by overload signature,
+    // innermost first, so these merge with the standard ones instead of replacing the
+    // declaration: `timestamp(string)` and `timestamp(int)` remain stdlib's, the latter
+    // reading a bare int as epoch seconds — the contract all seven clients share.
+    //
+    // (timestamp) -> timestamp has the same signature as stdlib's identity overload and so
+    // shadows it. That is the point: stdlib binds that overload to Instant alone, leaving
+    // every other java.time shape an Avro or Proto decoder can yield with no matching
+    // overload. TimestampUtils.toInstant accepts any Temporal — passing an Instant through,
+    // converting an OffsetDateTime / ZonedDateTime, and refusing a LocalDateTime, whose
+    // local-timestamp value carries no zone to convert from.
     decls.add(CelFunctionDecl.newFunctionDeclaration(
-        "timestamp.of",
+        "timestamp",
         CelOverloadDecl.newGlobalOverload(
-            "timestamp_of_dyn",
-            "Convert a value to a Timestamp (runtime dispatches on actual type)",
-            SimpleType.TIMESTAMP, ImmutableList.of(SimpleType.DYN)),
+            "timestamp_to_timestamp_temporal",
+            "Convert a java.time temporal to a Timestamp",
+            SimpleType.TIMESTAMP, ImmutableList.of(SimpleType.TIMESTAMP)),
         CelOverloadDecl.newGlobalOverload(
-            "timestamp_of_int_string",
-            "Construct from epoch numeric + unit (millis, micros, nanos, seconds)",
-            SimpleType.TIMESTAMP, ImmutableList.of(SimpleType.INT, SimpleType.STRING))));
+            "timestamp_int_int",
+            "Construct from an epoch value at a precision: 0 seconds, 3 millis, "
+                + "6 micros, 9 nanos",
+            SimpleType.TIMESTAMP, ImmutableList.of(SimpleType.INT, SimpleType.INT))));
   }
 
   // ---- Variant ----

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinDeclarations.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinDeclarations.java
@@ -248,13 +248,13 @@ public final class BuiltinDeclarations {
         CelOverloadDecl.newGlobalOverload(
             "variants_type_variant",
             "Variant type label as a string; CEL null in → CEL null out",
-            SimpleType.DYN, ImmutableList.of(VARIANT))));
+            SimpleType.DYN, ImmutableList.of(SimpleType.DYN))));
     decls.add(CelFunctionDecl.newFunctionDeclaration(
         "variants.isNull",
         CelOverloadDecl.newGlobalOverload(
             "variants_isnull_dyn",
             "True iff input is a Variant whose top type is NULL; false for CEL null",
-            SimpleType.BOOL, ImmutableList.of(VARIANT))));
+            SimpleType.BOOL, ImmutableList.of(SimpleType.DYN))));
 
     // Navigation. Each returns sub-Variant or CEL null on miss. For typed
     // extraction, compose with variants.as / variants.tryAs:
@@ -266,21 +266,21 @@ public final class BuiltinDeclarations {
             "variants_path_dyn_string",
             "JSONPath subset navigation; missing path → CEL null;"
                 + " explicit JSON null → variant-null; malformed path throws.",
-            VARIANT, ImmutableList.of(VARIANT, SimpleType.STRING))));
+            VARIANT, ImmutableList.of(SimpleType.DYN, SimpleType.STRING))));
     decls.add(CelFunctionDecl.newFunctionDeclaration(
         "variants.field",
         CelOverloadDecl.newGlobalOverload(
             "variants_field_dyn_string",
             "Object field by name; missing → CEL null; explicit JSON null →"
                 + " variant-null.",
-            VARIANT, ImmutableList.of(VARIANT, SimpleType.STRING))));
+            VARIANT, ImmutableList.of(SimpleType.DYN, SimpleType.STRING))));
     decls.add(CelFunctionDecl.newFunctionDeclaration(
         "variants.index",
         CelOverloadDecl.newGlobalOverload(
             "variants_index_dyn_int",
             "Array element by index; out-of-bounds → CEL null; explicit JSON"
                 + " null at index → variant-null.",
-            VARIANT, ImmutableList.of(VARIANT, SimpleType.INT))));
+            VARIANT, ImmutableList.of(SimpleType.DYN, SimpleType.INT))));
 
     // Standalone typed extraction. variants.as throws on type mismatch
     // (Spark variant_get root-path analog). variants.tryAs returns CEL null on
@@ -292,13 +292,13 @@ public final class BuiltinDeclarations {
             "variants_as_dyn_string",
             "Extract a typed value from a Variant; throws on type mismatch;"
                 + " null in → null out.",
-            SimpleType.DYN, ImmutableList.of(VARIANT, SimpleType.STRING))));
+            SimpleType.DYN, ImmutableList.of(SimpleType.DYN, SimpleType.STRING))));
     decls.add(CelFunctionDecl.newFunctionDeclaration(
         "variants.tryAs",
         CelOverloadDecl.newGlobalOverload(
             "variants_tryas_dyn_string",
             "Extract a typed value from a Variant; CEL null on type mismatch.",
-            SimpleType.DYN, ImmutableList.of(VARIANT, SimpleType.STRING))));
+            SimpleType.DYN, ImmutableList.of(SimpleType.DYN, SimpleType.STRING))));
 
     // variants.toJson(Variant) — serialize a Variant to its JSON string form.
     decls.add(CelFunctionDecl.newFunctionDeclaration(
@@ -306,7 +306,7 @@ public final class BuiltinDeclarations {
         CelOverloadDecl.newGlobalOverload(
             "variants_tojson_variant",
             "Serialize a Variant to its JSON string form; CEL null in → CEL null out",
-            SimpleType.DYN, ImmutableList.of(VARIANT))));
+            SimpleType.DYN, ImmutableList.of(SimpleType.DYN))));
   }
 
   private static String overloadId(String functionName, String suffix) {

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinDeclarations.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinDeclarations.java
@@ -237,8 +237,8 @@ public final class BuiltinDeclarations {
         "variants.type",
         CelOverloadDecl.newGlobalOverload(
             "variants_type_variant",
-            "Variant type label as a string",
-            SimpleType.STRING, ImmutableList.of(VARIANT))));
+            "Variant type label as a string; CEL null in → CEL null out",
+            SimpleType.DYN, ImmutableList.of(VARIANT))));
     decls.add(CelFunctionDecl.newFunctionDeclaration(
         "variants.isNull",
         CelOverloadDecl.newGlobalOverload(
@@ -295,8 +295,8 @@ public final class BuiltinDeclarations {
         "variants.toJson",
         CelOverloadDecl.newGlobalOverload(
             "variants_tojson_variant",
-            "Serialize a Variant to its JSON string form",
-            SimpleType.STRING, ImmutableList.of(VARIANT))));
+            "Serialize a Variant to its JSON string form; CEL null in → CEL null out",
+            SimpleType.DYN, ImmutableList.of(VARIANT))));
   }
 
   private static String overloadId(String functionName, String suffix) {

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinLibrary.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinLibrary.java
@@ -16,50 +16,71 @@
 
 package io.confluent.kafka.schemaregistry.rules.cel.builtin;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import dev.cel.checker.CelCheckerBuilder;
 import dev.cel.common.CelOptions;
 import dev.cel.compiler.CelCompilerLibrary;
-import dev.cel.runtime.CelFunctionBinding;
+import dev.cel.runtime.CelInternalRuntimeLibrary;
 import dev.cel.runtime.CelRuntimeBuilder;
 import dev.cel.runtime.CelRuntimeLibrary;
 import dev.cel.runtime.CelStandardFunctions.StandardFunction;
+import dev.cel.runtime.RuntimeEquality;
 
 /**
  * Schema Registry's built-in CEL function library. Implements both
  * {@link CelCompilerLibrary} (so {@link BuiltinDeclarations}'s function
  * declarations are added to the type-checker) and {@link CelRuntimeLibrary}
  * (so {@link BuiltinOverload}'s function bindings are added to the runtime).
+ *
+ * <p>Specifically {@link CelInternalRuntimeLibrary} rather than plain {@link CelRuntimeLibrary},
+ * because {@link BuiltinOverload#standardOverrides} needs the runtime's own
+ * {@link RuntimeEquality}: it re-registers standard function bindings, and its {@code ==}
+ * replacement delegates every non-decimal comparison to the standard implementation. Building one
+ * by hand is not an option — {@code RuntimeEquality.create(RuntimeHelpers.create(), options)}
+ * yields an instance whose {@code adaptProtoToValue} throws "Not implemented yet", so it fails on
+ * any comparison involving a protobuf message. The runtime constructs a {@code
+ * ProtoMessageRuntimeEquality} and hands it to internal libraries; receiving that is both correct
+ * and less machinery than replicating it.
+ *
+ * <p>{@link CelInternalRuntimeLibrary} and {@link RuntimeEquality} are cel-java {@code @Internal}
+ * types — the only two this repository depends on. {@code CelStandardEqualityTest} is the pin: its
+ * {@code protoMessageEquality} case fails outright if this hook stops supplying a message-capable
+ * equality, so a cel-java upgrade that changes it breaks the build here rather than silently
+ * downstream.
  */
-public class BuiltinLibrary implements CelCompilerLibrary, CelRuntimeLibrary {
+public class BuiltinLibrary
+    implements CelCompilerLibrary, CelRuntimeLibrary, CelInternalRuntimeLibrary {
 
   @Override
   public void setCheckerOptions(CelCheckerBuilder checkerBuilder) {
     checkerBuilder.addFunctionDeclarations(BuiltinDeclarations.create());
   }
 
+  /**
+   * Plain-{@link CelRuntimeLibrary} entry point. Reached only if a runtime implementation does not
+   * recognize {@link CelInternalRuntimeLibrary}; it registers the namespaced bindings and skips
+   * the standard-function overrides, which have no {@link RuntimeEquality} to bind against here.
+   */
   @Override
   public void setRuntimeOptions(CelRuntimeBuilder runtimeBuilder) {
     runtimeBuilder.addFunctionBindings(BuiltinOverload.create());
   }
 
-  /**
-   * The standard functions this library extends, which the caller must exclude from the
-   * runtime's standard functions before registering {@link #standardOverrides}.
-   */
-  public static ImmutableSet<StandardFunction> overriddenStandardFunctions() {
-    return BuiltinOverload.OVERRIDDEN_STANDARD_FUNCTIONS;
+  @Override
+  public void setRuntimeOptions(
+      CelRuntimeBuilder runtimeBuilder, RuntimeEquality runtimeEquality, CelOptions celOptions) {
+    runtimeBuilder
+        .addFunctionBindings(BuiltinOverload.create())
+        .addFunctionBindings(BuiltinOverload.standardOverrides(celOptions, runtimeEquality));
   }
 
   /**
-   * Bindings for the standard function names this library extends, regrouped with the standard
-   * library's own bindings so the planner runtime's name-keyed dispatch sees all of them. Not
-   * added by {@link #setRuntimeOptions}, because the exclusion above has to happen in the same
-   * place as any other standard-function subsetting: a second setStandardFunctions call would
-   * silently discard the first.
+   * The standard functions this library takes over, which the caller must exclude from the
+   * runtime's standard functions. The exclusion cannot happen here: it is a
+   * {@code setStandardFunctions} call, and a second such call silently discards the first, so it
+   * has to be made in the same place as any other standard-function subsetting.
    */
-  public static ImmutableList<CelFunctionBinding> standardOverrides(CelOptions celOptions) {
-    return BuiltinOverload.standardOverrides(celOptions);
+  public static ImmutableSet<StandardFunction> overriddenStandardFunctions() {
+    return BuiltinOverload.OVERRIDDEN_STANDARD_FUNCTIONS;
   }
 }

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinLibrary.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinLibrary.java
@@ -16,10 +16,15 @@
 
 package io.confluent.kafka.schemaregistry.rules.cel.builtin;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import dev.cel.checker.CelCheckerBuilder;
+import dev.cel.common.CelOptions;
 import dev.cel.compiler.CelCompilerLibrary;
+import dev.cel.runtime.CelFunctionBinding;
 import dev.cel.runtime.CelRuntimeBuilder;
 import dev.cel.runtime.CelRuntimeLibrary;
+import dev.cel.runtime.CelStandardFunctions.StandardFunction;
 
 /**
  * Schema Registry's built-in CEL function library. Implements both
@@ -37,5 +42,24 @@ public class BuiltinLibrary implements CelCompilerLibrary, CelRuntimeLibrary {
   @Override
   public void setRuntimeOptions(CelRuntimeBuilder runtimeBuilder) {
     runtimeBuilder.addFunctionBindings(BuiltinOverload.create());
+  }
+
+  /**
+   * The standard functions this library extends, which the caller must exclude from the
+   * runtime's standard functions before registering {@link #standardOverrides}.
+   */
+  public static ImmutableSet<StandardFunction> overriddenStandardFunctions() {
+    return BuiltinOverload.OVERRIDDEN_STANDARD_FUNCTIONS;
+  }
+
+  /**
+   * Bindings for the standard function names this library extends, regrouped with the standard
+   * library's own bindings so the planner runtime's name-keyed dispatch sees all of them. Not
+   * added by {@link #setRuntimeOptions}, because the exclusion above has to happen in the same
+   * place as any other standard-function subsetting: a second setStandardFunctions call would
+   * silently discard the first.
+   */
+  public static ImmutableList<CelFunctionBinding> standardOverrides(CelOptions celOptions) {
+    return BuiltinOverload.standardOverrides(celOptions);
   }
 }

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinOverload.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinOverload.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
 import dev.cel.common.CelOptions;
+import dev.cel.common.Operator;
 import dev.cel.common.values.CelByteString;
 import dev.cel.common.values.NullValue;
 import dev.cel.runtime.CelFunctionBinding;
@@ -28,6 +29,7 @@ import dev.cel.runtime.CelStandardFunctions.StandardFunction;
 import dev.cel.runtime.RuntimeEquality;
 import dev.cel.runtime.standard.CelStandardFunction;
 import dev.cel.runtime.standard.DoubleFunction;
+import dev.cel.runtime.standard.InOperator;
 import dev.cel.runtime.standard.StringFunction;
 import dev.cel.runtime.standard.TimestampFunction;
 import io.confluent.kafka.schemaregistry.type.Variant;
@@ -39,6 +41,7 @@ import java.net.URISyntaxException;
 import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
@@ -72,7 +75,8 @@ final class BuiltinOverload {
    */
   static final ImmutableSet<StandardFunction> OVERRIDDEN_STANDARD_FUNCTIONS =
       ImmutableSet.of(StandardFunction.TIMESTAMP, StandardFunction.STRING,
-          StandardFunction.DOUBLE, StandardFunction.EQUALS, StandardFunction.NOT_EQUALS);
+          StandardFunction.DOUBLE, StandardFunction.EQUALS, StandardFunction.NOT_EQUALS,
+          StandardFunction.IN);
 
   private BuiltinOverload() {
   }
@@ -346,6 +350,27 @@ final class BuiltinOverload {
     out.add(CelFunctionBinding.from("not_equals", Object.class, Object.class,
         (Object x, Object y) -> !decimalEquals(x, y, runtimeEquality)));
 
+    // `in` over a list has to follow ==: RuntimeEquality.inList uses List.contains, which is
+    // Java equality on the raw elements, so `this.subtotal in [this.total]` answered false for
+    // 1.50 against 1.5 while `==` on the same operands answered true. Regrouped rather than
+    // replaced, because `in` has two overloads and only the list one is affected — a CEL map key
+    // can only be int, uint, bool or string, so a decimal can never be one.
+    out.addAll(regroup(Operator.IN.getFunction(), InOperator.create(), celOptions, runtimeEquality,
+        CelFunctionBinding.from("in_list", Object.class, List.class,
+            // Raw List, matching the standard binding's own signature so the delegation below
+            // type-checks against RuntimeEquality.inList.
+            (Object value, List list) -> {
+              if (!hasDecimal(value) && !hasDecimal(list)) {
+                return runtimeEquality.inList(list, value);
+              }
+              for (Object element : list) {
+                if (decimalEquals(value, element, runtimeEquality)) {
+                  return true;
+                }
+              }
+              return false;
+            })));
+
     return ImmutableList.copyOf(out);
   }
 
@@ -371,7 +396,67 @@ final class BuiltinOverload {
       // false anyway, but only by accident of the shapes not matching; say it outright.
       return false;
     }
+    // Containers, but only when a decimal is actually inside one of them. The standard
+    // implementation recurses with its own equality, so a Decimal nested in a list or map was
+    // compared by protobuf encoding and `[this.subtotal] == [this.total]` answered false while
+    // `this.subtotal == this.total` answered true — the same values, disagreeing on nesting
+    // alone. Gating on hasDecimal keeps every decimal-free comparison on the standard path
+    // exactly as it was, and each element pair recurses back through here, so a non-decimal
+    // element inside a decimal-bearing container still gets standard semantics.
+    if (x instanceof List && y instanceof List && (hasDecimal(x) || hasDecimal(y))) {
+      List<?> xs = (List<?>) x;
+      List<?> ys = (List<?>) y;
+      if (xs.size() != ys.size()) {
+        return false;
+      }
+      for (int i = 0; i < xs.size(); i++) {
+        if (!decimalEquals(xs.get(i), ys.get(i), runtimeEquality)) {
+          return false;
+        }
+      }
+      return true;
+    }
+    if (x instanceof Map && y instanceof Map && (hasDecimal(x) || hasDecimal(y))) {
+      Map<?, ?> xm = (Map<?, ?>) x;
+      Map<?, ?> ym = (Map<?, ?>) y;
+      if (xm.size() != ym.size()) {
+        return false;
+      }
+      for (Map.Entry<?, ?> e : xm.entrySet()) {
+        if (!ym.containsKey(e.getKey())
+            || !decimalEquals(e.getValue(), ym.get(e.getKey()), runtimeEquality)) {
+          return false;
+        }
+      }
+      return true;
+    }
     return runtimeEquality.objectEquals(x, y);
+  }
+
+  /**
+   * Whether {@code o} is a decimal or holds one, at any depth. Only consulted once both operands
+   * are containers, so it never runs on the scalar comparison path.
+   */
+  private static boolean hasDecimal(Object o) {
+    if (asDecimalOrNull(o) != null) {
+      return true;
+    }
+    if (o instanceof List) {
+      for (Object element : (List<?>) o) {
+        if (hasDecimal(element)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    if (o instanceof Map) {
+      for (Object value : ((Map<?, ?>) o).values()) {
+        if (hasDecimal(value)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   /**
@@ -485,8 +570,14 @@ final class BuiltinOverload {
         }));
     out.add(CelFunctionBinding.from(
         "variants_isnull_dyn", Object.class,
-        (Object o) -> (o instanceof Variant)
-            && ((Variant) o).getType() == Variant.Type.NULL));
+        // Coerces like every other accessor. A raw `o instanceof Variant` would answer false for
+        // the shapes a variant-typed *field* decodes to — a confluent.type.Variant message, or
+        // the map an Avro variant record yields — which the dyn declaration now admits: a bare
+        // variant holding an explicit JSON null reported false instead of true.
+        (Object o) -> {
+          Variant v = requireVariantOrNull(o, "variants.isNull");
+          return v != null && v.getType() == Variant.Type.NULL;
+        }));
 
     // Navigation. Each function returns sub-Variant or CEL null on miss.
     // Accessor Java null -> CEL null; explicit JSON null at path -> Variant

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinOverload.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinOverload.java
@@ -296,8 +296,11 @@ final class BuiltinOverload {
     // Spark-equivalent: true iff input is a Variant with type=NULL (false for
     // non-Variant inputs — matches Spark is_variant_null on SQL NULL etc.).
     out.add(CelFunctionBinding.from(
-        "variants_type_variant", Variant.class,
-        (Variant v) -> variantTypeName(v.getType())));
+        "variants_type_variant", Object.class,
+        (Object o) -> {
+          Variant v = requireVariantOrNull(o, "variants.type");
+          return v == null ? NullValue.NULL_VALUE : variantTypeName(v.getType());
+        }));
     out.add(CelFunctionBinding.from(
         "variants_isnull_dyn", Object.class,
         (Object o) -> (o instanceof Variant)
@@ -361,7 +364,11 @@ final class BuiltinOverload {
 
     // variants.toJson(Variant) — serialize a Variant to its JSON string form.
     out.add(CelFunctionBinding.from(
-        "variants_tojson_variant", Variant.class, VariantUtils::toJsonString));
+        "variants_tojson_variant", Object.class,
+        (Object o) -> {
+          Variant v = requireVariantOrNull(o, "variants.toJson");
+          return v == null ? NullValue.NULL_VALUE : VariantUtils.toJsonString(v);
+        }));
   }
 
   /** True iff {@code o} represents "null" in the CEL sense — Java null or

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinOverload.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinOverload.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import org.apache.commons.validator.routines.DomainValidator;
@@ -136,7 +137,8 @@ final class BuiltinOverload {
     // String is handled by toBigDecimal(Object)'s String arm. See the comment
     // in BuiltinDeclarations.addDecimal for why we omit (string).
     out.add(CelFunctionBinding.from(
-        "dyn_to_decimal", Object.class, DecimalUtils::toBigDecimal));
+        "dyn_to_decimal", Object.class,
+        (Object o) -> CelDecimal.of(DecimalUtils.toBigDecimal(o))));
     // Bytes args arrive as CelByteString under CelOptions.DEFAULT
     // (evaluateCanonicalTypesToNativeValues=true converts proto ByteString and
     // bytes-field reads into CelByteString).
@@ -144,15 +146,15 @@ final class BuiltinOverload {
         "bytes_int_to_decimal",
         CelByteString.class, Long.class,
         (CelByteString bytes, Long scale) ->
-            DecimalUtils.toBigDecimal(bytes.toByteArray(),
-                requireIntScale(scale, "decimal(bytes, scale)"))));
+            CelDecimal.of(DecimalUtils.toBigDecimal(bytes.toByteArray(),
+                requireIntScale(scale, "decimal(bytes, scale)")))));
 
     // Comparison
-    out.add(decimalsBinary("decimals_eq_decimal_decimal", (a, b) -> a.compareTo(b) == 0));
-    out.add(decimalsBinary("decimals_lt_decimal_decimal", (a, b) -> a.compareTo(b) < 0));
-    out.add(decimalsBinary("decimals_le_decimal_decimal", (a, b) -> a.compareTo(b) <= 0));
-    out.add(decimalsBinary("decimals_gt_decimal_decimal", (a, b) -> a.compareTo(b) > 0));
-    out.add(decimalsBinary("decimals_ge_decimal_decimal", (a, b) -> a.compareTo(b) >= 0));
+    out.add(decimalsCompare("decimals_eq_decimal_decimal", (a, b) -> a.compareTo(b) == 0));
+    out.add(decimalsCompare("decimals_lt_decimal_decimal", (a, b) -> a.compareTo(b) < 0));
+    out.add(decimalsCompare("decimals_le_decimal_decimal", (a, b) -> a.compareTo(b) <= 0));
+    out.add(decimalsCompare("decimals_gt_decimal_decimal", (a, b) -> a.compareTo(b) > 0));
+    out.add(decimalsCompare("decimals_ge_decimal_decimal", (a, b) -> a.compareTo(b) >= 0));
 
     // Arithmetic
     out.add(decimalsBinary("decimals_add_decimal_decimal", BigDecimal::add));
@@ -199,26 +201,27 @@ final class BuiltinOverload {
     out.add(decimalsUnary("decimals_neg_decimal", BigDecimal::negate));
     out.add(decimalsUnary("decimals_abs_decimal", BigDecimal::abs));
     out.add(CelFunctionBinding.from(
-        "decimals_sign_decimal", BigDecimal.class,
-        (BigDecimal d) -> (long) d.signum()));
+        "decimals_sign_decimal", CelDecimal.class,
+        (CelDecimal d) -> (long) d.value().signum()));
     // string(Decimal) — extension overload on stdlib `string(...)`.
     out.add(CelFunctionBinding.from(
-        "decimal_to_string", BigDecimal.class,
-        BigDecimal::toPlainString));
+        "decimal_to_string", CelDecimal.class,
+        (CelDecimal d) -> d.value().toPlainString()));
     // double(Decimal) — extension overload on stdlib `double(...)`. Narrowing:
     // BigDecimal.doubleValue() returns the closest double (±Infinity if the
     // magnitude is out of range).
     out.add(CelFunctionBinding.from(
-        "decimal_to_double", BigDecimal.class,
-        BigDecimal::doubleValue));
+        "decimal_to_double", CelDecimal.class,
+        (CelDecimal d) -> d.value().doubleValue()));
 
     // Rounding family — Flink-aligned. Negative scale rounds left of the decimal.
     out.add(decimalsUnary(
         "decimals_round_unary", d -> d.setScale(0, RoundingMode.HALF_UP)));
     out.add(CelFunctionBinding.from(
-        "decimals_round_scale", BigDecimal.class, Long.class,
-        (BigDecimal d, Long scale) ->
-            d.setScale(requireIntScale(scale, "decimals.round"), RoundingMode.HALF_UP)));
+        "decimals_round_scale", CelDecimal.class, Long.class,
+        (CelDecimal d, Long scale) -> CelDecimal.of(
+            d.value().setScale(
+                requireIntScale(scale, "decimals.round"), RoundingMode.HALF_UP))));
     // Flink's TRUNCATE early-returns when the target scale is at-or-finer than
     // the current scale — it's a no-op there, so the result keeps the input's
     // representation. Without this guard, setScale(n>=cur, DOWN) would zero-pad
@@ -227,10 +230,11 @@ final class BuiltinOverload {
         "decimals_trunc_unary",
         d -> d.scale() <= 0 ? d : d.setScale(0, RoundingMode.DOWN)));
     out.add(CelFunctionBinding.from(
-        "decimals_trunc_scale", BigDecimal.class, Long.class,
-        (BigDecimal d, Long scale) -> {
+        "decimals_trunc_scale", CelDecimal.class, Long.class,
+        (CelDecimal d, Long scale) -> {
           int intScale = requireIntScale(scale, "decimals.trunc");
-          return intScale >= d.scale() ? d : d.setScale(intScale, RoundingMode.DOWN);
+          BigDecimal v = d.value();
+          return intScale >= v.scale() ? d : CelDecimal.of(v.setScale(intScale, RoundingMode.DOWN));
         }));
     out.add(decimalsUnary(
         "decimals_floor_decimal", d -> d.setScale(0, RoundingMode.FLOOR)));
@@ -238,15 +242,25 @@ final class BuiltinOverload {
         "decimals_ceil_decimal", d -> d.setScale(0, RoundingMode.CEILING)));
   }
 
-  private static <R> CelFunctionBinding decimalsBinary(
-      String overloadId, BiFunction<BigDecimal, BigDecimal, R> fn) {
+  private static CelFunctionBinding decimalsBinary(
+      String overloadId, BiFunction<BigDecimal, BigDecimal, BigDecimal> fn) {
     return CelFunctionBinding.from(
-        overloadId, BigDecimal.class, BigDecimal.class, fn::apply);
+        overloadId, CelDecimal.class, CelDecimal.class,
+        (CelDecimal a, CelDecimal b) -> CelDecimal.of(fn.apply(a.value(), b.value())));
+  }
+
+  /** Comparison family: the CEL bool result passes through, only Decimal results get wrapped. */
+  private static CelFunctionBinding decimalsCompare(
+      String overloadId, BiPredicate<BigDecimal, BigDecimal> fn) {
+    return CelFunctionBinding.from(
+        overloadId, CelDecimal.class, CelDecimal.class,
+        (CelDecimal a, CelDecimal b) -> fn.test(a.value(), b.value()));
   }
 
   private static CelFunctionBinding decimalsUnary(
       String overloadId, Function<BigDecimal, BigDecimal> fn) {
-    return CelFunctionBinding.from(overloadId, BigDecimal.class, fn::apply);
+    return CelFunctionBinding.from(overloadId, CelDecimal.class,
+        (CelDecimal d) -> CelDecimal.of(fn.apply(d.value())));
   }
 
   // ---- Timestamp ----
@@ -486,7 +500,10 @@ final class BuiltinOverload {
       case "decimal":
         if (t == Variant.Type.DECIMAL4 || t == Variant.Type.DECIMAL8
             || t == Variant.Type.DECIMAL16) {
-          return v.getDecimal();
+          // A bare BigDecimal here would make decimals.eq(variants.as(v, 'decimal'), ...) fail
+          // with "no matching overload" at runtime; the compiler can't catch it, since both
+          // sides are the DECIMAL OpaqueType at the CEL level.
+          return CelDecimal.of(v.getDecimal());
         }
         break;
       case "timestamp":

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinOverload.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinOverload.java
@@ -18,6 +18,7 @@ package io.confluent.kafka.schemaregistry.rules.cel.builtin;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
 import dev.cel.common.CelOptions;
 import dev.cel.common.values.CelByteString;
@@ -25,7 +26,6 @@ import dev.cel.common.values.NullValue;
 import dev.cel.runtime.CelFunctionBinding;
 import dev.cel.runtime.CelStandardFunctions.StandardFunction;
 import dev.cel.runtime.RuntimeEquality;
-import dev.cel.runtime.RuntimeHelpers;
 import dev.cel.runtime.standard.CelStandardFunction;
 import dev.cel.runtime.standard.DoubleFunction;
 import dev.cel.runtime.standard.StringFunction;
@@ -67,12 +67,12 @@ final class BuiltinOverload {
 
   /**
    * The standard functions {@link #standardOverrides} takes over. A caller must exclude these
-   * from the runtime's standard functions, or registering the regrouped bindings collides with
-   * the standard ones under the same name.
+   * from the runtime's standard functions, or registering the replacement bindings collides with
+   * the standard ones under the same overload id.
    */
   static final ImmutableSet<StandardFunction> OVERRIDDEN_STANDARD_FUNCTIONS =
       ImmutableSet.of(StandardFunction.TIMESTAMP, StandardFunction.STRING,
-          StandardFunction.DOUBLE);
+          StandardFunction.DOUBLE, StandardFunction.EQUALS, StandardFunction.NOT_EQUALS);
 
   private BuiltinOverload() {
   }
@@ -219,15 +219,15 @@ final class BuiltinOverload {
     out.add(decimalsUnary("decimals_neg_decimal", BigDecimal::negate));
     out.add(decimalsUnary("decimals_abs_decimal", BigDecimal::abs));
     out.add(CelFunctionBinding.from(
-        "decimals_sign_decimal", CelDecimal.class,
-        (CelDecimal d) -> (long) d.value().signum()));
+        "decimals_sign_decimal", Object.class,
+        (Object d) -> (long) DecimalUtils.toBigDecimal(d).signum()));
     // Rounding family — Flink-aligned. Negative scale rounds left of the decimal.
     out.add(decimalsUnary(
         "decimals_round_unary", d -> d.setScale(0, RoundingMode.HALF_UP)));
     out.add(CelFunctionBinding.from(
-        "decimals_round_scale", CelDecimal.class, Long.class,
-        (CelDecimal d, Long scale) -> CelDecimal.of(
-            d.value().setScale(
+        "decimals_round_scale", Object.class, Long.class,
+        (Object d, Long scale) -> CelDecimal.of(
+            DecimalUtils.toBigDecimal(d).setScale(
                 requireIntScale(scale, "decimals.round"), RoundingMode.HALF_UP))));
     // Flink's TRUNCATE early-returns when the target scale is at-or-finer than
     // the current scale — it's a no-op there, so the result keeps the input's
@@ -237,11 +237,12 @@ final class BuiltinOverload {
         "decimals_trunc_unary",
         d -> d.scale() <= 0 ? d : d.setScale(0, RoundingMode.DOWN)));
     out.add(CelFunctionBinding.from(
-        "decimals_trunc_scale", CelDecimal.class, Long.class,
-        (CelDecimal d, Long scale) -> {
+        "decimals_trunc_scale", Object.class, Long.class,
+        (Object d, Long scale) -> {
           int intScale = requireIntScale(scale, "decimals.trunc");
-          BigDecimal v = d.value();
-          return intScale >= v.scale() ? d : CelDecimal.of(v.setScale(intScale, RoundingMode.DOWN));
+          BigDecimal v = DecimalUtils.toBigDecimal(d);
+          return intScale >= v.scale()
+              ? CelDecimal.of(v) : CelDecimal.of(v.setScale(intScale, RoundingMode.DOWN));
         }));
     out.add(decimalsUnary(
         "decimals_floor_decimal", d -> d.setScale(0, RoundingMode.FLOOR)));
@@ -249,25 +250,41 @@ final class BuiltinOverload {
         "decimals_ceil_decimal", d -> d.setScale(0, RoundingMode.CEILING)));
   }
 
+  /**
+   * Every {@code decimals.*} binding takes {@code Object} and coerces, rather than binding
+   * {@link CelDecimal} directly. A value carrying {@link CelTypeLabels#DECIMAL} is a
+   * {@code CelDecimal} when it came from an Avro boundary conversion, the {@code decimal()}
+   * constructor, or another {@code decimals.*} result — but a plain proto {@code Decimal} message
+   * when it came from protobuf field selection, which happens inside the runtime where no boundary
+   * can reach it. {@link DecimalUtils#toBigDecimal(Object)} accepts either, so binding
+   * {@code CelDecimal} would reject exactly the bare-protobuf case these declarations now admit.
+   *
+   * <p>Safe here because {@code decimals.*} are our own namespaced functions with a single binding
+   * per overload id — unlike the extensions in {@link #standardOverrides}, where an
+   * {@code Object}-bound binding sitting in a dispatch group with the standard ones would claim
+   * every call.
+   */
   private static CelFunctionBinding decimalsBinary(
       String overloadId, BiFunction<BigDecimal, BigDecimal, BigDecimal> fn) {
     return CelFunctionBinding.from(
-        overloadId, CelDecimal.class, CelDecimal.class,
-        (CelDecimal a, CelDecimal b) -> CelDecimal.of(fn.apply(a.value(), b.value())));
+        overloadId, Object.class, Object.class,
+        (Object a, Object b) -> CelDecimal.of(
+            fn.apply(DecimalUtils.toBigDecimal(a), DecimalUtils.toBigDecimal(b))));
   }
 
   /** Comparison family: the CEL bool result passes through, only Decimal results get wrapped. */
   private static CelFunctionBinding decimalsCompare(
       String overloadId, BiPredicate<BigDecimal, BigDecimal> fn) {
     return CelFunctionBinding.from(
-        overloadId, CelDecimal.class, CelDecimal.class,
-        (CelDecimal a, CelDecimal b) -> fn.test(a.value(), b.value()));
+        overloadId, Object.class, Object.class,
+        (Object a, Object b) -> fn.test(
+            DecimalUtils.toBigDecimal(a), DecimalUtils.toBigDecimal(b)));
   }
 
   private static CelFunctionBinding decimalsUnary(
       String overloadId, Function<BigDecimal, BigDecimal> fn) {
-    return CelFunctionBinding.from(overloadId, CelDecimal.class,
-        (CelDecimal d) -> CelDecimal.of(fn.apply(d.value())));
+    return CelFunctionBinding.from(overloadId, Object.class,
+        (Object d) -> CelDecimal.of(fn.apply(DecimalUtils.toBigDecimal(d))));
   }
 
   // ---- Timestamp ----
@@ -289,9 +306,8 @@ final class BuiltinOverload {
    * standard functions and register these instead — the standard behavior is preserved because
    * the standard bindings are re-registered here verbatim, not reimplemented.
    */
-  static ImmutableList<CelFunctionBinding> standardOverrides(CelOptions celOptions) {
-    RuntimeEquality runtimeEquality =
-        RuntimeEquality.create(RuntimeHelpers.create(), celOptions);
+  static ImmutableList<CelFunctionBinding> standardOverrides(
+      CelOptions celOptions, RuntimeEquality runtimeEquality) {
     List<CelFunctionBinding> out = new ArrayList<>();
 
     // timestamp: the standard string / int / identity overloads, plus a Temporal binding
@@ -303,16 +319,96 @@ final class BuiltinOverload {
         CelFunctionBinding.from(
             "timestamp_int_int", Long.class, Long.class, TimestampUtils::fromEpochPrecision)));
 
-    // string(Decimal) / double(Decimal). The double form is narrowing:
-    // BigDecimal.doubleValue() returns the closest double (±Infinity when out of range).
+    // string(Decimal) / double(Decimal). Object-bound, not CelDecimal-bound: a decimal value is
+    // a CelDecimal or a proto Decimal message depending on where it came from, and the checker
+    // resolves the single declared string(Decimal) overload to one id, so that id has to accept
+    // both. Safe despite the width because regroup appends extras last and dispatch is
+    // first-match over insertion order (FunctionBindingImpl.DynamicDispatchOverload) — every
+    // standard overload gets first refusal, and these see only what none of them handled.
+    // The double form is narrowing: BigDecimal.doubleValue() returns the closest double
+    // (±Infinity when out of range).
     out.addAll(regroup("string", StringFunction.create(), celOptions, runtimeEquality,
-        CelFunctionBinding.from("decimal_to_string", CelDecimal.class,
-            (CelDecimal d) -> d.value().toPlainString())));
+        CelFunctionBinding.from("decimal_to_string", Object.class,
+            (Object d) -> requireDecimal(d, "string").toPlainString())));
     out.addAll(regroup("double", DoubleFunction.create(), celOptions, runtimeEquality,
-        CelFunctionBinding.from("decimal_to_double", CelDecimal.class,
-            (CelDecimal d) -> d.value().doubleValue())));
+        CelFunctionBinding.from("decimal_to_double", Object.class,
+            (Object d) -> requireDecimal(d, "double").doubleValue())));
+
+    // == and != . Unlike the three above, these are replaced rather than regrouped: stdlib
+    // binds each as a single generic (Object, Object) overload whose id equals the function
+    // name (EqualsOperator: CelFunctionBinding.from("equals", Object, Object,
+    // runtimeEquality::objectEquals)), so there is no dispatch group to extend and nothing to
+    // preserve alongside. Adding a narrower (Decimal, Decimal) declaration instead does not
+    // work: stdlib's (A, A) always matches too, so the checker cannot narrow to one overload id
+    // and the name fallback lands back on the standard binding.
+    out.add(CelFunctionBinding.from("equals", Object.class, Object.class,
+        (Object x, Object y) -> decimalEquals(x, y, runtimeEquality)));
+    out.add(CelFunctionBinding.from("not_equals", Object.class, Object.class,
+        (Object x, Object y) -> !decimalEquals(x, y, runtimeEquality)));
 
     return ImmutableList.copyOf(out);
+  }
+
+  /**
+   * CEL {@code ==} with decimals made numeric. A decimal operand may be a {@link CelDecimal} or
+   * a proto {@code Decimal} message, and proto equality is the wrong answer for both: it compares
+   * unscaled bytes and scale field-by-field, so {@code 1.50} and {@code 1.5} — the same number in
+   * two encodings — come out unequal.
+   *
+   * <p>A thin pre-filter, deliberately. When neither side is a decimal this delegates to the
+   * standard implementation verbatim, so every other {@code ==} in the language keeps stdlib
+   * semantics (numeric cross-type rules, list and map recursion, proto message comparison,
+   * the {@code disableCelStandardEquality} option).
+   */
+  private static boolean decimalEquals(Object x, Object y, RuntimeEquality runtimeEquality) {
+    BigDecimal a = asDecimalOrNull(x);
+    BigDecimal b = asDecimalOrNull(y);
+    if (a != null && b != null) {
+      return a.compareTo(b) == 0;
+    }
+    if (a != null || b != null) {
+      // A decimal is never equal to a non-decimal. Returning stdlib's answer here would be
+      // false anyway, but only by accident of the shapes not matching; say it outright.
+      return false;
+    }
+    return runtimeEquality.objectEquals(x, y);
+  }
+
+  /**
+   * {@code o} as a {@link BigDecimal} if it carries {@link CelTypeLabels#DECIMAL}, else null.
+   * Narrow on purpose — unlike {@link DecimalUtils#toBigDecimal(Object)}, which coerces numbers
+   * and strings too. This runs on every {@code ==} in every rule, so it must not turn
+   * {@code 1 == "1"} into a decimal comparison, and it must stay cheap for the common case.
+   */
+  private static BigDecimal asDecimalOrNull(Object o) {
+    if (o instanceof CelDecimal) {
+      return ((CelDecimal) o).value();
+    }
+    if (o instanceof Message
+        && CelTypeLabels.DECIMAL_NAME.equals(
+            ((Message) o).getDescriptorForType().getFullName())) {
+      return DecimalUtils.toBigDecimal(o);
+    }
+    return null;
+  }
+
+  /**
+   * {@code o} as a {@link BigDecimal}, or a clear failure. Uses the narrow
+   * {@link #asDecimalOrNull} rather than {@link DecimalUtils#toBigDecimal(Object)} because this
+   * backs the last-resort binding in the {@code string} / {@code double} dispatch groups: a value
+   * that reaches it is one no standard overload could handle, and reporting that plainly beats
+   * coercing, say, a list into a number.
+   */
+  private static BigDecimal requireDecimal(Object o, String functionName) {
+    BigDecimal d = asDecimalOrNull(o);
+    if (d == null) {
+      throw new IllegalArgumentException(
+          functionName + ": expected " + CelTypeLabels.DECIMAL_NAME + ", got "
+              + (o instanceof Message
+                 ? ((Message) o).getDescriptorForType().getFullName()
+                 : o.getClass().getName()));
+    }
+    return d;
   }
 
   /**

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinOverload.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinOverload.java
@@ -17,10 +17,19 @@
 package io.confluent.kafka.schemaregistry.rules.cel.builtin;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.Timestamp;
+import dev.cel.common.CelOptions;
 import dev.cel.common.values.CelByteString;
 import dev.cel.common.values.NullValue;
 import dev.cel.runtime.CelFunctionBinding;
+import dev.cel.runtime.CelStandardFunctions.StandardFunction;
+import dev.cel.runtime.RuntimeEquality;
+import dev.cel.runtime.RuntimeHelpers;
+import dev.cel.runtime.standard.CelStandardFunction;
+import dev.cel.runtime.standard.DoubleFunction;
+import dev.cel.runtime.standard.StringFunction;
+import dev.cel.runtime.standard.TimestampFunction;
 import io.confluent.kafka.schemaregistry.type.Variant;
 import java.math.BigDecimal;
 import java.math.MathContext;
@@ -56,6 +65,15 @@ final class BuiltinOverload {
    */
   private static final MathContext DIV_MC = new MathContext(38, RoundingMode.HALF_UP);
 
+  /**
+   * The standard functions {@link #standardOverrides} takes over. A caller must exclude these
+   * from the runtime's standard functions, or registering the regrouped bindings collides with
+   * the standard ones under the same name.
+   */
+  static final ImmutableSet<StandardFunction> OVERRIDDEN_STANDARD_FUNCTIONS =
+      ImmutableSet.of(StandardFunction.TIMESTAMP, StandardFunction.STRING,
+          StandardFunction.DOUBLE);
+
   private BuiltinOverload() {
   }
 
@@ -72,7 +90,6 @@ final class BuiltinOverload {
     out.add(unaryString("is_uuid", BuiltinOverload::validateUuid));
 
     addDecimal(out);
-    addTimestamp(out);
     addVariant(out);
 
     return ImmutableList.copyOf(out);
@@ -204,17 +221,6 @@ final class BuiltinOverload {
     out.add(CelFunctionBinding.from(
         "decimals_sign_decimal", CelDecimal.class,
         (CelDecimal d) -> (long) d.value().signum()));
-    // string(Decimal) — extension overload on stdlib `string(...)`.
-    out.add(CelFunctionBinding.from(
-        "decimal_to_string", CelDecimal.class,
-        (CelDecimal d) -> d.value().toPlainString()));
-    // double(Decimal) — extension overload on stdlib `double(...)`. Narrowing:
-    // BigDecimal.doubleValue() returns the closest double (±Infinity if the
-    // magnitude is out of range).
-    out.add(CelFunctionBinding.from(
-        "decimal_to_double", CelDecimal.class,
-        (CelDecimal d) -> d.value().doubleValue()));
-
     // Rounding family — Flink-aligned. Negative scale rounds left of the decimal.
     out.add(decimalsUnary(
         "decimals_round_unary", d -> d.setScale(0, RoundingMode.HALF_UP)));
@@ -266,16 +272,76 @@ final class BuiltinOverload {
 
   // ---- Timestamp ----
 
-  private static void addTimestamp(List<CelFunctionBinding> out) {
-    // Bound to Temporal, disjoint from the String and Long that stdlib's surviving
-    // `timestamp` overloads bind: when a dyn argument makes the checker list all three
-    // overload ids, exactly one of them can handle the runtime value, so the dispatch stays
-    // unambiguous. Anything wider here (Object) would match a String or Long too and make
-    // every timestamp(dyn) call ambiguous.
-    out.add(CelFunctionBinding.from(
-        "timestamp_to_timestamp_temporal", Temporal.class, TimestampUtils::toInstant));
-    out.add(CelFunctionBinding.from(
-        "timestamp_int_int", Long.class, Long.class, TimestampUtils::fromEpochPrecision));
+  /**
+   * The overloads we add to <em>standard</em> function names, regrouped together with the
+   * standard library's own bindings for those names.
+   *
+   * <p>Regrouping is required, not cosmetic. The planner runtime resolves a call to a single
+   * overload id at plan time and, when the checker could not narrow it that far — which is
+   * every call whose argument is {@code dyn}, i.e. every Avro logical-typed field — falls back
+   * to a <em>name</em>-keyed lookup ({@code ProgramPlanner}, "Parsed-only function dispatch").
+   * That name-keyed entry is a dynamic-dispatch group built from the bindings registered
+   * together under the name, so an overload merely added alongside the standard ones is invisible
+   * to it: {@code timestamp(this.ts)} fails with "No matching overload ... candidates:
+   * string_to_timestamp, timestamp_to_timestamp, int64_to_timestamp".
+   *
+   * <p>Callers must therefore exclude {@link #OVERRIDDEN_STANDARD_FUNCTIONS} from the runtime's
+   * standard functions and register these instead — the standard behavior is preserved because
+   * the standard bindings are re-registered here verbatim, not reimplemented.
+   */
+  static ImmutableList<CelFunctionBinding> standardOverrides(CelOptions celOptions) {
+    RuntimeEquality runtimeEquality =
+        RuntimeEquality.create(RuntimeHelpers.create(), celOptions);
+    List<CelFunctionBinding> out = new ArrayList<>();
+
+    // timestamp: the standard string / int / identity overloads, plus a Temporal binding
+    // (stdlib's identity overload binds Instant alone, leaving every other java.time shape an
+    // Avro or Proto decoder yields with no overload) and the (int, int) precision form.
+    out.addAll(regroup("timestamp", TimestampFunction.create(), celOptions, runtimeEquality,
+        CelFunctionBinding.from(
+            "timestamp_to_timestamp_temporal", Temporal.class, TimestampUtils::toInstant),
+        CelFunctionBinding.from(
+            "timestamp_int_int", Long.class, Long.class, TimestampUtils::fromEpochPrecision)));
+
+    // string(Decimal) / double(Decimal). The double form is narrowing:
+    // BigDecimal.doubleValue() returns the closest double (±Infinity when out of range).
+    out.addAll(regroup("string", StringFunction.create(), celOptions, runtimeEquality,
+        CelFunctionBinding.from("decimal_to_string", CelDecimal.class,
+            (CelDecimal d) -> d.value().toPlainString())));
+    out.addAll(regroup("double", DoubleFunction.create(), celOptions, runtimeEquality,
+        CelFunctionBinding.from("decimal_to_double", CelDecimal.class,
+            (CelDecimal d) -> d.value().doubleValue())));
+
+    return ImmutableList.copyOf(out);
+  }
+
+  /**
+   * One standard function's bindings plus {@code extras}, grouped under {@code functionName} so
+   * the name-keyed dynamic-dispatch entry covers all of them. The standard function's own
+   * name-keyed entry is dropped from the input, since {@code fromOverloads} rebuilds it.
+   */
+  private static ImmutableSet<CelFunctionBinding> regroup(
+      String functionName,
+      CelStandardFunction standardFunction,
+      CelOptions celOptions,
+      RuntimeEquality runtimeEquality,
+      CelFunctionBinding... extras) {
+    List<CelFunctionBinding> bindings = new ArrayList<>();
+    for (CelFunctionBinding binding :
+        standardFunction.newFunctionBindings(celOptions, runtimeEquality)) {
+      if (!binding.getOverloadId().equals(functionName)) {
+        bindings.add(binding);
+      }
+    }
+    for (CelFunctionBinding extra : extras) {
+      // An extra sharing a standard overload's id replaces it; a new id is added alongside.
+      // timestamp_to_timestamp_temporal is a new id, so stdlib's Instant-bound
+      // timestamp_to_timestamp stays in the group. Harmless: the declaration side shadows it
+      // (same signature), and for an Instant both bindings do the same thing.
+      bindings.removeIf(b -> b.getOverloadId().equals(extra.getOverloadId()));
+      bindings.add(extra);
+    }
+    return CelFunctionBinding.fromOverloads(functionName, bindings);
   }
 
   // ---- Variant ----
@@ -424,11 +490,19 @@ final class BuiltinOverload {
     if (isCelNull(o)) {
       return null;
     }
-    if (!(o instanceof Variant)) {
-      throw new IllegalArgumentException(
-          functionName + ": expected Variant, got " + o.getClass().getName());
+    if (o instanceof Variant) {
+      return (Variant) o;
     }
-    return (Variant) o;
+    // Otherwise accept the shapes a variant-typed *field* decodes to — a proto
+    // confluent.type.Variant message, or the Map an Avro variant record is converted to — so
+    // such a field can be used without a variant(...) call, as on the other clients. A shape
+    // toVariant doesn't recognize still yields a clear message rather than a ClassCastException.
+    try {
+      return VariantUtils.toVariant(o);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          functionName + ": expected Variant, got " + o.getClass().getName(), e);
+    }
   }
 
   /** {@code variant(dyn)} binding body. Propagates CEL null; rejects strings

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinOverload.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinOverload.java
@@ -27,6 +27,7 @@ import java.math.MathContext;
 import java.math.RoundingMode;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.temporal.Temporal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -266,10 +267,15 @@ final class BuiltinOverload {
   // ---- Timestamp ----
 
   private static void addTimestamp(List<CelFunctionBinding> out) {
+    // Bound to Temporal, disjoint from the String and Long that stdlib's surviving
+    // `timestamp` overloads bind: when a dyn argument makes the checker list all three
+    // overload ids, exactly one of them can handle the runtime value, so the dispatch stays
+    // unambiguous. Anything wider here (Object) would match a String or Long too and make
+    // every timestamp(dyn) call ambiguous.
     out.add(CelFunctionBinding.from(
-        "timestamp_of_dyn", Object.class, TimestampUtils::toTimestamp));
+        "timestamp_to_timestamp_temporal", Temporal.class, TimestampUtils::toInstant));
     out.add(CelFunctionBinding.from(
-        "timestamp_of_int_string", Long.class, String.class, TimestampUtils::fromEpoch));
+        "timestamp_int_int", Long.class, Long.class, TimestampUtils::fromEpochPrecision));
   }
 
   // ---- Variant ----

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/CelDecimal.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/CelDecimal.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rules.cel.builtin;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * The runtime Java representation of the CEL {@code confluent.type.Decimal} type
+ * ({@link CelTypeLabels#DECIMAL}): a {@link BigDecimal} whose {@code equals} is numeric, so
+ * {@code decimal("2.0")} and {@code decimal("2.00")} are one value everywhere CEL asks.
+ *
+ * <p><b>Must not extend {@link Number}.</b> cel-java's {@code RuntimeEquality.objectEquals}
+ * short-circuits on {@code instanceof Number} into {@code ComparisonFunctions.numericEquals},
+ * which understands only Double / Long / UnsignedLong and answers {@code false} for any pair of
+ * {@link BigDecimal}s. Staying outside the {@code Number} hierarchy is what routes equality here.
+ */
+public final class CelDecimal implements Comparable<CelDecimal> {
+
+  private final BigDecimal value;
+
+  private CelDecimal(BigDecimal value) {
+    this.value = value;
+  }
+
+  public static CelDecimal of(BigDecimal value) {
+    return new CelDecimal(Objects.requireNonNull(value, "value"));
+  }
+
+  /** The wrapped {@link BigDecimal} — the logical-type Java rep. */
+  public BigDecimal value() {
+    return value;
+  }
+
+  /** Numeric, scale-insensitive — the same answer {@code decimals.eq} gives. */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof CelDecimal)) {
+      return false;
+    }
+    return value.compareTo(((CelDecimal) o).value) == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    // stripTrailingZeros collapses the scale differences equals ignores, except for zero:
+    // BigDecimal zeros of differing scale don't all reduce to one representation, so pin them.
+    return value.signum() == 0 ? 0 : value.stripTrailingZeros().hashCode();
+  }
+
+  @Override
+  public int compareTo(CelDecimal other) {
+    return value.compareTo(other.value);
+  }
+
+  @Override
+  public String toString() {
+    return value.toPlainString();
+  }
+}

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/CelDecimal.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/CelDecimal.java
@@ -39,6 +39,14 @@ public final class CelDecimal implements Comparable<CelDecimal> {
     return new CelDecimal(Objects.requireNonNull(value, "value"));
   }
 
+  /**
+   * From unscaled two's-complement big-endian bytes plus a scale — the encoding an Avro
+   * {@code decimal} logical type and a {@code confluent.type.Decimal} message both use.
+   */
+  public static CelDecimal ofUnscaled(byte[] unscaled, int scale) {
+    return of(DecimalUtils.toBigDecimal(unscaled, scale));
+  }
+
   /** The wrapped {@link BigDecimal} — the logical-type Java rep. */
   public BigDecimal value() {
     return value;

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/CelDecimal.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/CelDecimal.java
@@ -21,13 +21,11 @@ import java.util.Objects;
 
 /**
  * The runtime Java representation of the CEL {@code confluent.type.Decimal} type
- * ({@link CelTypeLabels#DECIMAL}): a {@link BigDecimal} whose {@code equals} is numeric, so
- * {@code decimal("2.0")} and {@code decimal("2.00")} are one value everywhere CEL asks.
+ * ({@link CelTypeLabels#DECIMAL}): a {@link BigDecimal} whose {@code equals} is numeric.
  *
  * <p><b>Must not extend {@link Number}.</b> cel-java's {@code RuntimeEquality.objectEquals}
  * short-circuits on {@code instanceof Number} into {@code ComparisonFunctions.numericEquals},
- * which understands only Double / Long / UnsignedLong and answers {@code false} for any pair of
- * {@link BigDecimal}s. Staying outside the {@code Number} hierarchy is what routes equality here.
+ * which knows only Double / Long / UnsignedLong and answers {@code false} for any BigDecimal pair.
  */
 public final class CelDecimal implements Comparable<CelDecimal> {
 

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/CelTypeLabels.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/CelTypeLabels.java
@@ -17,13 +17,14 @@
 package io.confluent.kafka.schemaregistry.rules.cel.builtin;
 
 import dev.cel.common.types.OpaqueType;
+import dev.cel.common.types.StructTypeReference;
 
 /**
  * Canonical CEL type-name labels for the extended types (Decimal, Timestamp, Variant)
- * plus their Java cel-java {@link OpaqueType} decls. The labels are the cross-language
+ * plus their Java cel-java type decls. The labels are the cross-language
  * spec — every client must use the same strings; the backing Java class is an
  * implementation detail of this client. Timestamp uses CEL's built-in
- * {@code SimpleType.TIMESTAMP} so there is no OpaqueType for it.
+ * {@code SimpleType.TIMESTAMP} so there is no type declaration for it.
  */
 public final class CelTypeLabels {
 
@@ -44,8 +45,24 @@ public final class CelTypeLabels {
 
   /**
    * Java cel-java type declaration for {@link #DECIMAL_NAME}.
+   *
+   * <p>A {@link StructTypeReference}, not an {@link OpaqueType}, and deliberately so. A protobuf
+   * {@code confluent.type.Decimal} field is typed by cel-java as a struct reference under exactly
+   * this name, and {@code CelType.isAssignableFrom} is plain equality — so an opaque type of the
+   * same name would be a second, permanently incompatible identity for the same logical type.
+   * Every mixed pair ({@code this.amount == decimal("0")}, {@code decimals.add(this.a, this.b)})
+   * would fail to type-check, and no set of extra overloads closes that off completely. Making the
+   * two identities one instead means a decimal-typed proto field is accepted by every
+   * {@code decimals.*} declaration as-is, with no wrapper call.
+   *
+   * <p>The name needs no descriptor registration to be usable: the checker resolves struct
+   * references lazily, so Avro and JSON rules — which register no protobuf descriptors at all —
+   * type-check against it just as well. Runtime values under this type are {@link CelDecimal}
+   * (from an Avro boundary conversion, the {@code decimal()} constructor, or any
+   * {@code decimals.*} result) or a proto {@code Decimal} message (from protobuf field
+   * selection); {@code DecimalUtils.toBigDecimal} accepts either.
    */
-  public static final OpaqueType DECIMAL = OpaqueType.create(DECIMAL_NAME);
+  public static final StructTypeReference DECIMAL = StructTypeReference.create(DECIMAL_NAME);
 
   /**
    * Java cel-java type declaration for {@link #VARIANT_NAME}.

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/DecimalUtils.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/DecimalUtils.java
@@ -16,6 +16,7 @@
 
 package io.confluent.kafka.schemaregistry.rules.cel.builtin;
 
+import com.google.common.primitives.UnsignedLong;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
@@ -103,6 +104,11 @@ final class DecimalUtils {
     if (o instanceof Long || o instanceof Integer
         || o instanceof Short || o instanceof Byte) {
       return BigDecimal.valueOf(((Number) o).longValue());
+    }
+    if (o instanceof UnsignedLong) {
+      // cel-java binds proto uint32/uint64 fields to Guava UnsignedLong. longValue()
+      // would wrap for values > Long.MAX_VALUE, so go through the unsigned BigInteger.
+      return new BigDecimal(((UnsignedLong) o).bigIntegerValue());
     }
     if (o instanceof BigInteger) {
       // Jackson hands out BigInteger for JSON integers exceeding Long range;

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/DecimalUtils.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/DecimalUtils.java
@@ -28,7 +28,9 @@ import java.nio.ByteBuffer;
 /**
  * Conversion helpers backing {@code decimal(...)} and the {@code decimals.*} operator
  * functions. The CEL surface treats Decimal as the canonical type
- * {@link CelTypeLabels#DECIMAL_NAME}; this client backs it with {@link BigDecimal}.
+ * {@link CelTypeLabels#DECIMAL_NAME}; this client backs it with a {@link BigDecimal} wrapped in
+ * {@link CelDecimal}. The methods here produce the unwrapped {@code BigDecimal}; the
+ * {@code decimal(...)} bindings wrap the result.
  */
 final class DecimalUtils {
 
@@ -92,6 +94,10 @@ final class DecimalUtils {
     }
     if (o instanceof BigDecimal) {
       return (BigDecimal) o;
+    }
+    if (o instanceof CelDecimal) {
+      // Re-entry: decimal(decimal(x)), or a Decimal arriving back through a dyn-typed path.
+      return ((CelDecimal) o).value();
     }
     if (o instanceof Decimal) {
       return toBigDecimal((Decimal) o);

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/TimestampUtils.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/TimestampUtils.java
@@ -21,27 +21,93 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeParseException;
+import java.time.temporal.Temporal;
 
 /**
- * Conversion helpers backing the {@code timestamp.of} overloads.
- * The CEL surface uses the built-in timestamp type
- * ({@link CelTypeLabels#TIMESTAMP_NAME}); this client backs it with {@link Timestamp}.
+ * Conversion helpers backing the extension overloads on the standard {@code timestamp}
+ * function. The CEL surface uses the built-in timestamp type
+ * ({@link CelTypeLabels#TIMESTAMP_NAME}), whose runtime value is an {@link Instant}; the
+ * {@link Timestamp}-returning helpers below back the {@code variants.*} timestamp accessors.
  */
 final class TimestampUtils {
 
-  static final String UNIT_MILLIS = "millis";
-  static final String UNIT_MICROS = "micros";
-  static final String UNIT_NANOS = "nanos";
-  static final String UNIT_SECONDS = "seconds";
+  // CEL's timestamp range: 0001-01-01T00:00:00Z through 9999-12-31T23:59:59.999999999Z,
+  // the same bounds cel-java's standard timestamp(int) conversion enforces.
+  private static final long MIN_EPOCH_SECOND = -62135596800L;
+  private static final long MAX_EPOCH_SECOND = 253402300799L;
 
   private TimestampUtils() {
   }
 
-  static Timestamp fromEpochMillis(long ms) {
-    long sec = Math.floorDiv(ms, 1_000L);
-    int nanos = (int) (Math.floorMod(ms, 1_000L) * 1_000_000L);
-    return Timestamp.newBuilder().setSeconds(sec).setNanos(nanos).build();
+  /**
+   * Runtime dispatch backing the {@code timestamp(timestamp)} overload: the {@code java.time}
+   * shapes an Avro or Proto decoder produces, converted to the {@link Instant} that cel-java
+   * uses for CEL's timestamp type when canonical types evaluate to native values.
+   *
+   * <p>The standard library binds this overload to {@link Instant} alone, so every other
+   * temporal an Avro logical type can yield would have no matching overload. Partial temporals
+   * ({@code LocalDate}, {@code LocalTime}) are not timestamps at all and are refused here
+   * rather than guessed at.
+   */
+  static Instant toInstant(Temporal value) {
+    if (value instanceof Instant) {
+      return (Instant) value;
+    }
+    if (value instanceof LocalDateTime) {
+      // Avro `local-timestamp-*` produces this; the value carries no timezone.
+      // Refusing the conversion is more correct than silently picking UTC and
+      // returning wrong results for non-UTC producers. See the design doc
+      // "Avro logical-type scope" section.
+      throw new IllegalArgumentException(
+          "Cannot convert LocalDateTime to Timestamp: local-timestamp values "
+              + "carry no timezone. Use the regular timestamp-* logical type "
+              + "(UTC by spec), or carry a separate TZ-offset field and use "
+              + "timestamp(value, precision) on the offset-adjusted epoch value.");
+    }
+    if (value instanceof OffsetDateTime) {
+      return ((OffsetDateTime) value).toInstant();
+    }
+    if (value instanceof ZonedDateTime) {
+      return ((ZonedDateTime) value).toInstant();
+    }
+    throw new IllegalArgumentException(
+        "Cannot convert " + value.getClass().getName() + " to Timestamp");
+  }
+
+  /**
+   * Backing {@code timestamp(int, int)}: an epoch value read at a decimal precision, the same
+   * {0, 3, 6, 9} scale Flink uses — 0 seconds, 3 millis, 6 micros, 9 nanos. Any other
+   * precision is rejected: with the unit now a number rather than a name, that check is the
+   * only thing standing between a typo and a silently wrong instant.
+   */
+  static Instant fromEpochPrecision(long value, long precision) {
+    if (precision == 0L) {
+      return instantOfEpoch(value, 1L, 1_000_000_000L);
+    } else if (precision == 3L) {
+      return instantOfEpoch(value, 1_000L, 1_000_000L);
+    } else if (precision == 6L) {
+      return instantOfEpoch(value, 1_000_000L, 1_000L);
+    } else if (precision == 9L) {
+      return instantOfEpoch(value, 1_000_000_000L, 1L);
+    }
+    throw new IllegalArgumentException(
+        "Unknown timestamp precision " + precision + "; expected 0 (seconds), 3 (millis), "
+            + "6 (micros) or 9 (nanos)");
+  }
+
+  /**
+   * Epoch value in units of {@code perSecond} per second, each worth {@code nanosPerUnit}.
+   */
+  private static Instant instantOfEpoch(long epoch, long perSecond, long nanosPerUnit) {
+    // floorDiv/floorMod rather than / and %: a pre-epoch value is negative, and the
+    // nano-of-second adjustment must stay non-negative.
+    long seconds = Math.floorDiv(epoch, perSecond);
+    if (seconds < MIN_EPOCH_SECOND || seconds > MAX_EPOCH_SECOND) {
+      throw new IllegalArgumentException(
+          "Timestamp out of range: " + seconds + " seconds since the epoch is outside "
+              + "0001-01-01T00:00:00Z..9999-12-31T23:59:59.999999999Z");
+    }
+    return Instant.ofEpochSecond(seconds, Math.floorMod(epoch, perSecond) * nanosPerUnit);
   }
 
   static Timestamp fromEpochMicros(long us) {
@@ -56,87 +122,4 @@ final class TimestampUtils {
     return Timestamp.newBuilder().setSeconds(sec).setNanos(nanos).build();
   }
 
-  static Timestamp fromEpochSeconds(long s) {
-    return Timestamp.newBuilder().setSeconds(s).setNanos(0).build();
-  }
-
-  static Timestamp fromInstant(Instant i) {
-    return Timestamp.newBuilder()
-        .setSeconds(i.getEpochSecond())
-        .setNanos(i.getNano())
-        .build();
-  }
-
-  /** Construct from epoch numeric value plus unit string. */
-  static Timestamp fromEpoch(long value, String unit) {
-    if (unit == null) {
-      throw new IllegalArgumentException("timestamp.of unit must not be null");
-    }
-    switch (unit) {
-      case UNIT_MILLIS:  return fromEpochMillis(value);
-      case UNIT_MICROS:  return fromEpochMicros(value);
-      case UNIT_NANOS:   return fromEpochNanos(value);
-      case UNIT_SECONDS: return fromEpochSeconds(value);
-      default:
-        throw new IllegalArgumentException(
-            "Unknown timestamp.of unit '" + unit + "'; expected one of "
-                + "millis, micros, nanos, seconds");
-    }
-  }
-
-  /** Parse RFC 3339 (offset-aware) timestamp string. */
-  static Timestamp fromRfc3339(String s) {
-    try {
-      return fromInstant(OffsetDateTime.parse(s).toInstant());
-    } catch (DateTimeParseException e) {
-      throw new IllegalArgumentException(
-          "Cannot parse '" + s + "' as RFC 3339 timestamp", e);
-    }
-  }
-
-  /**
-   * Runtime dispatch backing {@code timestamp.of(dyn)}. Accepts the shapes
-   * Proto/Avro decoders typically produce. Raw {@code Long} lacks a unit and must use
-   * {@code timestamp.of(value, unit)} — we throw with a clear hint.
-   */
-  static Timestamp toTimestamp(Object o) {
-    if (o == null) {
-      throw new IllegalArgumentException("Cannot convert null to Timestamp");
-    }
-    if (o instanceof Timestamp) {
-      return (Timestamp) o;
-    }
-    if (o instanceof Instant) {
-      return fromInstant((Instant) o);
-    }
-    if (o instanceof LocalDateTime) {
-      // Avro `local-timestamp-*` produces this; the value carries no timezone.
-      // Refusing the conversion is more correct than silently picking UTC and
-      // returning wrong results for non-UTC producers. See the design doc
-      // "Avro logical-type scope" section.
-      throw new IllegalArgumentException(
-          "Cannot convert LocalDateTime to Timestamp: local-timestamp values "
-              + "carry no timezone. Use the regular timestamp-* logical type "
-              + "(UTC by spec), or carry a separate TZ-offset field and use "
-              + "timestamp.of(value, unit) on the offset-adjusted epoch value.");
-    }
-    if (o instanceof OffsetDateTime) {
-      return fromInstant(((OffsetDateTime) o).toInstant());
-    }
-    if (o instanceof ZonedDateTime) {
-      return fromInstant(((ZonedDateTime) o).toInstant());
-    }
-    if (o instanceof String) {
-      return fromRfc3339((String) o);
-    }
-    if (o instanceof Long || o instanceof Integer) {
-      throw new IllegalArgumentException(
-          "Cannot convert raw " + o.getClass().getSimpleName() + " to Timestamp without "
-              + "a unit; use timestamp.of(value, \"millis\"|\"micros\"|\"nanos\"|"
-              + "\"seconds\") or set useLogicalTypeConverters=true on the Avro client so "
-              + "timestamp fields arrive as Instant");
-    }
-    throw new IllegalArgumentException(
-        "Cannot convert " + o.getClass().getName() + " to Timestamp");
-  }
 }

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/VariantUtils.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/VariantUtils.java
@@ -16,15 +16,12 @@
 
 package io.confluent.kafka.schemaregistry.rules.cel.builtin;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
 import dev.cel.common.values.CelByteString;
 import io.confluent.avro.type.VariantConversion;
 import io.confluent.kafka.schemaregistry.type.Variant;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.apache.avro.generic.IndexedRecord;
 
@@ -36,13 +33,6 @@ import org.apache.avro.generic.IndexedRecord;
  * format).
  */
 final class VariantUtils {
-
-  /**
-   * Reused thread-safe Jackson mapper for JSON → Variant conversion. ObjectMapper
-   * instances are documented as thread-safe after configuration, and we don't
-   * mutate this one after construction.
-   */
-  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
   private static final VariantConversion VARIANT_CONVERSION = new VariantConversion();
 
@@ -149,13 +139,7 @@ final class VariantUtils {
    * {@code ValidationRuleError}.
    */
   static Variant fromJson(String json) {
-    try {
-      JsonNode node = JSON_MAPPER.readTree(json);
-      return io.confluent.kafka.schemaregistry.type.VariantUtils.fromJsonNode(node);
-    } catch (IOException | IllegalStateException e) {
-      throw new IllegalArgumentException(
-          "Cannot parse JSON for variant: " + e.getMessage(), e);
-    }
+    return io.confluent.kafka.schemaregistry.type.VariantUtils.fromJson(json);
   }
 
   /**

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelDecimalEqualityTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelDecimalEqualityTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rules.cel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import dev.cel.runtime.CelRuntime;
+import io.confluent.kafka.schemaregistry.rules.cel.CelUtils.RegexEngine;
+import io.confluent.kafka.schemaregistry.rules.cel.CelUtils.ScriptType;
+import io.confluent.kafka.schemaregistry.rules.cel.builtin.CelDecimal;
+import java.math.BigDecimal;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Numeric equality for CEL Decimals, everywhere CEL asks — not just at a top-level {@code ==}.
+ *
+ * <p>{@code in} and container / nested equality never consult the {@code equals} function
+ * binding; they go through {@code List.contains} and the recursive {@code objectEquals} walk,
+ * which reach the value's own {@code equals}. So under a bare-{@link BigDecimal} runtime value
+ * {@code decimal("2.0") == decimal("2.00")} could be patched true while
+ * {@code decimal("2.0") in [decimal("2.00")]} stayed false. {@link CelDecimal} fixes all of them
+ * at once.
+ */
+public class CelDecimalEqualityTest {
+
+  /** Evaluate a variable-free boolean expression. */
+  private static boolean evalBool(String expr) throws Exception {
+    CelRuntime.Program program = CelUtils.buildProgram(
+        ScriptType.JSON, expr, null, Collections.emptyList(), RegexEngine.DEFAULT);
+    return (Boolean) program.eval();
+  }
+
+  private static void assertEval(boolean expected, String expr) throws Exception {
+    assertEquals(expected, evalBool(expr), expr);
+  }
+
+  // ---- the baseline: a top-level == is numeric and scale-insensitive ----
+
+  @Test
+  void topLevelEquality() throws Exception {
+    assertEval(true, "decimal(\"2.0\") == decimal(\"2.00\")");
+    assertEval(true, "decimal(\"2.0\") == decimal(\"2.0\")");
+    assertEval(false, "decimal(\"2.0\") == decimal(\"2.1\")");
+    // Zero is the value hashCode has to special-case.
+    assertEval(true, "decimal(\"0\") == decimal(\"0.000\")");
+    assertEval(true, "decimal(\"-2.0\") == decimal(\"-2.000\")");
+  }
+
+  @Test
+  void topLevelInequalityNegates() throws Exception {
+    assertEval(false, "decimal(\"2.0\") != decimal(\"2.00\")");
+    assertEval(false, "decimal(\"2.0\") != decimal(\"2.0\")");
+    assertEval(true, "decimal(\"2.0\") != decimal(\"2.1\")");
+  }
+
+  @Test
+  void equalityAgreesWithDecimalsEq() throws Exception {
+    for (String[] pair : new String[][] {
+        {"2.0", "2.00"}, {"2.0", "2.0"}, {"2.0", "2.1"},
+        {"0", "0.000"}, {"-2.0", "-2.000"}, {"1e2", "100"}}) {
+      String a = "decimal(\"" + pair[0] + "\")";
+      String b = "decimal(\"" + pair[1] + "\")";
+      assertEquals(evalBool("decimals.eq(" + a + ", " + b + ")"), evalBool(a + " == " + b),
+          "== must agree with decimals.eq for " + pair[0] + " vs " + pair[1]);
+    }
+  }
+
+  // ---- THE PAYOFF: `in` (was FALSE for differing scales) ----
+
+  @Test
+  void inList_sameValueDifferentScale_isTrue() throws Exception {
+    assertEval(true, "decimal(\"2.0\") in [decimal(\"2.00\")]");
+  }
+
+  @Test
+  void inList_sameValueSameScale_isTrue() throws Exception {
+    assertEval(true, "decimal(\"2.0\") in [decimal(\"2.0\")]");
+  }
+
+  @Test
+  void inList_differentValue_isFalse() throws Exception {
+    assertEval(false, "decimal(\"2.0\") in [decimal(\"2.1\")]");
+  }
+
+  @Test
+  void inList_amongSeveralElements() throws Exception {
+    assertEval(true,
+        "decimal(\"2.0\") in [decimal(\"1.5\"), decimal(\"2.000\"), decimal(\"9\")]");
+    assertEval(false,
+        "decimal(\"2.0\") in [decimal(\"1.5\"), decimal(\"2.001\"), decimal(\"9\")]");
+    assertEval(false, "decimal(\"2.0\") in []");
+  }
+
+  // ---- THE PAYOFF: container equality ----
+
+  @Test
+  void listEquality() throws Exception {
+    assertEval(true, "[decimal(\"2.0\")] == [decimal(\"2.00\")]");
+    assertEval(false, "[decimal(\"2.0\")] == [decimal(\"2.1\")]");
+    assertEval(false, "[decimal(\"2.0\")] == [decimal(\"2.0\"), decimal(\"3.0\")]");
+    assertEval(true, "[decimal(\"1.0\"), decimal(\"2.0\")] "
+        + "== [decimal(\"1.000\"), decimal(\"2.00\")]");
+    assertEval(false, "[decimal(\"2.0\")] != [decimal(\"2.00\")]");
+  }
+
+  @Test
+  void mapEquality() throws Exception {
+    assertEval(true, "{\"k\": decimal(\"2.0\")} == {\"k\": decimal(\"2.00\")}");
+    assertEval(false, "{\"k\": decimal(\"2.0\")} == {\"k\": decimal(\"2.1\")}");
+    assertEval(false, "{\"k\": decimal(\"2.0\")} == {\"j\": decimal(\"2.00\")}");
+    assertEval(false, "{\"k\": decimal(\"2.0\")} != {\"k\": decimal(\"2.00\")}");
+  }
+
+  // ---- THE PAYOFF: nesting — the recursive objectEquals walk has to reach all the way down ----
+
+  @Test
+  void nestedListEquality() throws Exception {
+    assertEval(true, "[[decimal(\"2.0\")]] == [[decimal(\"2.00\")]]");
+    assertEval(false, "[[decimal(\"2.0\")]] == [[decimal(\"2.1\")]]");
+  }
+
+  @Test
+  void nestedMapInListEquality() throws Exception {
+    assertEval(true, "[{\"k\": decimal(\"2.0\")}] == [{\"k\": decimal(\"2.00\")}]");
+    assertEval(false, "[{\"k\": decimal(\"2.0\")}] == [{\"k\": decimal(\"2.1\")}]");
+    assertEval(true,
+        "{\"a\": {\"b\": [decimal(\"2.0\")]}} == {\"a\": {\"b\": [decimal(\"2.00\")]}}");
+    assertEval(false,
+        "{\"a\": {\"b\": [decimal(\"2.0\")]}} == {\"a\": {\"b\": [decimal(\"2.1\")]}}");
+  }
+
+  @Test
+  void containerInList() throws Exception {
+    assertEval(true, "[decimal(\"2.0\")] in [[decimal(\"2.00\")]]");
+    assertEval(false, "[decimal(\"2.0\")] in [[decimal(\"2.1\")]]");
+    assertEval(true, "{\"k\": decimal(\"2.0\")} in [{\"k\": decimal(\"2.00\")}]");
+    assertEval(false, "{\"k\": decimal(\"2.0\")} in [{\"k\": decimal(\"2.1\")}]");
+  }
+
+  // ---- derived values compare the same way as constructed ones ----
+
+  @Test
+  void derivedDecimalsCompareNumerically() throws Exception {
+    // Every decimals.* result must be a CelDecimal too, or these fail to dispatch.
+    assertEval(true, "decimals.add(decimal(\"1.5\"), decimal(\"0.50\")) == decimal(\"2\")");
+    assertEval(true, "decimals.round(decimal(\"2.004\"), 2) == decimal(\"2\")");
+    assertEval(true, "decimals.neg(decimal(\"2.0\")) == decimal(\"-2.00\")");
+    assertEval(true, "decimals.sqrt(decimal(\"144\")) == decimal(\"12.0\")");
+    assertEval(true, "decimals.trunc(decimal(\"2.99\"), 1) == decimal(\"2.9\")");
+    assertEval(true, "decimals.greatest(decimal(\"2.0\"), decimal(\"1\")) == decimal(\"2\")");
+    assertEval(true, "decimals.add(decimal(\"1\"), decimal(\"1\")) in [decimal(\"2.000\")]");
+    // And the scalar-returning consumers still unwrap.
+    assertEval(true, "decimals.sign(decimal(\"-2.0\")) == -1");
+    assertEval(true, "string(decimal(\"2.50\")) == \"2.50\"");
+    assertEval(true, "double(decimal(\"2.50\")) == 2.5");
+    // decimal(decimal(x)) — the dyn re-entry arm of DecimalUtils.toBigDecimal.
+    assertEval(true, "decimal(decimal(\"2.0\")) == decimal(\"2.00\")");
+  }
+
+  // ---- the wrapper's own contract ----
+
+  @Test
+  void wrapperEqualsAndHashCodeAreConsistent() {
+    CelDecimal a = CelDecimal.of(new BigDecimal("2.0"));
+    CelDecimal b = CelDecimal.of(new BigDecimal("2.00"));
+    CelDecimal c = CelDecimal.of(new BigDecimal("2.1"));
+    assertEquals(a, b, "2.0 and 2.00 must be equal");
+    assertEquals(a.hashCode(), b.hashCode(), "equal values must hash alike");
+    assertEquals(false, a.equals(c));
+    assertEquals(0, a.compareTo(b));
+    assertEquals(-1, Integer.signum(a.compareTo(c)));
+    // Zero across scales — the hashCode special case.
+    assertEquals(CelDecimal.of(new BigDecimal("0")), CelDecimal.of(new BigDecimal("0.000")));
+    assertEquals(CelDecimal.of(new BigDecimal("0")).hashCode(),
+        CelDecimal.of(new BigDecimal("0.000")).hashCode());
+    assertEquals(CelDecimal.of(new BigDecimal("-0.00")).hashCode(),
+        CelDecimal.of(new BigDecimal("0")).hashCode());
+    // Not a Number — load-bearing, see CelDecimal's javadoc.
+    assertEquals(false, Number.class.isAssignableFrom(CelDecimal.class),
+        "CelDecimal must not be a Number");
+    assertEquals(new BigDecimal("2.0"), a.value());
+    assertEquals("2.0", a.toString());
+    assertEquals(false, a.equals(new BigDecimal("2.0")),
+        "a raw BigDecimal is not a CelDecimal");
+  }
+}

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelDecimalTransformTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelDecimalTransformTest.java
@@ -212,4 +212,28 @@ public class CelDecimalTransformTest {
     assertSame(cleanList, CelUtils.unwrapCelDecimals(cleanList));
     assertSame(null, CelUtils.unwrapCelDecimals(null));
   }
+
+  /**
+   * The copy that unwrapping performs must preserve keys exactly. CEL maps can be keyed by int,
+   * uint or bool as well as string, so stringifying keys would both change their type and merge
+   * distinct keys — {@code 1} and {@code "1"} into one entry, silently dropping a value — and
+   * only when a Decimal happened to be present, since a map without one is returned as-is.
+   */
+  @Test
+  public void unwrapPreservesNonStringMapKeys() {
+    CelDecimal d = CelDecimal.of(new BigDecimal("2.50"));
+    Map<Object, Object> in = new LinkedHashMap<>();
+    in.put(1L, d);
+    in.put("1", "distinct from the long key");
+    in.put(true, "bool key");
+
+    @SuppressWarnings("unchecked")
+    Map<Object, Object> out = (Map<Object, Object>) CelUtils.unwrapCelDecimals(in);
+
+    assertEquals(3, out.size(), "no entry may be merged away");
+    assertEquals(new BigDecimal("2.50"), out.get(1L));
+    assertEquals("distinct from the long key", out.get("1"));
+    assertEquals("bool key", out.get(true));
+    assertEquals(Arrays.asList(1L, "1", true), new ArrayList<>(out.keySet()));
+  }
 }

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelDecimalTransformTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelDecimalTransformTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rules.cel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.client.rest.entities.Rule;
+import io.confluent.kafka.schemaregistry.client.rest.entities.RuleKind;
+import io.confluent.kafka.schemaregistry.client.rest.entities.RuleMode;
+import io.confluent.kafka.schemaregistry.rules.FieldTransform;
+import io.confluent.kafka.schemaregistry.rules.RuleContext;
+import io.confluent.kafka.schemaregistry.rules.RuleContext.FieldContext;
+import io.confluent.kafka.schemaregistry.rules.RuleContext.Type;
+import io.confluent.kafka.schemaregistry.rules.cel.builtin.CelDecimal;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The consumer side of the Decimal wrapper: what a TRANSFORM rule <em>returns</em>.
+ *
+ * <p>Inside CEL a Decimal is a {@link CelDecimal}; everything downstream of evaluation wants a
+ * {@link BigDecimal}. Both executors therefore unwrap before any result writer runs — recursively,
+ * since a rule can return a Decimal at top level or buried in a result map/list.
+ */
+public class CelDecimalTransformTest {
+
+  /** {@code record Money { bytes(decimal 10,2) amount; string label; }} */
+  private static Schema moneySchema() {
+    Schema decimalSchema = LogicalTypes.decimal(10, 2)
+        .addToSchema(Schema.create(Schema.Type.BYTES));
+    return SchemaBuilder.record("Money").namespace("test").fields()
+        .name("amount").type(decimalSchema).noDefault()
+        .requiredString("label")
+        .endRecord();
+  }
+
+  private static GenericRecord money(Schema schema, String amount, String label) {
+    GenericRecord r = new GenericData.Record(schema);
+    r.put("amount", new BigDecimal(amount));
+    r.put("label", label);
+    return r;
+  }
+
+  private static RuleContext ctx(String expr, String executorType, ParsedSchema target) {
+    Rule rule = new Rule("myRule", null, RuleKind.TRANSFORM, RuleMode.WRITE,
+        executorType, null, null, expr, null, null, false);
+    return new RuleContext(Collections.emptyMap(), null, null, target, "topic-value", "topic",
+        null, null, null, false, RuleMode.WRITE, rule, 0, Collections.singletonList(rule));
+  }
+
+  // ---- CelExecutor: the whole-message transform path ----
+
+  private static Object transformMessage(String expr, GenericRecord record) throws Exception {
+    AvroSchema target = new AvroSchema(record.getSchema());
+    RuleContext ruleCtx = ctx(expr, CelExecutor.TYPE, target);
+    return new CelExecutor().transform(ruleCtx, record);
+  }
+
+  @Test
+  public void decimalInsideResultMapReachesAvroAsBigDecimal() throws Exception {
+    Schema schema = moneySchema();
+    // Without the unwrap the AvroResultWriter rejects a CelDecimal at a bytes/decimal field.
+    Object result = transformMessage(
+        "{\"amount\": decimals.round(decimal(message.amount), 1), \"label\": message.label}",
+        money(schema, "100.56", "usd"));
+    GenericRecord out = assertInstanceOf(GenericRecord.class, result);
+    assertEquals(new BigDecimal("100.6"), out.get("amount"));
+    assertEquals("usd", out.get("label").toString());
+  }
+
+  @Test
+  public void decimalArithmeticInResultMap() throws Exception {
+    Schema schema = moneySchema();
+    Object result = transformMessage(
+        "{\"amount\": decimals.add(decimal(message.amount), decimal(\"1.00\")),"
+            + " \"label\": message.label}",
+        money(schema, "100.56", "usd"));
+    GenericRecord out = assertInstanceOf(GenericRecord.class, result);
+    assertEquals(new BigDecimal("101.56"), out.get("amount"));
+  }
+
+  @Test
+  public void unchangedResultIsPassedThroughUntouched() throws Exception {
+    // A rule that returns no decimals must not be reshaped by the unwrap pass.
+    Schema schema = moneySchema();
+    Object result = transformMessage(
+        "{\"amount\": message.amount, \"label\": message.label + \"!\"}",
+        money(schema, "100.56", "usd"));
+    GenericRecord out = assertInstanceOf(GenericRecord.class, result);
+    assertEquals(new BigDecimal("100.56"), out.get("amount"));
+    assertEquals("usd!", out.get("label").toString());
+  }
+
+  // ---- CelFieldExecutor: the field transform path ----
+
+  private static Object transformField(String expr, Schema schema, String fieldName,
+      Type fieldType, Object fieldValue) throws Exception {
+    AvroSchema target = new AvroSchema(schema);
+    RuleContext ruleCtx = ctx(expr, CelFieldExecutor.TYPE, target);
+    GenericRecord containing = money(schema, "100.56", "usd");
+    FieldTransform fieldTransform = new CelFieldExecutor().newTransform(ruleCtx);
+    try (FieldContext fc = ruleCtx.enterField(containing, "test.Money." + fieldName,
+        fieldName, fieldType, Collections.emptySet(), null)) {
+      return fieldTransform.transform(ruleCtx, fc, fieldValue);
+    }
+  }
+
+  @Test
+  public void decimalFieldResultIsUnwrappedForTheFieldSetter() throws Exception {
+    Object result = transformField(
+        "decimals.round(decimal(value), 1)", moneySchema(), "amount", Type.BYTES,
+        new BigDecimal("100.56"));
+    assertEquals(BigDecimal.class, result.getClass(),
+        "a Decimal result must reach the field setter as a BigDecimal");
+    assertEquals(new BigDecimal("100.6"), result);
+  }
+
+  @Test
+  public void decimalResultStillGoesThroughNumericNarrowing() throws Exception {
+    // The unwrap has to run BEFORE the Number-based narrowing chain, which a CelDecimal
+    // would silently skip.
+    Schema intSchema = SchemaBuilder.record("Money").namespace("test").fields()
+        .requiredInt("amount")
+        .requiredString("label")
+        .endRecord();
+    Object result = transformField(
+        "decimals.round(decimal(value), 0)", intSchema, "amount", Type.INT, 7);
+    assertEquals(Integer.class, result.getClass(),
+        "a Decimal result at an INT field must narrow to Integer");
+    assertEquals(7, result);
+  }
+
+  // ---- the unwrap helper's own contract ----
+
+  @Test
+  public void unwrapIsRecursiveAndIdentityPreserving() {
+    CelDecimal d = CelDecimal.of(new BigDecimal("2.50"));
+
+    assertEquals(new BigDecimal("2.50"), CelUtils.unwrapCelDecimals(d));
+
+    // Nested: map -> list -> map -> decimal.
+    Map<String, Object> inner = new LinkedHashMap<>();
+    inner.put("d", d);
+    inner.put("s", "keep");
+    Map<String, Object> outer = new LinkedHashMap<>();
+    outer.put("first", "untouched");
+    outer.put("nested", Collections.singletonList(inner));
+    @SuppressWarnings("unchecked")
+    Map<String, Object> unwrapped = (Map<String, Object>) CelUtils.unwrapCelDecimals(outer);
+    assertEquals("untouched", unwrapped.get("first"));
+    @SuppressWarnings("unchecked")
+    List<Object> nested = (List<Object>) unwrapped.get("nested");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> unwrappedInner = (Map<String, Object>) nested.get(0);
+    assertEquals(new BigDecimal("2.50"), unwrappedInner.get("d"));
+    assertEquals("keep", unwrappedInner.get("s"));
+    // Key order is preserved across the copy.
+    assertEquals(Arrays.asList("first", "nested"), new ArrayList<>(unwrapped.keySet()));
+    assertEquals(Arrays.asList("d", "s"), new ArrayList<>(unwrappedInner.keySet()));
+
+    // A decimal before the last entry still triggers the lazy copy correctly.
+    Map<String, Object> decimalFirst = new LinkedHashMap<>();
+    decimalFirst.put("d", d);
+    decimalFirst.put("s", "keep");
+    @SuppressWarnings("unchecked")
+    Map<String, Object> df = (Map<String, Object>) CelUtils.unwrapCelDecimals(decimalFirst);
+    assertEquals(new BigDecimal("2.50"), df.get("d"));
+    assertEquals("keep", df.get("s"));
+    assertEquals(2, df.size());
+
+    List<Object> list = Arrays.asList(d, "x", 1L);
+    @SuppressWarnings("unchecked")
+    List<Object> unwrappedList = (List<Object>) CelUtils.unwrapCelDecimals(list);
+    assertEquals(Arrays.asList(new BigDecimal("2.50"), "x", 1L), unwrappedList);
+
+    // Nothing to unwrap: the very same instance comes back, no copy.
+    Map<String, Object> clean = new LinkedHashMap<>();
+    clean.put("a", 1L);
+    clean.put("b", Collections.singletonList("c"));
+    assertSame(clean, CelUtils.unwrapCelDecimals(clean));
+    assertSame(list.get(1), CelUtils.unwrapCelDecimals(list.get(1)));
+    List<Object> cleanList = Arrays.asList(1L, "x");
+    assertSame(cleanList, CelUtils.unwrapCelDecimals(cleanList));
+    assertSame(null, CelUtils.unwrapCelDecimals(null));
+  }
+}

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelExecutorTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelExecutorTest.java
@@ -485,6 +485,52 @@ public class CelExecutorTest {
   }
 
   @Test
+  public void testKafkaAvroSerializerFieldConstraintTimestampMillisRawLong() throws Exception {
+    // A timestamp-millis field's unit lives only in the schema, and avro's logical-type
+    // converters are off by default, so the field rule's `value` binding has to be presented
+    // against the field's schema. Otherwise timestamp(value) reads 1700000000123 as epoch
+    // *seconds* and this equality fails. The field is a nullable union, so this covers the
+    // union-branch walk too.
+    Schema schema = createLogicalSchema();
+    GenericRecord avroRecord = new GenericData.Record(schema);
+    avroRecord.put("dewey_no", "921.00000000000000000");
+    avroRecord.put("removal_dt", 1700000000123L);
+    AvroSchema avroSchema = new AvroSchema(schema);
+    Rule rule = new Rule("myRule", null, RuleKind.CONDITION, RuleMode.WRITE,
+        CelFieldExecutor.TYPE, null, null,
+        "name == 'removal_dt' ; timestamp(value) == timestamp(\"2023-11-14T22:13:20.123Z\")",
+        null, null, false);
+    RuleSet ruleSet = new RuleSet(Collections.emptyList(), Collections.singletonList(rule));
+    avroSchema = avroSchema.copy(null, ruleSet);
+    schemaRegistry.register(topic + "-value", avroSchema);
+
+    byte[] bytes = avroSerializer.serialize(topic, avroRecord);
+    GenericRecord obj = (GenericRecord) avroDeserializer.deserialize(topic, bytes);
+    // The rule is a CONDITION, so nothing is written back; the round-trip value is what was
+    // serialized. This deserializer has the logical-type converters on, hence the Instant.
+    assertEquals(Instant.ofEpochMilli(1700000000123L), obj.get("removal_dt"));
+  }
+
+  @Test
+  public void testKafkaAvroSerializerFieldConstraintTimestampMillisInstant() throws Exception {
+    // The converters-on shape: the value is already an Instant, and reads identically.
+    Schema schema = createLogicalSchema();
+    GenericRecord avroRecord = new GenericData.Record(schema);
+    avroRecord.put("dewey_no", "921.00000000000000000");
+    avroRecord.put("removal_dt", Instant.ofEpochMilli(1700000000123L));
+    AvroSchema avroSchema = new AvroSchema(schema);
+    Rule rule = new Rule("myRule", null, RuleKind.CONDITION, RuleMode.WRITE,
+        CelFieldExecutor.TYPE, null, null,
+        "name == 'removal_dt' ; timestamp(value) == timestamp(\"2023-11-14T22:13:20.123Z\")",
+        null, null, false);
+    RuleSet ruleSet = new RuleSet(Collections.emptyList(), Collections.singletonList(rule));
+    avroSchema = avroSchema.copy(null, ruleSet);
+    schemaRegistry.register(topic + "-value", avroSchema);
+
+    avroSerializer.serialize(topic, avroRecord);
+  }
+
+  @Test
   public void testKafkaAvroSerializerFieldTransform() throws Exception {
     IndexedRecord avroRecord = createUserRecord();
     AvroSchema avroSchema = new AvroSchema(avroRecord.getSchema());

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelStandardEqualityTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelStandardEqualityTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rules.cel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.DynamicMessage;
+import dev.cel.common.CelValidationException;
+import dev.cel.common.CelVarDecl;
+import dev.cel.common.types.SimpleType;
+import dev.cel.common.types.StructTypeReference;
+import dev.cel.runtime.CelRuntime;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.kafka.schemaregistry.rules.cel.CelUtils.RegexEngine;
+import io.confluent.kafka.schemaregistry.rules.cel.CelUtils.ScriptType;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Sanity coverage for CEL {@code ==} / {@code !=} across the type surface, plus the PCRE
+ * {@code matches} override.
+ *
+ * <p>Equality here is the <em>stock</em> cel-java stdlib binding. {@link CelUtils} briefly
+ * replaced it to work around bare-{@link java.math.BigDecimal} decimals; that override is gone
+ * now that a Decimal is a non-{@link Number}
+ * {@link io.confluent.kafka.schemaregistry.rules.cel.builtin.CelDecimal}. This class is the
+ * insurance that handing equality back to the stdlib regressed nothing.
+ *
+ * <p>{@code matches} is still overridden in PCRE mode — now the sole
+ * {@code setStandardFunctions(...)} exclusion. Every case runs under BOTH regex engines, so that
+ * override's presence can't change an equality answer.
+ *
+ * @see CelDecimalEqualityTest for the decimal side
+ */
+public class CelStandardEqualityTest {
+
+  /** Evaluate a variable-free boolean expression under the given regex engine. */
+  private static boolean evalBool(String expr, RegexEngine engine) throws Exception {
+    CelRuntime.Program program = CelUtils.buildProgram(
+        ScriptType.JSON, expr, null, Collections.emptyList(), engine);
+    return (Boolean) program.eval();
+  }
+
+  /** Assert a variable-free boolean expression yields {@code expected} under both engines. */
+  private static void assertEval(boolean expected, String expr) throws Exception {
+    for (RegexEngine engine : RegexEngine.values()) {
+      assertEquals(expected, evalBool(expr, engine), expr + " (engine=" + engine + ")");
+    }
+  }
+
+  // ---- scalars ----
+
+  @Test
+  void intEquality() throws Exception {
+    assertEval(true, "1 == 1");
+    assertEval(false, "1 == 2");
+    assertEval(false, "1 != 1");
+    assertEval(true, "1 != 2");
+  }
+
+  @Test
+  void stringEquality() throws Exception {
+    assertEval(true, "'abc' == 'abc'");
+    assertEval(false, "'abc' == 'abd'");
+    assertEval(true, "'abc' != 'abd'");
+  }
+
+  @Test
+  void boolEquality() throws Exception {
+    assertEval(true, "true == true");
+    assertEval(false, "true == false");
+    assertEval(true, "true != false");
+  }
+
+  @Test
+  void doubleEquality() throws Exception {
+    assertEval(true, "1.5 == 1.5");
+    assertEval(false, "1.5 == 2.5");
+    assertEval(true, "1.5 != 2.5");
+  }
+
+  @Test
+  void uintEquality() throws Exception {
+    assertEval(true, "1u == 1u");
+    assertEval(false, "1u == 2u");
+  }
+
+  // ---- heterogeneous numerics ----
+  //
+  // cel-java's `_==_` declaration is homogeneous — `(%A0, %A0)` — so the heterogeneous path is
+  // reached only when one side is dyn, which is how it shows up in practice: CelUtils.findCelType
+  // returns DYN for logical types, unknown classes and null.
+
+  @Test
+  void heterogeneousNumericEquality() throws Exception {
+    assertEval(true, "dyn(1) == 1.0");
+    assertEval(false, "dyn(1) == 2.0");
+    assertEval(true, "dyn(1) == 1u");
+    assertEval(false, "dyn(1) == 2u");
+    assertEval(true, "dyn(1.0) == 1u");
+    assertEval(true, "dyn(1) != 2.0");
+    assertEval(false, "dyn(1) != 1.0");
+  }
+
+  @Test
+  void heterogeneousNumericEqualityIsNotDeclaredForLiterals() {
+    // Pinning the compiler behavior so the case above isn't mistaken for a runtime limitation:
+    // `==` is declared (%A0, %A0), and CelUtils leaves the compiler side alone.
+    assertThrows(CelValidationException.class, () -> evalBool("1 == 1.0", RegexEngine.PCRE));
+  }
+
+  // ---- bytes ----
+
+  @Test
+  void bytesEquality() throws Exception {
+    assertEval(true, "b'abc' == b'abc'");
+    assertEval(false, "b'abc' == b'abd'");
+    assertEval(false, "b'abc' == b'ab'");
+    assertEval(true, "b'abc' != b'abd'");
+  }
+
+  // ---- aggregates (recursive equality) ----
+
+  @Test
+  void listEquality() throws Exception {
+    assertEval(true, "[1, 2, 3] == [1, 2, 3]");
+    assertEval(false, "[1, 2, 3] == [1, 2, 4]");
+    assertEval(false, "[1, 2] == [1, 2, 3]");
+    assertEval(true, "[] == []");
+    // Recursion has to reach nested elements, and heterogeneous numerics inside them.
+    assertEval(true, "[[1, 2], ['a']] == [[1, 2], ['a']]");
+    assertEval(false, "[[1, 2], ['a']] == [[1, 2], ['b']]");
+    assertEval(true, "dyn([1, 2]) == [1.0, 2.0]");
+    assertEval(false, "dyn([1, 2]) == [1.0, 3.0]");
+  }
+
+  @Test
+  void mapEquality() throws Exception {
+    assertEval(true, "{'a': 1, 'b': 2} == {'b': 2, 'a': 1}");
+    assertEval(false, "{'a': 1} == {'a': 2}");
+    assertEval(false, "{'a': 1} == {'b': 1}");
+    assertEval(false, "{'a': 1} == {'a': 1, 'b': 2}");
+    assertEval(true, "{'a': {'b': [1]}} == {'a': {'b': [1]}}");
+    assertEval(false, "{'a': {'b': [1]}} == {'a': {'b': [2]}}");
+  }
+
+  // ---- well-known temporal types ----
+
+  @Test
+  void timestampEquality() throws Exception {
+    assertEval(true,
+        "timestamp('2020-01-01T00:00:00Z') == timestamp('2020-01-01T00:00:00Z')");
+    assertEval(false,
+        "timestamp('2020-01-01T00:00:00Z') == timestamp('2021-01-01T00:00:00Z')");
+    assertEval(true,
+        "timestamp('2020-01-01T00:00:00Z') != timestamp('2021-01-01T00:00:00Z')");
+  }
+
+  @Test
+  void durationEquality() throws Exception {
+    assertEval(true, "duration('1h') == duration('60m')");
+    assertEval(false, "duration('1h') == duration('2h')");
+    assertEval(true, "duration('1h') != duration('2h')");
+  }
+
+  // ---- null ----
+
+  @Test
+  void nullEquality() throws Exception {
+    assertEval(true, "null == null");
+    assertEval(false, "null != null");
+  }
+
+  @Test
+  void nullComparedToBoundValue() throws Exception {
+    // A DYN-declared var — what CelUtils.findCelType produces for a null value, and the only
+    // declaration under which `value == null` type-checks at all.
+    List<CelVarDecl> decls =
+        Collections.singletonList(CelVarDecl.newVarDeclaration("value", SimpleType.DYN));
+    for (RegexEngine engine : RegexEngine.values()) {
+      CelRuntime.Program program =
+          CelUtils.buildProgram(ScriptType.JSON, "value == null", null, decls, engine);
+      assertTrue((Boolean) program.eval(
+              Collections.singletonMap("value", CelUtils.toCelValue(null))),
+          "a bound null must equal null (engine=" + engine + ")");
+      assertFalse((Boolean) program.eval(
+              Collections.singletonMap("value", CelUtils.toCelValue("x"))),
+          "a bound non-null must not equal null (engine=" + engine + ")");
+      assertFalse((Boolean) CelUtils
+              .buildProgram(ScriptType.JSON, "value != null", null, decls, engine)
+              .eval(Collections.singletonMap("value", CelUtils.toCelValue(null))),
+          "!= must negate for a bound null (engine=" + engine + ")");
+    }
+  }
+
+  // ---- proto messages ----
+
+  private static final String PROTO = "syntax = \"proto3\";\n"
+      + "package test;\n"
+      + "message Point {\n"
+      + "  int32 x = 1;\n"
+      + "  int32 y = 2;\n"
+      + "}\n";
+
+  private static DynamicMessage point(Descriptor desc, int x, int y) {
+    return DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName("x"), x)
+        .setField(desc.findFieldByName("y"), y)
+        .build();
+  }
+
+  /** Evaluate a boolean expression over two Point messages bound as {@code this} / {@code other}. */
+  private static boolean evalProto(String expr, DynamicMessage self, DynamicMessage other,
+      Descriptor desc, RegexEngine engine) throws Exception {
+    List<CelVarDecl> decls = Arrays.asList(
+        CelVarDecl.newVarDeclaration("this", StructTypeReference.create(desc.getFullName())),
+        CelVarDecl.newVarDeclaration("other", StructTypeReference.create(desc.getFullName())));
+    CelRuntime.Program program =
+        CelUtils.buildProgram(ScriptType.PROTOBUF, expr, desc, decls, engine);
+    Map<String, Object> args = new HashMap<>();
+    args.put("this", self);
+    args.put("other", other);
+    return (Boolean) program.eval(args);
+  }
+
+  @Test
+  void protoMessageEquality() throws Exception {
+    Descriptor desc = new ProtobufSchema(PROTO).toDescriptor("test.Point");
+    DynamicMessage a = point(desc, 1, 2);
+    DynamicMessage sameAsA = point(desc, 1, 2);
+    DynamicMessage b = point(desc, 3, 4);
+
+    for (RegexEngine engine : RegexEngine.values()) {
+      String at = " (engine=" + engine + ")";
+      assertTrue(evalProto("this == this", a, b, desc, engine),
+          "a message must equal itself" + at);
+      assertFalse(evalProto("this != this", a, b, desc, engine),
+          "!= must negate self-equality" + at);
+      // Distinct instances with identical contents must compare equal — proto message
+      // equality must not degrade to reference identity.
+      assertTrue(evalProto("this == other", a, sameAsA, desc, engine),
+          "equal-valued distinct messages must compare equal" + at);
+      assertFalse(evalProto("this == other", a, b, desc, engine),
+          "different-valued messages must not compare equal" + at);
+      assertTrue(evalProto("this != other", a, b, desc, engine),
+          "!= must hold for different-valued messages" + at);
+      // Field-level equality through a message still works.
+      assertTrue(evalProto("this.x == 1 && this.y == 2", a, b, desc, engine),
+          "scalar field equality on a message" + at);
+    }
+  }
+
+  // ---- the PCRE matches override still composes with everything else ----
+
+  @Test
+  void matchesWorksUnderBothEngines() throws Exception {
+    assertEval(true, "'abc123'.matches('[a-z]+[0-9]+')");
+    assertEval(false, "'abc'.matches('[0-9]+')");
+    // And matches in the same expression as an equality.
+    assertEval(true, "'abc'.matches('[a-z]+') == true");
+  }
+
+  @Test
+  void pcreOnlyFeatureNeedsPcreEngine() throws Exception {
+    // Lookahead is the reason the PCRE override exists: java.util.regex supports it, RE2
+    // does not. Pins that the override is actually installed in PCRE mode.
+    assertTrue(evalBool("'abc1'.matches('^(?=.*[0-9]).*$')", RegexEngine.PCRE),
+        "PCRE mode must support lookahead");
+  }
+}

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelStandardEqualityTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelStandardEqualityTest.java
@@ -42,15 +42,20 @@ import org.junit.jupiter.api.Test;
  * Sanity coverage for CEL {@code ==} / {@code !=} across the type surface, plus the PCRE
  * {@code matches} override.
  *
- * <p>Equality here is the <em>stock</em> cel-java stdlib binding. {@link CelUtils} briefly
- * replaced it to work around bare-{@link java.math.BigDecimal} decimals; that override is gone
- * now that a Decimal is a non-{@link Number}
- * {@link io.confluent.kafka.schemaregistry.rules.cel.builtin.CelDecimal}. This class is the
- * insurance that handing equality back to the stdlib regressed nothing.
+ * <p>{@code ==} and {@code !=} are ours, not stdlib's: {@code BuiltinOverload.standardOverrides}
+ * replaces both so that a decimal operand compares numerically instead of by its protobuf
+ * encoding. Every case below uses non-decimals, so every case exercises the delegating arm of
+ * that replacement — this class is the insurance that taking over the most-used function in the
+ * language regressed nothing.
  *
- * <p>{@code matches} is still overridden in PCRE mode — now the sole
- * {@code setStandardFunctions(...)} exclusion. Every case runs under BOTH regex engines, so that
- * override's presence can't change an equality answer.
+ * <p>{@link #protoMessageEquality()} carries extra weight. The replacement delegates to the
+ * {@code RuntimeEquality} the runtime hands {@code BuiltinLibrary} as a
+ * {@code CelInternalRuntimeLibrary}; a hand-built one would instead throw "Not implemented yet"
+ * on any message operand. That test is what fails if a cel-java upgrade changes how the instance
+ * is supplied.
+ *
+ * <p>{@code matches} is also overridden in PCRE mode. Every case runs under BOTH regex engines,
+ * so neither override's presence can change an equality answer.
  *
  * @see CelDecimalEqualityTest for the decimal side
  */

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorDecimalEqualityTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorDecimalEqualityTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.kafka.schemaregistry.rules.cel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.DynamicMessage;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
+import io.confluent.kafka.schemaregistry.rules.ValidationRuleError;
+import io.confluent.kafka.schemaregistry.type.Variant;
+import io.confluent.kafka.schemaregistry.type.VariantBuilder;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for CEL {@code ==}/{@code !=} on {@code confluent.type.Decimal} values.
+ *
+ * <p>The {@code ==} operator must agree with {@code decimals.eq} / {@link BigDecimal#compareTo}:
+ * numeric equality that is scale-insensitive ({@code 2.0 == 2.00}). Decimal values used to travel
+ * through CEL as a plain {@link BigDecimal}, and cel-java's stdlib {@code equals} binding routes
+ * two {@link Number}s through {@code ComparisonFunctions.numericEquals}, which knows only
+ * Double / Long / UnsignedLong and answers {@code false} for any pair of BigDecimals — so even
+ * {@code decimal("2.0") == decimal("2.0")} was false. The runtime value is now a
+ * {@link io.confluent.kafka.schemaregistry.rules.cel.builtin.CelDecimal} wrapper, deliberately
+ * not a {@link Number}, whose {@code equals} is {@code compareTo(...) == 0} — so the stock stdlib
+ * bindings answer numerically. See {@link CelDecimalEqualityTest} for the {@code in} /
+ * container / nested cases that a binding-level override could not have reached.
+ *
+ * <p>Most rules here are field-level CONDITIONS on a {@code Money.amount} Decimal field. A
+ * satisfied rule yields no {@link ValidationRuleError}; an unsatisfied rule yields exactly one.
+ * The Variant section instead puts the decimal inside a {@code confluent.type.Variant} field, to
+ * cover the {@code variants.* } + {@code decimals.*} + {@code ==} composition.
+ */
+public class CelValidatorDecimalEqualityTest {
+
+  /** Build a Money schema whose {@code amount} field carries the given rule expression. */
+  private static ProtobufSchema schemaWithRule(String expr) {
+    String s = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "import \"confluent/type/decimal.proto\";\n"
+        + "message Money {\n"
+        + "  confluent.type.Decimal amount = 1 [(confluent.field_meta) = {\n"
+        + "    rules: [{name: \"eq\", expr: \"" + expr + "\"}]\n"
+        + "  }];\n"
+        + "}\n";
+    return new ProtobufSchema(s);
+  }
+
+  /** Build a Money message with the given decimal amount, encoded as a proto Decimal. */
+  private static DynamicMessage money(ProtobufSchema schema, String amount) {
+    Descriptor moneyDesc = schema.toDescriptor("test.Money");
+    FieldDescriptor amountField = moneyDesc.findFieldByName("amount");
+    Descriptor decimalDesc = amountField.getMessageType();
+
+    BigDecimal bd = new BigDecimal(amount);
+    BigInteger unscaled = bd.unscaledValue();
+
+    DynamicMessage decimalMsg = DynamicMessage.newBuilder(decimalDesc)
+        .setField(decimalDesc.findFieldByName("value"),
+            ByteString.copyFrom(unscaled.toByteArray()))
+        .setField(decimalDesc.findFieldByName("scale"), bd.scale())
+        .build();
+
+    return DynamicMessage.newBuilder(moneyDesc)
+        .setField(amountField, decimalMsg)
+        .build();
+  }
+
+  /** True iff the rule expr holds for a Money whose amount is {@code amount}. */
+  private static boolean holds(String expr, String amount) {
+    ProtobufSchema schema = schemaWithRule(expr);
+    List<ValidationRuleError> errors =
+        schema.validateMessage(new CelValidator(), money(schema, amount));
+    return errors.isEmpty();
+  }
+
+  // ---- TARGET CONTRACT: == is numeric, scale-insensitive ----
+
+  @Test
+  void eq_sameValueDifferentScale_isTrue() {
+    // decimal("2.0") == decimal("2.00") -> TRUE
+    assertTrue(holds("decimal(this) == decimal(\\\"2.00\\\")", "2.0"),
+        "2.0 == 2.00 should be true (scale-insensitive numeric equality)");
+  }
+
+  @Test
+  void eq_sameValueSameScale_isTrue() {
+    // decimal("2.0") == decimal("2.0") -> TRUE (was false under identity equality)
+    assertTrue(holds("decimal(this) == decimal(\\\"2.0\\\")", "2.0"),
+        "2.0 == 2.0 should be true");
+  }
+
+  @Test
+  void eq_differentValue_isFalse() {
+    // decimal("2.0") == decimal("2.1") -> FALSE
+    assertEquals(false, holds("decimal(this) == decimal(\\\"2.1\\\")", "2.0"),
+        "2.0 == 2.1 should be false");
+  }
+
+  // ---- TARGET CONTRACT: != is the negation of == ----
+
+  @Test
+  void ne_differentValue_isTrue() {
+    // decimal("2.0") != decimal("2.1") -> TRUE
+    assertTrue(holds("decimal(this) != decimal(\\\"2.1\\\")", "2.0"),
+        "2.0 != 2.1 should be true");
+  }
+
+  @Test
+  void ne_sameValueDifferentScale_isFalse() {
+    // decimal("2.0") != decimal("2.00") -> FALSE (negation of a true ==)
+    assertEquals(false, holds("decimal(this) != decimal(\\\"2.00\\\")", "2.0"),
+        "2.0 != 2.00 should be false (== is true, so != negates to false)");
+  }
+
+  @Test
+  void ne_sameValueSameScale_isFalse() {
+    // decimal("2.0") != decimal("2.0") -> FALSE
+    assertEquals(false, holds("decimal(this) != decimal(\\\"2.0\\\")", "2.0"),
+        "2.0 != 2.0 should be false");
+  }
+
+  // ---- == agrees with decimals.eq on the same operands ----
+
+  @Test
+  void eq_agreesWithDecimalsEq() {
+    assertEquals(
+        holds("decimals.eq(decimal(this), decimal(\\\"2.00\\\"))", "2.0"),
+        holds("decimal(this) == decimal(\\\"2.00\\\")", "2.0"),
+        "== must agree with decimals.eq for 2.0 vs 2.00");
+    assertEquals(
+        holds("decimals.eq(decimal(this), decimal(\\\"2.1\\\"))", "2.0"),
+        holds("decimal(this) == decimal(\\\"2.1\\\")", "2.0"),
+        "== must agree with decimals.eq for 2.0 vs 2.1");
+  }
+
+  // ---- COMPOSITION: a decimal pulled out of a Variant ----
+  //
+  // A Decimal inside a Variant reaches CEL through variants.as(..., "decimal"), which has to
+  // yield the very same runtime class that decimal(...) produces — dispatch is by Java class at
+  // runtime, and at the CEL level both are just the DECIMAL OpaqueType, so the compiler cannot
+  // catch a mismatch. All four consumers below therefore have to keep working off one value:
+  // ==, decimals.eq, decimals.add, and string(). These are the regression gate for the
+  // producer sweep.
+
+  /** Build a Doc schema whose {@code payload} Variant field carries the given rule expression. */
+  private static ProtobufSchema variantSchemaWithRule(String expr) {
+    String s = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "import \"confluent/type/variant.proto\";\n"
+        + "message Doc {\n"
+        + "  confluent.type.Variant payload = 1 [(confluent.field_meta) = {\n"
+        + "    rules: [{name: \"eq\", expr: \"" + expr + "\"}]\n"
+        + "  }];\n"
+        + "}\n";
+    return new ProtobufSchema(s);
+  }
+
+  /** Build a Doc message whose Variant payload is a single decimal value. */
+  private static DynamicMessage docWithVariantDecimal(ProtobufSchema schema, String amount) {
+    VariantBuilder vb = new VariantBuilder();
+    vb.appendDecimal(new BigDecimal(amount));
+    Variant v = vb.build();
+
+    Descriptor docDesc = schema.toDescriptor("test.Doc");
+    Descriptor variantDesc = docDesc.findFieldByName("payload").getMessageType();
+    DynamicMessage variantMsg = DynamicMessage.newBuilder(variantDesc)
+        .setField(variantDesc.findFieldByName("value"), toByteString(v.getValueBuffer()))
+        .setField(variantDesc.findFieldByName("metadata"), toByteString(v.getMetadataBuffer()))
+        .build();
+    return DynamicMessage.newBuilder(docDesc)
+        .setField(docDesc.findFieldByName("payload"), variantMsg)
+        .build();
+  }
+
+  private static ByteString toByteString(ByteBuffer buf) {
+    ByteBuffer dup = buf.duplicate();
+    byte[] out = new byte[dup.remaining()];
+    dup.get(out);
+    return ByteString.copyFrom(out);
+  }
+
+  /** True iff the rule expr holds for a Doc whose Variant payload is {@code amount}. */
+  private static boolean variantHolds(String expr, String amount) {
+    ProtobufSchema schema = variantSchemaWithRule(expr);
+    List<ValidationRuleError> errors =
+        schema.validateMessage(new CelValidator(), docWithVariantDecimal(schema, amount));
+    assertTrue(errors.isEmpty() || errors.get(0).getCause() == null,
+        "rule failed to evaluate: " + dumpCauses(errors));
+    return errors.isEmpty();
+  }
+
+  private static String dumpCauses(List<ValidationRuleError> errs) {
+    StringBuilder sb = new StringBuilder();
+    for (ValidationRuleError e : errs) {
+      Throwable t = e.getCause();
+      while (t != null) {
+        sb.append("\n  ").append(t.getClass().getSimpleName()).append(": ").append(t.getMessage());
+        t = t.getCause();
+      }
+    }
+    return sb.toString();
+  }
+
+  @Test
+  void variantDecimal_equalsDecimalLiteral() {
+    assertTrue(
+        variantHolds("variants.as(variant(this), \\\"decimal\\\") == decimal(\\\"2.50\\\")", "2.50"),
+        "a Variant decimal must compare equal to the same decimal literal via ==");
+  }
+
+  @Test
+  void variantDecimal_decimalsEq() {
+    assertTrue(
+        variantHolds(
+            "decimals.eq(variants.as(variant(this), \\\"decimal\\\"), decimal(\\\"2.50\\\"))",
+            "2.50"),
+        "decimals.eq must still accept a Variant-sourced decimal");
+  }
+
+  @Test
+  void variantDecimal_decimalsAdd() {
+    assertTrue(
+        variantHolds(
+            "decimals.eq("
+                + "decimals.add(variants.as(variant(this), \\\"decimal\\\"), decimal(\\\"1\\\")),"
+                + " decimal(\\\"3.50\\\"))",
+            "2.50"),
+        "decimals.add must still accept a Variant-sourced decimal");
+  }
+
+  @Test
+  void variantDecimal_stringConversion() {
+    assertTrue(
+        variantHolds(
+            "string(variants.as(variant(this), \\\"decimal\\\")) == \\\"2.50\\\"", "2.50"),
+        "string(Decimal) must still dispatch for a Variant-sourced decimal");
+  }
+}

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorDecimalEqualityTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorDecimalEqualityTest.java
@@ -17,6 +17,7 @@
 package io.confluent.kafka.schemaregistry.rules.cel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.protobuf.ByteString;
@@ -258,5 +259,43 @@ public class CelValidatorDecimalEqualityTest {
         variantHolds(
             "string(variants.as(variant(this), \\\"decimal\\\")) == \\\"2.50\\\"", "2.50"),
         "string(Decimal) must still dispatch for a Variant-sourced decimal");
+  }
+
+  // ---- Decimals nested in containers ----
+
+  /**
+   * A Decimal inside a list or map compares numerically too. Making the operands' own {@code ==}
+   * numeric is not enough on its own: the standard implementation recurses into containers with
+   * its own equality, so a bare protobuf Decimal nested one level deep was compared by its
+   * encoding and {@code [a] == [b]} disagreed with {@code a == b} on the very same values.
+   */
+  @Test
+  void containerEqualityIsNumericForNestedDecimals() {
+    // `this` is 1.50; decimal("1.500") is the same number with a different scale.
+    assertTrue(holds("[this] == [decimal(\\\"1.500\\\")]", "1.50"));
+    assertTrue(holds("{\\\"k\\\": this} == {\\\"k\\\": decimal(\\\"1.500\\\")}", "1.50"));
+    assertTrue(holds("[[this]] == [[decimal(\\\"1.500\\\")]]", "1.50"));
+    // Negative controls: a different number, and a size mismatch.
+    assertFalse(holds("[this] == [decimal(\\\"9\\\")]", "1.50"));
+    assertFalse(holds("[this] == [this, this]", "1.50"));
+  }
+
+  /** {@code in} over a list follows the same equality, or it contradicts {@code ==}. */
+  @Test
+  void listMembershipIsNumericForNestedDecimals() {
+    assertTrue(holds("this in [decimal(\\\"1.500\\\")]", "1.50"));
+    assertTrue(holds("this in [decimal(\\\"9\\\"), decimal(\\\"1.500\\\")]", "1.50"));
+    assertFalse(holds("this in [decimal(\\\"9\\\")]", "1.50"));
+  }
+
+  /** Decimal-free comparisons keep standard semantics — the recursion is gated on a Decimal. */
+  @Test
+  void containerEqualityUnchangedWithoutDecimals() {
+    assertTrue(holds("[1, 2] == [1, 2]", "1.50"));
+    assertFalse(holds("[1, 2] == [2, 1]", "1.50"));
+    assertTrue(holds("{\\\"a\\\": 1} == {\\\"a\\\": 1}", "1.50"));
+    assertTrue(holds("2 in [1, 2]", "1.50"));
+    assertFalse(holds("3 in [1, 2]", "1.50"));
+    assertTrue(holds("[\\\"x\\\"] == [\\\"x\\\"]", "1.50"));
   }
 }

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorDecimalTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorDecimalTest.java
@@ -624,6 +624,68 @@ public class CelValidatorDecimalTest {
     assertTrue(schema.validateMessage(new CelValidator(), r).isEmpty());
   }
 
+  /**
+   * Cross-client parity: an Avro {@code decimal} logical type is usable as a Decimal with
+   * <b>no {@code decimal(...)} call</b>, and the wrapped form keeps working alongside it. The
+   * boundary applies the schema's scale, so the value is already a {@link
+   * io.confluent.kafka.schemaregistry.rules.cel.builtin.CelDecimal} — which also means
+   * {@code ==} is numeric on it, since a bare {@link BigDecimal} would take cel-java's
+   * {@code instanceof Number} short-circuit and answer false for any BigDecimal pair.
+   */
+  @Test
+  void avroDecimal_usableWithoutTheConstructor() {
+    String s = ""
+        + "{"
+        + "  \"type\":\"record\","
+        + "  \"name\":\"Money\","
+        + "  \"namespace\":\"test\","
+        + "  \"fields\":["
+        + "    {"
+        + "      \"name\":\"amount\","
+        + "      \"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\","
+        + "                \"precision\":10,\"scale\":2},"
+        + "      \"confluent:rules\":[{\"name\":\"r\",\"expr\":\"%s\"}]"
+        + "    }"
+        + "  ]"
+        + "}";
+    // 123.45 as the two shapes the field can arrive in: unscaled bytes (converters off,
+    // the default) and an already-scaled BigDecimal (converters on).
+    BigDecimal expected = new BigDecimal("123.45");
+    Object[] shapes = {
+        ByteBuffer.wrap(expected.unscaledValue().toByteArray()),
+        expected,
+    };
+
+    for (Object shape : shapes) {
+      String kind = shape.getClass().getSimpleName();
+      // Bare: no constructor call anywhere in the expression.
+      assertTrue(evalAvro(s, "decimals.eq(this, decimal(\\\"123.45\\\"))", shape).isEmpty(),
+          "bare decimals.eq should hold for " + kind);
+      // The wrapped form must keep working — decimal(...) re-entry on an already-Decimal value.
+      assertTrue(evalAvro(s, "decimals.eq(decimal(this), decimal(\\\"123.45\\\"))", shape)
+              .isEmpty(),
+          "wrapped decimals.eq should hold for " + kind);
+      // `==` is numeric on it: 123.45 equals 123.450 despite the differing scale.
+      assertTrue(evalAvro(s, "this == decimal(\\\"123.450\\\")", shape).isEmpty(),
+          "bare == should be numeric for " + kind);
+      // The schema's scale is applied, not guessed: read as scale 0 this would be 12345.
+      assertTrue(evalAvro(s, "decimals.lt(this, decimal(\\\"1000\\\"))", shape).isEmpty(),
+          "the schema's scale should have been applied for " + kind);
+      // Negative control: a false comparison must still fail.
+      assertEquals(1, evalAvro(s, "decimals.gt(this, decimal(\\\"1000\\\"))", shape).size(),
+          "a false comparison should fail for " + kind);
+    }
+  }
+
+  /** Evaluate {@code expr} (a %s in {@code schemaTemplate}) against an {@code amount} value. */
+  private static List<ValidationRuleError> evalAvro(
+      String schemaTemplate, String expr, Object amount) {
+    AvroSchema schema = new AvroSchema(String.format(schemaTemplate, expr));
+    GenericRecord r = new GenericData.Record(schema.rawSchema());
+    r.put("amount", amount);
+    return schema.validateMessage(new CelValidator(), r);
+  }
+
   @Test
   void avroDecimal_logicalTypeSchemaResolves_atFieldLevel() {
     // Sanity: the decimal logical type from the schema doesn't confuse the

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorDecimalTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorDecimalTest.java
@@ -694,4 +694,163 @@ public class CelValidatorDecimalTest {
     Schema amountSchema = schema.getField("amount").schema();
     assertEquals("decimal", LogicalTypes.fromSchemaIgnoreInvalid(amountSchema).getName());
   }
+
+  // ---- Bare protobuf decimal: no decimal() wrapper ----
+  //
+  // A protobuf confluent.type.Decimal field is typed by cel-java as
+  // StructTypeReference("confluent.type.Decimal"), which is exactly CelTypeLabels.DECIMAL, so
+  // every decimals.* declaration accepts such a field directly. The runtime value is a proto
+  // Decimal message rather than a CelDecimal, which the bindings coerce.
+
+  /** Order schema with a message-level rule, so `this` is the record and fields are selectable. */
+  private static String bareOrderSchema(String expr) {
+    return "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "import \"confluent/type/decimal.proto\";\n"
+        + "message Order {\n"
+        + "  option (confluent.message_meta) = {\n"
+        + "    rules: [{name: \"bare\", expr: \"" + expr + "\"}]\n"
+        + "  };\n"
+        + "  confluent.type.Decimal subtotal = 1;\n"
+        + "  confluent.type.Decimal tax = 2;\n"
+        + "  confluent.type.Decimal total = 3;\n"
+        + "}\n";
+  }
+
+  private static List<ValidationRuleError> evalBareOrder(
+      String expr, String subtotal, String tax, String total) {
+    ProtobufSchema schema = new ProtobufSchema(bareOrderSchema(expr));
+    Descriptor desc = schema.toDescriptor("test.Order");
+    DynamicMessage order = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName("subtotal"), decimal(desc, "subtotal", subtotal))
+        .setField(desc.findFieldByName("tax"), decimal(desc, "tax", tax))
+        .setField(desc.findFieldByName("total"), decimal(desc, "total", total))
+        .build();
+    return schema.validateMessage(new CelValidator(), order);
+  }
+
+  @Test
+  void bareProtoDecimal_fieldRule_needsNoConstructor() {
+    // The field-level shape: `this` is the Decimal message itself.
+    String s = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "import \"confluent/type/decimal.proto\";\n"
+        + "message Money {\n"
+        + "  confluent.type.Decimal amount = 1 [(confluent.field_meta) = {\n"
+        + "    rules: [{name: \"nonNegative\","
+        + "             expr: \"decimals.ge(this, decimal(\\\"0\\\"))\"}]\n"
+        + "  }];\n"
+        + "}\n";
+    ProtobufSchema schema = new ProtobufSchema(s);
+    Descriptor moneyDesc = schema.toDescriptor("test.Money");
+    DynamicMessage ok = DynamicMessage.newBuilder(moneyDesc)
+        .setField(moneyDesc.findFieldByName("amount"), decimal(moneyDesc, "amount", "100.50"))
+        .build();
+    assertTrue(schema.validateMessage(new CelValidator(), ok).isEmpty());
+
+    DynamicMessage bad = DynamicMessage.newBuilder(moneyDesc)
+        .setField(moneyDesc.findFieldByName("amount"), decimal(moneyDesc, "amount", "-0.01"))
+        .build();
+    List<ValidationRuleError> errors = schema.validateMessage(new CelValidator(), bad);
+    assertEquals(1, errors.size());
+    assertEquals("nonNegative", errors.get(0).getRule().getName());
+  }
+
+  @Test
+  void bareProtoDecimal_arithmeticOnSelectedFields() {
+    assertTrue(evalBareOrder(
+        "decimals.eq(decimals.add(this.subtotal, this.tax), this.total)",
+        "100.00", "8.50", "108.50").isEmpty());
+    assertEquals(1, evalBareOrder(
+        "decimals.eq(decimals.add(this.subtotal, this.tax), this.total)",
+        "100.00", "8.50", "999.00").size());
+  }
+
+  @Test
+  void bareProtoDecimal_mixesWithConstructedDecimals() {
+    // decimal("...") yields CelTypeLabels.DECIMAL and this.subtotal yields the proto field's
+    // struct type. Those are one type now, so the mixed pair type-checks.
+    assertTrue(evalBareOrder(
+        "decimals.gt(this.subtotal, decimal(\\\"1\\\"))",
+        "100.00", "8.50", "108.50").isEmpty());
+  }
+
+  @Test
+  void bareProtoDecimal_stringAndDoubleConversion() {
+    assertTrue(evalBareOrder(
+        "string(this.subtotal) == \\\"100.00\\\"", "100.00", "8.50", "108.50").isEmpty());
+    assertTrue(evalBareOrder(
+        "double(this.subtotal) == 100.0", "100.00", "8.50", "108.50").isEmpty());
+  }
+
+  @Test
+  void bareProtoDecimal_equalityIsNumericNotProtoEncoding() {
+    // The whole point of the == override: 1.50 and 1.5 are the same number in two encodings.
+    // Proto equality compares unscaled bytes and scale field-by-field and answers false.
+    assertTrue(evalBareOrder(
+        "this.subtotal == this.total", "1.50", "0", "1.5").isEmpty(),
+        "1.50 == 1.5 must be true");
+    assertTrue(evalBareOrder(
+        "this.subtotal == this.total", "1.50", "0", "1.50").isEmpty());
+    assertEquals(1, evalBareOrder(
+        "this.subtotal == this.total", "1.50", "0", "2.5").size());
+  }
+
+  @Test
+  void bareProtoDecimal_equalityAcrossRepresentations() {
+    // A proto Decimal message on one side, a CelDecimal on the other.
+    assertTrue(evalBareOrder(
+        "this.subtotal == decimal(\\\"1.5\\\")", "1.50", "0", "0").isEmpty());
+    assertTrue(evalBareOrder(
+        "decimal(\\\"1.5\\\") == this.subtotal", "1.50", "0", "0").isEmpty());
+    assertTrue(evalBareOrder(
+        "this.subtotal == decimals.add(this.tax, this.total)", "3.00", "1.0", "2.000").isEmpty());
+  }
+
+  @Test
+  void bareProtoDecimal_inequalityIsNumericToo() {
+    assertEquals(1, evalBareOrder(
+        "this.subtotal != this.total", "1.50", "0", "1.5").size(),
+        "1.50 != 1.5 must be false");
+    assertTrue(evalBareOrder(
+        "this.subtotal != this.total", "1.50", "0", "2.5").isEmpty());
+  }
+
+  @Test
+  void bareProtoDecimal_canonicalParitySet() {
+    // The cross-client parity contract, mirrored in all seven clients. `this` is a bare
+    // confluent.type.Decimal field holding 12.34 (unscaled 1234, scale 2) and no expression
+    // wraps it in decimal(...). The discriminating case is the scale-differing equality: a
+    // client comparing by protobuf encoding answers false for decimal("12.340").
+    String s = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "import \"confluent/type/decimal.proto\";\n"
+        + "message Money {\n"
+        + "  confluent.type.Decimal amount = 1 [(confluent.field_meta) = {\n"
+        + "    rules: [{name: \"r\", expr: \"%s\"}]\n"
+        + "  }];\n"
+        + "}\n";
+    String[][] cases = {
+        {"decimals.gt(this, decimal(\\\"10.00\\\"))", "true"},
+        {"decimals.eq(this, decimal(\\\"12.340\\\"))", "true"},
+        {"this == decimal(\\\"12.34\\\")", "true"},
+        {"this == decimal(\\\"12.340\\\")", "true"},
+        {"this != decimal(\\\"12.340\\\")", "false"},
+        {"this == decimal(\\\"99\\\")", "false"},
+        {"string(this) == \\\"12.34\\\"", "true"},
+        {"double(this) == 12.34", "true"},
+    };
+    for (String[] c : cases) {
+      ProtobufSchema schema = new ProtobufSchema(String.format(s, c[0]));
+      Descriptor desc = schema.toDescriptor("test.Money");
+      DynamicMessage msg = DynamicMessage.newBuilder(desc)
+          .setField(desc.findFieldByName("amount"), decimal(desc, "amount", "12.34"))
+          .build();
+      boolean passed = schema.validateMessage(new CelValidator(), msg).isEmpty();
+      assertEquals(Boolean.parseBoolean(c[1]), passed, c[0]);
+    }
+  }
 }

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorTimestampTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorTimestampTest.java
@@ -354,6 +354,59 @@ public class CelValidatorTimestampTest {
     assertTrue(schema.validateMessage(new CelValidator(), outer).isEmpty());
   }
 
+  /**
+   * Cross-client parity: an Avro timestamp logical type is usable as a timestamp with **no
+   * constructor call at all**. The boundary applies the schema's unit, so the value is already a
+   * CEL timestamp — comparable against {@code now}, and carrying the timestamp accessors. Every
+   * one of the seven clients has this test; the wrapper is only needed for a plain numeric field
+   * whose unit the schema cannot supply.
+   */
+  @Test
+  void avroTimestampMillis_usableWithoutTheConstructor() {
+    String s = ""
+        + "{"
+        + "  \"type\":\"record\","
+        + "  \"name\":\"Event\","
+        + "  \"namespace\":\"test\","
+        + "  \"fields\":["
+        + "    {"
+        + "      \"name\":\"ts\","
+        + "      \"type\":{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"},"
+        + "      \"confluent:rules\":[{\"name\":\"r\",\"expr\":\"%s\"}]"
+        + "    }"
+        + "  ]"
+        + "}";
+    long past = Instant.now().minusSeconds(60).toEpochMilli();
+
+    // Bare comparison against `now`, with the converters off (a raw long) and on (an Instant).
+    for (Object value : new Object[] {past, Instant.ofEpochMilli(past)}) {
+      AvroSchema schema = new AvroSchema(String.format(s, "this < now"));
+      GenericRecord r = new GenericData.Record(schema.rawSchema());
+      r.put("ts", value);
+      assertTrue(schema.validateMessage(new CelValidator(), r).isEmpty(),
+          "bare `this < now` should hold for a past " + value.getClass().getSimpleName());
+    }
+
+    // Negative control: a future value must fail, so the comparison is really happening.
+    AvroSchema future = new AvroSchema(String.format(s, "this < now"));
+    GenericRecord fr = new GenericData.Record(future.rawSchema());
+    fr.put("ts", Instant.now().plusSeconds(3600).toEpochMilli());
+    assertEquals(1, future.validateMessage(new CelValidator(), fr).size());
+
+    // The schema's millis unit is applied, not guessed: bare equality against a known instant.
+    AvroSchema exact = new AvroSchema(
+        String.format(s, "this == timestamp(\\\"2023-11-14T22:13:20.123Z\\\")"));
+    GenericRecord er = new GenericData.Record(exact.rawSchema());
+    er.put("ts", 1700000000123L);
+    assertTrue(exact.validateMessage(new CelValidator(), er).isEmpty());
+
+    // And the timestamp accessors work on it directly.
+    AvroSchema accessor = new AvroSchema(String.format(s, "this.getFullYear() == 2023"));
+    GenericRecord ar = new GenericData.Record(accessor.rawSchema());
+    ar.put("ts", 1700000000123L);
+    assertTrue(accessor.validateMessage(new CelValidator(), ar).isEmpty());
+  }
+
   @Test
   void avroMultiBranchUnion_resolvesTheBranchTheValueTook() {
     // A legal multi-branch union whose arms are a timestamp-millis long AND a plain int. An

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorTimestampTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorTimestampTest.java
@@ -17,24 +17,36 @@
 package io.confluent.kafka.schemaregistry.rules.cel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.Timestamp;
+import dev.cel.common.CelVarDecl;
+import dev.cel.common.types.SimpleType;
+import dev.cel.runtime.CelEvaluationException;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.confluent.kafka.schemaregistry.rules.ValidationRuleError;
+import io.confluent.kafka.schemaregistry.rules.cel.CelUtils.RegexEngine;
+import io.confluent.kafka.schemaregistry.rules.cel.CelUtils.ScriptType;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.List;
+import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.junit.jupiter.api.Test;
 
 /**
- * Integration tests for {@code timestamp.of(dyn)} and
- * {@code timestamp.of(int, string)} against a Proto schema with a
- * {@code google.protobuf.Timestamp} field and a long timestamp-millis field.
+ * Integration tests for the {@code timestamp} constructor: the extension overloads
+ * {@code timestamp(timestamp)} and {@code timestamp(int, int)} alongside the standard
+ * {@code timestamp(string)} and {@code timestamp(int)}, over Proto and Avro schemas.
  */
 public class CelValidatorTimestampTest {
 
@@ -45,7 +57,7 @@ public class CelValidatorTimestampTest {
       + "message Event {\n"
       + "  google.protobuf.Timestamp created_at = 1 [(confluent.field_meta) = {\n"
       + "    rules: [{name: \"notFuture\","
-      + "             expr: \"timestamp.of(this) < now\"}]\n"
+      + "             expr: \"timestamp(this) < now\"}]\n"
       + "  }];\n"
       + "}\n";
 
@@ -80,14 +92,14 @@ public class CelValidatorTimestampTest {
 
   @Test
   void fromEpochMillis_unitArg() {
-    // long field interpreted as epoch millis via timestamp.of(long, "millis").
+    // long field interpreted as epoch millis via timestamp(long, 3).
     String s = "syntax = \"proto3\";\n"
         + "package test;\n"
         + "import \"confluent/meta.proto\";\n"
         + "message X {\n"
         + "  int64 ts_ms = 1 [(confluent.field_meta) = {\n"
         + "    rules: [{name: \"r\","
-        + "             expr: \"timestamp.of(this, \\\"millis\\\") < now\"}]\n"
+        + "             expr: \"timestamp(this, 3) < now\"}]\n"
         + "  }];\n"
         + "}\n";
     ProtobufSchema schema = new ProtobufSchema(s);
@@ -109,14 +121,14 @@ public class CelValidatorTimestampTest {
   }
 
   @Test
-  void fromEpochUnknownUnit_failsAtRuntime() {
+  void unknownPrecision_failsAtRuntime() {
     String s = "syntax = \"proto3\";\n"
         + "package test;\n"
         + "import \"confluent/meta.proto\";\n"
         + "message X {\n"
         + "  int64 ts_ms = 1 [(confluent.field_meta) = {\n"
         + "    rules: [{name: \"r\","
-        + "             expr: \"timestamp.of(this, \\\"weeks\\\") < now\"}]\n"
+        + "             expr: \"timestamp(this, 7) < now\"}]\n"
         + "  }];\n"
         + "}\n";
     ProtobufSchema schema = new ProtobufSchema(s);
@@ -144,7 +156,7 @@ public class CelValidatorTimestampTest {
       + "      },"
       + "      \"confluent:rules\":["
       + "        {\"name\":\"notFuture\","
-      + "         \"expr\":\"timestamp.of(this) < now\"}]"
+      + "         \"expr\":\"timestamp(this) < now\"}]"
       + "    }"
       + "  ]"
       + "}";
@@ -152,7 +164,7 @@ public class CelValidatorTimestampTest {
   @Test
   void avroTimestampMillis_convertersOn_instantArrives_pastPasses() {
     // With useLogicalTypeConverters=true, the timestamp-millis field arrives
-    // as an Instant. timestamp.of(dyn) routes it via TimestampUtils.fromInstant.
+    // as an Instant, which TimestampUtils.toInstant passes straight through.
     AvroSchema schema = new AvroSchema(AVRO_TIMESTAMP_MILLIS_SCHEMA);
     GenericRecord r = new GenericData.Record(schema.rawSchema());
     r.put("created_at", Instant.now().minusSeconds(60));
@@ -170,9 +182,10 @@ public class CelValidatorTimestampTest {
   }
 
   @Test
-  void avroTimestampMillis_convertersOff_rawLongRequiresUnitArg() {
-    // With useLogicalTypeConverters=false, the value is a raw Long; the one-
-    // arg timestamp.of(dyn) throws (no unit). Use the two-arg overload.
+  void avroPlainLong_needsThePrecisionArg() {
+    // A plain long field carries no logical type, so nothing at the boundary can supply a
+    // unit and the one-arg form would read it as epoch seconds. The two-arg overload is how
+    // a rule says what the number means.
     String s = ""
         + "{"
         + "  \"type\":\"record\","
@@ -184,7 +197,7 @@ public class CelValidatorTimestampTest {
         + "      \"type\":\"long\","
         + "      \"confluent:rules\":["
         + "        {\"name\":\"r\","
-        + "         \"expr\":\"timestamp.of(this, \\\"millis\\\") < now\"}]"
+        + "         \"expr\":\"timestamp(this, 3) < now\"}]"
         + "    }"
         + "  ]"
         + "}";
@@ -192,6 +205,153 @@ public class CelValidatorTimestampTest {
     GenericRecord r = new GenericData.Record(schema.rawSchema());
     r.put("ts_ms", Instant.now().minusSeconds(60).toEpochMilli());
     assertTrue(schema.validateMessage(new CelValidator(), r).isEmpty());
+  }
+
+  /** Whether {@code needle} appears anywhere in the cause chain's messages. */
+  private static boolean causeChainContains(Throwable t, String needle) {
+    for (Throwable cause = t; cause != null; cause = cause.getCause()) {
+      if (cause.getMessage() != null && cause.getMessage().contains(needle)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Test
+  void avroTimestampMillis_convertersOff_schemaUnitIsApplied() {
+    // avro.use.logical.type.converters defaults to false, so this value is a bare long whose
+    // unit lives only in the schema. Applying it at the boundary makes the rule read the same
+    // either way; without that, CEL would take the long for epoch seconds.
+    AvroSchema schema = new AvroSchema(AVRO_TIMESTAMP_MILLIS_SCHEMA);
+    GenericRecord past = new GenericData.Record(schema.rawSchema());
+    past.put("created_at", Instant.now().minusSeconds(60).toEpochMilli());
+    assertTrue(schema.validateMessage(new CelValidator(), past).isEmpty());
+
+    GenericRecord future = new GenericData.Record(schema.rawSchema());
+    future.put("created_at", Instant.now().plusSeconds(3600).toEpochMilli());
+    assertEquals(1, schema.validateMessage(new CelValidator(), future).size());
+  }
+
+  @Test
+  void avroTimestampMillis_convertersOff_isNotReadAsSeconds() {
+    // 1700000000123 millis is 2023-11-14T22:13:20.123Z. Read as seconds it would be some
+    // 55000 years on, so this equality is what distinguishes the two readings.
+    String s = ""
+        + "{"
+        + "  \"type\":\"record\","
+        + "  \"name\":\"Event\","
+        + "  \"namespace\":\"test\","
+        + "  \"fields\":["
+        + "    {"
+        + "      \"name\":\"created_at\","
+        + "      \"type\":{"
+        + "        \"type\":\"long\","
+        + "        \"logicalType\":\"timestamp-millis\""
+        + "      },"
+        + "      \"confluent:rules\":["
+        + "        {\"name\":\"exact\","
+        + "         \"expr\":\"timestamp(this) == timestamp(\\\""
+        + "2023-11-14T22:13:20.123Z\\\")\"}]"
+        + "    }"
+        + "  ]"
+        + "}";
+    AvroSchema schema = new AvroSchema(s);
+    GenericRecord r = new GenericData.Record(schema.rawSchema());
+    r.put("created_at", 1700000000123L);
+    assertTrue(schema.validateMessage(new CelValidator(), r).isEmpty());
+  }
+
+  @Test
+  void avroTimestampMicros_convertersOff_schemaUnitIsApplied() {
+    // Sub-millisecond precision survives: 1700000000123456 micros keeps the .123456.
+    String s = ""
+        + "{"
+        + "  \"type\":\"record\","
+        + "  \"name\":\"Event\","
+        + "  \"namespace\":\"test\","
+        + "  \"fields\":["
+        + "    {"
+        + "      \"name\":\"created_at\","
+        + "      \"type\":{"
+        + "        \"type\":\"long\","
+        + "        \"logicalType\":\"timestamp-micros\""
+        + "      },"
+        + "      \"confluent:rules\":["
+        + "        {\"name\":\"exact\","
+        + "         \"expr\":\"timestamp(this) == timestamp(\\\""
+        + "2023-11-14T22:13:20.123456Z\\\")\"}]"
+        + "    }"
+        + "  ]"
+        + "}";
+    AvroSchema schema = new AvroSchema(s);
+    GenericRecord r = new GenericData.Record(schema.rawSchema());
+    r.put("created_at", 1700000000123456L);
+    assertTrue(schema.validateMessage(new CelValidator(), r).isEmpty());
+  }
+
+  @Test
+  void avroLocalTimestampMillis_convertersOff_isStillRefused() {
+    // A local-timestamp value carries no zone, so it is refused rather than silently read at
+    // UTC. Presenting it as a LocalDateTime is what routes it to that refusal instead of
+    // letting a bare long through as an epoch value.
+    String s = ""
+        + "{"
+        + "  \"type\":\"record\","
+        + "  \"name\":\"Event\","
+        + "  \"namespace\":\"test\","
+        + "  \"fields\":["
+        + "    {"
+        + "      \"name\":\"local_at\","
+        + "      \"type\":{"
+        + "        \"type\":\"long\","
+        + "        \"logicalType\":\"local-timestamp-millis\""
+        + "      },"
+        + "      \"confluent:rules\":["
+        + "        {\"name\":\"r\","
+        + "         \"expr\":\"timestamp(this) < now\"}]"
+        + "    }"
+        + "  ]"
+        + "}";
+    AvroSchema schema = new AvroSchema(s);
+    GenericRecord r = new GenericData.Record(schema.rawSchema());
+    r.put("local_at", 1700000000123L);
+    List<ValidationRuleError> errors = schema.validateMessage(new CelValidator(), r);
+    assertEquals(1, errors.size());
+    assertTrue(causeChainContains(errors.get(0).getCause(), "local-timestamp"),
+        "Expected the local-timestamp refusal, got: " + errors.get(0));
+  }
+
+  @Test
+  void avroTimestampMillis_inNestedRecordAndArray_schemaUnitIsApplied() {
+    // The boundary walk has to reach a timestamp nested in a record and inside an array, not
+    // only a top-level field.
+    String s = ""
+        + "{"
+        + "  \"type\":\"record\","
+        + "  \"name\":\"Outer\","
+        + "  \"namespace\":\"test\","
+        + "  \"confluent:rules\":["
+        + "    {\"name\":\"r\","
+        + "     \"expr\":\"timestamp(this.inner.at) == timestamp(\\\""
+        + "2023-11-14T22:13:20.123Z\\\") && "
+        + "timestamp(this.stamps[0]) == timestamp(\\\"2023-11-14T22:13:20.123Z\\\")\"}],"
+        + "  \"fields\":["
+        + "    {\"name\":\"inner\",\"type\":{"
+        + "       \"type\":\"record\",\"name\":\"Inner\",\"fields\":["
+        + "         {\"name\":\"at\",\"type\":{\"type\":\"long\","
+        + "          \"logicalType\":\"timestamp-millis\"}}]}},"
+        + "    {\"name\":\"stamps\",\"type\":{\"type\":\"array\",\"items\":{"
+        + "       \"type\":\"long\",\"logicalType\":\"timestamp-millis\"}}}"
+        + "  ]"
+        + "}";
+    AvroSchema schema = new AvroSchema(s);
+    Schema raw = schema.rawSchema();
+    GenericRecord inner = new GenericData.Record(raw.getField("inner").schema());
+    inner.put("at", 1700000000123L);
+    GenericRecord outer = new GenericData.Record(raw);
+    outer.put("inner", inner);
+    outer.put("stamps", Collections.singletonList(1700000000123L));
+    assertTrue(schema.validateMessage(new CelValidator(), outer).isEmpty());
   }
 
   @Test
@@ -212,7 +372,7 @@ public class CelValidatorTimestampTest {
         + "      },"
         + "      \"confluent:rules\":["
         + "        {\"name\":\"r\","
-        + "         \"expr\":\"timestamp.of(this) < now\"}]"
+        + "         \"expr\":\"timestamp(this) < now\"}]"
         + "    }"
         + "  ]"
         + "}";
@@ -220,5 +380,146 @@ public class CelValidatorTimestampTest {
     GenericRecord r = new GenericData.Record(schema.rawSchema());
     r.put("created_at", Instant.now().minusSeconds(60));
     assertTrue(schema.validateMessage(new CelValidator(), r).isEmpty());
+  }
+
+  // ---- stdlib timestamp(int): bare ints are epoch SECONDS ----
+
+  /** Evaluate a variable-free expression under both regex engines, asserting they agree. */
+  private static Object eval(String expr) throws Exception {
+    Object result = null;
+    for (RegexEngine engine : RegexEngine.values()) {
+      Object current = CelUtils
+          .buildProgram(ScriptType.JSON, expr, null, Collections.emptyList(), engine)
+          .eval();
+      if (result == null) {
+        result = current;
+      } else {
+        assertEquals(result, current, expr + " differed across regex engines");
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Pins the cross-client contract: the stdlib one-arg {@code timestamp(int)} conversion treats a
+   * bare integer as Unix epoch <em>seconds</em>, never millis. cel-java declares this as
+   * {@code int64_to_timestamp} ("Type conversion of integers as Unix epoch seconds to
+   * timestamps") and gates it on {@code CelOptions.enableTimestampEpoch}, which
+   * {@code CelOptions.current()} — and therefore {@code CelOptions.DEFAULT}, which
+   * {@link CelUtils} derives its options from — sets to true. All seven Schema Registry clients
+   * agree on seconds here; this test is the Java anchor for that.
+   */
+  @Test
+  void bareIntToTimestamp_isEpochSeconds() throws Exception {
+    assertEquals("2023-11-14T22:13:20Z", eval("string(timestamp(1700000000))"));
+    assertEquals(Boolean.TRUE,
+        eval("timestamp(1700000000) == timestamp(\"2023-11-14T22:13:20Z\")"));
+    // Not millis: if the int were read as millis this would be 1970-01-20T16:13:20Z.
+    assertEquals(Boolean.FALSE,
+        eval("timestamp(1700000000) == timestamp(\"1970-01-20T16:13:20Z\")"));
+    // Epoch itself, and one second past it.
+    assertEquals("1970-01-01T00:00:00Z", eval("string(timestamp(0))"));
+    assertEquals("1970-01-01T00:00:01Z", eval("string(timestamp(1))"));
+  }
+
+  /** Evaluate {@code expr} with {@code x} declared dyn and bound to {@code value}. */
+  private static Object evalWithDyn(String expr, Object value) throws Exception {
+    return CelUtils.buildProgram(ScriptType.JSON, expr, null,
+            Collections.singletonList(CelVarDecl.newVarDeclaration("x", SimpleType.DYN)))
+        .eval(Collections.singletonMap("x", value));
+  }
+
+  /**
+   * The dispatch that the extension overload has to keep unambiguous. A dyn argument is
+   * assignable to string, int and timestamp alike, so the checker lists all three of
+   * {@code timestamp}'s overload ids and cel-java picks between them by the runtime value's
+   * Java class. That only resolves because the three bindings take disjoint classes — String,
+   * Long and Temporal. Anything wider on our side (Object) would match a String or a Long too
+   * and every one of these calls would fail with AMBIGUOUS_OVERLOAD.
+   */
+  @Test
+  void timestampOfDyn_dispatchesByRuntimeType() throws Exception {
+    // String → stdlib's RFC 3339 parse.
+    assertEquals(Boolean.TRUE,
+        evalWithDyn("timestamp(x) == timestamp(\"2023-11-14T22:13:20Z\")",
+            "2023-11-14T22:13:20Z"));
+    // Long → stdlib's epoch seconds.
+    assertEquals(Boolean.TRUE,
+        evalWithDyn("timestamp(x) == timestamp(\"2023-11-14T22:13:20Z\")", 1700000000L));
+    // Instant → our Temporal overload, passing it through.
+    assertEquals(Boolean.TRUE,
+        evalWithDyn("timestamp(x) == timestamp(\"2023-11-14T22:13:20Z\")",
+            Instant.ofEpochSecond(1700000000L)));
+  }
+
+  /**
+   * The temporal shapes beyond Instant. The standard identity overload binds Instant alone, so
+   * without the extension overload shadowing it these would have no matching overload.
+   */
+  @Test
+  void timestampOfDyn_acceptsOffsetAndZonedDateTime() throws Exception {
+    assertEquals(Boolean.TRUE,
+        evalWithDyn("timestamp(x) == timestamp(\"2023-11-14T22:13:20Z\")",
+            OffsetDateTime.ofInstant(Instant.ofEpochSecond(1700000000L), ZoneOffset.ofHours(5))));
+    assertEquals(Boolean.TRUE,
+        evalWithDyn("timestamp(x) == timestamp(\"2023-11-14T22:13:20Z\")",
+            ZonedDateTime.ofInstant(Instant.ofEpochSecond(1700000000L), ZoneOffset.UTC)));
+  }
+
+  /** A LocalDateTime carries no zone, so it is refused rather than read at some guessed one. */
+  @Test
+  void timestampOfDyn_refusesLocalDateTime() {
+    CelEvaluationException e = assertThrows(CelEvaluationException.class,
+        () -> evalWithDyn("timestamp(x) == timestamp(0)", LocalDateTime.of(2023, 11, 14, 22, 13, 20)));
+    assertTrue(causeChainContains(e, "local-timestamp"),
+        "Expected the local-timestamp refusal, got: " + e);
+  }
+
+  /** All four precisions of the two-arg constructor, and the rejection outside {0, 3, 6, 9}. */
+  @Test
+  void twoArgPrecisions() throws Exception {
+    assertEquals(Boolean.TRUE,
+        eval("timestamp(1700000000, 0) == timestamp(\"2023-11-14T22:13:20Z\")"));
+    assertEquals(Boolean.TRUE,
+        eval("timestamp(1700000000123, 3) == timestamp(\"2023-11-14T22:13:20.123Z\")"));
+    assertEquals(Boolean.TRUE,
+        eval("timestamp(1700000000123456, 6) == timestamp(\"2023-11-14T22:13:20.123456Z\")"));
+    assertEquals(Boolean.TRUE,
+        eval("timestamp(1700000000123456789, 9) "
+            + "== timestamp(\"2023-11-14T22:13:20.123456789Z\")"));
+
+    CelEvaluationException e = assertThrows(CelEvaluationException.class,
+        () -> eval("timestamp(1700000000, 4) == timestamp(0)"));
+    assertTrue(causeChainContains(e, "Unknown timestamp precision"),
+        "Expected the precision rejection, got: " + e);
+  }
+
+  /** Negative bare ints are pre-epoch seconds, not an error and not millis. */
+  @Test
+  void negativeBareIntToTimestamp_isPreEpochSeconds() throws Exception {
+    assertEquals("1969-12-31T23:59:59Z", eval("string(timestamp(-1))"));
+    assertEquals("1969-12-31T00:00:00Z", eval("string(timestamp(-86400))"));
+    assertEquals(Boolean.TRUE,
+        eval("timestamp(-86400) == timestamp(\"1969-12-31T00:00:00Z\")"));
+  }
+
+  /**
+   * The two-arg form is unaffected by the epoch-seconds contract above: it honors the explicit
+   * precision, so the same integer means different instants through the two arities. Keeps the
+   * two entry points distinguishable now that they share a name.
+   */
+  @Test
+  void twoArgPrecision_isUnaffectedByEpochSecondsContract() throws Exception {
+    // Same instant as timestamp(1700000000), reached with an explicit millis value.
+    assertEquals("2023-11-14T22:13:20Z", eval("string(timestamp(1700000000000, 3))"));
+    assertEquals(Boolean.TRUE,
+        eval("timestamp(1700000000000, 3) == timestamp(1700000000)"));
+    // The same integer differs between the two surfaces: seconds vs. millis.
+    assertEquals("1970-01-20T16:13:20Z", eval("string(timestamp(1700000000, 3))"));
+    assertEquals(Boolean.FALSE,
+        eval("timestamp(1700000000, 3) == timestamp(1700000000)"));
+    // "seconds" explicitly agrees with the bare-int conversion.
+    assertEquals(Boolean.TRUE,
+        eval("timestamp(1700000000, 0) == timestamp(1700000000)"));
   }
 }

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorTimestampTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorTimestampTest.java
@@ -355,6 +355,39 @@ public class CelValidatorTimestampTest {
   }
 
   @Test
+  void avroMultiBranchUnion_resolvesTheBranchTheValueTook() {
+    // A legal multi-branch union whose arms are a timestamp-millis long AND a plain int. An
+    // Integer belongs to the int arm, so it must NOT be read as a timestamp; picking the first
+    // non-null branch instead would convert 5 to 1970-01-01T00:00:00.005Z.
+    String s = ""
+        + "{"
+        + "  \"type\":\"record\","
+        + "  \"name\":\"Event\","
+        + "  \"namespace\":\"test\","
+        + "  \"confluent:rules\":["
+        + "    {\"name\":\"r\",\"expr\":\"this.either == 5\"}],"
+        + "  \"fields\":["
+        + "    {\"name\":\"either\",\"type\":["
+        + "       {\"type\":\"long\",\"logicalType\":\"timestamp-millis\"},\"int\"]}"
+        + "  ]"
+        + "}";
+    AvroSchema schema = new AvroSchema(s);
+    GenericRecord asInt = new GenericData.Record(schema.rawSchema());
+    asInt.put("either", 5);
+    assertTrue(schema.validateMessage(new CelValidator(), asInt).isEmpty(),
+        "an int-arm value must stay an int");
+
+    // The long arm of the same union is still normalized to a timestamp.
+    String tsRule = s.replace("this.either == 5",
+        "timestamp(this.either) == timestamp(\\\"2023-11-14T22:13:20.123Z\\\")");
+    AvroSchema tsSchema = new AvroSchema(tsRule);
+    GenericRecord asLong = new GenericData.Record(tsSchema.rawSchema());
+    asLong.put("either", 1700000000123L);
+    assertTrue(tsSchema.validateMessage(new CelValidator(), asLong).isEmpty(),
+        "a long-arm value must be read at the schema's millis unit");
+  }
+
+  @Test
   void avroTimestampMicros_convertersOn_instantArrives() {
     // Same as millis but with the micros logical type. With converters on,
     // Instant arrives regardless of underlying precision.

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorVariantTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorVariantTest.java
@@ -190,6 +190,46 @@ public class CelValidatorVariantTest {
   }
 
   @Test
+  void variantsType_onMissingField_returnsCelNull() throws Exception {
+    // Null-passthrough: variants.type of a missing (CEL null) receiver is CEL null,
+    // not a rule error. Regression for the type/toJson Variant.class binding, which
+    // previously errored on a null receiver instead of propagating it.
+    String s = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "import \"confluent/type/variant.proto\";\n"
+        + "message Doc {\n"
+        + "  confluent.type.Variant payload = 1 [(confluent.field_meta) = {\n"
+        + "    rules: [{name: \"r\","
+        + "             expr: \"variants.type(variants.field(variant(this), \\\"missing\\\"))"
+        + "                    == null\"}]\n"
+        + "  }];\n"
+        + "}\n";
+    ProtobufSchema schema = new ProtobufSchema(s);
+    DynamicMessage doc = docWithVariantJson(schema, "{\"name\":\"alice\"}");
+    assertTrue(schema.validateMessage(new CelValidator(), doc).isEmpty());
+  }
+
+  @Test
+  void variantsToJson_onMissingField_returnsCelNull() throws Exception {
+    // Null-passthrough for variants.toJson (same fix as variants.type above).
+    String s = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "import \"confluent/type/variant.proto\";\n"
+        + "message Doc {\n"
+        + "  confluent.type.Variant payload = 1 [(confluent.field_meta) = {\n"
+        + "    rules: [{name: \"r\","
+        + "             expr: \"variants.toJson(variants.field(variant(this), \\\"missing\\\"))"
+        + "                    == null\"}]\n"
+        + "  }];\n"
+        + "}\n";
+    ProtobufSchema schema = new ProtobufSchema(s);
+    DynamicMessage doc = docWithVariantJson(schema, "{\"name\":\"alice\"}");
+    assertTrue(schema.validateMessage(new CelValidator(), doc).isEmpty());
+  }
+
+  @Test
   void variantsIsNull_onNonNullVariant_returnsFalse() throws Exception {
     String s = "syntax = \"proto3\";\n"
         + "package test;\n"

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorVariantTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorVariantTest.java
@@ -804,6 +804,28 @@ public class CelValidatorVariantTest {
     assertTrue(schema.validateMessage(new CelValidator(), msg).isEmpty());
   }
 
+  @Test
+  void variantsParseJsonNonFinite_isDouble() throws Exception {
+    // Bareword non-finite JSON (NaN/Infinity/-Infinity) parses to a DOUBLE variant.
+    String s = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "message X {\n"
+        + "  int32 anchor = 1 [(confluent.field_meta) = {\n"
+        + "    rules: [{name: \"r\","
+        + "             expr: \"variants.type(variants.parseJson(\\\"NaN\\\")) == \\\"double\\\""
+        + "                    && variants.type(variants.parseJson(\\\"Infinity\\\")) == \\\"double\\\""
+        + "                    && variants.type(variants.parseJson(\\\"-Infinity\\\")) == \\\"double\\\"\"}]\n"
+        + "  }];\n"
+        + "}\n";
+    ProtobufSchema schema = new ProtobufSchema(s);
+    Descriptor desc = schema.toDescriptor("test.X");
+    DynamicMessage msg = DynamicMessage.newBuilder(desc)
+        .setField(desc.findFieldByName("anchor"), 1)
+        .build();
+    assertTrue(schema.validateMessage(new CelValidator(), msg).isEmpty());
+  }
+
   // ---- Avro variant logical type ----
 
   /**

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorVariantTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorVariantTest.java
@@ -1020,4 +1020,40 @@ public class CelValidatorVariantTest {
     List<ValidationRuleError> errs = schema.validateMessage(new CelValidator(), doc);
     assertTrue(errs.isEmpty(), "got: " + errs + " causes: " + dumpCauses(errs));
   }
+
+  /**
+   * {@code variants.isNull} must coerce its receiver like every other accessor. It is declared
+   * over dyn, so a bare variant field reaches it; a raw {@code instanceof Variant} check answered
+   * false for the shapes a variant-typed field actually decodes to, reporting "not null" for a
+   * variant that holds an explicit JSON null.
+   */
+  @Test
+  void variantIsNull_coercesBareReceiver() throws Exception {
+    String template = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "import \"confluent/type/variant.proto\";\n"
+        + "message Doc {\n"
+        + "  confluent.type.Variant payload = 1 [(confluent.field_meta) = {\n"
+        + "    rules: [{name: \"r\", expr: \"%s\"}]\n"
+        + "  }];\n"
+        + "}\n";
+    // An explicit JSON null is a present variant whose top type is NULL.
+    ProtobufSchema nullSchema = new ProtobufSchema(
+        String.format(template, "variants.isNull(this)"));
+    assertTrue(nullSchema.validateMessage(
+            new CelValidator(), docWithVariantJson(nullSchema, "null")).isEmpty(),
+        "bare variants.isNull should hold for an explicit JSON null");
+    // The wrapped form has always worked and must keep working.
+    ProtobufSchema wrapped = new ProtobufSchema(
+        String.format(template, "variants.isNull(variant(this))"));
+    assertTrue(wrapped.validateMessage(
+            new CelValidator(), docWithVariantJson(wrapped, "null")).isEmpty());
+    // A non-null variant is not null.
+    ProtobufSchema notNull = new ProtobufSchema(
+        String.format(template, "!variants.isNull(this)"));
+    assertTrue(notNull.validateMessage(
+            new CelValidator(), docWithVariantJson(notNull, "5")).isEmpty(),
+        "a variant holding 5 is not variant-null");
+  }
 }

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorVariantTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorVariantTest.java
@@ -87,6 +87,46 @@ public class CelValidatorVariantTest {
     assertTrue(errs.isEmpty(), "got: " + errs + " causes: " + dumpCauses(errs));
   }
 
+  /**
+   * Cross-client parity, Protobuf half: a {@code confluent.type.Variant} field is usable with
+   * the {@code variants.*} accessors with <b>no {@code variant(...)} call</b>. The bindings
+   * coerce through {@code VariantUtils.toVariant}, which recognizes the message by its
+   * descriptor's full name — so a {@code DynamicMessage} from a registry-parsed schema works
+   * as well as the generated type.
+   */
+  @Test
+  void protoVariant_usableWithoutTheConstructor() throws Exception {
+    String template = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "import \"confluent/type/variant.proto\";\n"
+        + "message Doc {\n"
+        + "  confluent.type.Variant payload = 1 [(confluent.field_meta) = {\n"
+        + "    rules: [{name: \"r\", expr: \"%s\"}]\n"
+        + "  }];\n"
+        + "}\n";
+    for (String expr : new String[] {
+        // Bare: no constructor call on the field.
+        "variants.type(this) == \\\"object\\\"",
+        "variants.as(variants.field(this, \\\"name\\\"), \\\"string\\\") == \\\"alice\\\"",
+        "variants.as(variants.path(this, \\\"$.name\\\"), \\\"string\\\") == \\\"alice\\\"",
+        // The wrapped form must keep working (variant(...) re-entry).
+        "variants.as(variants.field(variant(this), \\\"name\\\"), \\\"string\\\") == \\\"alice\\\"",
+        // A missing key is CEL null, not an error.
+        "variants.field(this, \\\"nope\\\") == null",
+    }) {
+      ProtobufSchema schema = new ProtobufSchema(String.format(template, expr));
+      DynamicMessage doc = docWithVariantJson(schema, "{\"name\":\"alice\"}");
+      List<ValidationRuleError> errs = schema.validateMessage(new CelValidator(), doc);
+      assertTrue(errs.isEmpty(), expr + " -> " + errs + " causes: " + dumpCauses(errs));
+    }
+    // Negative control: a false comparison must fail.
+    ProtobufSchema schema = new ProtobufSchema(String.format(template,
+        "variants.as(variants.field(this, \\\"name\\\"), \\\"string\\\") == \\\"bob\\\""));
+    assertEquals(1, schema.validateMessage(
+        new CelValidator(), docWithVariantJson(schema, "{\"name\":\"alice\"}")).size());
+  }
+
   private static String dumpCauses(List<ValidationRuleError> errs) {
     StringBuilder sb = new StringBuilder();
     for (ValidationRuleError e : errs) {
@@ -508,13 +548,19 @@ public class CelValidatorVariantTest {
   // ---- variants.* on non-Variant input: clear IAE, not ClassCastException ----
 
   @Test
-  void variantsField_onNonVariantInput_rejectedAtCompileTime() throws Exception {
-    // The Variant-typed receiver lets the type checker reject obviously-wrong
-    // calls at rule compilation time. A rule author who passes a literal
-    // string by mistake gets a "no matching overload" / type-mismatch error
-    // before the rule ever runs, rather than only finding out at evaluation
-    // time. The error surfaces as a RuleException at validateMessage time
-    // because compilation is lazy (deferred until first evaluation).
+  void variantsField_onNonVariantInput_rejectedWithAClearMessage() throws Exception {
+    // A rule author who passes a literal string by mistake gets a clear
+    // "expected Variant, got java.lang.String" rather than a ClassCastException.
+    //
+    // This is an *evaluation*-time error, not a compile-time one: every variants.*
+    // accessor declares its subject as dyn, because a variant value reaches CEL as
+    // whatever the format decoded it to — a Map for an Avro record, a
+    // confluent.type.Variant message for Protobuf — and neither is assignable to an
+    // opaque Variant type at check time. (Before, only some of the accessors were
+    // strict, so the check was inconsistent: variants.as / tryAs / isNull already
+    // took dyn.) The binding coerces through VariantUtils.toVariant, which is what
+    // lets a variant field be used with no variant(...) call, as on every other
+    // client.
     String s = "syntax = \"proto3\";\n"
         + "package test;\n"
         + "import \"confluent/meta.proto\";\n"
@@ -532,13 +578,9 @@ public class CelValidatorVariantTest {
     List<ValidationRuleError> errs = schema.validateMessage(new CelValidator(), msg);
     assertEquals(1, errs.size(),
         "expected non-Variant input to be rejected; got: " + errs);
-    // cel-java's type checker reports either "no matching overload" or
-    // "found no matching overload" depending on version. Match either form.
     String causes = dumpCauses(errs);
-    assertTrue(
-        causes.contains("no matching overload")
-            || causes.contains("found no matching overload"),
-        "expected compile-time overload-mismatch error; got causes: " + causes);
+    assertTrue(causes.contains("expected Variant, got java.lang.String"),
+        "expected a clear non-Variant message; got causes: " + causes);
   }
 
   // ---- variants.tryAs — type-mismatch returns CEL null ----
@@ -882,6 +924,52 @@ public class CelValidatorVariantTest {
     GenericRecord doc = avroDocWithVariantJson("{\"name\":\"alice\"}");
     List<ValidationRuleError> errs = schema.validateMessage(new CelValidator(), doc);
     assertTrue(errs.isEmpty(), "got: " + errs + " causes: " + dumpCauses(errs));
+  }
+
+  /**
+   * Cross-client parity, Avro half: a variant field is usable with the {@code variants.*}
+   * accessors with <b>no {@code variant(...)} call</b>, and the wrapped form keeps working
+   * alongside it. The {@code variants.*} bindings take {@code Object} and coerce through
+   * {@code VariantUtils.toVariant}, which handles the Map the Avro record is converted to —
+   * the same leniency the whole variant surface is built on.
+   */
+  @Test
+  void avroVariant_usableWithoutTheConstructor() throws Exception {
+    for (String expr : new String[] {
+        // Bare: no constructor call on the field.
+        "variants.type(this) == \\\"object\\\"",
+        "variants.as(variants.field(this, \\\"name\\\"), \\\"string\\\") == \\\"alice\\\"",
+        "variants.as(variants.path(this, \\\"$.name\\\"), \\\"string\\\") == \\\"alice\\\"",
+        // The wrapped form must keep working (variant(...) re-entry).
+        "variants.as(variants.field(variant(this), \\\"name\\\"), \\\"string\\\") == \\\"alice\\\"",
+        // A missing key is CEL null, not an error — the null model holds on a bare field too.
+        "variants.field(this, \\\"nope\\\") == null",
+    }) {
+      List<ValidationRuleError> errs = evalAvroVariant(expr, "{\"name\":\"alice\"}");
+      assertTrue(errs.isEmpty(), expr + " -> " + errs + " causes: " + dumpCauses(errs));
+    }
+    // Negative control: a false comparison must fail.
+    assertEquals(1, evalAvroVariant(
+        "variants.as(variants.field(this, \\\"name\\\"), \\\"string\\\") == \\\"bob\\\"",
+        "{\"name\":\"alice\"}").size());
+  }
+
+  /** Evaluate a field-level rule over an Avro variant payload carrying {@code json}. */
+  private static List<ValidationRuleError> evalAvroVariant(String expr, String json)
+      throws Exception {
+    String s = AVRO_VARIANT_SCHEMA.replace(
+        "variants.as(variants.field(variant(this), \\\"name\\\"), \\\"string\\\") "
+            + "== \\\"alice\\\"", expr);
+    AvroSchema schema = new AvroSchema(s);
+    org.apache.avro.Schema docSchema = schema.rawSchema();
+    Variant v = VariantUtils.fromJsonNode(MAPPER.readTree(json));
+    GenericRecord variantRec =
+        new GenericData.Record(docSchema.getField("payload").schema());
+    variantRec.put("metadata", v.getMetadataBuffer());
+    variantRec.put("value", v.getValueBuffer());
+    GenericRecord doc = new GenericData.Record(docSchema);
+    doc.put("payload", variantRec);
+    return schema.validateMessage(new CelValidator(), doc);
   }
 
   @Test

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/DecimalUtilsTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/DecimalUtilsTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.common.primitives.UnsignedLong;
 import com.google.protobuf.ByteString;
 import io.confluent.protobuf.type.Decimal;
 import java.math.BigDecimal;
@@ -48,6 +49,15 @@ public class DecimalUtilsTest {
   @Test
   void dispatchLong_widensExactly() {
     assertEquals(new BigDecimal("42"), DecimalUtils.toBigDecimal(42L));
+  }
+
+  @Test
+  void dispatchUnsignedLong_widensExactly() {
+    // cel-java binds proto uint32/uint64 to Guava UnsignedLong; a value above Long.MAX_VALUE
+    // must not wrap through longValue().
+    assertEquals(new BigDecimal("42"), DecimalUtils.toBigDecimal(UnsignedLong.valueOf(42L)));
+    assertEquals(new BigDecimal("18446744073709551615"),
+        DecimalUtils.toBigDecimal(UnsignedLong.valueOf("18446744073709551615")));
   }
 
   @Test

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/TimestampUtilsTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/TimestampUtilsTest.java
@@ -17,117 +17,117 @@
 package io.confluent.kafka.schemaregistry.rules.cel.builtin;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.protobuf.Timestamp;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import org.junit.jupiter.api.Test;
 
 /**
- * Unit tests for {@link TimestampUtils} — {@link TimestampUtils#toTimestamp(Object)}
- * dispatch and the {@link TimestampUtils#fromEpoch(long, String)} unit-dispatch.
+ * Unit tests for {@link TimestampUtils} — the {@link TimestampUtils#toInstant} dispatch
+ * backing {@code timestamp(timestamp)} and the {@link TimestampUtils#fromEpochPrecision}
+ * precision dispatch backing {@code timestamp(int, int)}.
  */
 public class TimestampUtilsTest {
 
   @Test
-  void dispatchIdentity_passesTimestampThrough() {
-    Timestamp t = Timestamp.newBuilder().setSeconds(100).setNanos(500).build();
-    assertEquals(t, TimestampUtils.toTimestamp(t));
-  }
-
-  @Test
-  void dispatchInstant_converts() {
+  void instant_passesThroughUnchanged() {
     Instant i = Instant.ofEpochSecond(1700000000L, 123456789);
-    Timestamp t = TimestampUtils.toTimestamp(i);
-    assertEquals(1700000000L, t.getSeconds());
-    assertEquals(123456789, t.getNanos());
+    assertSame(i, TimestampUtils.toInstant(i));
   }
 
   @Test
-  void dispatchOffsetDateTime_converts() {
-    OffsetDateTime odt = OffsetDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
-    Timestamp t = TimestampUtils.toTimestamp(odt);
-    assertEquals(odt.toInstant().getEpochSecond(), t.getSeconds());
+  void offsetDateTime_converts() {
+    OffsetDateTime odt = OffsetDateTime.of(2026, 1, 1, 5, 0, 0, 0, ZoneOffset.ofHours(5));
+    assertEquals(odt.toInstant(), TimestampUtils.toInstant(odt));
   }
 
   @Test
-  void dispatchString_parsesRfc3339() {
-    Timestamp t = TimestampUtils.toTimestamp("2026-01-01T00:00:00Z");
-    assertEquals(1767225600L, t.getSeconds());
+  void zonedDateTime_converts() {
+    ZonedDateTime zdt = ZonedDateTime.of(2026, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    assertEquals(zdt.toInstant(), TimestampUtils.toInstant(zdt));
   }
 
   @Test
-  void dispatchLocalDateTime_refusedWithHint() {
+  void localDateTime_refusedWithHint() {
     LocalDateTime ldt = LocalDateTime.of(2026, 1, 1, 12, 0);
     IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-        () -> TimestampUtils.toTimestamp(ldt));
+        () -> TimestampUtils.toInstant(ldt));
     assertTrue(e.getMessage().contains("LocalDateTime"));
-    assertTrue(e.getMessage().contains("timestamp.of"));
+    assertTrue(e.getMessage().contains("local-timestamp"));
   }
 
+  /** A partial temporal is not a timestamp; refused rather than guessed at. */
   @Test
-  void dispatchRawLong_throwsWithUnitHint() {
+  void localDate_refused() {
     IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-        () -> TimestampUtils.toTimestamp(1700000000000L));
-    assertTrue(e.getMessage().contains("timestamp.of"));
+        () -> TimestampUtils.toInstant(LocalDate.of(2026, 1, 1)));
+    assertTrue(e.getMessage().contains("LocalDate"));
   }
 
   @Test
-  void dispatchNull_throws() {
-    assertThrows(IllegalArgumentException.class,
-        () -> TimestampUtils.toTimestamp(null));
+  void precisionSeconds() {
+    assertEquals(Instant.ofEpochSecond(1700000000L),
+        TimestampUtils.fromEpochPrecision(1700000000L, 0));
   }
 
   @Test
-  void fromEpochMillis_basicConversion() {
-    Timestamp t = TimestampUtils.fromEpoch(1500L, "millis");
-    assertEquals(1L, t.getSeconds());
-    assertEquals(500_000_000, t.getNanos());
+  void precisionMillis() {
+    assertEquals(Instant.ofEpochSecond(1L, 500_000_000),
+        TimestampUtils.fromEpochPrecision(1500L, 3));
   }
 
   @Test
-  void fromEpochMicros_basicConversion() {
-    Timestamp t = TimestampUtils.fromEpoch(1_500_000L, "micros");
-    assertEquals(1L, t.getSeconds());
-    assertEquals(500_000_000, t.getNanos());
+  void precisionMicros() {
+    assertEquals(Instant.ofEpochSecond(1L, 500_000_000),
+        TimestampUtils.fromEpochPrecision(1_500_000L, 6));
   }
 
   @Test
-  void fromEpochNanos_basicConversion() {
-    Timestamp t = TimestampUtils.fromEpoch(1_500_000_000L, "nanos");
-    assertEquals(1L, t.getSeconds());
-    assertEquals(500_000_000, t.getNanos());
+  void precisionNanos() {
+    assertEquals(Instant.ofEpochSecond(1L, 500_000_000),
+        TimestampUtils.fromEpochPrecision(1_500_000_000L, 9));
   }
 
+  /** Pre-epoch: floorDiv/floorMod, so the nano adjustment stays non-negative. */
   @Test
-  void fromEpochSeconds_basicConversion() {
-    Timestamp t = TimestampUtils.fromEpoch(1700000000L, "seconds");
-    assertEquals(1700000000L, t.getSeconds());
-    assertEquals(0, t.getNanos());
+  void negativeMillis_floorsCorrectly() {
+    assertEquals(Instant.ofEpochSecond(-1L, 500_000_000),
+        TimestampUtils.fromEpochPrecision(-500L, 3));
   }
 
+  /**
+   * With the unit a number rather than a name, rejecting anything outside {0, 3, 6, 9} is the
+   * only thing between a typo and a silently wrong instant.
+   */
   @Test
-  void fromEpochNegativeMillis_floorDivCorrect() {
-    Timestamp t = TimestampUtils.fromEpoch(-500L, "millis");
-    assertEquals(-1L, t.getSeconds());
-    assertEquals(500_000_000, t.getNanos());
-  }
-
-  @Test
-  void fromEpochUnknownUnit_throws() {
+  void unknownPrecision_throws() {
     IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
-        () -> TimestampUtils.fromEpoch(1L, "weeks"));
-    assertTrue(e.getMessage().contains("weeks"));
+        () -> TimestampUtils.fromEpochPrecision(1L, 7));
+    assertTrue(e.getMessage().contains("7"));
     assertTrue(e.getMessage().contains("millis"));
+
+    // Neighbours of the valid values, and a negative, are all rejected too.
+    for (long precision : new long[] {-3, 1, 2, 4, 5, 8, 10, 12}) {
+      assertThrows(IllegalArgumentException.class,
+          () -> TimestampUtils.fromEpochPrecision(1L, precision),
+          "precision " + precision + " should be rejected");
+    }
   }
 
   @Test
-  void fromEpochNullUnit_throws() {
-    assertThrows(IllegalArgumentException.class,
-        () -> TimestampUtils.fromEpoch(1L, null));
+  void outOfRange_throws() {
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+        () -> TimestampUtils.fromEpochPrecision(Long.MAX_VALUE, 0));
+    assertTrue(e.getMessage().contains("out of range"));
+    // The same value at nanos precision is only ~292 years, so it stays in range.
+    assertEquals(Instant.ofEpochSecond(9223372036L, 854775807L),
+        TimestampUtils.fromEpochPrecision(Long.MAX_VALUE, 9));
   }
 }

--- a/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/Variant.java
+++ b/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/Variant.java
@@ -239,6 +239,8 @@ public final class Variant {
         }
       }
     } else {
+      // Encode the lookup key once, outside the loop, rather than on every comparison.
+      byte[] keyBytes = VariantFormat.encodeKey(key);
       int low = 0;
       int high = info.numElements - 1;
       while (low <= high) {
@@ -249,7 +251,7 @@ public final class Variant {
         int midId = VariantFormat.readUnsignedLittleEndian(
             value, idStart + info.idSize * mid, info.idSize);
         String midKey = VariantFormat.getMetadataKey(metadata, midId);
-        int cmp = VariantFormat.compareKeys(midKey, key);
+        int cmp = VariantFormat.compareKeys(VariantFormat.encodeKey(midKey), keyBytes);
         if (cmp < 0) {
           low = mid + 1;
         } else if (cmp > 0) {

--- a/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/Variant.java
+++ b/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/Variant.java
@@ -207,7 +207,7 @@ public final class Variant {
    * @return the number of object fields in the variant
    * @throws IllegalArgumentException if `getType()` does not return `Type.OBJECT`
    */
-  public int numObjectElements() {
+  public int numObjectFields() {
     return objectInfo().numElements;
   }
 

--- a/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/Variant.java
+++ b/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/Variant.java
@@ -249,7 +249,7 @@ public final class Variant {
         int midId = VariantFormat.readUnsignedLittleEndian(
             value, idStart + info.idSize * mid, info.idSize);
         String midKey = VariantFormat.getMetadataKey(metadata, midId);
-        int cmp = midKey.compareTo(key);
+        int cmp = VariantFormat.compareKeys(midKey, key);
         if (cmp < 0) {
           low = mid + 1;
         } else if (cmp > 0) {

--- a/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantBuilder.java
+++ b/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantBuilder.java
@@ -676,6 +676,12 @@ public class VariantBuilder {
     final int offset;
     int valueSize = 0;
 
+    /**
+     * Lazy cache of the UTF-8 encoding of `key`, which sorting an object compares O(log n) times
+     * per entry. Encoded on demand so single-field objects, which are never compared, skip it.
+     */
+    private byte[] keyBytes;
+
     FieldEntry(String key, int id, int offset) {
       this.key = key;
       this.id = id;
@@ -686,9 +692,16 @@ public class VariantBuilder {
       valueSize = size;
     }
 
+    private byte[] keyBytes() {
+      if (keyBytes == null) {
+        keyBytes = VariantFormat.encodeKey(key);
+      }
+      return keyBytes;
+    }
+
     @Override
     public int compareTo(FieldEntry other) {
-      return VariantFormat.compareKeys(key, other.key);
+      return VariantFormat.compareKeys(keyBytes(), other.keyBytes());
     }
 
     @Override

--- a/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantBuilder.java
+++ b/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantBuilder.java
@@ -455,7 +455,7 @@ public class VariantBuilder {
 
     // copy values to a new builder
     Variant variant = new Variant(value, metadata);
-    for (int index = 0; index < variant.numObjectElements(); index += 1) {
+    for (int index = 0; index < variant.numObjectFields(); index += 1) {
       Variant.ObjectField field = variant.getFieldAtIndex(index);
       if (!suppressedKeys.contains(field.key)) {
         objectBuilder.appendKey(field.key);

--- a/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantBuilder.java
+++ b/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantBuilder.java
@@ -688,7 +688,7 @@ public class VariantBuilder {
 
     @Override
     public int compareTo(FieldEntry other) {
-      return key.compareTo(other.key);
+      return VariantFormat.compareKeys(key, other.key);
     }
 
     @Override

--- a/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantFormat.java
+++ b/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantFormat.java
@@ -305,8 +305,17 @@ class VariantFormat {
   }
 
   /**
-   * Compares two object field keys by the unsigned lexicographic order of their UTF-8 encoded
-   * bytes, as required by the Variant spec for object field ordering.
+   * Encodes an object field key to the UTF-8 bytes that {@link #compareKeys} orders. Callers that
+   * compare the same key repeatedly - sorting an object, or binary-searching it for one key -
+   * should encode it once and reuse the result rather than re-encoding per comparison.
+   */
+  static byte[] encodeKey(String key) {
+    return key.getBytes(StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Compares two object field keys, given their UTF-8 encodings, by unsigned lexicographic byte
+   * order, as required by the Variant spec for object field ordering.
    *
    * <p>This intentionally differs from {@link String#compareTo}, which compares UTF-16 code
    * units. The two orderings agree for all keys in the Basic Multilingual Plane but diverge for
@@ -316,9 +325,8 @@ class VariantFormat {
    * ids are mis-sorted relative to the spec, breaking binary-search lookups by any reader that
    * follows the spec's UTF-8 byte ordering.
    */
-  static int compareKeys(String a, String b) {
-    return Arrays.compareUnsigned(
-        a.getBytes(StandardCharsets.UTF_8), b.getBytes(StandardCharsets.UTF_8));
+  static int compareKeys(byte[] a, byte[] b) {
+    return Arrays.compareUnsigned(a, b);
   }
 
   /**

--- a/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantFormat.java
+++ b/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantFormat.java
@@ -305,6 +305,23 @@ class VariantFormat {
   }
 
   /**
+   * Compares two object field keys by the unsigned lexicographic order of their UTF-8 encoded
+   * bytes, as required by the Variant spec for object field ordering.
+   *
+   * <p>This intentionally differs from {@link String#compareTo}, which compares UTF-16 code
+   * units. The two orderings agree for all keys in the Basic Multilingual Plane but diverge for
+   * supplementary-plane characters (U+10000 and above): {@code String#compareTo} orders a leading
+   * high surrogate (0xD800-0xDBFF) before code points in U+E000..U+FFFF, whereas UTF-8 byte order
+   * (and the spec) orders them after. Using UTF-16 order here would produce objects whose field
+   * ids are mis-sorted relative to the spec, breaking binary-search lookups by any reader that
+   * follows the spec's UTF-8 byte ordering.
+   */
+  static int compareKeys(String a, String b) {
+    return Arrays.compareUnsigned(
+        a.getBytes(StandardCharsets.UTF_8), b.getBytes(StandardCharsets.UTF_8));
+  }
+
+  /**
    * Fast little-endian unsigned read using bulk ByteBuffer operations.
    * Requires the buffer to have {@link java.nio.ByteOrder#LITTLE_ENDIAN} byte order.
    * Adapted from Apache Iceberg's VariantUtil.readLittleEndianUnsigned.

--- a/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantUtils.java
+++ b/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantUtils.java
@@ -16,10 +16,13 @@
 
 package io.confluent.kafka.schemaregistry.type;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamWriteFeature;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
+import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -48,11 +51,18 @@ public class VariantUtils {
   private static final JsonNodeFactory FACTORY = JsonNodeFactory.instance;
 
   /**
-   * Serializer for {@link #toJsonString}. WRITE_BIGDECIMAL_AS_PLAIN renders decimals in
-   * fixed-point form (never scientific), the cross-language contract for variant JSON.
+   * Shared Jackson mapper for both {@link #fromJson} and {@link #toJsonString}.
+   * ALLOW_NON_NUMERIC_NUMBERS reads bareword {@code NaN}/{@code Infinity}/{@code -Infinity};
+   * WRITE_BIGDECIMAL_AS_PLAIN renders decimals in fixed-point form (never scientific), the
+   * cross-language contract for variant JSON; WRITE_NAN_AS_STRINGS is disabled so non-finite
+   * doubles/floats are written as barewords ({@code NaN}) rather than quoted strings
+   * ({@code "NaN"}) — a deliberate divergence from Spark, keeping the round-trip symmetric.
    */
-  private static final ObjectMapper JSON_MAPPER = new ObjectMapper()
-      .configure(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN, true);
+  private static final ObjectMapper JSON_MAPPER = JsonMapper.builder()
+      .enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)
+      .enable(StreamWriteFeature.WRITE_BIGDECIMAL_AS_PLAIN)
+      .disable(JsonWriteFeature.WRITE_NAN_AS_STRINGS)
+      .build();
 
   /**
    * Converts a Variant into a Jackson JsonNode.
@@ -195,6 +205,23 @@ public class VariantUtils {
       return String.format(Locale.ROOT, ".%06d", nano / 1_000);
     }
     return String.format(Locale.ROOT, ".%09d", nano);
+  }
+
+  /**
+   * Parses a JSON string into a Variant using the shared mapper. Bareword non-finite
+   * numbers ({@code NaN}, {@code Infinity}, {@code -Infinity}) are accepted, as are
+   * out-of-range magnitudes ({@code 1e400} becomes {@code Infinity}).
+   *
+   * @param json the JSON string to parse
+   * @return a Variant containing the encoded metadata and value
+   * @throws IllegalArgumentException if the JSON cannot be parsed
+   */
+  public static Variant fromJson(String json) {
+    try {
+      return fromJsonNode(JSON_MAPPER.readTree(json));
+    } catch (JsonProcessingException | IllegalStateException e) {
+      throw new IllegalArgumentException("Cannot parse JSON for variant: " + e.getMessage(), e);
+    }
   }
 
   /**

--- a/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantUtils.java
+++ b/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantUtils.java
@@ -121,7 +121,7 @@ public class VariantUtils {
 
   private static JsonNode objectToJson(Variant variant) {
     ObjectNode obj = FACTORY.objectNode();
-    for (int i = 0; i < variant.numObjectElements(); i++) {
+    for (int i = 0; i < variant.numObjectFields(); i++) {
       Variant.ObjectField field = variant.getFieldAtIndex(i);
       obj.set(field.key, toJsonNode(field.value));
     }

--- a/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantUtils.java
+++ b/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantUtils.java
@@ -56,7 +56,7 @@ public class VariantUtils {
    * WRITE_BIGDECIMAL_AS_PLAIN renders decimals in fixed-point form (never scientific), the
    * cross-language contract for variant JSON; WRITE_NAN_AS_STRINGS is disabled so non-finite
    * doubles/floats are written as barewords ({@code NaN}) rather than quoted strings
-   * ({@code "NaN"}) — a deliberate divergence from Spark, keeping the round-trip symmetric.
+   * ({@code "NaN"}).
    */
   private static final ObjectMapper JSON_MAPPER = JsonMapper.builder()
       .enable(JsonReadFeature.ALLOW_NON_NUMERIC_NUMBERS)
@@ -218,7 +218,12 @@ public class VariantUtils {
    */
   public static Variant fromJson(String json) {
     try {
-      return fromJsonNode(JSON_MAPPER.readTree(json));
+      JsonNode node = JSON_MAPPER.readTree(json);
+      if (node == null) {
+        // readTree returns null for empty or whitespace-only input.
+        throw new IllegalArgumentException("Cannot parse JSON for variant: empty input");
+      }
+      return fromJsonNode(node);
     } catch (JsonProcessingException | IllegalStateException e) {
       throw new IllegalArgumentException("Cannot parse JSON for variant: " + e.getMessage(), e);
     }

--- a/schema-types/src/test/java/io/confluent/kafka/schemaregistry/type/TestVariantArrayBuilder.java
+++ b/schema-types/src/test/java/io/confluent/kafka/schemaregistry/type/TestVariantArrayBuilder.java
@@ -117,7 +117,7 @@ public class TestVariantArrayBuilder {
       Assert.assertTrue(v.getElementAtIndex(0).getBoolean());
 
       VariantTestUtils.checkType(v.getElementAtIndex(1), VariantFormat.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(1, v.getElementAtIndex(1).numObjectElements());
+      Assert.assertEquals(1, v.getElementAtIndex(1).numObjectFields());
       VariantTestUtils.checkType(
           v.getElementAtIndex(1).getFieldByKey("key"), VariantFormat.PRIMITIVE, Variant.Type.INT);
       Assert.assertEquals(321, v.getElementAtIndex(1).getFieldByKey("key").getInt());
@@ -133,7 +133,7 @@ public class TestVariantArrayBuilder {
       VariantTestUtils.checkType(nested.getElementAtIndex(1), VariantFormat.SHORT_STR, Variant.Type.STRING);
       Assert.assertEquals("variant", nested.getElementAtIndex(1).getString());
       VariantTestUtils.checkType(nested.getElementAtIndex(2), VariantFormat.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(0, nested.getElementAtIndex(2).numObjectElements());
+      Assert.assertEquals(0, nested.getElementAtIndex(2).numObjectFields());
     });
   }
 

--- a/schema-types/src/test/java/io/confluent/kafka/schemaregistry/type/TestVariantJsonConverter.java
+++ b/schema-types/src/test/java/io/confluent/kafka/schemaregistry/type/TestVariantJsonConverter.java
@@ -351,6 +351,63 @@ public class TestVariantJsonConverter {
     Assert.assertEquals("0.0000001", VariantUtils.toJsonString(builder.build()));
   }
 
+  // -- non-finite doubles/floats: bareword round-trip --
+
+  @Test
+  public void testFromJsonNonFiniteBarewordRoundTrip() {
+    // Non-finite values parse from and serialize back to BAREWORDS (no quotes) — a
+    // deliberate divergence from Spark, which quotes them. The round-trip is symmetric.
+    Assert.assertEquals("NaN", VariantUtils.toJsonString(VariantUtils.fromJson("NaN")));
+    Assert.assertEquals("Infinity", VariantUtils.toJsonString(VariantUtils.fromJson("Infinity")));
+    Assert.assertEquals(
+        "-Infinity", VariantUtils.toJsonString(VariantUtils.fromJson("-Infinity")));
+  }
+
+  @Test
+  public void testFromJsonOverflowBecomesInfinity() {
+    // A magnitude too large for double overflows to Infinity and serializes as a bareword.
+    Assert.assertEquals("Infinity", VariantUtils.toJsonString(VariantUtils.fromJson("1e400")));
+  }
+
+  @Test
+  public void testFromJsonNanIsDouble() {
+    Variant variant = VariantUtils.fromJson("NaN");
+    Assert.assertEquals(Variant.Type.DOUBLE, variant.getType());
+    Assert.assertTrue(Double.isNaN(variant.getDouble()));
+  }
+
+  @Test
+  public void testBuilderNonFiniteDoubleBareword() {
+    // The builder accepts non-finite doubles (no guard), and toJsonString emits a bareword.
+    VariantBuilder builder = new VariantBuilder();
+    builder.appendDouble(Double.NaN);
+    Variant variant = builder.build();
+    Assert.assertEquals("NaN", VariantUtils.toJsonString(variant));
+
+    builder = new VariantBuilder();
+    builder.appendDouble(Double.POSITIVE_INFINITY);
+    Assert.assertEquals("Infinity", VariantUtils.toJsonString(builder.build()));
+
+    builder = new VariantBuilder();
+    builder.appendDouble(Double.NEGATIVE_INFINITY);
+    Assert.assertEquals("-Infinity", VariantUtils.toJsonString(builder.build()));
+  }
+
+  @Test
+  public void testBuilderNonFiniteFloatBareword() {
+    VariantBuilder builder = new VariantBuilder();
+    builder.appendFloat(Float.NaN);
+    Assert.assertEquals("NaN", VariantUtils.toJsonString(builder.build()));
+
+    builder = new VariantBuilder();
+    builder.appendFloat(Float.POSITIVE_INFINITY);
+    Assert.assertEquals("Infinity", VariantUtils.toJsonString(builder.build()));
+
+    builder = new VariantBuilder();
+    builder.appendFloat(Float.NEGATIVE_INFINITY);
+    Assert.assertEquals("-Infinity", VariantUtils.toJsonString(builder.build()));
+  }
+
   @Test
   public void testToJsonTemporalUsesAsciiDigitsRegardlessOfLocale() {
     // The temporal formatters must emit ASCII digits even when the default locale uses

--- a/schema-types/src/test/java/io/confluent/kafka/schemaregistry/type/TestVariantJsonConverter.java
+++ b/schema-types/src/test/java/io/confluent/kafka/schemaregistry/type/TestVariantJsonConverter.java
@@ -409,6 +409,16 @@ public class TestVariantJsonConverter {
   }
 
   @Test
+  public void testFromJsonEmptyInputThrowsIllegalArgument() {
+    // readTree returns null for empty/whitespace-only input; fromJson must surface that as
+    // IllegalArgumentException (its documented contract) rather than a NullPointerException,
+    // so the CEL soft-failure handler (variants.tryParseJson) can catch it.
+    Assert.assertThrows(IllegalArgumentException.class, () -> VariantUtils.fromJson(""));
+    Assert.assertThrows(IllegalArgumentException.class, () -> VariantUtils.fromJson("   "));
+    Assert.assertThrows(IllegalArgumentException.class, () -> VariantUtils.fromJson("\t\n"));
+  }
+
+  @Test
   public void testToJsonTemporalUsesAsciiDigitsRegardlessOfLocale() {
     // The temporal formatters must emit ASCII digits even when the default locale uses
     // non-ASCII native digits (here Arabic-Indic, forced via the -u-nu-arab extension).

--- a/schema-types/src/test/java/io/confluent/kafka/schemaregistry/type/TestVariantObject.java
+++ b/schema-types/src/test/java/io/confluent/kafka/schemaregistry/type/TestVariantObject.java
@@ -137,7 +137,7 @@ public class TestVariantObject {
     Variant value = new Variant(ByteBuffer.wrap(new byte[] {0b10, 0x00}), VariantTestUtils.EMPTY_METADATA);
     VariantTestUtils.testVariant(value, v -> {
       VariantTestUtils.checkType(v, VariantFormat.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(0, v.numObjectElements());
+      Assert.assertEquals(0, v.numObjectFields());
     });
   }
 
@@ -147,7 +147,7 @@ public class TestVariantObject {
         ByteBuffer.wrap(new byte[] {0b1000010, 0x00, 0x00, 0x00, 0x00}), VariantTestUtils.EMPTY_METADATA);
     VariantTestUtils.testVariant(value, v -> {
       VariantTestUtils.checkType(v, VariantFormat.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(0, v.numObjectElements());
+      Assert.assertEquals(0, v.numObjectFields());
     });
   }
 
@@ -161,7 +161,7 @@ public class TestVariantObject {
         constructMetadata(false, ImmutableList.of("c", "b", "a")));
     VariantTestUtils.testVariant(value, v -> {
       VariantTestUtils.checkType(v, VariantFormat.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(3, v.numObjectElements());
+      Assert.assertEquals(3, v.numObjectFields());
       VariantTestUtils.checkType(v.getFieldByKey("a"), VariantFormat.PRIMITIVE, Variant.Type.INT);
       Assert.assertEquals(1234567890, v.getFieldByKey("a").getInt());
       VariantTestUtils.checkType(v.getFieldByKey("b"), VariantFormat.PRIMITIVE, Variant.Type.BOOLEAN);
@@ -182,7 +182,7 @@ public class TestVariantObject {
         constructMetadata(true, ImmutableList.of("a", "b", "c")));
     VariantTestUtils.testVariant(value, v -> {
       VariantTestUtils.checkType(v, VariantFormat.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(3, v.numObjectElements());
+      Assert.assertEquals(3, v.numObjectFields());
       VariantTestUtils.checkType(v.getFieldByKey("a"), VariantFormat.PRIMITIVE, Variant.Type.INT);
       Assert.assertEquals(1234567890, v.getFieldByKey("a").getInt());
       VariantTestUtils.checkType(v.getFieldByKey("b"), VariantFormat.PRIMITIVE, Variant.Type.BOOLEAN);
@@ -190,7 +190,7 @@ public class TestVariantObject {
       VariantTestUtils.checkType(v.getFieldByKey("c"), VariantFormat.OBJECT, Variant.Type.OBJECT);
 
       Variant nestedV = v.getFieldByKey("c");
-      Assert.assertEquals(2, nestedV.numObjectElements());
+      Assert.assertEquals(2, nestedV.numObjectFields());
       VariantTestUtils.checkType(nestedV.getFieldByKey("a"), VariantFormat.PRIMITIVE, Variant.Type.DATE);
       Assert.assertEquals(
           LocalDate.parse("2025-04-17"),
@@ -209,7 +209,7 @@ public class TestVariantObject {
         constructMetadata(true, ImmutableList.of("a", "b", "c")));
     VariantTestUtils.testVariant(value, v -> {
       VariantTestUtils.checkType(v, VariantFormat.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(3, v.numObjectElements());
+      Assert.assertEquals(3, v.numObjectFields());
       VariantTestUtils.checkType(v.getFieldByKey("a"), VariantFormat.PRIMITIVE, Variant.Type.INT);
       Assert.assertEquals(1234567890, v.getFieldByKey("a").getInt());
       VariantTestUtils.checkType(v.getFieldByKey("b"), VariantFormat.PRIMITIVE, Variant.Type.BOOLEAN);
@@ -229,7 +229,7 @@ public class TestVariantObject {
         constructMetadata(true, ImmutableList.of("a", "b", "c")));
     VariantTestUtils.testVariant(value, v -> {
       VariantTestUtils.checkType(v, VariantFormat.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(3, v.numObjectElements());
+      Assert.assertEquals(3, v.numObjectFields());
       VariantTestUtils.checkType(v.getFieldByKey("a"), VariantFormat.PRIMITIVE, Variant.Type.STRING);
       Assert.assertEquals(randomString, v.getFieldByKey("a").getString());
       VariantTestUtils.checkType(v.getFieldByKey("b"), VariantFormat.PRIMITIVE, Variant.Type.BOOLEAN);
@@ -273,7 +273,7 @@ public class TestVariantObject {
         constructMetadata(true, fieldNames));
     VariantTestUtils.testVariant(value, v -> {
       VariantTestUtils.checkType(v, VariantFormat.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(2, v.numObjectElements());
+      Assert.assertEquals(2, v.numObjectFields());
       VariantTestUtils.checkType(v.getFieldByKey("z1"), VariantFormat.PRIMITIVE, Variant.Type.BOOLEAN);
       Assert.assertTrue(v.getFieldByKey("z1").getBoolean());
       VariantTestUtils.checkType(v.getFieldByKey("z2"), VariantFormat.PRIMITIVE, Variant.Type.INT);
@@ -316,7 +316,7 @@ public class TestVariantObject {
         new Variant(ByteBuffer.wrap(constructObject(keys, fields, false)), constructMetadata(true, sortedKeys));
     VariantTestUtils.testVariant(value, v -> {
       VariantTestUtils.checkType(v, VariantFormat.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(1000, v.numObjectElements());
+      Assert.assertEquals(1000, v.numObjectFields());
 
       for (int i = 0; i < 1000; i++) {
         String name = String.format("a%04d", i);
@@ -333,7 +333,7 @@ public class TestVariantObject {
     try {
       // An array header
       Variant value = new Variant(ByteBuffer.wrap(new byte[] {0b10011}), VariantTestUtils.EMPTY_METADATA);
-      value.numObjectElements();
+      value.numObjectFields();
       Assert.fail("Expected exception not thrown");
     } catch (Exception e) {
       Assert.assertEquals("Cannot read ARRAY value as OBJECT", e.getMessage());

--- a/schema-types/src/test/java/io/confluent/kafka/schemaregistry/type/TestVariantObjectBuilder.java
+++ b/schema-types/src/test/java/io/confluent/kafka/schemaregistry/type/TestVariantObjectBuilder.java
@@ -33,7 +33,7 @@ public class TestVariantObjectBuilder {
     b.endObject();
     VariantTestUtils.testVariant(b.build(), v -> {
       VariantTestUtils.checkType(v, VariantFormat.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(0, v.numObjectElements());
+      Assert.assertEquals(0, v.numObjectFields());
     });
   }
 
@@ -48,7 +48,7 @@ public class TestVariantObjectBuilder {
     b.endObject();
     VariantTestUtils.testVariant(b.build(), v -> {
       VariantTestUtils.checkType(v, VariantFormat.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(1234, v.numObjectElements());
+      Assert.assertEquals(1234, v.numObjectFields());
       for (int i = 0; i < 1234; i++) {
         VariantTestUtils.checkType(v.getFieldByKey("a" + i), VariantFormat.PRIMITIVE, Variant.Type.LONG);
         Assert.assertEquals(i, v.getFieldByKey("a" + i).getLong());
@@ -81,7 +81,7 @@ public class TestVariantObjectBuilder {
 
     VariantTestUtils.testVariant(b.build(), v -> {
       VariantTestUtils.checkType(v, VariantFormat.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(v.numObjectElements(), 2);
+      Assert.assertEquals(v.numObjectFields(), 2);
       // UTF-8 byte order: EF BF BF < F0 90 80 80, so the BMP key comes first.
       Assert.assertEquals(v.getFieldAtIndex(0).key, bmpKey);
       Assert.assertEquals(v.getFieldAtIndex(1).key, supplementaryKey);
@@ -115,7 +115,7 @@ public class TestVariantObjectBuilder {
     b.endObject();
 
     VariantTestUtils.testVariant(b.build(), v -> {
-      Assert.assertEquals(v.numObjectElements(), 42);
+      Assert.assertEquals(v.numObjectFields(), 42);
       Assert.assertNotNull(v.getFieldByKey(bmpKey));
       Assert.assertEquals(v.getFieldByKey(bmpKey).getLong(), 998);
       Assert.assertNotNull(v.getFieldByKey(supplementaryKey));
@@ -157,7 +157,7 @@ public class TestVariantObjectBuilder {
 
     VariantTestUtils.testVariant(b.build(), v -> {
       VariantTestUtils.checkType(v, VariantFormat.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(4, v.numObjectElements());
+      Assert.assertEquals(4, v.numObjectFields());
       VariantTestUtils.checkType(v.getFieldByKey("outer 1"), VariantFormat.PRIMITIVE, Variant.Type.BOOLEAN);
       Assert.assertTrue(v.getFieldByKey("outer 1").getBoolean());
       VariantTestUtils.checkType(v.getFieldByKey("outer 2"), VariantFormat.PRIMITIVE, Variant.Type.LONG);
@@ -165,9 +165,9 @@ public class TestVariantObjectBuilder {
       VariantTestUtils.checkType(v.getFieldByKey("outer 3"), VariantFormat.OBJECT, Variant.Type.OBJECT);
 
       Variant nested = v.getFieldByKey("outer 3");
-      Assert.assertEquals(3, nested.numObjectElements());
+      Assert.assertEquals(3, nested.numObjectFields());
       VariantTestUtils.checkType(nested.getFieldByKey("nested 1"), VariantFormat.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(0, nested.getFieldByKey("nested 1").numObjectElements());
+      Assert.assertEquals(0, nested.getFieldByKey("nested 1").numObjectFields());
       VariantTestUtils.checkType(nested.getFieldByKey("nested 2"), VariantFormat.SHORT_STR, Variant.Type.STRING);
       Assert.assertEquals("variant", nested.getFieldByKey("nested 2").getString());
       VariantTestUtils.checkType(nested.getFieldByKey("nested 3"), VariantFormat.ARRAY, Variant.Type.ARRAY);
@@ -198,7 +198,7 @@ public class TestVariantObjectBuilder {
 
     VariantTestUtils.testVariant(b.build(), v -> {
       VariantTestUtils.checkType(v, VariantFormat.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(2, v.numObjectElements());
+      Assert.assertEquals(2, v.numObjectFields());
       Assert.assertEquals(
           ByteBuffer.wrap(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
           v.getFieldByKey("as_binary").getBinary());
@@ -238,9 +238,9 @@ public class TestVariantObjectBuilder {
       for (int i = 1000; i >= 0; i--) {
         VariantTestUtils.checkType(curr, VariantFormat.OBJECT, Variant.Type.OBJECT);
         if (i == 0) {
-          Assert.assertEquals(0, curr.numObjectElements());
+          Assert.assertEquals(0, curr.numObjectFields());
         } else {
-          Assert.assertEquals(2, curr.numObjectElements());
+          Assert.assertEquals(2, curr.numObjectFields());
           VariantTestUtils.checkType(
               curr.getFieldByKey("key" + i), VariantFormat.SHORT_STR, Variant.Type.STRING);
           Assert.assertEquals("str" + i, curr.getFieldByKey("key" + i).getString());
@@ -263,7 +263,7 @@ public class TestVariantObjectBuilder {
 
     Variant v = b.build();
     VariantTestUtils.checkType(v, VariantFormat.OBJECT, Variant.Type.OBJECT);
-    Assert.assertEquals(3, v.numObjectElements());
+    Assert.assertEquals(3, v.numObjectFields());
     VariantTestUtils.checkType(v.getFieldByKey("key1"), VariantFormat.PRIMITIVE, Variant.Type.STRING);
     Assert.assertEquals(randomString, v.getFieldByKey("key1").getString());
     VariantTestUtils.checkType(v.getFieldByKey("key2"), VariantFormat.PRIMITIVE, Variant.Type.BOOLEAN);
@@ -301,7 +301,7 @@ public class TestVariantObjectBuilder {
 
     Variant v = b.build();
     VariantTestUtils.checkType(v, VariantFormat.OBJECT, Variant.Type.OBJECT);
-    Assert.assertEquals(numKeys, v.numObjectElements());
+    Assert.assertEquals(numKeys, v.numObjectFields());
     // Only check a few keys, to avoid slowing down the test
     VariantTestUtils.checkType(v.getFieldByKey("k" + 0), VariantFormat.PRIMITIVE, Variant.Type.LONG);
     Assert.assertEquals(0, v.getFieldByKey("k" + 0).getLong());
@@ -338,7 +338,7 @@ public class TestVariantObjectBuilder {
     objBuilder.appendLong(1);
     b.endObject();
     Variant v = b.build();
-    Assert.assertEquals(1, v.numObjectElements());
+    Assert.assertEquals(1, v.numObjectFields());
     VariantTestUtils.checkType(v.getFieldByKey("duplicate"), VariantFormat.PRIMITIVE, Variant.Type.LONG);
     Assert.assertEquals(1, v.getFieldByKey("duplicate").getLong());
   }
@@ -356,7 +356,7 @@ public class TestVariantObjectBuilder {
     b.endObject();
     VariantTestUtils.testVariant(b.build(), v -> {
       VariantTestUtils.checkType(v, VariantFormat.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(1, v.numObjectElements());
+      Assert.assertEquals(1, v.numObjectFields());
       Variant variant = v.getFieldByKey("duplicate");
       VariantTestUtils.checkType(variant, VariantFormat.SHORT_STR, Variant.Type.STRING);
       Assert.assertEquals("hello", variant.getString());
@@ -376,7 +376,7 @@ public class TestVariantObjectBuilder {
     b.endObject();
     VariantTestUtils.testVariant(b.build(), v -> {
       VariantTestUtils.checkType(v, VariantFormat.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(1, v.numObjectElements());
+      Assert.assertEquals(1, v.numObjectFields());
       Variant variant = v.getFieldByKey("duplicate");
       VariantTestUtils.checkType(variant, VariantFormat.PRIMITIVE, Variant.Type.INT);
       Assert.assertEquals(1, variant.getInt());
@@ -402,7 +402,7 @@ public class TestVariantObjectBuilder {
     b.endObject();
     VariantTestUtils.testVariant(b.build(), v -> {
       VariantTestUtils.checkType(v, VariantFormat.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(3, v.numObjectElements());
+      Assert.assertEquals(3, v.numObjectFields());
       Assert.assertEquals("a-final", v.getFieldByKey("a").getString());
       Assert.assertEquals(123456789L, v.getFieldByKey("b").getLong());
       Assert.assertEquals("c-only", v.getFieldByKey("c").getString());
@@ -423,7 +423,7 @@ public class TestVariantObjectBuilder {
     objBuilder.appendString("22");
     b.endObject();
     Variant v = b.build();
-    Assert.assertEquals(4, v.numObjectElements());
+    Assert.assertEquals(4, v.numObjectFields());
     VariantTestUtils.checkType(v.getFieldByKey("0"), VariantFormat.SHORT_STR, Variant.Type.STRING);
     Assert.assertEquals("", v.getFieldByKey("0").getString());
     VariantTestUtils.checkType(v.getFieldByKey("1"), VariantFormat.SHORT_STR, Variant.Type.STRING);

--- a/schema-types/src/test/java/io/confluent/kafka/schemaregistry/type/TestVariantObjectBuilder.java
+++ b/schema-types/src/test/java/io/confluent/kafka/schemaregistry/type/TestVariantObjectBuilder.java
@@ -56,6 +56,74 @@ public class TestVariantObjectBuilder {
     });
   }
 
+  /**
+   * Object field keys must be ordered by the unsigned byte order of their UTF-8 encoding, not by
+   * {@link String#compareTo} (UTF-16 code-unit order). The two orderings disagree for
+   * supplementary-plane keys: U+FFFF encodes to UTF-8 {@code EF BF BF} and U+10000 to
+   * {@code F0 90 80 80}, so U+FFFF must sort first; but in UTF-16 the leading high surrogate
+   * 0xD800 of U+10000 sorts before 0xFFFF, which would wrongly put U+10000 first. See
+   * {@link VariantFormat#compareKeys}.
+   */
+  @Test
+  public void testObjectKeysSortedByUtf8ByteOrder() {
+    String bmpKey = "￿"; // U+FFFF -> UTF-8 EF BF BF
+    String supplementaryKey = "𐀀"; // U+10000 -> UTF-8 F0 90 80 80
+
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder o = b.startObject();
+    // Appended in the "wrong" order on purpose, to prove the builder sorts rather than
+    // preserving insertion order.
+    o.appendKey(supplementaryKey);
+    o.appendLong(2);
+    o.appendKey(bmpKey);
+    o.appendLong(1);
+    b.endObject();
+
+    VariantTestUtils.testVariant(b.build(), v -> {
+      VariantTestUtils.checkType(v, VariantFormat.OBJECT, Variant.Type.OBJECT);
+      Assert.assertEquals(v.numObjectElements(), 2);
+      // UTF-8 byte order: EF BF BF < F0 90 80 80, so the BMP key comes first.
+      Assert.assertEquals(v.getFieldAtIndex(0).key, bmpKey);
+      Assert.assertEquals(v.getFieldAtIndex(1).key, supplementaryKey);
+      Assert.assertEquals(v.getFieldByKey(bmpKey).getLong(), 1);
+      Assert.assertEquals(v.getFieldByKey(supplementaryKey).getLong(), 2);
+    });
+  }
+
+  /**
+   * A large object (>= BINARY_SEARCH_THRESHOLD) that mixes ASCII keys with U+FFFF and a
+   * supplementary-plane key, exercising the reader's binary-search path in
+   * {@link Variant#getFieldByKey}. The binary search must use the same UTF-8 byte ordering as the
+   * builder's sort; with a UTF-16 comparator on the read side, the supplementary key would be
+   * mis-navigated and not found.
+   */
+  @Test
+  public void testLargeObjectBinarySearchWithSupplementaryKey() {
+    String bmpKey = "￿"; // UTF-8 EF BF BF
+    String supplementaryKey = "𐀀"; // UTF-8 F0 90 80 80
+
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder o = b.startObject();
+    for (int i = 0; i < 40; i++) { // well above BINARY_SEARCH_THRESHOLD (32)
+      o.appendKey(String.format("a%03d", i));
+      o.appendLong(i);
+    }
+    o.appendKey(bmpKey);
+    o.appendLong(998);
+    o.appendKey(supplementaryKey);
+    o.appendLong(999);
+    b.endObject();
+
+    VariantTestUtils.testVariant(b.build(), v -> {
+      Assert.assertEquals(v.numObjectElements(), 42);
+      Assert.assertNotNull(v.getFieldByKey(bmpKey));
+      Assert.assertEquals(v.getFieldByKey(bmpKey).getLong(), 998);
+      Assert.assertNotNull(v.getFieldByKey(supplementaryKey));
+      Assert.assertEquals(v.getFieldByKey(supplementaryKey).getLong(), 999);
+      Assert.assertEquals(v.getFieldByKey("a037").getLong(), 37);
+    });
+  }
+
   @Test
   public void testMixedObjectBuilder() {
     VariantBuilder b = new VariantBuilder();


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
### 1. Fix object field-name comparison to UTF-8 byte order (correctness)
Field names must be ordered by the unsigned byte order of their UTF-8 encoding, not
`String.compareTo` (UTF-16). The two disagree for supplementary-plane keys (e.g. U+FFFF
vs U+10000), mis-ordering keys on write and mis-resolving them on binary-search read.
Added `VariantFormat.compareKeys(byte[],byte[])` (`Arrays.compareUnsigned` on UTF-8) and
`encodeKey`, used by the builder sort and `Variant.getFieldByKey`.

### 2. Rename `numObjectElements` → `numObjectFields`
Cross-language consistency with the six ports (which already use `numObjectFields`).
This API has not shipped yet.

### 3. Null-passthrough and bare-receiver coercion for `variants.*`
`variants.type`, `variants.toJson`, and `variants.isNull` now uniformly propagate CEL
null on a navigation miss and coerce a bare variant-typed field (a proto
`confluent.type.Variant` message, or the Map an Avro variant record converts to) the
same way every other `variants.*` accessor already does — so a variant field can be
used with `variants.*` directly, with no `variant(...)` wrapper call, matching the other
six clients.

### 4. Support `decimal(<unsigned int>)`
`DecimalUtils.toBigDecimal` gained an `UnsignedLong` (Guava) arm — cel-java binds proto
`uint32`/`uint64` to `UnsignedLong`, which previously fell through to a throw. Widens via
`bigIntegerValue()` (no `longValue()` wrap, so values > `Long.MAX_VALUE` stay exact).

### 5. Support non-finite doubles/floats as bareword JSON
The Variant binary format stores non-finite `double`/`float`; JSON now round-trips them
as **bareword** `NaN`/`Infinity`/`-Infinity`. Consolidated the single read+write mapper in
`schema-types VariantUtils` (`ALLOW_NON_NUMERIC_NUMBERS` on read; `WRITE_NAN_AS_STRINGS`
disabled so output is bareword; `WRITE_BIGDECIMAL_AS_PLAIN` retained), added a shared
`VariantUtils.fromJson(String)`, and had the CEL-layer `VariantUtils` delegate to it.

### 6. Fix Decimal equality (`CelDecimal` wrapper)
`decimal("2.0") == decimal("2.0")` was **false**: cel-java's stdlib equality routes two
`BigDecimal`s through `ComparisonFunctions.numericEquals`, which only understands
Double/Long/UnsignedLong. Introduced `CelDecimal`, a deliberately non-`Number` wrapper
whose `equals` is `compareTo(...) == 0`, so the stock stdlib bindings (and every place
that reaches a value's own `equals` directly — `in`, container/nested equality) answer
numerically. Also fixes decimal equality when a Decimal is nested one level inside a
list or map (`[a] == [b]`, `a in [b]`), which the standard container-recursion path
compares independently of top-level `==` and would otherwise disagree with it.

### 7. Bare Decimal / Variant fields — no constructor call needed
A protobuf `confluent.type.Decimal` field, or an Avro `decimal`-logical-type field, can
now be used directly with `decimals.*` and `==`/`!=` with no `decimal(...)` wrapper —
matching what the other six clients already do. `CelTypeLabels.DECIMAL` changed from an
`OpaqueType` to a `StructTypeReference` so a bare proto Decimal field and a
`decimal(...)`-constructed value share one type identity at the checker level. `==`/`!=`
are overridden (via `CelInternalRuntimeLibrary`) to compare numerically whenever either
side carries a Decimal, delegating to the standard implementation otherwise.


### 8. Avro schema-aware boundary normalization for timestamp and decimal logical types
A `timestamp-millis`/`-micros`/`-nanos` or `decimal` Avro field reaches a rule as a bare
`long`/bytes value when `useLogicalTypeConverters=false` (the default) — its unit/scale
lives only in the schema. `CelUtils.toCelValue(value, schema)` now normalizes such a
field to the `java.time`/`CelDecimal` value the `timestamp`/`decimals.*` overloads
expect, taking the unit or scale from the schema — including through nested records,
arrays, and multi-branch unions (resolved via Avro's own `resolveUnion`, not a
first-non-null-branch guess). Without this, `timestamp(this.ts)` on a raw
`timestamp-millis` long would silently read it as epoch *seconds*.

### 9. Upgrade cel-java to 0.13.1 and migrate to the planner runtime
`CelRuntimeFactory.plannerRuntimeBuilder()` replaces `standardCelRuntimeBuilder()` (the
legacy runtime is being deprecated upstream). `BuiltinLibrary` now also implements
`CelInternalRuntimeLibrary` so it can re-register `timestamp`/`string`/`double`/`==`/
`!=`/`in` as extended standard functions rather than a separate namespace, which the
planner runtime's dyn-argument dispatch requires.

<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
