### PR TITLE
Fix Timestamp overflow and use RFC 3339/date range bounds

### DIFF
--- a/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantUtils.java
+++ b/schema-types/src/main/java/io/confluent/kafka/schemaregistry/type/VariantUtils.java
@@ -104,10 +104,9 @@ public class VariantUtils {
       case NULL:
         return FACTORY.nullNode();
       case DATE:
-        return FACTORY.textNode(LocalDate.ofEpochDay(variant.getInt()).toString());
+        return FACTORY.textNode(LocalDate.ofEpochDay(checkDateRange(variant.getInt())).toString());
       case TIMESTAMP_TZ:
-        return FACTORY.textNode(
-            Instant.ofEpochSecond(0, variant.getLong() * 1000).toString());
+        return FACTORY.textNode(instantFromMicros(variant.getLong()).toString());
       case TIMESTAMP_NTZ:
         return FACTORY.textNode(formatLocalDateTimeMicros(variant.getLong()));
       case TIMESTAMP_NANOS_TZ:
@@ -163,12 +162,99 @@ public class VariantUtils {
     }
   }
 
+  /**
+   * The range a timestamp may occupy when rendered to JSON, in microseconds since the epoch:
+   * 0001-01-01T00:00:00 through 9999-12-31T23:59:59.999999.
+   *
+   * <p>This is the four-digit-year form every client renders. For the zone-aware types it is
+   * RFC 3339 - also {@code google.protobuf.Timestamp}'s range, and the range
+   * {@code timestamp(...)} enforces when constructing a CEL timestamp. The zone-less types carry no
+   * offset, so they are ISO-8601 local date-times rather than RFC 3339 (which has no zone-less
+   * form); they share the range so both stay readable by the same date parsers.
+   *
+   * <p>A variant TIMESTAMP_TZ / TIMESTAMP_NTZ is an arbitrary int64 of microseconds - roughly
+   * +/-292,471 years - so it can hold instants outside that form. Rendering those as ISO-8601's
+   * expanded year ({@code +10000-01-01T00:00:00Z}) would emit JSON that most parsers,
+   * {@code variants.parseJson} included, reject; so they are refused instead, as protobuf's
+   * {@code Timestamps.toString} does. It is also exactly what Python's {@code datetime} and .NET's
+   * {@code DateTime} can hold, so every client can enforce it natively.
+   *
+   * <p>The nanosecond-based types need no such check: an int64 of nanoseconds spans only
+   * 1677-2262, which is inside this range at both ends.
+   */
+  private static final long MIN_TIMESTAMP_MICROS = -62135596800000000L;
+  private static final long MAX_TIMESTAMP_MICROS = 253402300799999999L;
+
+  /**
+   * The range a DATE may occupy when rendered to JSON, in days since the epoch: 0001-01-01 through
+   * 9999-12-31. RFC 3339's {@code full-date} requires {@code date-fullyear = 4DIGIT}, so an
+   * expanded or negative year ({@code +10000-01-01}, {@code -0044-01-01}) is not a valid
+   * {@code full-date}. A variant DATE is an int32 of days - roughly +/-5.8 million years - so
+   * those are reachable, and are refused rather than rendered.
+   */
+  private static final int MIN_DATE_EPOCH_DAY = -719162;
+  private static final int MAX_DATE_EPOCH_DAY = 2932896;
+
+  private static int checkDateRange(int epochDay) {
+    if (epochDay < MIN_DATE_EPOCH_DAY || epochDay > MAX_DATE_EPOCH_DAY) {
+      throw new IllegalArgumentException(
+          "Date is not valid. Epoch day (" + epochDay + ") must be in range ["
+              + MIN_DATE_EPOCH_DAY + ", " + MAX_DATE_EPOCH_DAY + "].");
+    }
+    return epochDay;
+  }
+
+  /**
+   * The range a TIME may occupy, in microseconds since midnight: 00:00:00 through
+   * 23:59:59.999999. RFC 3339's {@code partial-time} requires {@code time-hour = 2DIGIT} in
+   * 00-23, so a value at or past 24 hours (or negative) has no valid form. A variant TIME is an
+   * int64 of microseconds, so those are reachable; checking also removes an overflow, since
+   * {@code micros * 1000} wraps for a large enough value.
+   */
+  private static final long MIN_TIME_MICROS = 0L;
+  private static final long MAX_TIME_MICROS = 86_400_000_000L - 1L;
+
+  private static long checkTimeRange(long micros) {
+    if (micros < MIN_TIME_MICROS || micros > MAX_TIME_MICROS) {
+      throw new IllegalArgumentException(
+          "Time is not valid. Microseconds of day (" + micros + ") must be in range ["
+              + MIN_TIME_MICROS + ", " + MAX_TIME_MICROS + "].");
+    }
+    return micros;
+  }
+
+  private static long checkMicrosRange(long micros) {
+    if (micros < MIN_TIMESTAMP_MICROS || micros > MAX_TIMESTAMP_MICROS) {
+      throw new IllegalArgumentException(
+          "Timestamp is not valid. Microseconds (" + micros + ") must be in range ["
+              + MIN_TIMESTAMP_MICROS + ", " + MAX_TIMESTAMP_MICROS + "].");
+    }
+    return micros;
+  }
+
+  /**
+   * Builds an {@link Instant} from microseconds since the epoch, splitting into whole seconds
+   * before scaling to nanoseconds.
+   *
+   * <p>The direct form, {@code Instant.ofEpochSecond(0, micros * 1000)}, overflows a long for any
+   * value past {@code 9223372036854775} micros - 2262-04-11T23:47:16.854775Z - and wrapped
+   * silently to a plausible-looking date well in the past (year 10000 rendered as 1816). This is
+   * the same floorDiv/floorMod split {@link #formatLocalDateTimeMicros} already used, which is why
+   * the zone-less arm never had that bug.
+   */
+  private static Instant instantFromMicros(long micros) {
+    checkMicrosRange(micros);
+    return Instant.ofEpochSecond(
+        Math.floorDiv(micros, 1_000_000L), Math.floorMod(micros, 1_000_000L) * 1000L);
+  }
+
   // Formats an NTZ timestamp / time to ISO-8601 with the seconds field ALWAYS present. This
   // is the cross-language contract: it deviates from LocalDateTime/LocalTime.toString(),
   // which omit the seconds field when both seconds and fraction are zero, so that the NTZ
   // form stays consistent with the TZ (Instant) form. The fractional-second field uses the
   // same 0/3/6/9-digit grouping as Instant.toString().
   private static String formatLocalDateTimeMicros(long micros) {
+    checkMicrosRange(micros);
     return formatLocalDateTime(
         Math.floorDiv(micros, 1_000_000L), (int) Math.floorMod(micros, 1_000_000L) * 1000);
   }
@@ -188,7 +274,7 @@ public class VariantUtils {
   }
 
   private static String formatLocalTime(long micros) {
-    LocalTime time = LocalTime.ofNanoOfDay(micros * 1000);
+    LocalTime time = LocalTime.ofNanoOfDay(checkTimeRange(micros) * 1000);
     return String.format(Locale.ROOT, "%02d:%02d:%02d%s",
         time.getHour(), time.getMinute(), time.getSecond(), fractionOfSecond(time.getNano()));
   }

--- a/schema-types/src/test/java/io/confluent/kafka/schemaregistry/type/TestVariantJsonConverter.java
+++ b/schema-types/src/test/java/io/confluent/kafka/schemaregistry/type/TestVariantJsonConverter.java
@@ -173,6 +173,102 @@ public class TestVariantJsonConverter {
     Assert.assertTrue(node.textValue().contains("2025-04-17"));
   }
 
+  /**
+   * A microsecond timestamp beyond 2262 must not wrap. {@code Instant.ofEpochSecond(0,
+   * micros * 1000)} overflows a long past 9223372036854775 micros
+   * (2262-04-11T23:47:16.854775Z), and used to render year 3000 as a plausible-looking date in
+   * the past instead. The fix splits into whole seconds before scaling the remainder, which is
+   * what the zone-less arm always did - hence only TIMESTAMP_TZ ever had the bug.
+   */
+  @Test
+  public void testToJsonTimestampBeyond2262DoesNotWrap() {
+    long micros = 32_503_680_000_000_000L; // 3000-01-01T00:00:00Z
+    Assert.assertEquals("\"3000-01-01T00:00:00Z\"", toJsonString(b -> b.appendTimestampTz(micros)));
+    Assert.assertEquals("\"3000-01-01T00:00:00.123456Z\"",
+        toJsonString(b -> b.appendTimestampTz(micros + 123_456)));
+    Assert.assertEquals("\"3000-01-01T00:00:00\"", toJsonString(b -> b.appendTimestampNtz(micros)));
+    Assert.assertEquals("\"3000-01-01T00:00:00.123456\"",
+        toJsonString(b -> b.appendTimestampNtz(micros + 123_456)));
+  }
+
+  /**
+   * The renderable range is 0001-01-01T00:00:00 through 9999-12-31T23:59:59.999999 - RFC 3339's
+   * four-digit year. Both boundaries render; one microsecond beyond either end is refused rather
+   * than rendered with ISO-8601's expanded year ({@code +10000-01-01T00:00:00Z}), which is not
+   * RFC 3339 and would not parse back. Every other client enforces the same bound.
+   */
+  @Test
+  public void testToJsonTimestampRangeBoundaries() {
+    long min = -62135596800000000L; // 0001-01-01T00:00:00
+    long max = 253402300799999999L; // 9999-12-31T23:59:59.999999
+    Assert.assertEquals("\"0001-01-01T00:00:00Z\"", toJsonString(b -> b.appendTimestampTz(min)));
+    Assert.assertEquals("\"9999-12-31T23:59:59.999999Z\"",
+        toJsonString(b -> b.appendTimestampTz(max)));
+    Assert.assertEquals("\"0001-01-01T00:00:00\"", toJsonString(b -> b.appendTimestampNtz(min)));
+    Assert.assertEquals("\"9999-12-31T23:59:59.999999\"",
+        toJsonString(b -> b.appendTimestampNtz(max)));
+
+    for (long outOfRange : new long[] {min - 1, max + 1}) {
+      Assert.assertThrows(IllegalArgumentException.class,
+          () -> toJsonString(b -> b.appendTimestampTz(outOfRange)));
+      Assert.assertThrows(IllegalArgumentException.class,
+          () -> toJsonString(b -> b.appendTimestampNtz(outOfRange)));
+    }
+  }
+
+  /**
+   * The nanosecond-based types need no range check: an int64 of nanoseconds spans only 1677-2262,
+   * inside the renderable range at both ends, so the extremes still render.
+   */
+  @Test
+  public void testToJsonTimestampNanosExtremesRender() {
+    Assert.assertEquals("\"2262-04-11T23:47:16.854775807Z\"",
+        toJsonString(b -> b.appendTimestampNanosTz(Long.MAX_VALUE)));
+    Assert.assertEquals("\"1677-09-21T00:12:43.145224192\"",
+        toJsonString(b -> b.appendTimestampNanosNtz(Long.MIN_VALUE)));
+  }
+
+  /**
+   * DATE renders RFC 3339 {@code full-date}, which requires {@code date-fullyear = 4DIGIT}. A
+   * variant DATE is an int32 of days (roughly +/-5.8 million years), so an expanded or negative
+   * year is reachable; it used to render as {@code +10000-01-01} / {@code -0044-01-01}, neither of
+   * which is a valid full-date, and is now refused.
+   */
+  @Test
+  public void testToJsonDateRangeBoundaries() {
+    int min = -719162; // 0001-01-01
+    int max = 2932896; // 9999-12-31
+    Assert.assertEquals("\"0001-01-01\"", toJsonString(b -> b.appendDate(min)));
+    Assert.assertEquals("\"9999-12-31\"", toJsonString(b -> b.appendDate(max)));
+    for (int outOfRange : new int[] {min - 1, max + 1, 4_000_000, -1_000_000}) {
+      Assert.assertThrows(IllegalArgumentException.class,
+          () -> toJsonString(b -> b.appendDate(outOfRange)));
+    }
+  }
+
+  /**
+   * TIME renders RFC 3339 {@code partial-time}, whose {@code time-hour = 2DIGIT} is 00-23. A
+   * variant TIME is an int64 of microseconds since midnight, so a value at or past 24 hours (or
+   * negative) is reachable and has no valid form; it is refused. This also covers the
+   * {@code micros * 1000} overflow, which wrapped for a large enough value.
+   */
+  @Test
+  public void testToJsonTimeRangeBoundaries() {
+    Assert.assertEquals("\"00:00:00\"", toJsonString(b -> b.appendTime(0L)));
+    Assert.assertEquals("\"23:59:59.999999\"", toJsonString(b -> b.appendTime(86_399_999_999L)));
+    // Exactly 24 hours is out of range: "24:00:00" is not a valid time-hour.
+    for (long outOfRange : new long[] {86_400_000_000L, -1L, Long.MAX_VALUE, Long.MIN_VALUE}) {
+      Assert.assertThrows(IllegalArgumentException.class,
+          () -> toJsonString(b -> b.appendTime(outOfRange)));
+    }
+  }
+
+  private static String toJsonString(java.util.function.Consumer<VariantBuilder> append) {
+    VariantBuilder builder = new VariantBuilder();
+    append.accept(builder);
+    return VariantUtils.toJsonString(builder.build());
+  }
+
   @Test
   public void testToJsonTime() {
     VariantBuilder builder = new VariantBuilder();


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
`VariantUtils.toJson`'s `TIMESTAMP_TZ` case built an `Instant` via `Instant.ofEpochSecond(0, variant.getLong() * 1000)`. Multiplying the raw microsecond value by 1000 to get nanoseconds overflows a `long` past `9223372036854775` micros (2262-04-11T23:47:16.854775Z), silently wrapping to a plausible-looking but wrong date (e.g. year 3000 rendered as 1816). Fixed by adding `instantFromMicros`, which splits into whole seconds (`floorDiv`) before scaling only the sub-second remainder to nanoseconds — the same split `formatLocalDateTimeMicros` already used for the zone-less arm, which is why that path never had the bug.



<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
