### PR TITLE
neutralize store-write error message

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/client/LocalSchemaRegistryClient.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/client/LocalSchemaRegistryClient.java
@@ -214,7 +214,7 @@ public class LocalSchemaRegistryClient implements SchemaRegistryClient {
       throw Errors.operationTimeoutException("Register operation timed out", e);
     } catch (SchemaRegistryStoreException e) {
       throw Errors.storeException("Register schema operation failed while writing"
-          + " to the Kafka store", e);
+          + " to the backend store", e);
     } catch (SchemaRegistryRequestForwardingException e) {
       throw Errors.requestForwardingFailedException("Error while forwarding register schema request"
           + " to the leader", e);
@@ -681,7 +681,7 @@ public class LocalSchemaRegistryClient implements SchemaRegistryClient {
       throw Errors.operationTimeoutException("Delete Schema Version operation timed out", e);
     } catch (SchemaRegistryStoreException e) {
       throw Errors.storeException("Delete Schema Version operation failed while writing"
-          + " to the Kafka store", e);
+          + " to the backend store", e);
     } catch (SchemaRegistryRequestForwardingException e) {
       throw Errors
           .requestForwardingFailedException("Error while forwarding delete schema version request"

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/AssociationsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/AssociationsResource.java
@@ -289,9 +289,9 @@ public class AssociationsResource {
     } catch (OperationNotPermittedException e) {
       throw Errors.operationNotPermittedException(e.getMessage());
     } catch (SchemaRegistryTimeoutException e) {
-      throw Errors.operationTimeoutException("Register operation timed out", e);
+      throw Errors.operationTimeoutException("Create association operation timed out", e);
     } catch (SchemaRegistryStoreException e) {
-      throw Errors.storeException("Register schema operation failed while writing"
+      throw Errors.storeException("Create association operation failed while writing"
           + " to the backend store", e);
     } catch (SchemaRegistryRequestForwardingException e) {
       throw Errors.requestForwardingFailedException(
@@ -380,9 +380,9 @@ public class AssociationsResource {
     } catch (OperationNotPermittedException e) {
       throw Errors.operationNotPermittedException(e.getMessage());
     } catch (SchemaRegistryTimeoutException e) {
-      throw Errors.operationTimeoutException("Register operation timed out", e);
+      throw Errors.operationTimeoutException("Create or update association operation timed out", e);
     } catch (SchemaRegistryStoreException e) {
-      throw Errors.storeException("Register schema operation failed while writing"
+      throw Errors.storeException("Create or update association operation failed while writing"
           + " to the backend store", e);
     } catch (SchemaRegistryRequestForwardingException e) {
       throw Errors.requestForwardingFailedException(
@@ -459,9 +459,9 @@ public class AssociationsResource {
           context, dryRun, request, headerProperties);
       asyncResponse.resume(Response.status(207).entity(response).build());
     } catch (SchemaRegistryTimeoutException e) {
-      throw Errors.operationTimeoutException("Register operation timed out", e);
+      throw Errors.operationTimeoutException("Mutate associations operation timed out", e);
     } catch (SchemaRegistryStoreException e) {
-      throw Errors.storeException("Register schema operation failed while writing"
+      throw Errors.storeException("Mutate associations operation failed while writing"
           + " to the backend store", e);
     } catch (SchemaRegistryRequestForwardingException e) {
       throw Errors.requestForwardingFailedException(
@@ -532,9 +532,9 @@ public class AssociationsResource {
     } catch (OperationNotPermittedException e) {
       throw Errors.operationNotPermittedException(e.getMessage());
     } catch (SchemaRegistryTimeoutException e) {
-      throw Errors.operationTimeoutException("Register operation timed out", e);
+      throw Errors.operationTimeoutException("Delete associations operation timed out", e);
     } catch (SchemaRegistryStoreException e) {
-      throw Errors.storeException("Register schema operation failed while writing"
+      throw Errors.storeException("Delete associations operation failed while writing"
           + " to the backend store", e);
     } catch (SchemaRegistryRequestForwardingException e) {
       throw Errors.requestForwardingFailedException(

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/AssociationsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/AssociationsResource.java
@@ -294,8 +294,9 @@ public class AssociationsResource {
       throw Errors.storeException("Register schema operation failed while writing"
           + " to the backend store", e);
     } catch (SchemaRegistryRequestForwardingException e) {
-      throw Errors.requestForwardingFailedException("Error while forwarding register schema request"
-          + " to the leader", e);
+      throw Errors.requestForwardingFailedException(
+          "Error while forwarding create association request"
+              + " to the leader", e);
     } catch (UnknownLeaderException e) {
       throw Errors.unknownLeaderException("Leader not known.", e);
     } catch (SchemaRegistryException e) {
@@ -384,8 +385,9 @@ public class AssociationsResource {
       throw Errors.storeException("Register schema operation failed while writing"
           + " to the backend store", e);
     } catch (SchemaRegistryRequestForwardingException e) {
-      throw Errors.requestForwardingFailedException("Error while forwarding register schema request"
-          + " to the leader", e);
+      throw Errors.requestForwardingFailedException(
+          "Error while forwarding create or update association request"
+              + " to the leader", e);
     } catch (UnknownLeaderException e) {
       throw Errors.unknownLeaderException("Leader not known.", e);
     } catch (SchemaRegistryException e) {
@@ -462,8 +464,9 @@ public class AssociationsResource {
       throw Errors.storeException("Register schema operation failed while writing"
           + " to the backend store", e);
     } catch (SchemaRegistryRequestForwardingException e) {
-      throw Errors.requestForwardingFailedException("Error while forwarding register schema request"
-          + " to the leader", e);
+      throw Errors.requestForwardingFailedException(
+          "Error while forwarding mutate associations request"
+              + " to the leader", e);
     } catch (UnknownLeaderException e) {
       throw Errors.unknownLeaderException("Leader not known.", e);
     } catch (SchemaRegistryException e) {
@@ -534,8 +537,9 @@ public class AssociationsResource {
       throw Errors.storeException("Register schema operation failed while writing"
           + " to the backend store", e);
     } catch (SchemaRegistryRequestForwardingException e) {
-      throw Errors.requestForwardingFailedException("Error while forwarding register schema request"
-          + " to the leader", e);
+      throw Errors.requestForwardingFailedException(
+          "Error while forwarding delete associations request"
+              + " to the leader", e);
     } catch (UnknownLeaderException e) {
       throw Errors.unknownLeaderException("Leader not known.", e);
     } catch (SchemaRegistryException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/AssociationsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/AssociationsResource.java
@@ -292,7 +292,7 @@ public class AssociationsResource {
       throw Errors.operationTimeoutException("Register operation timed out", e);
     } catch (SchemaRegistryStoreException e) {
       throw Errors.storeException("Register schema operation failed while writing"
-          + " to the Kafka store", e);
+          + " to the backend store", e);
     } catch (SchemaRegistryRequestForwardingException e) {
       throw Errors.requestForwardingFailedException("Error while forwarding register schema request"
           + " to the leader", e);
@@ -382,7 +382,7 @@ public class AssociationsResource {
       throw Errors.operationTimeoutException("Register operation timed out", e);
     } catch (SchemaRegistryStoreException e) {
       throw Errors.storeException("Register schema operation failed while writing"
-          + " to the Kafka store", e);
+          + " to the backend store", e);
     } catch (SchemaRegistryRequestForwardingException e) {
       throw Errors.requestForwardingFailedException("Error while forwarding register schema request"
           + " to the leader", e);
@@ -460,7 +460,7 @@ public class AssociationsResource {
       throw Errors.operationTimeoutException("Register operation timed out", e);
     } catch (SchemaRegistryStoreException e) {
       throw Errors.storeException("Register schema operation failed while writing"
-          + " to the Kafka store", e);
+          + " to the backend store", e);
     } catch (SchemaRegistryRequestForwardingException e) {
       throw Errors.requestForwardingFailedException("Error while forwarding register schema request"
           + " to the leader", e);
@@ -532,7 +532,7 @@ public class AssociationsResource {
       throw Errors.operationTimeoutException("Register operation timed out", e);
     } catch (SchemaRegistryStoreException e) {
       throw Errors.storeException("Register schema operation failed while writing"
-          + " to the Kafka store", e);
+          + " to the backend store", e);
     } catch (SchemaRegistryRequestForwardingException e) {
       throw Errors.requestForwardingFailedException("Error while forwarding register schema request"
           + " to the leader", e);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -722,9 +722,9 @@ public class SubjectVersionsResource {
     } catch (OperationNotPermittedException e) {
       throw Errors.operationNotPermittedException(e.getMessage());
     } catch (SchemaRegistryTimeoutException e) {
-      throw Errors.operationTimeoutException("Register operation timed out", e);
+      throw Errors.operationTimeoutException("Modify tags operation timed out", e);
     } catch (SchemaRegistryStoreException e) {
-      throw Errors.storeException("Register schema operation failed while writing"
+      throw Errors.storeException("Modify tags operation failed while writing"
           + " to the backend store", e);
     } catch (SchemaRegistryRequestForwardingException e) {
       throw Errors.requestForwardingFailedException("Error while forwarding modify tags request"

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -511,7 +511,7 @@ public class SubjectVersionsResource {
       throw Errors.operationTimeoutException("Register operation timed out", e);
     } catch (SchemaRegistryStoreException e) {
       throw Errors.storeException("Register schema operation failed while writing"
-                                  + " to the Kafka store", e);
+                                  + " to the backend store", e);
     } catch (SchemaRegistryRequestForwardingException e) {
       throw Errors.requestForwardingFailedException("Error while forwarding register schema request"
                                                     + " to the leader", e);
@@ -599,7 +599,7 @@ public class SubjectVersionsResource {
       throw Errors.operationTimeoutException("Delete Schema Version operation timed out", e);
     } catch (SchemaRegistryStoreException e) {
       throw Errors.storeException("Delete Schema Version operation failed while writing"
-                                  + " to the Kafka store", e);
+                                  + " to the backend store", e);
     } catch (SchemaRegistryRequestForwardingException e) {
       throw Errors
           .requestForwardingFailedException("Error while forwarding delete schema version request"
@@ -725,7 +725,7 @@ public class SubjectVersionsResource {
       throw Errors.operationTimeoutException("Register operation timed out", e);
     } catch (SchemaRegistryStoreException e) {
       throw Errors.storeException("Register schema operation failed while writing"
-          + " to the Kafka store", e);
+          + " to the backend store", e);
     } catch (SchemaRegistryRequestForwardingException e) {
       throw Errors.requestForwardingFailedException("Error while forwarding register schema request"
           + " to the leader", e);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -727,7 +727,7 @@ public class SubjectVersionsResource {
       throw Errors.storeException("Register schema operation failed while writing"
           + " to the backend store", e);
     } catch (SchemaRegistryRequestForwardingException e) {
-      throw Errors.requestForwardingFailedException("Error while forwarding register schema request"
+      throw Errors.requestForwardingFailedException("Error while forwarding modify tags request"
           + " to the leader", e);
     } catch (IncompatibleSchemaException e) {
       throw Errors.incompatibleSchemaException("Schema being registered is incompatible with"


### PR DESCRIPTION
## Summary

Improves the user-facing error messages returned when a write operation fails:

- Neutralizes wording that named a specific internal storage implementation.
- Corrects forwarded-request error messages that named the wrong operation.

## Changes

**Neutralize store-write wording**

Reworded `SchemaRegistryStoreException` failure messages from "Kafka store" to
the more neutral "backend store" in the subject-versions and associations REST
resources and in the local client (register / delete flows).

**Correct forwarded-request wording**

The request-forwarding failure messages for the association endpoints and the
modify-tags endpoint previously all read "register schema request" regardless
of the endpoint. Each now names its actual operation:

- create association
- create or update association
- mutate associations
- delete associations
- modify tags

## Notes

- Error-message text only; no behavior or public API changes.
