### PR TITLE
DGS-25119 Bound Struct/List/Map materialization in AvroData.toConnectData

### DIFF
--- a/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-data/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -336,6 +336,7 @@ public class AvroData {
   private boolean discardTypeDocDefault;
   private boolean allowOptionalMapKey;
   private boolean flattenSingletonUnions;
+  private int maxToConnectDataObjects;
 
   public AvroData(int cacheSize) {
     this(new AvroDataConfig.Builder()
@@ -354,6 +355,7 @@ public class AvroData {
     this.discardTypeDocDefault = avroDataConfig.isDiscardTypeDocDefault();
     this.allowOptionalMapKey = avroDataConfig.isAllowOptionalMapKeys();
     this.flattenSingletonUnions = avroDataConfig.isFlattenSingletonUnions();
+    this.maxToConnectDataObjects = avroDataConfig.getMaxToConnectDataObjects();
   }
 
   /**
@@ -1601,6 +1603,7 @@ public class AvroData {
           Schema valueSchema = schema.valueSchema();
           Collection<Object> original = (Collection<Object>) value;
           List<Object> result = new ArrayList<>(original.size());
+          trackConvertedContainer(toConnectContext);
           for (Object elem : original) {
             result.add(toConnectData(valueSchema, elem, toConnectContext));
           }
@@ -1616,6 +1619,7 @@ public class AvroData {
             // Non-optional string keys
             Map<CharSequence, Object> original = (Map<CharSequence, Object>) value;
             Map<CharSequence, Object> result = new HashMap<>(original.size());
+            trackConvertedContainer(toConnectContext);
             for (Map.Entry<CharSequence, Object> entry : original.entrySet()) {
               result.put(entry.getKey().toString(),
                          toConnectData(valueSchema, entry.getValue(), toConnectContext));
@@ -1625,6 +1629,7 @@ public class AvroData {
             // Arbitrary keys
             Collection<IndexedRecord> original = (Collection<IndexedRecord>) value;
             Map<Object, Object> result = new HashMap<>(original.size());
+            trackConvertedContainer(toConnectContext);
             for (IndexedRecord entry : original) {
               int avroKeyFieldIndex = entry.getSchema().getField(KEY_FIELD).pos();
               int avroValueFieldIndex = entry.getSchema().getField(VALUE_FIELD).pos();
@@ -1653,6 +1658,7 @@ public class AvroData {
               Schema fieldSchema = field.schema();
               if (isInstanceOfAvroSchemaTypeForSimpleSchema(fieldSchema, value, index)
                   || (valueRecordSchema != null && schemaEquals(valueRecordSchema, fieldSchema))) {
+                trackConvertedContainer(toConnectContext);
                 converted = new Struct(schema).put(
                     unionMemberFieldName(fieldSchema, index),
                     toConnectData(fieldSchema, value, toConnectContext));
@@ -1667,6 +1673,7 @@ public class AvroData {
             // Default values from Avro are returned as Map
             Map<CharSequence, Object> original = (Map<CharSequence, Object>) value;
             Struct result = new Struct(schema);
+            trackConvertedContainer(toConnectContext);
             for (Field field : schema.fields()) {
               String fieldName = scrubName(field.name());
               Object convertedFieldValue = toConnectData(field.schema(),
@@ -1678,6 +1685,7 @@ public class AvroData {
           } else {
             IndexedRecord original = (IndexedRecord) value;
             Struct result = new Struct(schema);
+            trackConvertedContainer(toConnectContext);
             for (Field field : schema.fields()) {
               String fieldName = scrubName(field.name());
               int avroFieldIndex = original.getSchema().getField(fieldName).pos();
@@ -1704,6 +1712,20 @@ public class AvroData {
     } catch (ClassCastException e) {
       String schemaType = schema != null ? schema.type().toString() : "null";
       throw new DataException("Invalid type for " + schemaType + ": " + value.getClass());
+    }
+  }
+
+  /**
+   * Tracks one more Struct/List/Map materialized while converting the current record, failing
+   * fast if the record has exceeded the configured limit rather than continuing to allocate.
+   */
+  private void trackConvertedContainer(ToConnectContext toConnectContext) {
+    if (++toConnectContext.convertedObjectCount > maxToConnectDataObjects) {
+      throw new DataException(
+          "Exceeded the maximum of " + maxToConnectDataObjects + " Struct/List/Map objects "
+          + "allowed while converting a single Avro record to Connect data (see the '"
+          + AvroDataConfig.MAX_TO_CONNECT_DATA_OBJECTS_CONFIG + "' configuration); rejecting "
+          + "this record instead of risking exhaustion of the worker's memory.");
     }
   }
 
@@ -2680,6 +2702,9 @@ public class AvroData {
   private static class ToConnectContext {
     private final Map<org.apache.avro.Schema, CyclicSchemaWrapper> cycleReferences;
     private final Set<org.apache.avro.Schema> detectedCycles;
+    // Count of Struct/List/Map objects materialized so far while converting the current
+    // top-level record, used to bound memory use for deeply or widely nested records.
+    private int convertedObjectCount = 0;
 
     /**
      * cycleReferences - map that holds connect Schema references to resolve cycles

--- a/avro-data/src/main/java/io/confluent/connect/avro/AvroDataConfig.java
+++ b/avro-data/src/main/java/io/confluent/connect/avro/AvroDataConfig.java
@@ -51,6 +51,15 @@ public class AvroDataConfig extends AbstractDataConfig {
   public static final boolean FLATTEN_SINGLETON_UNIONS_DEFAULT = true;
   public static final String FLATTEN_SINGLETON_UNIONS_DOC = "Whether to flatten singleton unions";
 
+  public static final String MAX_TO_CONNECT_DATA_OBJECTS_CONFIG = "max.to.connect.data.objects";
+  public static final int MAX_TO_CONNECT_DATA_OBJECTS_DEFAULT = 1_000_000;
+  public static final String MAX_TO_CONNECT_DATA_OBJECTS_DOC =
+      "The maximum number of Struct, List, and Map objects that may be materialized while "
+      + "converting a single Avro record to Connect data. Deeply or widely nested records can "
+      + "otherwise expand into an unbounded number of objects during conversion and exhaust "
+      + "the JVM heap. Once a record would exceed this limit, conversion fails with a "
+      + "DataException for that record instead of continuing to allocate memory.";
+
   @Deprecated
   public static final String DISCARD_TYPE_DOC_DEFAULT_CONFIG = "discard.type.doc.default";
   public static final boolean DISCARD_TYPE_DOC_DEFAULT_DEFAULT = false;
@@ -83,7 +92,12 @@ public class AvroDataConfig extends AbstractDataConfig {
                 ConfigDef.Type.BOOLEAN,
             FLATTEN_SINGLETON_UNIONS_DEFAULT,
                 ConfigDef.Importance.LOW,
-            FLATTEN_SINGLETON_UNIONS_DOC);
+            FLATTEN_SINGLETON_UNIONS_DOC)
+        .define(MAX_TO_CONNECT_DATA_OBJECTS_CONFIG,
+                ConfigDef.Type.INT,
+                MAX_TO_CONNECT_DATA_OBJECTS_DEFAULT,
+                ConfigDef.Importance.LOW,
+                MAX_TO_CONNECT_DATA_OBJECTS_DOC);
   }
 
   public AvroDataConfig(Map<?, ?> props) {
@@ -112,6 +126,10 @@ public class AvroDataConfig extends AbstractDataConfig {
 
   public boolean isFlattenSingletonUnions() {
     return this.getBoolean(FLATTEN_SINGLETON_UNIONS_CONFIG);
+  }
+
+  public int getMaxToConnectDataObjects() {
+    return this.getInt(MAX_TO_CONNECT_DATA_OBJECTS_CONFIG);
   }
 
   public static class Builder {

--- a/avro-data/src/test/java/io/confluent/connect/avro/AvroDataTest.java
+++ b/avro-data/src/test/java/io/confluent/connect/avro/AvroDataTest.java
@@ -3192,6 +3192,65 @@ public class AvroDataTest {
     assertEquals(person, genericRecord);
   }
 
+  @Test(expected = DataException.class)
+  public void testToConnectDataFailsFastOnDeeplyNestedRecordExceedingObjectLimit() {
+    // A record whose friends chain is deeper than the configured object limit should be
+    // rejected with a DataException rather than being fully materialized into memory.
+    AvroDataConfig avroDataConfig = new AvroDataConfig.Builder()
+        .with(AvroDataConfig.CONNECT_META_DATA_CONFIG, false)
+        .with(AvroDataConfig.MAX_TO_CONNECT_DATA_OBJECTS_CONFIG, 5)
+        .build();
+    AvroData graphAvroData = new AvroData(avroDataConfig);
+
+    org.apache.avro.Schema graphSchema = buildFriendsChainSchema();
+    org.apache.avro.Schema friendsListSchema =
+        graphSchema.getField("friends").schema().getTypes().get(1);
+    GenericRecord person = buildFriendsChain(graphSchema, friendsListSchema, 10);
+
+    graphAvroData.toConnectData(graphSchema, person);
+  }
+
+  @Test
+  public void testToConnectDataSucceedsWhenWithinObjectLimit() {
+    // The same shape of record succeeds when it falls within the configured object limit.
+    AvroDataConfig avroDataConfig = new AvroDataConfig.Builder()
+        .with(AvroDataConfig.CONNECT_META_DATA_CONFIG, false)
+        .with(AvroDataConfig.MAX_TO_CONNECT_DATA_OBJECTS_CONFIG, 100)
+        .build();
+    AvroData graphAvroData = new AvroData(avroDataConfig);
+
+    org.apache.avro.Schema graphSchema = buildFriendsChainSchema();
+    org.apache.avro.Schema friendsListSchema =
+        graphSchema.getField("friends").schema().getTypes().get(1);
+    GenericRecord person = buildFriendsChain(graphSchema, friendsListSchema, 10);
+
+    SchemaAndValue schemaAndValue = graphAvroData.toConnectData(graphSchema, person);
+    assertNonNullSchemaValue(schemaAndValue);
+  }
+
+  private org.apache.avro.Schema buildFriendsChainSchema() {
+    org.apache.avro.Schema.Parser avroParser = new org.apache.avro.Schema.Parser();
+    String graphAvroSchema = "{\"type\": \"record\",\"name\": \"Users\",\"fields\" : [{\"name\": " +
+        "\"name\", \"type\": \"string\"},{\"name\": \"friends\", \"type\" : [ \"null\", " +
+        "{\"type\": \"array\", \"items\":\"Users\"}], \"default\" : null}]}";
+    return avroParser.parse(graphAvroSchema);
+  }
+
+  // Builds a chain of `depth` records, each with exactly one friend: the previous record.
+  private GenericRecord buildFriendsChain(
+      org.apache.avro.Schema graphSchema, org.apache.avro.Schema friendsListSchema, int depth) {
+    GenericRecord current = new GenericRecordBuilder(graphSchema)
+        .set("name", "Person 0")
+        .build();
+    for (int i = 1; i < depth; i++) {
+      current = new GenericRecordBuilder(graphSchema)
+          .set("name", "Person " + i)
+          .set("friends", new GenericData.Array(friendsListSchema, Arrays.asList(current)))
+          .build();
+    }
+    return current;
+  }
+
   private void assertMapCycle(
       Long current, Object value, Map<Long, Map<String, Long>> expectedMap) {
 


### PR DESCRIPTION
## Summary
- `AvroData.toConnectData` fully materializes a converted Avro record into Connect's `Struct`/`List`/`Map` representation with no bound on depth or fan-out. A record with deep nesting and array fan-out (e.g. a self-referential/tree-shaped schema) can expand into tens of millions of these objects during conversion, exhausting the worker's heap before the record ever reaches the sink task.
- Adds a new `AvroDataConfig` setting, `max.to.connect.data.objects` (default `1,000,000`), that bounds how many `Struct`/`List`/`Map` objects a single record's conversion may materialize.
- Once a record would exceed the limit, conversion now fails fast with a `DataException` for that one record, instead of continuing to allocate. Connect's existing error-tolerance/DLQ handling (`errors.tolerance: all`) then skips just that record — the worker no longer OOMs and crashes every task on the pod.

## Context
Fixes [DGS-25119](https://confluentinc.atlassian.net/browse/DGS-25119), root-caused from INC-12805 ("High pod restarts on pcc-ze72ngw") — a customer's S3 sink connector was consuming a deeply-nested, self-referential Avro schema; live thread dumps showed the connector stuck recursing through `AvroData.toConnectData`/`ConnectSchema.validateValue`, never reaching `S3SinkTask.put`, and heap histograms showed ~32.7M live `Struct`/`ArrayList` objects (~9.6GB) for what was a ~90-byte-on-the-wire record. This isn't Cloud-specific — `AvroData`/`AvroConverter` backs any Kafka Connect deployment (Cloud, Platform, or self-managed) using the Avro converter, so any such deployment consuming a similarly deep/wide record is exposed to the same failure mode.

The incident was mitigated by lowering `consumer.override.max.poll.records` from 500 to 10; this PR is the actual fix so the class of issue doesn't recur.

## Test plan
- [x] Added `testToConnectDataFailsFastOnDeeplyNestedRecordExceedingObjectLimit` — a 10-deep self-referential "friends chain" record with the limit set to 5 throws `DataException`.
- [x] Added `testToConnectDataSucceedsWhenWithinObjectLimit` — the same record shape with the limit set to 100 converts normally.
- [x] `mvn -pl avro-data test` — 143/143 tests pass (existing suite + the 2 new tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DGS-25119]: https://confluentinc.atlassian.net/browse/DGS-25119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ