### PR TITLE
Improve compatibility check error messages

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/Difference.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/Difference.java
@@ -63,9 +63,9 @@ public class Difference {
         errorDescription = "";
     }
 
-    return "{errorType:'" + errorType + '\''
-             + ", description:'" + errorDescription + '\''
-             + ", additionalInfo:'" + incompatibility.getMessage() + "'}";
+    return "{errorType:\"" + errorType + '"'
+             + ", description:\"" + errorDescription + '"'
+             + ", additionalInfo:\"" + incompatibility.getMessage() + "\"}";
   }
 
   public String toString() {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistry.java
@@ -1285,14 +1285,14 @@ public abstract class AbstractSchemaRegistry implements SchemaRegistry,
                       getCompatibilityGroupValue(s.schema(), compatibilityGroup)))
               .collect(Collectors.toList());
     }
-    errorMessages.addAll(
-            parsedSchema.isCompatible(compatibility, compatibilityPolicy, previousSchemas));
     if (compatibilityPolicy == CompatibilityPolicy.LOGICAL) {
-      // Additive: the native check above still runs; LOGICAL layers the Flink/Iceberg logical-type
+      // Additive: the native check below still runs; LOGICAL layers the Flink/Iceberg logical-type
       // validity and compatibility checks on top, so it can only make registration stricter.
       errorMessages.addAll(
               LogicalPolicyChecker.check(parsedSchema, previousSchemas, compatibility));
     }
+    errorMessages.addAll(
+            parsedSchema.isCompatible(compatibility, compatibilityPolicy, previousSchemas));
     if (!errorMessages.isEmpty()) {
       try {
         errorMessages.add(String.format("{validateFields: '%b', compatibility: '%s'}",

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LogicalPolicyChecker.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/LogicalPolicyChecker.java
@@ -24,13 +24,17 @@ import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.confluent.kafka.schemaregistry.type.logical.LogicalType;
 import io.confluent.kafka.schemaregistry.type.logical.avro.AvroToLogicalTypeConverter;
 import io.confluent.kafka.schemaregistry.type.logical.json.JsonToLogicalTypeConverter;
-import io.confluent.kafka.schemaregistry.type.logical.policy.CompatibilityResult;
+import io.confluent.kafka.schemaregistry.type.logical.policy.Incompatibility;
+import io.confluent.kafka.schemaregistry.type.logical.policy.Invalidity;
 import io.confluent.kafka.schemaregistry.type.logical.policy.LogicalTypeChecker;
 import io.confluent.kafka.schemaregistry.type.logical.policy.LogicalTypeChecker.Mode;
-import io.confluent.kafka.schemaregistry.type.logical.policy.ValidityResult;
 import io.confluent.kafka.schemaregistry.type.logical.protobuf.ProtoToLogicalTypeConverter;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,12 +112,7 @@ public final class LogicalPolicyChecker {
     }
 
     // Validity: a property of the new schema itself, independent of any previous version.
-    for (Mode mode : MODES) {
-      ValidityResult validity = LogicalTypeChecker.validate(mode, newLogical);
-      if (!validity.isValid()) {
-        errors.add("Logical validity (" + mode + "): " + validity.describe());
-      }
-    }
+    errors.addAll(describeValidity(newLogical));
 
     List<ParsedSchemaHolder> toCompare = selectForComparison(previousSchemas, level);
     boolean checksBackward = checksBackward(level);
@@ -130,24 +129,97 @@ public final class LogicalPolicyChecker {
       }
       if (checksBackward) {
         // BACKWARD: the new schema must read data written with the previous schema.
-        addCompareErrors(errors, "backward", previousLogical, newLogical);
+        addCompareErrors(errors, previousLogical, newLogical);
       }
       if (checksForward) {
         // FORWARD: the previous schema must read data written with the new schema.
-        addCompareErrors(errors, "forward", newLogical, previousLogical);
+        addCompareErrors(errors, newLogical, previousLogical);
       }
     }
     return errors;
   }
 
-  private static void addCompareErrors(
-      List<String> errors, String direction, LogicalType original, LogicalType update) {
+  private static List<String> describeValidity(LogicalType newLogical) {
+    Map<FindingKey, Map<Mode, String>> byFinding = new LinkedHashMap<>();
     for (Mode mode : MODES) {
-      CompatibilityResult result = LogicalTypeChecker.compare(mode, original, update);
-      if (!result.isCompatible()) {
-        errors.add(
-            "Logical compatibility (" + mode + ", " + direction + "): " + result.describe());
+      for (Invalidity invalidity
+          : LogicalTypeChecker.validate(mode, newLogical).getInvalidities()) {
+        byFinding
+            .computeIfAbsent(
+                new FindingKey(invalidity.getRule().name(), invalidity.getPath()),
+                k -> new LinkedHashMap<>())
+            .put(mode, invalidity.getMessage());
       }
+    }
+    List<String> errors = new ArrayList<>();
+    for (Map.Entry<FindingKey, Map<Mode, String>> entry : byFinding.entrySet()) {
+      errors.add(describeFinding(entry.getKey(), entry.getValue()));
+    }
+    return errors;
+  }
+
+  private static void addCompareErrors(
+      List<String> errors, LogicalType original, LogicalType update) {
+    Map<FindingKey, Map<Mode, String>> byFinding = new LinkedHashMap<>();
+    for (Mode mode : MODES) {
+      for (Incompatibility incompatibility
+          : LogicalTypeChecker.compare(mode, original, update).getIncompatibilities()) {
+        byFinding
+            .computeIfAbsent(
+                new FindingKey(incompatibility.getRule().name(), incompatibility.getPath()),
+                k -> new LinkedHashMap<>())
+            .put(mode, incompatibility.getMessage());
+      }
+    }
+    for (Map.Entry<FindingKey, Map<Mode, String>> entry : byFinding.entrySet()) {
+      errors.add(describeFinding(entry.getKey(), entry.getValue()));
+    }
+  }
+
+  /**
+   * Renders one finding as {@code {errorType:"<rule>", category:["<mode>", ...],
+   * description:"<message>", additionalInfo:"<path>"}} -- mirroring the {@code {errorType,
+   * description, additionalInfo}} shape the native JSON/Protobuf checks already use (see
+   * {@code io.confluent.kafka.schemaregistry.json.diff.Difference}), with {@code category} added
+   * to carry which mode(s) flagged it.
+   *
+   * <p>{@code category} lists every mode that flagged this {@code (rule, path)} -- {@link
+   * Mode#FLINK} and {@link Mode#ICEBERG_V2} frequently flag the same underlying violation at the
+   * same path, since their checkers are independent implementations. Only one message is ever
+   * shown: when modes disagree on the wording, {@link #MODES}' order (FLINK before ICEBERG_V2)
+   * picks a single representative rather than repeating the same finding once per mode.
+   */
+  private static String describeFinding(FindingKey key, Map<Mode, String> messagesByMode) {
+    String modes = messagesByMode.keySet().stream()
+        .map(mode -> "\"" + mode + "\"")
+        .collect(Collectors.joining(", "));
+    String message = messagesByMode.values().iterator().next();
+    return "{errorType:\"" + key.rule + "\", category:[" + modes + "], description:\""
+        + message + "\", additionalInfo:\"" + key.path + "\"}";
+  }
+
+  /** Groups a validity/compatibility finding by the rule it violated and the field path. */
+  private static final class FindingKey {
+    private final String rule;
+    private final String path;
+
+    FindingKey(String rule, String path) {
+      this.rule = rule;
+      this.path = path == null ? "" : path;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof FindingKey)) {
+        return false;
+      }
+      FindingKey that = (FindingKey) o;
+      return rule.equals(that.rule) && path.equals(that.path);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(rule, path);
     }
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistryLogicalPolicyTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/AbstractSchemaRegistryLogicalPolicyTest.java
@@ -15,7 +15,6 @@
 
 package io.confluent.kafka.schemaregistry.storage;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
@@ -25,6 +24,7 @@ import io.confluent.kafka.schemaregistry.ParsedSchemaHolder;
 import io.confluent.kafka.schemaregistry.SimpleParsedSchemaHolder;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Config;
+import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -64,7 +64,9 @@ class AbstractSchemaRegistryLogicalPolicyTest {
         "LOGICAL",
         new AvroSchema(RECORD_A),
         List.of(new SimpleParsedSchemaHolder(new AvroSchema(RECORD_A_B))));
-    assertTrue(errors.stream().anyMatch(e -> e.contains("Logical")),
+    // FIELD_DELETED is a logical-checker-only Rule (native Avro treats a dropped field as
+    // backward-compatible and never reports this), so its presence isolates the LOGICAL branch.
+    assertTrue(errors.stream().anyMatch(e -> e.contains("FIELD_DELETED")),
         "expected a logical finding under LOGICAL policy: " + errors);
   }
 
@@ -74,17 +76,42 @@ class AbstractSchemaRegistryLogicalPolicyTest {
         "STRICT",
         new AvroSchema(RECORD_A),
         List.of(new SimpleParsedSchemaHolder(new AvroSchema(RECORD_A_B))));
-    assertTrue(errors.stream().noneMatch(e -> e.contains("Logical")),
+    assertTrue(errors.stream().noneMatch(e -> e.contains("FIELD_DELETED")),
         "logical checks must not run unless policy is LOGICAL: " + errors);
   }
 
   @Test
   void logicalPolicyPassesAValidCompatibleSchema() {
-    // Identical schema, so both native and logical see no change.
+    // Identical schema, so both native and logical see no change -- no findings at all.
     List<String> errors = check(
         "LOGICAL",
         new AvroSchema(RECORD_A_B),
         List.of(new SimpleParsedSchemaHolder(new AvroSchema(RECORD_A_B))));
-    assertFalse(errors.stream().anyMatch(e -> e.contains("Logical")), errors.toString());
+    assertTrue(errors.isEmpty(), errors.toString());
+  }
+
+  @Test
+  void allErrorTypeFindingsStayContiguous() {
+    // new(A_B) adding required field 'b' (no default) trips both checks: native Avro reports
+    // READER_FIELD_MISSING_DEFAULT_VALUE, and the logical checker reports REQUIRED_FIELD_ADDED.
+    // The native check also appends an {oldSchema...} context entry after its own finding -- that
+    // context entry (and the trailing {validateFields...} debug entry) must not land in between
+    // the two checks' {errorType...} findings and split them apart.
+    List<String> errors = check(
+        "LOGICAL",
+        new AvroSchema(RECORD_A_B),
+        List.of(new SimpleParsedSchemaHolder(new AvroSchema(RECORD_A))));
+
+    List<Integer> errorTypeIndexes = new ArrayList<>();
+    for (int i = 0; i < errors.size(); i++) {
+      if (errors.get(i).contains("errorType")) {
+        errorTypeIndexes.add(i);
+      }
+    }
+    assertTrue(errorTypeIndexes.size() >= 2, "expected findings from both checks: " + errors);
+    int first = errorTypeIndexes.get(0);
+    int last = errorTypeIndexes.get(errorTypeIndexes.size() - 1);
+    assertTrue(last - first + 1 == errorTypeIndexes.size(),
+        "errorType findings are not contiguous: " + errors);
   }
 }

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/storage/LogicalPolicyCheckerTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/storage/LogicalPolicyCheckerTest.java
@@ -73,7 +73,7 @@ class LogicalPolicyCheckerTest {
     List<String> errors = LogicalPolicyChecker.check(
         new AvroSchema(EMPTY_RECORD), List.of(), CompatibilityLevel.NONE);
     assertFalse(errors.isEmpty(), "empty struct should fail Iceberg validity even with no previous");
-    assertTrue(errors.stream().anyMatch(e -> e.contains("validity")));
+    assertTrue(errors.stream().anyMatch(e -> e.contains("EMPTY_STRUCT")), errors.toString());
   }
 
   @Test
@@ -90,8 +90,7 @@ class LogicalPolicyCheckerTest {
     List<String> errors = LogicalPolicyChecker.check(
         new AvroSchema(RECORD_A_B), List.of(holder(RECORD_A)), CompatibilityLevel.BACKWARD);
     assertFalse(errors.isEmpty());
-    assertTrue(errors.stream().anyMatch(e -> e.contains("compatibility") && e.contains("backward")),
-        errors.toString());
+    assertTrue(errors.stream().anyMatch(e -> e.contains("REQUIRED_FIELD_ADDED")), errors.toString());
   }
 
   @Test
@@ -103,26 +102,33 @@ class LogicalPolicyCheckerTest {
   }
 
   @Test
-  void backwardLabelsDirectionBackward() {
-    List<String> errors = LogicalPolicyChecker.check(
+  void backwardAndForwardCheckOppositeDirections() {
+    // BACKWARD: new(A_B) must read old(A) -- adding required field 'b' breaks that ->
+    // REQUIRED_FIELD_ADDED, but nothing is FIELD_DELETED since A_B has every field A has.
+    List<String> backwardErrors = LogicalPolicyChecker.check(
         new AvroSchema(RECORD_A_B), List.of(holder(RECORD_A)), CompatibilityLevel.BACKWARD);
-    assertTrue(errors.stream().allMatch(e -> !e.contains("forward")), errors.toString());
-    assertTrue(errors.stream().anyMatch(e -> e.contains("backward")), errors.toString());
-  }
+    assertTrue(backwardErrors.stream().anyMatch(e -> e.contains("REQUIRED_FIELD_ADDED")),
+        backwardErrors.toString());
+    assertFalse(backwardErrors.stream().anyMatch(e -> e.contains("FIELD_DELETED")),
+        backwardErrors.toString());
 
-  @Test
-  void forwardLabelsDirectionForward() {
-    List<String> errors = LogicalPolicyChecker.check(
+    // FORWARD: old(A) must read new(A_B) -- from A_B's perspective, 'b' is now FIELD_DELETED
+    // (ICEBERG_V2 only; FLINK has no such rule), not a required-field addition.
+    List<String> forwardErrors = LogicalPolicyChecker.check(
         new AvroSchema(RECORD_A_B), List.of(holder(RECORD_A)), CompatibilityLevel.FORWARD);
-    assertTrue(errors.stream().anyMatch(e -> e.contains("forward")), errors.toString());
+    assertTrue(forwardErrors.stream().anyMatch(e -> e.contains("FIELD_DELETED")),
+        forwardErrors.toString());
+    assertFalse(forwardErrors.stream().anyMatch(e -> e.contains("REQUIRED_FIELD_ADDED")),
+        forwardErrors.toString());
   }
 
   @Test
   void fullChecksBothDirections() {
+    // FULL runs both comparisons, so both directions' findings should be present together.
     List<String> errors = LogicalPolicyChecker.check(
         new AvroSchema(RECORD_A_B), List.of(holder(RECORD_A)), CompatibilityLevel.FULL);
-    assertTrue(errors.stream().anyMatch(e -> e.contains("backward")), errors.toString());
-    assertTrue(errors.stream().anyMatch(e -> e.contains("forward")), errors.toString());
+    assertTrue(errors.stream().anyMatch(e -> e.contains("REQUIRED_FIELD_ADDED")), errors.toString());
+    assertTrue(errors.stream().anyMatch(e -> e.contains("FIELD_DELETED")), errors.toString());
   }
 
   // -- transitivity: which previous versions are compared ----------------------------------------
@@ -145,7 +151,7 @@ class LogicalPolicyCheckerTest {
     List<String> errors = LogicalPolicyChecker.check(
         new AvroSchema(RECORD_A_B), previous, CompatibilityLevel.BACKWARD_TRANSITIVE);
     assertFalse(errors.isEmpty());
-    assertTrue(errors.stream().anyMatch(e -> e.contains("compatibility")), errors.toString());
+    assertTrue(errors.stream().anyMatch(e -> e.contains("REQUIRED_FIELD_ADDED")), errors.toString());
   }
 
   // -- conversion failures ------------------------------------------------------------------------
@@ -158,6 +164,62 @@ class LogicalPolicyCheckerTest {
         unconvertible, List.of(), CompatibilityLevel.BACKWARD);
     assertEquals(1, errors.size());
     assertTrue(errors.get(0).contains("cannot be represented as a logical type"), errors.toString());
+  }
+
+  // -- merging findings across modes ---------------------------------------------------------
+
+  @Test
+  void mergesRequiredFieldAddedAcrossFlinkAndIcebergIntoOneLine() {
+    // Both FLINK and ICEBERG_V2 report REQUIRED_FIELD_ADDED at the same path ('b') for this
+    // change, so they should collapse into a single tagged line rather than two near-duplicates.
+    List<String> errors = LogicalPolicyChecker.check(
+        new AvroSchema(RECORD_A_B), List.of(holder(RECORD_A)), CompatibilityLevel.BACKWARD);
+
+    long mergedLines = errors.stream()
+        .filter(e -> e.contains("REQUIRED_FIELD_ADDED")
+            && e.contains("category:[\"FLINK\", \"ICEBERG_V2\"]"))
+        .count();
+    assertEquals(1, mergedLines, errors.toString());
+    // Only one message should appear for the merged finding, not one per mode.
+    long occurrencesOfRule = errors.stream()
+        .filter(e -> e.contains("REQUIRED_FIELD_ADDED"))
+        .count();
+    assertEquals(1, occurrencesOfRule, errors.toString());
+  }
+
+  @Test
+  void doesNotMergeFindingsUniqueToOneMode() {
+    // Dropping field 'b' is FIELD_DELETED under ICEBERG_V2 only -- FLINK has no such rule -- so
+    // that finding must stay on its own single-mode line, not be folded away.
+    List<String> errors = LogicalPolicyChecker.check(
+        new AvroSchema(RECORD_A), List.of(holder(RECORD_A_B)), CompatibilityLevel.BACKWARD);
+
+    assertTrue(errors.stream().anyMatch(
+        e -> e.contains("FIELD_DELETED") && e.contains("category:[\"ICEBERG_V2\"]")),
+        errors.toString());
+    assertFalse(errors.stream().anyMatch(e -> e.contains("FIELD_DELETED") && e.contains("FLINK")),
+        errors.toString());
+  }
+
+  @Test
+  void singleModeAndMultiModeFindingsShareTheSameHeaderShape() {
+    // A single-mode finding (FIELD_DELETED, ICEBERG_V2 only) and a multi-mode finding
+    // (REQUIRED_FIELD_ADDED, both modes) should both read as
+    // "{errorType:\"<rule>\", category:[\"<mode>\", ...], description:\"...\",
+    // additionalInfo:\"...\"}", not switch to a different shape depending on how many modes are
+    // involved -- with no label in front of the object, and no mention of "backward"/"forward".
+    List<String> errors = LogicalPolicyChecker.check(
+        new AvroSchema(RECORD_A), List.of(holder(RECORD_A_B)), CompatibilityLevel.BACKWARD);
+
+    String singleModeLine = errors.stream()
+        .filter(e -> e.contains("FIELD_DELETED"))
+        .findFirst()
+        .orElseThrow();
+    assertTrue(singleModeLine.startsWith(
+        "{errorType:\"FIELD_DELETED\", category:[\"ICEBERG_V2\"], description:\""),
+        singleModeLine);
+    assertFalse(singleModeLine.contains("backward") || singleModeLine.contains("forward"),
+        singleModeLine);
   }
 
   @Test

--- a/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/Difference.java
+++ b/json-schema-provider/src/main/java/io/confluent/kafka/schemaregistry/json/diff/Difference.java
@@ -217,6 +217,6 @@ public class Difference {
 
   @Override
   public String toString() {
-    return "{errorType:\"" + type + "\"" + ", description:\"" + error() + "'}";
+    return "{errorType:\"" + type + "\"" + ", description:\"" + error() + "\"}";
   }
 }


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----

  - Native Avro/JSON/Protobuf compatibility findings and `CompatibilityPolicy.LOGICAL`'s Flink/Iceberg findings were rendered in inconsistent, hard-to-parse shapes: native findings
  used `{errorType, description, additionalInfo}` (Avro single-quoted, JSON/Protobuf double-quoted, with a stray-quote bug in JSON's `Difference.toString()`), while logical        
  findings were prose-prefixed (`"Logical compatibility (FLINK, backward): ..."`) with no shared structure, duplicated near-identical wording when both FLINK and ICEBERG_V2 flagged
  the same underlying issue, and got physically separated from the native findings by the `{oldSchemaVersion...}`/`{oldSchema...}` context entries landing in between.          
  - `LogicalPolicyChecker`'s findings now render in the same `{errorType, category, description, additionalInfo}` shape as the native checks (`category` lists which mode(s) --     
  `FLINK`/`ICEBERG_V2` -- flagged it), with no direction (`backward`/`forward`) or kind label attached; `errorType` alone still disambiguates compatibility vs. validity findings   
  since the two `Rule` enums are disjoint.                                                                                                                                          
  - When both FLINK and ICEBERG_V2 flag the same `(rule, path)`, that now collapses into a single line instead of two near-duplicates.                                              
  - Fixed `Difference.toString()` in both the Avro and JSON providers so their quoting is self-consistent (Avro switched to double-quote delimiters to avoid clashing with the      
  single-quoted field/path markers embedded in its own description text; JSON's stray trailing `'` before the closing brace is fixed).                                              
  - Reordered `AbstractSchemaRegistry#isCompatibleWithPrevious` so `LOGICAL` findings are appended before the native check's, keeping every `{errorType...}` entry contiguous       
  instead of split apart by the native check's trailing context entries.    


<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
