### PR TITLE
DGS-25100: Use getAllVersions in isSubjectReferenced 

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -1676,8 +1676,12 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
    */
   protected boolean isSubjectReferenced(String subject) throws SchemaRegistryException {
     try {
-      for (SchemaKey key : getAllSchemaKeysDescending(subject)) {
-        if (!getReferencedBy(key, true).isEmpty()) {
+      // Use getAllVersions rather than getAllSchemaKeysDescending: subclasses can override the
+      // former with a store-native version lookup, whereas the latter's range scan over
+      // SchemaKeys is not implemented by every backing store. Order is irrelevant here.
+      Iterator<SchemaKey> versions = getAllVersions(subject, LookupFilter.INCLUDE_DELETED);
+      while (versions.hasNext()) {
+        if (!getReferencedBy(versions.next(), true).isEmpty()) {
           return true;
         }
       }


### PR DESCRIPTION
## Summary

Follow-up to #4513 (already merged). Routes the association-side reference check through `getAllVersions` instead of `getAllSchemaKeysDescending`.

Behavior is unchanged: both return all versions including soft-deleted, and iteration order is irrelevant to the check.

## Testing

`RestApiAssociationTest` (full class, 81 tests) passes, including `testCreateStrongAssociationRejectedWhenSoftDeletedHigherVersionIsReferenced`, which proves the swap still returns soft-deleted versions. Checkstyle and spotbugs clean.
