### PR TITLE
DGS-25181 Preserve name of root message when converting to LT

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
@@ -163,6 +163,7 @@ final class LogicalFormat {
       throw new InvalidSchemaException("Could not resolve schema references: " + e.getMessage(), e);
     }
     return new LogicalType(
+        parsed.getName(),
         parsed.getNamespace(),
         parsed.getRootSchema(),
         parsed.getNamedTypes(),

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalType.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalType.java
@@ -530,6 +530,11 @@ public class LogicalType {
     if (!Objects.equals(fqnNamespace, namespace)) {
       return new RootUnwrap(rootSchema, null);
     }
+    if (isReferencedByPeer(fqn, namedTypes)) {
+      // A local peer references the root; removing its body would dangle that reference (and every
+      // format writer resolves peer refs only through namedTypes). Keep the shared root as a ref.
+      return new RootUnwrap(rootSchema, null);
+    }
     namedTypes.remove(fqn);
     body.setNullable(rootSchema.isNullable());
     int nameDot = fqn.lastIndexOf('.');
@@ -541,6 +546,25 @@ public class LogicalType {
     String prefix = fqn + ".";
     for (String key : namedTypes.keySet()) {
       if (key.startsWith(prefix)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * True iff a named type other than {@code fqn} carries a {@code NAMED_TYPE_REF} to {@code fqn}.
+   * Used to keep a peer-referenced root as a {@code NAMED_TYPE_REF} so its definition stays in
+   * {@code namedTypes} where writers resolve the peer's reference.
+   */
+  public static boolean isReferencedByPeer(String fqn, Map<String, Schema> namedTypes) {
+    for (Map.Entry<String, Schema> entry : namedTypes.entrySet()) {
+      if (entry.getKey().equals(fqn)) {
+        continue;
+      }
+      Set<String> refs = new LinkedHashSet<>();
+      collectNamedRefs(entry.getValue(), refs);
+      if (refs.contains(fqn)) {
         return true;
       }
     }

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalType.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalType.java
@@ -470,6 +470,84 @@ public class LogicalType {
   }
 
   /**
+   * Outcome of {@link #unwrapLeafNamedRoot}: the (possibly rewritten) root and carried name.
+   */
+  public static final class RootUnwrap {
+    private final Schema rootSchema;
+    private final String name;
+
+    private RootUnwrap(Schema rootSchema, String name) {
+      this.rootSchema = rootSchema;
+      this.name = name;
+    }
+
+    public Schema getRootSchema() {
+      return rootSchema;
+    }
+
+    /**
+     * Simple name to carry on {@link LogicalType#getName()}, or {@code null} if root was kept.
+     */
+    public String getName() {
+      return name;
+    }
+  }
+
+  /**
+   * If {@code rootSchema} is a {@code NAMED_TYPE_REF} to a local <em>leaf</em> named type, unwrap
+   * it to the bare {@code STRUCT}/{@code ENUM} body carrying its simple name, mirroring the
+   * canonical named-root shape shared by every format reader and the DDL visitor. The body is
+   * removed from
+   * {@code namedTypes} (mutated in place); peers referencing the root still resolve by name.
+   *
+   * <p>The unwrap is gated so it stays lossless through {@code LT → format/DDL → LT}; otherwise the
+   * root keeps its {@code NAMED_TYPE_REF} form:
+   * <ul>
+   *   <li>external/unresolved, cyclic, or has nested named types — unwrapping would orphan the
+   *       {@code namedTypes} entry needed for resolution or recurse forever;</li>
+   *   <li>the root's own namespace differs from {@code namespace} — simple name + {@code namespace}
+   *       would reconstruct a different FQN, so the full FQN is kept as the {@code namedTypes} key.
+   *   </li>
+   * </ul>
+   *
+   * <p>The root's nullability is preserved onto the bare body.
+   */
+  public static RootUnwrap unwrapLeafNamedRoot(
+      Schema rootSchema, Map<String, Schema> namedTypes, String namespace) {
+    if (rootSchema == null || rootSchema.getType() != Schema.Type.NAMED_TYPE_REF) {
+      return new RootUnwrap(rootSchema, null);
+    }
+    String fqn = rootSchema.getQualifiedName();
+    Schema body = namedTypes.get(fqn);
+    if (body == null) {
+      return new RootUnwrap(rootSchema, null);
+    }
+    if (isCyclic(fqn, namedTypes) || hasNestedNamedTypes(fqn, namedTypes)) {
+      return new RootUnwrap(rootSchema, null);
+    }
+    int dot = fqn.lastIndexOf('.');
+    String fqnNamespace = dot < 0 ? null : fqn.substring(0, dot);
+    if (!Objects.equals(fqnNamespace, namespace)) {
+      return new RootUnwrap(rootSchema, null);
+    }
+    namedTypes.remove(fqn);
+    body.setNullable(rootSchema.isNullable());
+    int nameDot = fqn.lastIndexOf('.');
+    String simpleName = nameDot < 0 ? fqn : fqn.substring(nameDot + 1);
+    return new RootUnwrap(body, simpleName);
+  }
+
+  private static boolean hasNestedNamedTypes(String fqn, Map<String, Schema> namedTypes) {
+    String prefix = fqn + ".";
+    for (String key : namedTypes.keySet()) {
+      if (key.startsWith(prefix)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Path-keyed map of field-default values collected during conversion.
    *
    * <p>Each key is a list of zero-based indices that walks from the root schema

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalType.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalType.java
@@ -44,6 +44,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class LogicalType {
 
+  private final String name;
   private final String namespace;
   private final Schema rootSchema;
   private final Map<String, Schema> namedTypes;
@@ -116,6 +117,30 @@ public class LogicalType {
       final List<SchemaReference> references,
       final Map<String, String> resolvedReferences,
       final Map<List<Integer>, Object> defaultValues) {
+    this(null, namespace, rootSchema, namedTypes, externalTypes, externalImports,
+        references, resolvedReferences, defaultValues);
+  }
+
+  /**
+   * Canonical constructor. {@code name} is the root type's own name, carried only when it would
+   * otherwise be lost — i.e. when the root is an inline (bare) STRUCT/ENUM whose name is not
+   * already the key of a {@link #namedTypes} entry (a Protobuf message unwrapped to a bare struct,
+   * or a JSON root object's {@code title}). It is {@code null} for a {@code NAMED_TYPE_REF} root
+   * (the name is the {@code namedTypes} key) and for anonymous roots. Display metadata for DDL
+   * emission; see {@link #getName()}.
+   */
+  public LogicalType(
+      final String name,
+      final String namespace,
+      final Schema rootSchema,
+      final Map<String, Schema> namedTypes,
+      final Set<String> externalTypes,
+      final Map<String, String> externalImports,
+      final List<SchemaReference> references,
+      final Map<String, String> resolvedReferences,
+      final Map<List<Integer>, Object> defaultValues) {
+    // Treat empty string as no name, so callers don't have to.
+    this.name = (name == null || name.isEmpty()) ? null : name;
     // Treat empty string as no namespace, so callers don't have to.
     this.namespace = (namespace == null || namespace.isEmpty()) ? null : namespace;
     this.rootSchema = requireNonNull(rootSchema, "rootSchema");
@@ -239,6 +264,17 @@ public class LogicalType {
   /** The document-level namespace, or null if none. */
   public String getNamespace() {
     return namespace;
+  }
+
+  /**
+   * The root type's own name, or {@code null} when the root has no otherwise-lost name (a
+   * {@code NAMED_TYPE_REF} root, whose name is the {@link #getNamedTypes()} key, or an anonymous
+   * root). Set only for an inline root whose name would otherwise be discarded — a Protobuf message
+   * unwrapped to a bare struct, or a JSON root object's {@code title}. Used by the DDL writer to
+   * emit a named root declaration.
+   */
+  public String getName() {
+    return name;
   }
 
   /**
@@ -498,7 +534,8 @@ public class LogicalType {
       return false;
     }
     LogicalType that = (LogicalType) o;
-    return Objects.equals(rootSchema, that.rootSchema)
+    return Objects.equals(name, that.name)
+        && Objects.equals(rootSchema, that.rootSchema)
         && Objects.equals(namedTypes, that.namedTypes)
         && Objects.equals(externalTypes, that.externalTypes)
         && Objects.equals(externalImports, that.externalImports)
@@ -509,14 +546,15 @@ public class LogicalType {
 
   @Override
   public int hashCode() {
-    return Objects.hash(rootSchema, namedTypes, externalTypes, externalImports,
+    return Objects.hash(name, rootSchema, namedTypes, externalTypes, externalImports,
         references, namespace, defaultValues);
   }
 
   @Override
   public String toString() {
     return "LogicalType{"
-        + "rootSchema=" + rootSchema
+        + "name=" + name
+        + ", rootSchema=" + rootSchema
         + ", namedTypes=" + namedTypes
         + ", externalTypes=" + externalTypes
         + ", externalImports=" + externalImports

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalType.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalType.java
@@ -503,8 +503,12 @@ public class LogicalType {
    * <p>The unwrap is gated so it stays lossless through {@code LT → format/DDL → LT}; otherwise the
    * root keeps its {@code NAMED_TYPE_REF} form:
    * <ul>
-   *   <li>external/unresolved, cyclic, or has nested named types — unwrapping would orphan the
-   *       {@code namedTypes} entry needed for resolution or recurse forever;</li>
+   *   <li>unresolved (no body in {@code namedTypes}), cyclic, or has nested named types —
+   *       unwrapping would orphan the {@code namedTypes} entry needed for resolution or recurse
+   *       forever;</li>
+   *   <li>external (in {@code externalTypes}) — the body was promoted from a referenced schema;
+   *       emitting it locally would misrepresent it as locally-defined;</li>
+   *   <li>referenced by a local peer — removing the body would dangle the peer's reference;</li>
    *   <li>the root's own namespace differs from {@code namespace} — simple name + {@code namespace}
    *       would reconstruct a different FQN, so the full FQN is kept as the {@code namedTypes} key.
    *   </li>
@@ -513,13 +517,20 @@ public class LogicalType {
    * <p>The root's nullability is preserved onto the bare body.
    */
   public static RootUnwrap unwrapLeafNamedRoot(
-      Schema rootSchema, Map<String, Schema> namedTypes, String namespace) {
+      Schema rootSchema, Map<String, Schema> namedTypes, Set<String> externalTypes,
+      String namespace) {
     if (rootSchema == null || rootSchema.getType() != Schema.Type.NAMED_TYPE_REF) {
       return new RootUnwrap(rootSchema, null);
     }
     String fqn = rootSchema.getQualifiedName();
     Schema body = namedTypes.get(fqn);
     if (body == null) {
+      return new RootUnwrap(rootSchema, null);
+    }
+    if (externalTypes != null && externalTypes.contains(fqn)) {
+      // The root's body was promoted from a referenced schema (e.g. Avro pre-walks external
+      // record/enum bodies into namedTypes but marks them external). Emitting it as a local bare
+      // root would misrepresent it as locally-defined and orphan the externalTypes marker.
       return new RootUnwrap(rootSchema, null);
     }
     if (isCyclic(fqn, namedTypes) || hasNestedNamedTypes(fqn, namedTypes)) {

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverter.java
@@ -105,10 +105,21 @@ public final class LogicalTypeToDdlConverter {
         printCreateType(name, lt.getNamedTypes().get(name));
       }
 
-      // Trailing root-registration `TYPE <typeExpr>`: omit when the visitor's
-      // auto-detect would produce the same root from the local types alone.
-      if (!sugarWouldInferRoot()) {
-        sb.append("TYPE ").append(typeExpr(lt.getRootSchema())).append(";\n");
+      // A named inline root (bare STRUCT/ENUM carrying LogicalType.name — e.g. a Protobuf message
+      // unwrapped to a struct, or a JSON root object's title) is emitted as a named declaration so
+      // its name shows in the DDL; the visitor infers the sole/unreferenced named type as the root
+      // on read-back. (Display only — exact-shape round-trip is revisited later.)
+      Schema root = lt.getRootSchema();
+      boolean rootIsNamedInline =
+          (root.getType() == Schema.Type.STRUCT || root.getType() == Schema.Type.ENUM)
+              && lt.getName() != null
+              && !lt.getNamedTypes().containsKey(lt.getName());
+      if (rootIsNamedInline) {
+        printCreateType(lt.getName(), root);
+      } else if (!sugarWouldInferRoot()) {
+        // Trailing root-registration `TYPE <typeExpr>`: omit when the visitor's
+        // auto-detect would produce the same root from the local types alone.
+        sb.append("TYPE ").append(typeExpr(root)).append(";\n");
       }
 
       return sb.toString();

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverter.java
@@ -122,9 +122,21 @@ public final class LogicalTypeToDdlConverter {
         printCreateType(name, lt.getNamedTypes().get(name));
       }
 
-      // Trailing root-registration `TYPE <typeExpr>` for a root not emitted as a named declaration,
-      // omitted when the visitor's auto-detect would produce the same root from the declarations.
-      if (!rootIsNamedInline && !sugarWouldInferRoot()) {
+      // Root registration.
+      if (rootIsNamedInline) {
+        // Inference selects the inline root only when no peer references it — a referenced type is
+        // dropped from the unreferenced set, so inference would pick a peer instead. When a peer
+        // references the root, force it with an explicit trailing TYPE, preserving its nullability.
+        if (inlineRootReferencedByPeer()) {
+          sb.append("TYPE ").append(qualifiedName(lt.getName()));
+          if (!root.isNullable()) {
+            sb.append(" NOT NULL");
+          }
+          sb.append(";\n");
+        }
+      } else if (!sugarWouldInferRoot()) {
+        // Trailing `TYPE <typeExpr>` for a root not emitted as a named declaration, omitted when
+        // the visitor's auto-detect would produce the same root from the declarations alone.
         sb.append("TYPE ").append(typeExpr(root)).append(";\n");
       }
 
@@ -436,6 +448,32 @@ public final class LogicalTypeToDdlConverter {
       }
       String ns = lt.getNamespace();
       return ns != null && lt.getNamedTypes().containsKey(ns + "." + rootName);
+    }
+
+    /**
+     * True if any local named type references the inline root (by its raw or namespace-qualified
+     * name). Such a reference removes the root from the visitor's unreferenced-root set, so
+     * inference would pick a peer instead and an explicit trailing TYPE is required.
+     */
+    private boolean inlineRootReferencedByPeer() {
+      Set<String> candidates = new LinkedHashSet<>();
+      candidates.add(lt.getName());
+      if (lt.getNamespace() != null) {
+        candidates.add(lt.getNamespace() + "." + lt.getName());
+      }
+      for (Map.Entry<String, Schema> e : lt.getNamedTypes().entrySet()) {
+        if (lt.getExternalTypes().contains(e.getKey())) {
+          continue; // externals are inferred from usage; they don't affect root inference
+        }
+        Set<String> refs = new LinkedHashSet<>();
+        LogicalType.collectNamedRefs(e.getValue(), refs);
+        for (String candidate : candidates) {
+          if (refs.contains(candidate)) {
+            return true;
+          }
+        }
+      }
+      return false;
     }
 
     private boolean sugarWouldInferRoot() {

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverter.java
@@ -39,9 +39,18 @@ import java.util.Set;
  *   <li>Path-keyed {@code defaultValues} aren't re-emitted; field-level
  *       defaults survive via {@link Schema.Field#getDefaultValue()}.</li>
  *   <li>The single-root sugar is detected and the trailing root-registration
- *       {@code TYPE} statement is elided when it would be redundant. The
- *       multi-root UNION sugar is detected similarly.</li>
+ *       {@code TYPE} statement is elided when it would be redundant. There is
+ *       no multi-root UNION sugar: when several independent types are
+ *       unreferenced, root inference selects the first declared and the rest
+ *       remain peer named types; a UNION-of-named-types root must be written
+ *       explicitly ({@code TYPE UNION(...)}).</li>
  * </ul>
+ *
+ * <p>A named inline root — a bare {@code STRUCT}/{@code ENUM} carrying
+ * {@link LogicalType#getName()} (e.g. an unwrapped Protobuf message) — is emitted as a named
+ * declaration and round-trips: the visitor unwraps a leaf named root back to a bare body carrying
+ * {@code LogicalType.name} (see {@code LogicalTypesSchemaVisitor.maybeUnwrapNamedRoot}), so the
+ * bare-root + name shape is preserved through {@code LT → DDL → LT}.
  */
 public final class LogicalTypeToDdlConverter {
 

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverter.java
@@ -93,10 +93,27 @@ public final class LogicalTypeToDdlConverter {
             .append(";\n");
       }
 
-      // Named-type declarations (`STRUCT <name> (...)` / `ENUM <name> (...)`) in
-      // declaration order, LOCAL types only. Externals' bodies are also in
-      // namedTypes (lazy-promoted by the reader from resolvedReferences),
-      // but they're external by inference on read-back — must NOT be
+      // A named inline root (bare STRUCT/ENUM carrying LogicalType.name — e.g. a Protobuf message
+      // unwrapped to a struct, or a JSON root object's title) is emitted as a named declaration so
+      // its name shows in the DDL. It is emitted FIRST, before the peer declarations, because the
+      // visitor infers the root as the first-declared type not referenced by another — so ordering
+      // it first makes it the root even when independent peer types follow.
+      //
+      // The one guard is a name collision: if the root's namespace-qualified name already names a
+      // local type, emitting the declaration would duplicate it on parse, so fall back to the
+      // anonymous `TYPE STRUCT(...)` form instead. (Display only — exact-shape round-trip later.)
+      Schema root = lt.getRootSchema();
+      boolean rootIsBareNamed =
+          (root.getType() == Schema.Type.STRUCT || root.getType() == Schema.Type.ENUM)
+              && lt.getName() != null;
+      boolean rootIsNamedInline = rootIsBareNamed && !namedTypeKeyExistsForRoot(lt.getName());
+      if (rootIsNamedInline) {
+        printCreateType(lt.getName(), root);
+      }
+
+      // Peer named-type declarations (`STRUCT <name> (...)` / `ENUM <name> (...)`), LOCAL types
+      // only. Externals' bodies are also in namedTypes (lazy-promoted by the reader from
+      // resolvedReferences), but they're external by inference on read-back — must NOT be
       // re-emitted here.
       for (String name : orderedLocalNames()) {
         if (lt.getExternalTypes().contains(name)) {
@@ -105,20 +122,9 @@ public final class LogicalTypeToDdlConverter {
         printCreateType(name, lt.getNamedTypes().get(name));
       }
 
-      // A named inline root (bare STRUCT/ENUM carrying LogicalType.name — e.g. a Protobuf message
-      // unwrapped to a struct, or a JSON root object's title) is emitted as a named declaration so
-      // its name shows in the DDL; the visitor infers the sole/unreferenced named type as the root
-      // on read-back. (Display only — exact-shape round-trip is revisited later.)
-      Schema root = lt.getRootSchema();
-      boolean rootIsNamedInline =
-          (root.getType() == Schema.Type.STRUCT || root.getType() == Schema.Type.ENUM)
-              && lt.getName() != null
-              && !lt.getNamedTypes().containsKey(lt.getName());
-      if (rootIsNamedInline) {
-        printCreateType(lt.getName(), root);
-      } else if (!sugarWouldInferRoot()) {
-        // Trailing root-registration `TYPE <typeExpr>`: omit when the visitor's
-        // auto-detect would produce the same root from the local types alone.
+      // Trailing root-registration `TYPE <typeExpr>` for a root not emitted as a named declaration,
+      // omitted when the visitor's auto-detect would produce the same root from the declarations.
+      if (!rootIsNamedInline && !sugarWouldInferRoot()) {
         sb.append("TYPE ").append(typeExpr(root)).append(";\n");
       }
 
@@ -420,6 +426,18 @@ public final class LogicalTypeToDdlConverter {
      * the same {@code rootSchema} we have. When true, the trailing
      * root-registration {@code TYPE} statement is elided.
      */
+    /**
+     * True if the root's name, qualified by the document namespace, already names a local type —
+     * in which case emitting the root as a named declaration would duplicate it on parse.
+     */
+    private boolean namedTypeKeyExistsForRoot(String rootName) {
+      if (lt.getNamedTypes().containsKey(rootName)) {
+        return true;
+      }
+      String ns = lt.getNamespace();
+      return ns != null && lt.getNamedTypes().containsKey(ns + "." + rootName);
+    }
+
     private boolean sugarWouldInferRoot() {
       if (lt.getNamedTypes().isEmpty()) {
         return false;
@@ -458,34 +476,11 @@ public final class LogicalTypeToDdlConverter {
         }
         return roots.iterator().next().equals(root.getQualifiedName());
       }
-      if (roots.isEmpty()) {
-        // Cycle in local types — visitor can't infer; explicit trailing TYPE required.
-        return false;
-      }
-      // Multi-root sugar: UNION of NAMED_TYPE_REFs (NOT NULL) to all roots,
-      // each branch named with the simple name.
-      if (root.getType() != Schema.Type.UNION || root.isNullable()) {
-        return false;
-      }
-      List<Schema.UnionBranch> branches = root.getBranches();
-      if (branches.size() != roots.size()) {
-        return false;
-      }
-      int i = 0;
-      for (String fqn : roots) {
-        Schema.UnionBranch b = branches.get(i++);
-        if (!b.getName().equals(simpleNameOf(fqn))) {
-          return false;
-        }
-        Schema bs = b.getSchema();
-        if (bs.getType() != Schema.Type.NAMED_TYPE_REF) {
-          return false;
-        }
-        if (bs.isNullable() || !fqn.equals(bs.getQualifiedName())) {
-          return false;
-        }
-      }
-      return true;
+      // Zero roots (cycle) or multiple unreferenced roots: the visitor infers a single root — the
+      // first-declared unreferenced type — which won't match a cyclic or UNION-of-refs root, so an
+      // explicit trailing TYPE is required. (A UNION-of-named-types root is no longer sugared; it
+      // must be written as an explicit `TYPE UNION(...)`.)
+      return false;
     }
 
     private static String simpleNameOf(String qualifiedName) {

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverter.java
@@ -133,10 +133,13 @@ public final class LogicalTypeToDdlConverter {
 
       // Root registration.
       if (rootIsNamedInline) {
-        // Inference selects the inline root only when no peer references it — a referenced type is
-        // dropped from the unreferenced set, so inference would pick a peer instead. When a peer
-        // references the root, force it with an explicit trailing TYPE, preserving its nullability.
-        if (inlineRootReferencedByPeer()) {
+        // Force the root with an explicit trailing TYPE in two cases:
+        //   - a peer references it: inference drops referenced types from the unreferenced set, so
+        //     sugar would pick a peer instead;
+        //   - the root is nullable: a bare named declaration re-parses under sugar as NOT NULL
+        //     (ambient), so without the explicit TYPE the root's nullability would be lost.
+        // The trailing TYPE carries the nullability marker the bare declaration cannot.
+        if (inlineRootReferencedByPeer() || root.isNullable()) {
           sb.append("TYPE ").append(qualifiedName(lt.getName()));
           if (!root.isNullable()) {
             sb.append(" NOT NULL");

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitor.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitor.java
@@ -66,6 +66,7 @@ import java.util.stream.Collectors;
  */
 public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
 
+  private String name;
   private String namespace;
   private final Map<String, String> externalImports = new LinkedHashMap<>();
   private final Map<String, Schema> namedTypes = new LinkedHashMap<>();
@@ -106,7 +107,7 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
    * here is guaranteed to satisfy both invariants.
    */
   public LogicalType toLogicalType() {
-    return new LogicalType(namespace, rootSchema, namedTypes,
+    return new LogicalType(name, namespace, rootSchema, namedTypes,
         inferExternalTypes(),
         externalImports,
         java.util.Collections.emptyList(), java.util.Collections.emptyMap(),
@@ -159,8 +160,27 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
     } else {
       inferAndRegisterRoot(ctx);
     }
+    maybeUnwrapNamedRoot();
     validateAliases();
     return null;
+  }
+
+  /**
+   * Unwrap a leaf named root to the bare {@code STRUCT}/{@code ENUM} body + {@link #name}, the
+   * canonical named-root shape shared with the format readers. Delegates to
+   * {@link LogicalType#unwrapLeafNamedRoot} for the gating (external/cyclic/nested roots, and
+   * foreign-namespace roots, stay {@code NAMED_TYPE_REF}). Note a bare named-root declaration is
+   * ambient (re-parses as
+   * {@code NOT NULL}), so a nullable named root's null-ness is not carried through DDL — consistent
+   * with the convention that a registered root is non-null at the wire level.
+   */
+  private void maybeUnwrapNamedRoot() {
+    LogicalType.RootUnwrap unwrap =
+        LogicalType.unwrapLeafNamedRoot(rootSchema, namedTypes, namespace);
+    rootSchema = unwrap.getRootSchema();
+    if (unwrap.getName() != null) {
+      name = unwrap.getName();
+    }
   }
 
   /**

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitor.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitor.java
@@ -169,10 +169,9 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
    * Unwrap a leaf named root to the bare {@code STRUCT}/{@code ENUM} body + {@link #name}, the
    * canonical named-root shape shared with the format readers. Delegates to
    * {@link LogicalType#unwrapLeafNamedRoot} for the gating (external/cyclic/nested roots, and
-   * foreign-namespace roots, stay {@code NAMED_TYPE_REF}). Note a bare named-root declaration is
-   * ambient (re-parses as
-   * {@code NOT NULL}), so a nullable named root's null-ness is not carried through DDL — consistent
-   * with the convention that a registered root is non-null at the wire level.
+   * foreign-namespace roots, stay {@code NAMED_TYPE_REF}). A bare named-root declaration alone is
+   * ambient and re-parses as {@code NOT NULL}; the DDL writer therefore emits an explicit trailing
+   * {@code TYPE} for nullable named roots so their nullability is preserved.
    */
   private void maybeUnwrapNamedRoot() {
     // The visitor never places external bodies in namedTypes (externals are inferred from usage and

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitor.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitor.java
@@ -175,8 +175,10 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
    * with the convention that a registered root is non-null at the wire level.
    */
   private void maybeUnwrapNamedRoot() {
+    // The visitor never places external bodies in namedTypes (externals are inferred from usage and
+    // held via externalImports), so there is no external root to guard against here — pass empty.
     LogicalType.RootUnwrap unwrap =
-        LogicalType.unwrapLeafNamedRoot(rootSchema, namedTypes, namespace);
+        LogicalType.unwrapLeafNamedRoot(rootSchema, namedTypes, Set.of(), namespace);
     rootSchema = unwrap.getRootSchema();
     if (unwrap.getName() != null) {
       name = unwrap.getName();

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitor.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitor.java
@@ -244,13 +244,12 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
    * root nullability by design. Callers wanting a nullable root must write
    * the trailing {@code TYPE Foo} (or {@code ... NULL}) explicitly.
    *
-   * <p>Multi-root: when more than one defined type is unreferenced (e.g.,
-   * a script with several peer messages and no explicit trailing
-   * registration), the inferred root is a {@code UNION} of
-   * {@code NAMED_TYPE_REF}s to all of them. Avro/JSON writers emit this as a
-   * tagged union / {@code oneOf}; the proto writer detects the shape and
-   * treats it as a multi-message file (first member becomes the primary root,
-   * rest emit as peer messages).
+   * <p>Multiple unreferenced types (e.g. a script with several independent peer
+   * messages and no explicit trailing registration): the FIRST-declared one is
+   * the root; the rest remain as peer named types. This matches Protobuf's
+   * "first message is the root" convention and the writer, which emits the root
+   * declaration first. A genuine multi-root {@code UNION} at the root is no
+   * longer inferred — write it explicitly as {@code TYPE UNION(a A, b B) NOT NULL}.
    *
    * <p>Errors:
    * <ul>
@@ -291,14 +290,6 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
     // pollute the "no unique root" / "multiple roots" diagnostics.
     roots.removeIf(name -> LogicalType.parentOf(name, defined) != null);
 
-    if (roots.size() == 1) {
-      String name = roots.iterator().next();
-      Schema ref = Schema.createNamedTypeRef(name);
-      ref.setNullable(false);
-      rootSchema = ref;
-      return;
-    }
-
     if (roots.isEmpty()) {
       List<String> cycle = findCycle(uses);
       throw error(ctx,
@@ -307,30 +298,15 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
               + ". Add an explicit trailing 'TYPE <name>' statement.");
     }
 
-    // Multiple unreferenced top-level types → wrap them in a UNION at the root.
-    // Avro/JSON emit this as a tagged union / oneOf, which is the natural
-    // multi-message representation. The proto writer detects this shape (UNION
-    // whose members are all NAMED_TYPE_REFs to local types at the root) and
-    // treats it as a multi-message file: the first member becomes the primary
-    // root, the rest emit as peer messages via the existing namedTypes path.
-    List<Schema.UnionBranch> branches = new ArrayList<>(roots.size());
-    for (String name : roots) {
-      branches.add(new Schema.UnionBranch(
-          simpleNameOf(name),
-          Schema.createNamedTypeRef(name).setNullable(false),
-          null, null));
-    }
-    rootSchema = Schema.createUnion(branches).setNullable(false);
-  }
-
-  /**
-   * Simple-name slice of a qualified name: everything after the last dot, or
-   * the full name if it's unqualified. Used as the union branch name in
-   * multi-root sugar.
-   */
-  private static String simpleNameOf(String qualifiedName) {
-    int dot = qualifiedName.lastIndexOf('.');
-    return dot < 0 ? qualifiedName : qualifiedName.substring(dot + 1);
+    // The root is the first-declared type not referenced by another. When several are unreferenced
+    // (e.g. independent peer messages), the first wins and the rest remain as peer named types;
+    // this matches the writer (which emits the root declaration first) and Protobuf's "first
+    // message is the root" convention. A genuine multi-root UNION must be written explicitly, e.g.
+    // `TYPE UNION(a A, b B) NOT NULL`.
+    String name = roots.iterator().next();
+    Schema ref = Schema.createNamedTypeRef(name);
+    ref.setNullable(false);
+    rootSchema = ref;
   }
 
   /**

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
@@ -89,11 +89,18 @@ public class AvroToLogicalTypeConverter {
     }
     final Schema schema =
         convertWithCycleDetection(avroSchema.rawSchema(), false, ctx, new ArrayList<>());
+    final String namespace = extractNamespace(avroSchema);
+    // Unwrap a leaf named root record/enum to a bare STRUCT/ENUM + LogicalType.name, the canonical
+    // named-root shape shared with the DDL visitor and the other format readers.
+    final LogicalType.RootUnwrap unwrap =
+        LogicalType.unwrapLeafNamedRoot(schema, ctx.getNamedTypes(), namespace);
     return new LogicalType(
-        extractNamespace(avroSchema),
-        schema,
+        unwrap.getName(),
+        namespace,
+        unwrap.getRootSchema(),
         ctx.getNamedTypes(),
         ctx.getExternalTypes(),
+        Map.of(),
         avroSchema.references(),
         avroSchema.resolvedReferences(),
         ctx.getDefaultValues());

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
@@ -92,8 +92,8 @@ public class AvroToLogicalTypeConverter {
     final String namespace = extractNamespace(avroSchema);
     // Unwrap a leaf named root record/enum to a bare STRUCT/ENUM + LogicalType.name, the canonical
     // named-root shape shared with the DDL visitor and the other format readers.
-    final LogicalType.RootUnwrap unwrap =
-        LogicalType.unwrapLeafNamedRoot(schema, ctx.getNamedTypes(), namespace);
+    final LogicalType.RootUnwrap unwrap = LogicalType.unwrapLeafNamedRoot(
+        schema, ctx.getNamedTypes(), ctx.getExternalTypes(), namespace);
     return new LogicalType(
         unwrap.getName(),
         namespace,

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/LogicalTypeToAvroConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/LogicalTypeToAvroConverter.java
@@ -135,8 +135,17 @@ public class LogicalTypeToAvroConverter {
 
       return applyMetadata(avroSchema, metadataProps, logicalType, ctx.isV1());
     }
+    // A named root (bare STRUCT/ENUM carrying LogicalType.name) emits under its own name, taking
+    // precedence over the caller's rowName. The reader unwraps only when the root's namespace
+    // matches, so namespace + name reconstructs the original Avro full name.
+    String rootName = rowName;
+    if (logicalType.getName() != null) {
+      rootName = logicalType.getNamespace() != null
+          ? logicalType.getNamespace() + "." + logicalType.getName()
+          : logicalType.getName();
+    }
     org.apache.avro.Schema notNullSchema =
-        fromLogicalTypeIgnoreNullable(schema, rowName, ctx);
+        fromLogicalTypeIgnoreNullable(schema, rootName, ctx);
     org.apache.avro.Schema result = schema.isNullable()
         ? nullableSchema(notNullSchema) : notNullSchema;
     return applyMetadata(result, metadataProps, logicalType, ctx.isV1());

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/LogicalTypeToAvroConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/LogicalTypeToAvroConverter.java
@@ -151,6 +151,25 @@ public class LogicalTypeToAvroConverter {
     return applyMetadata(result, metadataProps, logicalType, ctx.isV1());
   }
 
+  /**
+   * True when {@code rowName} is the name of the LogicalType's named root — i.e. the root was
+   * unwrapped to a bare inline STRUCT/ENUM carrying {@link LogicalType#getName()}, and is being
+   * emitted under that name. Such a root is a genuine named record/enum (not anonymous), so its
+   * name survives the round-trip; anonymous roots ({@code getName() == null}) and nested inline
+   * structs remain anonymous.
+   */
+  private static boolean isNamedRoot(
+      String rowName, FromLogicalContext<org.apache.avro.Schema> ctx) {
+    LogicalType lt = ctx.getLogicalType();
+    if (lt.getName() == null) {
+      return false;
+    }
+    String rootName = lt.getNamespace() != null
+        ? lt.getNamespace() + "." + lt.getName()
+        : lt.getName();
+    return rootName.equals(rowName);
+  }
+
   private static AvroSchema applyMetadata(
       org.apache.avro.Schema schema, Map<String, String> metadataProps,
       LogicalType logicalType, boolean isV1) {
@@ -302,12 +321,13 @@ public class LogicalTypeToAvroConverter {
               fieldName, fieldAvroSchema, field.getDoc(), defaultVal));
         }
         recordSchema.setFields(avroFields);
-        // Add schema-level tags and params as record props. Mark as anonymous:
-        // case STRUCT is only reached for inline LT structs (named types go
-        // through buildNamedRecord, not this case).
+        // Add schema-level tags and params as record props. Inline structs are
+        // anonymous, EXCEPT the named root: since Option A a named root is a bare
+        // inline STRUCT carrying LogicalType.name, and it must stay a named record
+        // (no logical.anonymous marker) so the reader recovers its name.
         if (!ctx.isV1()) {
           addSchemaTags(recordSchema, schema);
-          addSchemaParams(recordSchema, schema, true);
+          addSchemaParams(recordSchema, schema, !isNamedRoot(rowName, ctx));
           addSchemaRules(recordSchema, schema);
           // Add field-level and union branch metadata as field props
           for (Field field : schema.getFields()) {
@@ -338,8 +358,10 @@ public class LogicalTypeToAvroConverter {
         if (!ctx.isV1()) {
           addSchemaTags(enumSchema, schema);
           // Anonymous unless this enum was reached as a named-type reference
-          // (rowName equals the qualified name of a registered named type).
-          addSchemaParams(enumSchema, schema, !ctx.hasNamedType(rowName));
+          // (rowName equals the qualified name of a registered named type), or it
+          // is the named root (a bare inline ENUM carrying LogicalType.name).
+          addSchemaParams(enumSchema, schema,
+              !ctx.hasNamedType(rowName) && !isNamedRoot(rowName, ctx));
           addEnumValueMeta(enumSchema, schema);
         }
         return enumSchema;

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/JsonToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/JsonToLogicalTypeConverter.java
@@ -131,7 +131,13 @@ public class JsonToLogicalTypeConverter {
             Collections.emptyList());
     Object ns = schema.rawSchema().getUnprocessedProperties()
         .get("confluent:namespace");
+    // An inline root object/enum has no namedTypes key to carry its name, so carry the JSON
+    // `title` as the root name; a $ref root (NAMED_TYPE_REF) is already named by its key.
+    final String rootName = (logicalType.getType() == Schema.Type.STRUCT
+        || logicalType.getType() == Schema.Type.ENUM)
+        ? schema.rawSchema().getTitle() : null;
     return new LogicalType(
+        rootName,
         ns instanceof String ? (String) ns : null,
         logicalType,
         ctx.getNamedTypes(),

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/LogicalTypeToJsonConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/LogicalTypeToJsonConverter.java
@@ -106,6 +106,13 @@ public class LogicalTypeToJsonConverter {
 
     org.everit.json.schema.Schema.Builder<?> rootBuilder =
         fromLogicalTypeBuilder(schema, rootName, ctx);
+    // A nullable named STRUCT/ENUM root is wrapped in an outer combined schema whose title (the
+    // name) lands only on the inner branch. The reader recovers the root name from the OUTER
+    // title, so re-apply the name to the outer builder or it is lost on read-back.
+    if (logicalType.getName() != null && schema.isNullable()
+        && (schema.getType() == Schema.Type.STRUCT || schema.getType() == Schema.Type.ENUM)) {
+      rootBuilder.title(logicalType.getName());
+    }
 
     // Some everit primitive builders initialize unprocessedProperties as an
     // immutable singleton map (e.g., {connect.type=int32}). Build a fresh

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/LogicalTypeToJsonConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/json/LogicalTypeToJsonConverter.java
@@ -91,6 +91,11 @@ public class LogicalTypeToJsonConverter {
     FromLogicalContext<String> ctx =
         new FromLogicalContext<>(logicalType, version);
 
+    // A named root (bare object/enum carrying LogicalType.name) emits its name as the root schema's
+    // `title`, taking precedence over the caller's rowName (mirrors the JSON reader, which recovers
+    // the name from the root `title`).
+    String rootName = logicalType.getName() != null ? logicalType.getName() : rowName;
+
     // Register each external type name → source doc URI. The NAMED_TYPE_REF
     // case uses this mapping to emit `<doc>#/$defs/<name>` refs. Throws on
     // duplicate-name collisions across resolvedReferences.
@@ -100,7 +105,7 @@ public class LogicalTypeToJsonConverter {
     }
 
     org.everit.json.schema.Schema.Builder<?> rootBuilder =
-        fromLogicalTypeBuilder(schema, rowName, ctx);
+        fromLogicalTypeBuilder(schema, rootName, ctx);
 
     // Some everit primitive builders initialize unprocessedProperties as an
     // immutable singleton map (e.g., {connect.type=int32}). Build a fresh

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/LogicalTypeToProtoConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/LogicalTypeToProtoConverter.java
@@ -129,6 +129,15 @@ public class LogicalTypeToProtoConverter {
     }
     Schema schema = logicalType.getRootSchema();
 
+    // A named root (bare STRUCT/ENUM carrying LogicalType.name) emits as the file's root message
+    // under its own simple name, taking precedence over the caller's rowName. The namespace lives
+    // on the file's package declaration (logicalType.getNamespace()), so only the simple name is
+    // used here — mirroring the NAMED_TYPE_REF-root resolution below.
+    if (logicalType.getName() != null
+        && (schema.getType() == Schema.Type.STRUCT || schema.getType() == Schema.Type.ENUM)) {
+      rowName = logicalType.getName();
+    }
+
     // Multi-root sugar: when the root is a UNION whose members are all
     // NAMED_TYPE_REFs to local types, the visitor's sugar inferred it from
     // multiple unreferenced top-level named-type declarations. Proto's wire

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverter.java
@@ -199,18 +199,25 @@ public class ProtoToLogicalTypeConverter {
     //     preserves the historical "namedTypes = peers; root is direct"
     //     convention for the simple case.
     final Schema rootSchema;
+    final String rootName;
     if (LogicalType.isCyclic(rootFqn, ctx.getNamedTypes())
         || hasNestedNamedTypes(rootFqn, ctx.getNamedTypes())) {
       rootSchema = Schema.createNamedTypeRef(rootFqn).setNullable(false);
+      // Root kept as a NAMED_TYPE_REF: its name is the namedTypes key, so don't duplicate it.
+      rootName = null;
     } else {
       rootSchema = rootBody;
       ((java.util.Map<String, Schema>) ctx.getNamedTypes()).remove(rootFqn);
+      // Root unwrapped to a bare STRUCT: its message name would otherwise be lost, so carry it.
+      rootName = rootMessage.getName();
     }
     return new LogicalType(
+        rootName,
         emptyToNull(file.getPackage()),
         rootSchema,
         ctx.getNamedTypes(),
         ctx.getExternalTypes(),
+        Map.of(),
         schema.references(),
         schema.resolvedReferences(),
         ctx.getDefaultValues());

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverter.java
@@ -188,20 +188,17 @@ public class ProtoToLogicalTypeConverter {
     for (Descriptor topLevel : messageTypes) {
       buildNestedBodies(topLevel, ctx);
     }
-    // Decide the rootSchema shape:
-    //   - Recursive (self or mutual cycle): keep as NAMED_TYPE_REF, body in
-    //     namedTypes — necessary for cyclic field references to resolve.
-    //   - Has nested types in namedTypes (auto-promoted via cycle detection
-    //     or user-marked): keep as NAMED_TYPE_REF — the nested types use
-    //     parentOf() to find their parent, which requires the root to be in
-    //     namedTypes.
-    //   - Otherwise: unwrap to STRUCT and remove root from namedTypes —
-    //     preserves the historical "namedTypes = peers; root is direct"
-    //     convention for the simple case.
+    // Decide the rootSchema shape. Keep the root as a NAMED_TYPE_REF (body in namedTypes) when:
+    //   - recursive (self/mutual cycle) — cyclic field references need the body present;
+    //   - it has nested types in namedTypes — they use parentOf(), which needs the root present;
+    //   - a peer references it — unwrapping would remove the body and dangle that reference.
+    // Otherwise unwrap to a bare STRUCT and remove the root from namedTypes, preserving the
+    // historical "namedTypes = peers; root is direct" convention for the simple case.
     final Schema rootSchema;
     final String rootName;
     if (LogicalType.isCyclic(rootFqn, ctx.getNamedTypes())
-        || hasNestedNamedTypes(rootFqn, ctx.getNamedTypes())) {
+        || hasNestedNamedTypes(rootFqn, ctx.getNamedTypes())
+        || LogicalType.isReferencedByPeer(rootFqn, ctx.getNamedTypes())) {
       rootSchema = Schema.createNamedTypeRef(rootFqn).setNullable(false);
       // Root kept as a NAMED_TYPE_REF: its name is the namedTypes key, so don't duplicate it.
       rootName = null;

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverterTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class LogicalTypeToDdlConverterTest {
@@ -39,16 +40,21 @@ class LogicalTypeToDdlConverterTest {
     return visitor.toLogicalType();
   }
 
-  /** Round-trip: emit, re-parse, compare schemas/named-types. */
+  /**
+   * Round-trip: assert the DDL projection is stable across {@code emit -> parse -> emit}.
+   *
+   * <p>This is idempotence rather than {@code LogicalType} equality on purpose: a leaf named root
+   * canonicalizes on parse (a {@code NAMED_TYPE_REF} root + {@code namedTypes} entry unwraps to a
+   * bare {@code STRUCT}/{@code ENUM} root carrying {@link LogicalType#getName()}), so the parsed
+   * {@code LogicalType} may differ in shape from an original built the older way while representing
+   * the same schema. DDL-string stability still catches real losses — a dropped root name, for
+   * instance, would re-emit as an anonymous {@code TYPE STRUCT(...)} and fail here.
+   */
   private static void assertRoundTrip(LogicalType original) {
     String ddl = LogicalTypeToDdlConverter.toDdl(original);
-    LogicalType parsed = parse(ddl);
-    assertEquals(original.getNamespace(), parsed.getNamespace(),
-        "namespace should round-trip\nDDL:\n" + ddl);
-    assertEquals(original.getRootSchema(), parsed.getRootSchema(),
-        "rootSchema should round-trip\nDDL:\n" + ddl);
-    assertEquals(original.getNamedTypes(), parsed.getNamedTypes(),
-        "namedTypes should round-trip\nDDL:\n" + ddl);
+    String reemitted = LogicalTypeToDdlConverter.toDdl(parse(ddl));
+    assertEquals(ddl, reemitted,
+        "DDL should be stable across emit -> parse -> emit\nDDL:\n" + ddl);
   }
 
   // -----------------------------------------------------------------------
@@ -158,12 +164,19 @@ class LogicalTypeToDdlConverterTest {
   @Test
   void declareNamespace() {
     Schema struct = Schema.createStruct(Arrays.asList(
-        new Schema.Field("x", Schema.create(Schema.Type.INT).setNullable(false), 0)));
+        new Schema.Field("x", Schema.create(Schema.Type.INT).setNullable(false), 0)))
+        .setNullable(false);
+    // Canonical shape for a leaf named root: bare STRUCT root carrying name + namespace,
+    // no namedTypes entry (this is what parsing the DDL back yields).
     LogicalType lt = new LogicalType(
+        "Row",
         "com.example",
-        Schema.createNamedTypeRef("com.example.Row").setNullable(false),
-        Map.of("com.example.Row", struct),
+        struct,
+        Map.of(),
+        Set.of(),
+        Map.of(),
         List.of(),
+        Map.of(),
         Map.of());
     assertRoundTrip(lt);
     String ddl = LogicalTypeToDdlConverter.toDdl(lt);
@@ -286,17 +299,27 @@ class LogicalTypeToDdlConverterTest {
   }
 
   @Test
-  void explicitRegisterEmittedWhenSugarWouldDiffer() {
-    // Root is the local type but NULLABLE — sugar would produce NOT NULL,
-    // so we MUST emit explicit TYPE to preserve nullability.
+  void namedRootNullabilityIsAmbient() {
+    // Under Option A a leaf named root canonicalizes to a bare STRUCT/ENUM carrying a name;
+    // the root's own nullability is ambient (a named root carries its name, not its
+    // null-ness). So the converter elides TYPE for a named root regardless of nullability,
+    // and it round-trips stably — there is no longer an "explicit TYPE to preserve root
+    // nullability" case for named roots.
     Schema struct = Schema.createStruct(Arrays.asList(
         new Schema.Field("x", Schema.create(Schema.Type.INT).setNullable(false), 0)));
     LogicalType lt = new LogicalType(
-        Schema.createNamedTypeRef("Row"),  // nullable
-        Map.of("Row", struct));
+        "Row",
+        null,
+        struct,  // nullable (ambient for a named root)
+        Map.of(),
+        Set.of(),
+        Map.of(),
+        List.of(),
+        Map.of(),
+        Map.of());
     String ddl = LogicalTypeToDdlConverter.toDdl(lt);
-    assertTrue(ddl.contains("TYPE"),
-        "nullable root should emit explicit TYPE, got:\n" + ddl);
+    assertTrue(!ddl.contains("TYPE"),
+        "named root should elide TYPE (nullability is ambient), got:\n" + ddl);
     assertRoundTrip(lt);
   }
 
@@ -318,5 +341,26 @@ class LogicalTypeToDdlConverterTest {
     Schema.Field a = parsed.getRootSchema().getField("a");
     assertEquals(Integer.valueOf(42), a.getFieldNumber());
     assertEquals(Arrays.asList("a_old", "a_older"), a.getAliases());
+  }
+
+  @Test
+  void namedInlineRootRoundTripsThroughDdl() {
+    // A named inline root (bare STRUCT + LogicalType.name) round-trips: it emits as a named
+    // declaration and re-parses to the SAME bare-STRUCT root carrying the name (the visitor unwraps
+    // a leaf named root back to bare + name).
+    Schema root = Schema.createStruct(Arrays.asList(
+        new Schema.Field("a", Schema.create(Schema.Type.INT).setNullable(false), 0)))
+        .setNullable(false);
+    LogicalType original = new LogicalType("Order", null, root,
+        Map.of(), Set.of(), Map.of(), List.of(), Map.of(), Map.of());
+
+    String ddl = LogicalTypeToDdlConverter.toDdl(original);
+    assertTrue(ddl.contains("STRUCT Order ("), ddl);
+
+    LogicalType parsed = parse(ddl);
+    assertEquals(Schema.Type.STRUCT, parsed.getRootSchema().getType());
+    assertEquals("Order", parsed.getName());
+    assertEquals(original.getRootSchema(), parsed.getRootSchema());
+    assertTrue(parsed.getNamedTypes().isEmpty(), parsed.getNamedTypes().keySet().toString());
   }
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverterTest.java
@@ -299,18 +299,17 @@ class LogicalTypeToDdlConverterTest {
   }
 
   @Test
-  void namedRootNullabilityIsAmbient() {
-    // Under Option A a leaf named root canonicalizes to a bare STRUCT/ENUM carrying a name;
-    // the root's own nullability is ambient (a named root carries its name, not its
-    // null-ness). So the converter elides TYPE for a named root regardless of nullability,
-    // and it round-trips stably — there is no longer an "explicit TYPE to preserve root
-    // nullability" case for named roots.
+  void namedRootNullabilityIsPreserved() {
+    // A leaf named root canonicalizes to a bare STRUCT/ENUM carrying a name. A bare named
+    // declaration re-parses under sugar as NOT NULL (ambient), so to keep a *nullable* root
+    // lossless the converter forces an explicit trailing `TYPE <name>` (no NOT NULL). A NOT NULL
+    // named root still elides TYPE (sugar re-infers it NOT NULL). Both round-trip stably.
     Schema struct = Schema.createStruct(Arrays.asList(
         new Schema.Field("x", Schema.create(Schema.Type.INT).setNullable(false), 0)));
     LogicalType lt = new LogicalType(
         "Row",
         null,
-        struct,  // nullable (ambient for a named root)
+        struct,  // nullable (Schema default)
         Map.of(),
         Set.of(),
         Map.of(),
@@ -318,9 +317,27 @@ class LogicalTypeToDdlConverterTest {
         Map.of(),
         Map.of());
     String ddl = LogicalTypeToDdlConverter.toDdl(lt);
-    assertTrue(!ddl.contains("TYPE"),
-        "named root should elide TYPE (nullability is ambient), got:\n" + ddl);
+    assertTrue(ddl.contains("TYPE `Row`;"),
+        "nullable named root should force an explicit nullable TYPE, got:\n" + ddl);
+    assertTrue(!ddl.contains("TYPE `Row` NOT NULL"),
+        "nullable named root's TYPE must not carry NOT NULL, got:\n" + ddl);
+    // Nullability survives the round-trip.
+    assertTrue(parse(ddl).getRootSchema().isNullable(),
+        "re-parsed nullable named root should stay nullable, got:\n" + ddl);
     assertRoundTrip(lt);
+
+    // A NOT NULL named root elides TYPE (sugar re-infers NOT NULL — nothing to preserve).
+    Schema notNullStruct = Schema.createStruct(Arrays.asList(
+        new Schema.Field("x", Schema.create(Schema.Type.INT).setNullable(false), 0)))
+        .setNullable(false);
+    LogicalType notNull = new LogicalType(
+        "Row", null, notNullStruct, Map.of(), Set.of(), Map.of(), List.of(), Map.of(), Map.of());
+    String notNullDdl = LogicalTypeToDdlConverter.toDdl(notNull);
+    assertTrue(!notNullDdl.contains("TYPE"),
+        "NOT NULL named root should elide TYPE, got:\n" + notNullDdl);
+    assertTrue(!parse(notNullDdl).getRootSchema().isNullable(),
+        "re-parsed NOT NULL named root should stay NOT NULL, got:\n" + notNullDdl);
+    assertRoundTrip(notNull);
   }
 
   @Test

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitorTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitorTest.java
@@ -1524,44 +1524,32 @@ class LogicalTypesSchemaVisitorTest {
   }
 
   @Test
-  void testSugarMultipleRootsInferredAsUnion() {
-    // Two unreferenced top-level types and no explicit trailing TYPE → sugar
-    // infers a non-nullable UNION of NAMED_TYPE_REFs at the root. Avro/JSON
-    // emit this as a tagged union; the proto writer detects the shape and
-    // treats it as a multi-message file.
+  void testSugarMultipleRootsFirstWins() {
+    // Two unreferenced top-level types and no explicit trailing TYPE → the FIRST-declared type is
+    // the root (matching Protobuf's "first message is the root"); the rest remain as peer named
+    // types. A genuine UNION-of-refs root must be written explicitly.
     LogicalTypesSchemaVisitor v = parseScript(
         "STRUCT Foo (x INT);"
         + "STRUCT Bar (y INT)");
     Schema root = v.getRootSchema();
-    assertEquals(Schema.Type.UNION, root.getType());
-    assertFalse(root.isNullable(), "sugar root must be NOT NULL");
-    assertEquals(2, root.getBranches().size());
-    assertEquals("Foo", root.getBranches().get(0).getName());
-    assertEquals(Schema.Type.NAMED_TYPE_REF,
-        root.getBranches().get(0).getSchema().getType());
-    assertEquals("Foo",
-        root.getBranches().get(0).getSchema().getQualifiedName());
-    assertEquals("Bar", root.getBranches().get(1).getName());
-    assertEquals("Bar",
-        root.getBranches().get(1).getSchema().getQualifiedName());
+    assertEquals(Schema.Type.NAMED_TYPE_REF, root.getType());
+    assertEquals("Foo", root.getQualifiedName());
+    assertFalse(root.isNullable(), "inferred root must be NOT NULL");
+    assertTrue(v.toLogicalType().getNamedTypes().containsKey("Bar"),
+        "the non-root peer stays a named type");
   }
 
   @Test
-  void testSugarMultipleRootsInNamespace() {
-    // Multi-root with default namespace — branch names use the simple name,
-    // member NAMED_TYPE_REFs carry the qualified key.
+  void testSugarMultipleRootsFirstWinsInNamespace() {
+    // First-wins with a default namespace — the root's qualified key wins.
     LogicalTypesSchemaVisitor v = parseScript(
         "NAMESPACE com.example;"
         + "STRUCT Foo (x INT);"
         + "STRUCT Bar (y INT)");
     Schema root = v.getRootSchema();
-    assertEquals(Schema.Type.UNION, root.getType());
-    assertEquals("Foo", root.getBranches().get(0).getName());
-    assertEquals("com.example.Foo",
-        root.getBranches().get(0).getSchema().getQualifiedName());
-    assertEquals("Bar", root.getBranches().get(1).getName());
-    assertEquals("com.example.Bar",
-        root.getBranches().get(1).getSchema().getQualifiedName());
+    assertEquals(Schema.Type.NAMED_TYPE_REF, root.getType());
+    assertEquals("com.example.Foo", root.getQualifiedName());
+    assertTrue(v.toLogicalType().getNamedTypes().containsKey("com.example.Bar"));
   }
 
   @Test
@@ -1586,8 +1574,8 @@ class LogicalTypesSchemaVisitorTest {
 
   @Test
   void testExplicitRegisterOverridesAmbiguity() {
-    // Two unrelated types — would be a multi-root error under sugar.
-    // Explicit TYPE disambiguates without complaint.
+    // Two unrelated types — first-wins would pick Foo as root; the explicit TYPE overrides that
+    // and registers Bar as the root instead.
     LogicalTypesSchemaVisitor v = parseScript(
         "STRUCT Foo (x INT);"
         + "STRUCT Bar (y INT);"

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitorTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitorTest.java
@@ -489,9 +489,9 @@ class LogicalTypesSchemaVisitorTest {
   void testRowKeywordIsAliasForStructDeclaration() {
     // `ROW <name> (...)` declares the same named STRUCT as `STRUCT <name> (...)`.
     Schema viaRow = parseScript("ROW Addr (zip INT, city STRING);")
-        .getNamedTypes().get("Addr");
+        .getRootSchema();
     Schema viaStruct = parseScript("STRUCT Addr (zip INT, city STRING);")
-        .getNamedTypes().get("Addr");
+        .getRootSchema();
     assertEquals(Schema.Type.STRUCT, viaRow.getType());
     assertEquals(viaStruct.toDdl(), viaRow.toDdl());
   }
@@ -619,8 +619,8 @@ class LogicalTypesSchemaVisitorTest {
         + ");"
         + "TYPE MyOrder"
     );
-    Schema order = v.getNamedTypes().get("MyOrder");
-    assertNotNull(order);
+    Schema order = v.getRootSchema();
+    assertEquals(Schema.Type.STRUCT, order.getType());
     assertEquals(Schema.Type.NAMED_TYPE_REF,
         order.getField("amount").getSchema().getType());
     assertEquals("com.example.Money",
@@ -775,15 +775,12 @@ class LogicalTypesSchemaVisitorTest {
         "STRUCT Person (id BIGINT NOT NULL, name STRING);"
         + "TYPE Person"
     );
-    // Named type registered.
-    Schema person = v.getNamedTypes().get("Person");
+    // A leaf named root unwraps to the bare STRUCT, carrying its name on LogicalType.
+    Schema person = v.getRootSchema();
     assertNotNull(person);
     assertEquals(Schema.Type.STRUCT, person.getType());
     assertEquals(2, person.getFields().size());
-    // Root is a NAMED_TYPE_REF pointing at Person.
-    Schema root = v.getRootSchema();
-    assertEquals(Schema.Type.NAMED_TYPE_REF, root.getType());
-    assertEquals("Person", root.getQualifiedName());
+    assertEquals("Person", v.toLogicalType().getName());
   }
 
   @Test
@@ -792,13 +789,11 @@ class LogicalTypesSchemaVisitorTest {
         "ENUM Color ('RED', 'GREEN', 'BLUE');"
         + "TYPE Color"
     );
-    Schema color = v.getNamedTypes().get("Color");
+    Schema color = v.getRootSchema();
     assertNotNull(color);
     assertEquals(Schema.Type.ENUM, color.getType());
     assertEquals(3, color.getEnumValues().size());
-    Schema root = v.getRootSchema();
-    assertEquals(Schema.Type.NAMED_TYPE_REF, root.getType());
-    assertEquals("Color", root.getQualifiedName());
+    assertEquals("Color", v.toLogicalType().getName());
   }
 
   @Test
@@ -810,7 +805,7 @@ class LogicalTypesSchemaVisitorTest {
         + " WITH('owner' = 'team-x');"
         + "TYPE Person"
     );
-    Schema person = v.getNamedTypes().get("Person");
+    Schema person = v.getRootSchema();
     assertEquals("a person", person.getDoc());
     assertEquals(1, person.getTags().size());
     assertEquals("PII", person.getTags().get(0));
@@ -825,7 +820,7 @@ class LogicalTypesSchemaVisitorTest {
         + " WITH('version' = '1');"
         + "TYPE Status"
     );
-    Schema status = v.getNamedTypes().get("Status");
+    Schema status = v.getRootSchema();
     assertEquals("user status", status.getDoc());
     assertEquals("1", status.getParams().get("version"));
   }
@@ -837,9 +832,10 @@ class LogicalTypesSchemaVisitorTest {
         + "STRUCT Person (name STRING);"
         + "TYPE Person"
     );
-    // Name is qualified by the declared namespace.
-    assertNotNull(v.getNamedTypes().get("com.example.Person"));
-    assertEquals("com.example.Person", v.getRootSchema().getQualifiedName());
+    // A leaf named root unwraps; the namespace stays on the LT and the simple name on getName().
+    assertEquals(Schema.Type.STRUCT, v.getRootSchema().getType());
+    assertEquals("com.example", v.toLogicalType().getNamespace());
+    assertEquals("Person", v.toLogicalType().getName());
   }
 
   @Test
@@ -873,11 +869,9 @@ class LogicalTypesSchemaVisitorTest {
         + "TYPE Person NOT NULL"
     );
     Schema root = v.getRootSchema();
-    assertEquals(Schema.Type.NAMED_TYPE_REF, root.getType());
-    assertEquals("Person", root.getQualifiedName());
+    assertEquals(Schema.Type.STRUCT, root.getType());
+    assertEquals("Person", v.toLogicalType().getName());
     assertFalse(root.isNullable());
-    // Named type body is registered (with default nullability for its kind).
-    assertNotNull(v.getNamedTypes().get("Person"));
   }
 
   @Test
@@ -887,9 +881,9 @@ class LogicalTypesSchemaVisitorTest {
         + "TYPE Color NOT NULL"
     );
     Schema root = v.getRootSchema();
-    assertEquals(Schema.Type.NAMED_TYPE_REF, root.getType());
+    assertEquals(Schema.Type.ENUM, root.getType());
     assertFalse(root.isNullable());
-    assertEquals("rgb colors", v.getNamedTypes().get("Color").getDoc());
+    assertEquals("rgb colors", root.getDoc());
   }
 
   @Test
@@ -951,7 +945,9 @@ class LogicalTypesSchemaVisitorTest {
     LogicalTypesSchemaVisitor v = parseScript(script);
 
     assertEquals("com.example", v.getNamespace());
-    assertEquals(2, v.getNamedTypes().size());
+    // The root UserProfile unwraps onto the LogicalType; only the referenced peer Status
+    // remains as a named type.
+    assertEquals(1, v.getNamedTypes().size());
 
     // Named-type declarations get the namespace prefix
     Schema status = v.getNamedTypes().get("com.example.Status");
@@ -960,9 +956,10 @@ class LogicalTypesSchemaVisitorTest {
     assertEquals(3, status.getEnumValues().size());
     assertEquals("currently active", status.getEnumValues().get(0).getDoc());
 
-    Schema profile = v.getNamedTypes().get("com.example.UserProfile");
+    Schema profile = v.getRootSchema();
     assertNotNull(profile);
     assertEquals(Schema.Type.STRUCT, profile.getType());
+    assertEquals("UserProfile", v.toLogicalType().getName());
     assertEquals(7, profile.getFields().size());
 
     Schema.Field idField = profile.getField("id");
@@ -993,11 +990,12 @@ class LogicalTypesSchemaVisitorTest {
     assertEquals(Schema.Type.TIMESTAMP, createdField.getSchema().getType());
     assertEquals(3, createdField.getSchema().getPrecision());
 
-    // Root schema reference also gets the namespace prefix
+    // The root is the unwrapped UserProfile body (same object as profile above).
     Schema root = v.getRootSchema();
     assertNotNull(root);
-    assertEquals(Schema.Type.NAMED_TYPE_REF, root.getType());
-    assertEquals("com.example.UserProfile", root.getQualifiedName());
+    assertEquals(Schema.Type.STRUCT, root.getType());
+    assertEquals("UserProfile", v.toLogicalType().getName());
+    assertEquals("com.example", v.toLogicalType().getNamespace());
   }
 
   // =========================================================================
@@ -1010,7 +1008,10 @@ class LogicalTypesSchemaVisitorTest {
         "NAMESPACE a.b;"
         + "STRUCT Foo (x INT);"
         + "TYPE Foo");
-    assertNotNull(v.getNamedTypes().get("a.b.Foo"));
+    // Foo is the root; it unwraps to namespace a.b + simple name Foo (reconstructs a.b.Foo).
+    assertEquals(Schema.Type.STRUCT, v.getRootSchema().getType());
+    assertEquals("a.b", v.toLogicalType().getNamespace());
+    assertEquals("Foo", v.toLogicalType().getName());
   }
 
   @Test
@@ -1020,18 +1021,26 @@ class LogicalTypesSchemaVisitorTest {
         "NAMESPACE a.b;"
         + "STRUCT a.b.Foo (x INT);"
         + "TYPE a.b.Foo");
-    assertNotNull(v.getNamedTypes().get("a.b.Foo"));
-    assertEquals(1, v.getNamedTypes().size());
+    // a.b.Foo is not double-qualified: it unwraps to namespace a.b + simple name Foo (which
+    // reconstructs a.b.Foo, not a.b.a.b.Foo).
+    assertEquals(Schema.Type.STRUCT, v.getRootSchema().getType());
+    assertEquals("a.b", v.toLogicalType().getNamespace());
+    assertEquals("Foo", v.toLogicalType().getName());
+    assertEquals(0, v.getNamedTypes().size());
   }
 
   @Test
   void testNamespaceDoesNotOverrideQualified() {
-    // A different qualified name overrides the namespace.
+    // An explicit qualifier is not overridden by the active namespace: x.y.Foo stays x.y.Foo,
+    // not a.b.x.y.Foo. Here x.y.Foo is a referenced peer (the root is the same-namespace
+    // Holder), so it is preserved as a named type rather than unwrapped onto the root.
     LogicalTypesSchemaVisitor v = parseScript(
         "NAMESPACE a.b;"
         + "STRUCT x.y.Foo (n INT);"
-        + "TYPE x.y.Foo");
+        + "STRUCT Holder (foo x.y.Foo);"
+        + "TYPE Holder");
     assertNotNull(v.getNamedTypes().get("x.y.Foo"));
+    assertEquals("x.y.Foo", v.getRootSchema().getField("foo").getSchema().getQualifiedName());
   }
 
   @Test
@@ -1044,7 +1053,7 @@ class LogicalTypesSchemaVisitorTest {
         + "STRUCT Inner (x INT);"
         + "STRUCT Outer (inner Inner);"
         + "TYPE Outer");
-    Schema outer = v.getNamedTypes().get("a.b.Outer");
+    Schema outer = v.getRootSchema();
     Schema.Field innerField = outer.getField("inner");
     assertEquals(Schema.Type.NAMED_TYPE_REF, innerField.getSchema().getType());
     assertEquals("a.b.Inner", innerField.getSchema().getQualifiedName());
@@ -1060,7 +1069,7 @@ class LogicalTypesSchemaVisitorTest {
         "NAMESPACE a.b;"
         + "STRUCT Holder (amount Money);"
         + "TYPE Holder");
-    Schema holder = v.getNamedTypes().get("a.b.Holder");
+    Schema holder = v.getRootSchema();
     Schema.Field amount = holder.getField("amount");
     assertEquals(Schema.Type.NAMED_TYPE_REF, amount.getSchema().getType());
     assertEquals("a.b.Money", amount.getSchema().getQualifiedName());
@@ -1073,7 +1082,7 @@ class LogicalTypesSchemaVisitorTest {
         "NAMESPACE a.b;"
         + "STRUCT Holder (cur x.y.Currency);"
         + "TYPE Holder");
-    Schema holder = v.getNamedTypes().get("a.b.Holder");
+    Schema holder = v.getRootSchema();
     assertEquals("x.y.Currency",
         holder.getField("cur").getSchema().getQualifiedName());
   }
@@ -1083,9 +1092,10 @@ class LogicalTypesSchemaVisitorTest {
     LogicalTypesSchemaVisitor v = parseScript(
         "STRUCT Holder (amount Money, name STRING);"
         + "TYPE Holder");
-    assertNotNull(v.getNamedTypes().get("Holder"));
-    assertEquals("Money",
-        v.getNamedTypes().get("Holder").getField("amount").getSchema().getQualifiedName());
+    Schema holder = v.getRootSchema();
+    assertEquals(Schema.Type.STRUCT, holder.getType());
+    assertEquals("Holder", v.toLogicalType().getName());
+    assertEquals("Money", holder.getField("amount").getSchema().getQualifiedName());
     assertTrue(v.toLogicalType().isExternal("Money"));
   }
 
@@ -1112,7 +1122,7 @@ class LogicalTypesSchemaVisitorTest {
         + "  externalFoo other.Foo"
         + ");"
         + "TYPE Holder");
-    Schema holder = v.getNamedTypes().get("a.b.Holder");
+    Schema holder = v.getRootSchema();
     assertEquals("a.b.Foo",
         holder.getField("localFoo").getSchema().getQualifiedName());
     assertEquals("other.Foo",
@@ -1482,8 +1492,8 @@ class LogicalTypesSchemaVisitorTest {
         "STRUCT Foo (x INT)"
     );
     Schema root = v.getRootSchema();
-    assertEquals(Schema.Type.NAMED_TYPE_REF, root.getType());
-    assertEquals("Foo", root.getQualifiedName());
+    assertEquals(Schema.Type.STRUCT, root.getType());
+    assertEquals("Foo", v.toLogicalType().getName());
     assertFalse(root.isNullable(), "sugar root must be NOT NULL");
   }
 
@@ -1506,9 +1516,11 @@ class LogicalTypesSchemaVisitorTest {
         + "STRUCT User (name STRING, addr Address)"
     );
     Schema root = v.getRootSchema();
-    assertEquals(Schema.Type.NAMED_TYPE_REF, root.getType());
-    assertEquals("User", root.getQualifiedName());
+    assertEquals(Schema.Type.STRUCT, root.getType());
+    assertEquals("User", v.toLogicalType().getName());
     assertFalse(root.isNullable());
+    // Address is referenced by the root, so it stays a peer named type.
+    assertTrue(v.getNamedTypes().containsKey("Address"));
   }
 
   @Test
@@ -1519,7 +1531,8 @@ class LogicalTypesSchemaVisitorTest {
         "STRUCT Foo (x Ext)"
     );
     Schema root = v.getRootSchema();
-    assertEquals("Foo", root.getQualifiedName());
+    assertEquals(Schema.Type.STRUCT, root.getType());
+    assertEquals("Foo", v.toLogicalType().getName());
     assertTrue(v.toLogicalType().isExternal("Ext"));
   }
 
@@ -1532,8 +1545,8 @@ class LogicalTypesSchemaVisitorTest {
         "STRUCT Foo (x INT);"
         + "STRUCT Bar (y INT)");
     Schema root = v.getRootSchema();
-    assertEquals(Schema.Type.NAMED_TYPE_REF, root.getType());
-    assertEquals("Foo", root.getQualifiedName());
+    assertEquals(Schema.Type.STRUCT, root.getType());
+    assertEquals("Foo", v.toLogicalType().getName());
     assertFalse(root.isNullable(), "inferred root must be NOT NULL");
     assertTrue(v.toLogicalType().getNamedTypes().containsKey("Bar"),
         "the non-root peer stays a named type");
@@ -1547,8 +1560,9 @@ class LogicalTypesSchemaVisitorTest {
         + "STRUCT Foo (x INT);"
         + "STRUCT Bar (y INT)");
     Schema root = v.getRootSchema();
-    assertEquals(Schema.Type.NAMED_TYPE_REF, root.getType());
-    assertEquals("com.example.Foo", root.getQualifiedName());
+    assertEquals(Schema.Type.STRUCT, root.getType());
+    assertEquals("com.example", v.toLogicalType().getNamespace());
+    assertEquals("Foo", v.toLogicalType().getName());
     assertTrue(v.toLogicalType().getNamedTypes().containsKey("com.example.Bar"));
   }
 
@@ -1581,7 +1595,8 @@ class LogicalTypesSchemaVisitorTest {
         + "STRUCT Bar (y INT);"
         + "TYPE Bar"
     );
-    assertEquals("Bar", v.getRootSchema().getQualifiedName());
+    assertEquals(Schema.Type.STRUCT, v.getRootSchema().getType());
+    assertEquals("Bar", v.toLogicalType().getName());
   }
 
   @Test
@@ -1657,11 +1672,13 @@ class LogicalTypesSchemaVisitorTest {
   @Test
   void testDottedNameWithoutMatchingPrefixIsForeignNamespace() {
     // Other.Bar — no Other defined locally → treated as namespace-qualified
-    // (top-level type in namespace Other), stored verbatim.
+    // (top-level type in namespace Other), stored verbatim. It is a referenced peer
+    // (the root is the same-namespace Holder), so it stays as a named type.
     LogicalTypesSchemaVisitor v = parseScript(
         "NAMESPACE com.example;"
         + "STRUCT Other.Bar (x INT);"
-        + "TYPE Other.Bar"
+        + "STRUCT Holder (bar Other.Bar);"
+        + "TYPE Holder"
     );
     assertNotNull(v.getNamedTypes().get("Other.Bar"));
     assertNull(v.getNamedTypes().get("com.example.Other.Bar"));
@@ -1734,7 +1751,7 @@ class LogicalTypesSchemaVisitorTest {
         + "STRUCT Holder (inner Outer.Inner);"
         + "TYPE Holder"
     );
-    Schema holder = v.getNamedTypes().get("com.example.Holder");
+    Schema holder = v.getRootSchema();
     Schema.Field innerField = holder.getField("inner");
     assertEquals(Schema.Type.NAMED_TYPE_REF, innerField.getSchema().getType());
     assertEquals("com.example.Outer.Inner",
@@ -1751,7 +1768,7 @@ class LogicalTypesSchemaVisitorTest {
         + "STRUCT Holder (b Other.Bar);"
         + "TYPE Holder"
     );
-    Schema holder = v.getNamedTypes().get("com.example.Holder");
+    Schema holder = v.getRootSchema();
     assertEquals("Other.Bar", holder.getField("b").getSchema().getQualifiedName());
   }
 
@@ -1764,7 +1781,7 @@ class LogicalTypesSchemaVisitorTest {
         + "STRUCT Holder (inner com.other.Outer.Inner);"
         + "TYPE Holder"
     );
-    Schema holder = v.getNamedTypes().get("com.example.Holder");
+    Schema holder = v.getRootSchema();
     assertEquals("com.other.Outer.Inner",
         holder.getField("inner").getSchema().getQualifiedName());
     assertTrue(v.toLogicalType().isExternal("com.other.Outer.Inner"));
@@ -1800,6 +1817,21 @@ class LogicalTypesSchemaVisitorTest {
     String script = sb.toString();
     assertThrows(ValidationException.class,
         () -> LogicalTypesParserFactory.parse(script));
+  }
+
+  @Test
+  void testRootUnwrapSkippedWhenNamespaceDiffersFromDocument() {
+    // Root FQN namespace (x.y) differs from the document namespace (a.b): unwrapping would carry
+    // only the simple name and reconstruct a.b.Foo, dropping x.y. So the root stays a
+    // NAMED_TYPE_REF preserving the full FQN, and LogicalType.name is not set.
+    LogicalTypesSchemaVisitor v = parseScript(
+        "NAMESPACE a.b;"
+        + "STRUCT x.y.Foo (n INT)");
+    Schema root = v.getRootSchema();
+    assertEquals(Schema.Type.NAMED_TYPE_REF, root.getType());
+    assertEquals("x.y.Foo", root.getQualifiedName());
+    assertNull(v.toLogicalType().getName());
+    assertTrue(v.getNamedTypes().containsKey("x.y.Foo"));
   }
 
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitorTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitorTest.java
@@ -1834,4 +1834,21 @@ class LogicalTypesSchemaVisitorTest {
     assertTrue(v.getNamedTypes().containsKey("x.y.Foo"));
   }
 
+  @Test
+  void testPeerReferencedRootStaysNamedTypeRef() {
+    // A local peer (Wrapper) references the explicit root (Order). Unwrapping Order to a bare
+    // STRUCT would remove its body from namedTypes and dangle Wrapper.order (which every format
+    // writer resolves only through namedTypes), so the shared root stays a NAMED_TYPE_REF.
+    LogicalTypesSchemaVisitor v = parseScript(
+        "STRUCT Order (id INT);"
+        + "STRUCT Wrapper (payload Order);"
+        + "TYPE Order");
+    Schema root = v.getRootSchema();
+    assertEquals(Schema.Type.NAMED_TYPE_REF, root.getType());
+    assertEquals("Order", root.getQualifiedName());
+    assertNull(v.toLogicalType().getName());
+    assertTrue(v.getNamedTypes().containsKey("Order"));
+    assertTrue(v.getNamedTypes().containsKey("Wrapper"));
+  }
+
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverterTest.java
@@ -17,6 +17,7 @@
 package io.confluent.kafka.schemaregistry.type.logical.avro;
 
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.type.logical.LogicalTypeToDdlConverter;
 import io.confluent.kafka.schemaregistry.type.logical.Schema;
 import io.confluent.kafka.schemaregistry.type.logical.ValidationException;
 import org.apache.avro.SchemaBuilder;
@@ -122,6 +123,26 @@ class AvroToLogicalTypeConverterTest {
     assertEquals("RED", named.getEnumValues().get(0).getSymbol());
     assertEquals("GREEN", named.getEnumValues().get(1).getSymbol());
     assertEquals("BLUE", named.getEnumValues().get(2).getSymbol());
+  }
+
+  @Test
+  void namedLeafRootNameRoundTripsThroughAvro() {
+    // Avro -> LT -> Avro: a non-recursive named record root unwraps to a bare STRUCT carrying its
+    // name on read, and the writer re-emits it under the same record name (identity preserved).
+    String json = "{\"type\":\"record\",\"name\":\"Order\",\"fields\":["
+        + "{\"name\":\"id\",\"type\":\"int\"}]}";
+    io.confluent.kafka.schemaregistry.type.logical.LogicalType lt =
+        AvroToLogicalTypeConverter.toLogicalType(new AvroSchema(json));
+    assertEquals(Schema.Type.STRUCT, lt.getRootSchema().getType());
+    assertEquals("Order", lt.getName());
+    AvroSchema out = LogicalTypeToAvroConverter.fromLogicalType(lt, "IGNORED");
+    assertEquals("Order", out.rawSchema().getName());
+
+    // The DDL projection declares the root as a named STRUCT; a single unreferenced root needs no
+    // explicit trailing TYPE (first-wins inference recovers it).
+    String ddl = LogicalTypeToDdlConverter.toDdl(lt);
+    assertThat(ddl).contains("STRUCT Order (");
+    assertThat(ddl).doesNotContain("TYPE");
   }
 
   @Test

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverterTest.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -137,6 +138,10 @@ class AvroToLogicalTypeConverterTest {
     assertEquals("Order", lt.getName());
     AvroSchema out = LogicalTypeToAvroConverter.fromLogicalType(lt, "IGNORED");
     assertEquals("Order", out.rawSchema().getName());
+    // A named root is a genuine named record, NOT marked logical.anonymous, so its name survives
+    // a further Avro -> LT read-back (rather than being discarded as a synthetic row wrapper).
+    assertNull(out.rawSchema().getProp("logical.anonymous"));
+    assertEquals("Order", AvroToLogicalTypeConverter.toLogicalType(out).getName());
 
     // The DDL projection declares the root as a named STRUCT; a single unreferenced root needs no
     // explicit trailing TYPE (first-wins inference recovers it).

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverterTest.java
@@ -108,16 +108,16 @@ class AvroToLogicalTypeConverterTest {
 
   @Test
   void testEnumConversion() {
-    // Unmarked Avro enum is recovered as a NAMED_TYPE_REF; the actual ENUM
-    // body lives in localNamedTypes keyed by the Avro full name.
+    // A leaf named enum root is unwrapped to a bare ENUM body carrying its name on
+    // LogicalType.name (the canonical named-root shape), not a NAMED_TYPE_REF into namedTypes.
     org.apache.avro.Schema enumSchema = SchemaBuilder.enumeration("Color")
         .symbols("RED", "GREEN", "BLUE");
     io.confluent.kafka.schemaregistry.type.logical.LogicalType lt =
         AvroToLogicalTypeConverter.toLogicalType(new AvroSchema(enumSchema));
-    assertEquals(Schema.Type.NAMED_TYPE_REF, lt.getRootSchema().getType());
-    assertEquals("Color", lt.getRootSchema().getQualifiedName());
-    Schema named = lt.getNamedTypes().get("Color");
-    assertEquals(Schema.Type.ENUM, named.getType());
+    assertEquals(Schema.Type.ENUM, lt.getRootSchema().getType());
+    assertEquals("Color", lt.getName());
+    assertTrue(lt.getNamedTypes().isEmpty());
+    Schema named = lt.getRootSchema();
     assertEquals(3, named.getEnumValues().size());
     assertEquals("RED", named.getEnumValues().get(0).getSymbol());
     assertEquals("GREEN", named.getEnumValues().get(1).getSymbol());
@@ -233,7 +233,7 @@ class AvroToLogicalTypeConverterTest {
     org.apache.avro.Schema parsed = new org.apache.avro.Schema.Parser().parse(json);
 
     Schema struct = AvroToLogicalTypeConverter.toLogicalType(new AvroSchema(parsed))
-        .getNamedTypes().get("M");
+        .getRootSchema();
 
     assertThat(struct.getField("a").getAliases())
         .containsExactlyInAnyOrder("a_old", "a_older");
@@ -249,7 +249,7 @@ class AvroToLogicalTypeConverterTest {
     org.apache.avro.Schema parsed = new org.apache.avro.Schema.Parser().parse(json);
 
     Schema struct = AvroToLogicalTypeConverter.toLogicalType(new AvroSchema(parsed))
-        .getNamedTypes().get("M");
+        .getRootSchema();
 
     assertThat(struct.getField("a").getAliases()).containsExactly("a_old");
   }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/constraint/CheckConstraintTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/constraint/CheckConstraintTest.java
@@ -77,7 +77,7 @@ class CheckConstraintTest {
         + "data VARIANT,"
         + "CHECK (" + checkExpr + ")"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     String cel = schema.getRules().get(0).getExpr();
     // Gate every emitted CEL through the strict cel-java checker. `this`
     // is a typed object resolved via ConstraintTypeProvider, so
@@ -106,7 +106,7 @@ class CheckConstraintTest {
     String script = "STRUCT T ("
         + columnDecl + " CHECK (" + checkExpr + ")"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     // The CEL is on the column's rules list (not the struct's).
     return schema.getFields().get(0).getRules().get(0).getExpr();
   }
@@ -325,7 +325,7 @@ class CheckConstraintTest {
         + "binData BYTES,"
         + "CHECK (binData || x'00' = x'01')"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     assertEquals("this.binData + b\"\\x00\" == b\"\\x01\"",
         schema.getRules().get(0).getExpr());
   }
@@ -338,7 +338,7 @@ class CheckConstraintTest {
         + "binData BYTES,"
         + "CHECK (binData = x'deadbeef')"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     assertEquals("this.binData == b\"\\xDE\\xAD\\xBE\\xEF\"",
         schema.getRules().get(0).getExpr());
   }
@@ -470,7 +470,7 @@ class CheckConstraintTest {
         + "x INT,"
         + "CHECK (`x` > 0)"  // backticked column ref to existing field `x`
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     Rule r = schema.getRules().get(0);
     assertEquals("this.x > 0", r.getExpr());
   }
@@ -483,7 +483,7 @@ class CheckConstraintTest {
         + "type STRING,"
         + "CHECK (`type` = 'A')"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     Rule r = schema.getRules().get(0);
     assertEquals("this.type == 'A'", r.getExpr());
   }
@@ -547,7 +547,7 @@ class CheckConstraintTest {
         + "x INT,"
         + "CHECK (x > 0)"  // table-level so it can reference x
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     Rule r = schema.getRules().get(0);
     assertEquals("this.x > 0", r.getExpr());
   }
@@ -559,7 +559,7 @@ class CheckConstraintTest {
         + "addr STRUCT(zip INT) NOT NULL,"
         + "CHECK (addr.zip > 0)"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     Rule r = schema.getRules().get(0);
     assertEquals("this.addr.zip > 0", r.getExpr());
   }
@@ -571,7 +571,7 @@ class CheckConstraintTest {
         + "tags STRING ARRAY,"
         + "CHECK (tags[1] = 'first')"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     Rule r = schema.getRules().get(0);
     assertEquals("this.tags[(1) - 1] == 'first'", r.getExpr());
   }
@@ -585,7 +585,7 @@ class CheckConstraintTest {
         + "props MAP<STRING, STRING>,"
         + "CHECK (props['name'] = 'alice')"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     Rule r = schema.getRules().get(0);
     assertEquals("this.props['name'] == 'alice'", r.getExpr());
   }
@@ -597,7 +597,7 @@ class CheckConstraintTest {
         + "scores MAP<INT, INT>,"
         + "CHECK (scores[42] > 0)"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     Rule r = schema.getRules().get(0);
     assertEquals("this.scores[42] > 0", r.getExpr());
   }
@@ -612,7 +612,7 @@ class CheckConstraintTest {
         + "tags STRING ARRAY,"
         + "CHECK ((tags)[1] = 'first')"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     Rule r = schema.getRules().get(0);
     assertEquals("(this.tags)[(1) - 1] == 'first'", r.getExpr());
   }
@@ -749,7 +749,7 @@ class CheckConstraintTest {
         + "ages INT ARRAY,"
         + "CHECK (EVERY(ages, n, n > 0))"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     assertEquals("this.ages.all(n, n > 0)", schema.getRules().get(0).getExpr());
   }
 
@@ -776,7 +776,7 @@ class CheckConstraintTest {
         + "name STRING ARRAY,"
         + "CHECK (EVERY(name, name, LENGTH(name) > 0))"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     Rule r = schema.getRules().get(0);
     // Outer `name` (the collection) → this.name; iter-var `name` (binding)
     // and the body ref → bare.
@@ -794,7 +794,7 @@ class CheckConstraintTest {
         + "meta MAP<STRING, STRING> ARRAY,"
         + "CHECK (EVERY(meta, meta, meta['k'] = 'v'))"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     Rule r = schema.getRules().get(0);
     assertEquals("this.meta.all(meta, meta['k'] == 'v')", r.getExpr());
   }
@@ -863,7 +863,7 @@ class CheckConstraintTest {
     String script = "STRUCT T ("
         + "x INT CHECK (x > 0) CHECK (x < 100)"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     List<Rule> rules = schema.getField("x").getRules();
     assertEquals(2, rules.size());
     assertEquals("this > 0", rules.get(0).getExpr());
@@ -875,7 +875,7 @@ class CheckConstraintTest {
     String script = "STRUCT T ("
         + "x INT CONSTRAINT positive_x CHECK (x > 0)"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     Rule r = schema.getField("x").getRules().get(0);
     assertEquals("positive_x", r.getName());
     assertNull(r.getDoc());
@@ -887,7 +887,7 @@ class CheckConstraintTest {
     String script = "STRUCT T ("
         + "x INT CHECK (x > 0) MESSAGE 'must be positive'"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     Rule r = schema.getField("x").getRules().get(0);
     assertNull(r.getName());
     assertEquals("must be positive", r.getDoc());
@@ -898,7 +898,7 @@ class CheckConstraintTest {
     String script = "STRUCT T ("
         + "x INT CONSTRAINT positive_x CHECK (x > 0) MESSAGE 'must be positive'"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     Rule r = schema.getField("x").getRules().get(0);
     assertEquals("positive_x", r.getName());
     assertEquals("must be positive", r.getDoc());
@@ -916,7 +916,7 @@ class CheckConstraintTest {
         + "hi INT,"
         + "CONSTRAINT bounds CHECK (lo < hi) MESSAGE 'lo must be < hi'"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     assertTrue(schema.getField("lo").getRules().isEmpty());
     assertTrue(schema.getField("hi").getRules().isEmpty());
     List<Rule> tableRules = schema.getRules();
@@ -934,7 +934,7 @@ class CheckConstraintTest {
         + "hi INT CHECK (hi <= 100),"
         + "CHECK (lo <= hi)"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     assertEquals(1, schema.getField("lo").getRules().size());
     assertEquals(1, schema.getField("hi").getRules().size());
     assertEquals(1, schema.getRules().size());
@@ -950,7 +950,7 @@ class CheckConstraintTest {
     String script = "STRUCT T ("
         + "x INT CHECK (x > 0 AND x < 100)"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     Rule r = schema.getField("x").getRules().get(0);
     // The visitor pulls the source slice from the input stream so the
     // user's original whitespace, casing, and operator spacing all survive.
@@ -963,7 +963,7 @@ class CheckConstraintTest {
     // Tabs, multiple spaces, and a newline inside the expression all
     // survive verbatim in Rule.sql.
     String script = "STRUCT T (x INT CHECK (x  >\t0\nAND  x<100));";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     Rule r = schema.getField("x").getRules().get(0);
     assertEquals("x  >\t0\nAND  x<100", r.getSql());
   }
@@ -973,7 +973,7 @@ class CheckConstraintTest {
     // SQL keywords are case-insensitive; we should preserve whatever the
     // user wrote (lower-case `and` here) rather than normalize.
     String script = "STRUCT T (x INT CHECK (x > 0 and x < 100));";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     Rule r = schema.getField("x").getRules().get(0);
     assertEquals("x > 0 and x < 100", r.getSql());
   }
@@ -981,7 +981,7 @@ class CheckConstraintTest {
   @Test
   void rulesAreNonNullEvenWhenAbsent() {
     String script = "STRUCT T (x INT);";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     assertNotNull(schema.getField("x").getRules());
     assertTrue(schema.getField("x").getRules().isEmpty());
     assertNotNull(schema.getRules());
@@ -1014,7 +1014,7 @@ class CheckConstraintTest {
         + "addr STRUCT(zip INT) NOT NULL,"
         + "CHECK (addr.zip IS NOT NULL)"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     Rule r = schema.getRules().get(0);
     assertEquals("(has(this.addr.zip) && dyn(this.addr.zip) != null)", r.getExpr());
   }
@@ -1057,7 +1057,7 @@ class CheckConstraintTest {
         + "tags STRING ARRAY,"
         + "CHECK (value IN tags)"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     assertEquals("this.value in this.tags", schema.getRules().get(0).getExpr());
   }
 
@@ -1068,7 +1068,7 @@ class CheckConstraintTest {
         + "tags STRING ARRAY,"
         + "CHECK (value NOT IN tags)"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     assertEquals("!(this.value in this.tags)", schema.getRules().get(0).getExpr());
   }
 
@@ -2131,7 +2131,7 @@ class CheckConstraintTest {
         + "tags STRING ARRAY,"
         + "CHECK (EVERY(tags, t, LENGTH(t) > 0))"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     assertEquals("this.tags.all(t, size(t) > 0)", schema.getRules().get(0).getExpr());
   }
 
@@ -2141,7 +2141,7 @@ class CheckConstraintTest {
         + "tags STRING ARRAY,"
         + "CHECK (ANY(tags, t, t = 'admin'))"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     assertEquals("this.tags.exists(t, t == 'admin')", schema.getRules().get(0).getExpr());
   }
 
@@ -2151,7 +2151,7 @@ class CheckConstraintTest {
         + "addresses STRING ARRAY,"
         + "CHECK (ONE(addresses, a, STARTS_WITH(a, 'primary:')))"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     assertEquals("this.addresses.exists_one(a, a.startsWith('primary:'))",
         schema.getRules().get(0).getExpr());
   }
@@ -2162,7 +2162,7 @@ class CheckConstraintTest {
         + "tags STRING ARRAY,"
         + "CHECK (every(tags, t, LENGTH(t) > 0))"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     assertEquals("this.tags.all(t, size(t) > 0)", schema.getRules().get(0).getExpr());
   }
 
@@ -2173,7 +2173,7 @@ class CheckConstraintTest {
         + "matrix INT ARRAY ARRAY,"
         + "CHECK (EVERY(matrix, r, EVERY(r, cell, cell > 0)))"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     assertEquals("this.matrix.all(r, r.all(cell, cell > 0))",
         schema.getRules().get(0).getExpr());
   }
@@ -2184,7 +2184,7 @@ class CheckConstraintTest {
         + "ages INT ARRAY,"
         + "CHECK (ANY(ages, a, a BETWEEN 18 AND 65))"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     assertEquals("this.ages.exists(a, 18 <= a && a <= 65)",
         schema.getRules().get(0).getExpr());
   }
@@ -2195,7 +2195,7 @@ class CheckConstraintTest {
         + "emails STRING ARRAY,"
         + "CHECK (EVERY(emails, e, IS_EMAIL(e)))"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     assertEquals("this.emails.all(e, e.isEmail())",
         schema.getRules().get(0).getExpr());
   }
@@ -2273,7 +2273,7 @@ class CheckConstraintTest {
     String script = "STRUCT T ("
         + "addr STRUCT(zip INT) NOT NULL CHECK (addr.zip > 0)"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     assertEquals("this.zip > 0",
         schema.getField("addr").getRules().get(0).getExpr());
   }
@@ -2314,7 +2314,7 @@ class CheckConstraintTest {
         + "a INT, b INT,"
         + "CHECK (a < b)"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     assertEquals("this.a < this.b", schema.getRules().get(0).getExpr());
   }
 
@@ -2339,14 +2339,14 @@ class CheckConstraintTest {
   @Test
   void acceptsBooleanColumnRef() {
     String script = "STRUCT T (active BOOLEAN, CHECK (active));";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     assertEquals("this.active", schema.getRules().get(0).getExpr());
   }
 
   @Test
   void acceptsBooleanLiteralRoot() {
     String script = "STRUCT T (x INT, CHECK (TRUE));";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     assertEquals("true", schema.getRules().get(0).getExpr());
   }
 
@@ -2958,7 +2958,7 @@ class CheckConstraintTest {
         + "ts TIMESTAMP_LTZ,"
         + "CHECK (ts <= CURRENT_TIMESTAMP)"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     assertEquals("timestamp(this.ts) <= now", schema.getRules().get(0).getExpr());
   }
 
@@ -3021,7 +3021,7 @@ class CheckConstraintTest {
   void ddlRoundTripPreservesColumnCheck() {
     String script = "STRUCT T (x INT CHECK (x > 0)); TYPE T;";
     LogicalType after = ddlRoundTrip(script);
-    Schema struct = after.getNamedTypes().get("T");
+    Schema struct = after.getRootSchema();
     List<Rule> rules = struct.getField("x").getRules();
     assertEquals(1, rules.size());
     assertEquals("this > 0", rules.get(0).getExpr());
@@ -3033,7 +3033,7 @@ class CheckConstraintTest {
         + "x INT CONSTRAINT positive_x CHECK (x > 0) MESSAGE 'must be positive'"
         + "); TYPE T;";
     LogicalType after = ddlRoundTrip(script);
-    Schema struct = after.getNamedTypes().get("T");
+    Schema struct = after.getRootSchema();
     Rule r = struct.getField("x").getRules().get(0);
     assertEquals("positive_x", r.getName());
     assertEquals("must be positive", r.getDoc());
@@ -3062,7 +3062,7 @@ class CheckConstraintTest {
         + "addr STRUCT(zip INT CHECK (zip > 0)) NOT NULL"
         + "); TYPE T;";
     LogicalType after = ddlRoundTrip(script);
-    Schema addr = after.getNamedTypes().get("T").getField("addr").getSchema();
+    Schema addr = after.getRootSchema().getField("addr").getSchema();
     Schema.Field zip = addr.getField("zip");
     List<Rule> rules = zip.getRules();
     assertEquals(1, rules.size(), "inline STRUCT field rule should round-trip");
@@ -3076,7 +3076,7 @@ class CheckConstraintTest {
         + "CHECK (lo < hi)"
         + "); TYPE T;";
     LogicalType after = ddlRoundTrip(script);
-    Schema struct = after.getNamedTypes().get("T");
+    Schema struct = after.getRootSchema();
     assertEquals(1, struct.getRules().size());
     assertEquals("this.lo < this.hi", struct.getRules().get(0).getExpr());
   }
@@ -3089,7 +3089,7 @@ class CheckConstraintTest {
         + "CONSTRAINT cross CHECK (x + y > 0) MESSAGE 'sum must be positive'"
         + "); TYPE T;";
     LogicalType after = ddlRoundTrip(script);
-    Schema struct = after.getNamedTypes().get("T");
+    Schema struct = after.getRootSchema();
     assertEquals(2, struct.getField("x").getRules().size());
     assertEquals(1, struct.getRules().size());
     assertEquals("cross", struct.getRules().get(0).getName());
@@ -3582,7 +3582,7 @@ class CheckConstraintTest {
         new io.confluent.kafka.schemaregistry.avro.AvroSchema(avroSchema);
     LogicalType lt = io.confluent.kafka.schemaregistry.type.logical.avro
         .AvroToLogicalTypeConverter.toLogicalType(s);
-    Schema rec = lt.getNamedTypes().get(lt.getRootSchema().getQualifiedName());
+    Schema rec = lt.getRootSchema();
     assertEquals("in", rec.getFields().get(0).getName());
   }
 
@@ -3610,7 +3610,7 @@ class CheckConstraintTest {
         + "TYPE Person";
     LogicalTypesSchemaVisitor v = new LogicalTypesSchemaVisitor();
     v.visit(LogicalTypesParserFactory.parse(script));
-    String cel = v.getNamedTypes().get("Person").getRules().get(0).getExpr();
+    String cel = v.getRootSchema().getRules().get(0).getExpr();
     assertEquals("this.a.zip > 0", cel);
   }
 
@@ -3748,7 +3748,7 @@ class CheckConstraintTest {
     String script = "STRUCT T (`null` INT, x INT); TYPE T";
     LogicalTypesSchemaVisitor v = new LogicalTypesSchemaVisitor();
     v.visit(LogicalTypesParserFactory.parse(script));
-    assertEquals("null", v.getNamedTypes().get("T").getFields().get(0).getName());
+    assertEquals("null", v.getRootSchema().getFields().get(0).getName());
   }
 
   @Test
@@ -3868,7 +3868,7 @@ class CheckConstraintTest {
         + "m MAP<STRING, STRING>,"
         + "CHECK ((m)['k'] = 'v')"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     String r = schema.getRules().get(0).getExpr();
     assertTrue(r.contains("['k']") && !r.contains("- 1]"),
         "expected map-style indexing (no - 1 offset), got: " + r);
@@ -3975,7 +3975,7 @@ class CheckConstraintTest {
         + "  addr Address NOT NULL,"
         + "  CHECK (addr.zip > 0)"
         + ");";
-    Schema person = parseScript(script).getNamedTypes().get("Person");
+    Schema person = parseScript(script).getRootSchema();
     assertEquals("this.addr.zip > 0", person.getRules().get(0).getExpr());
   }
 
@@ -3987,7 +3987,7 @@ class CheckConstraintTest {
         + "STRUCT Person ("
         + "  addr Address NOT NULL CHECK (addr.zip > 0)"
         + ");";
-    Schema person = parseScript(script).getNamedTypes().get("Person");
+    Schema person = parseScript(script).getRootSchema();
     String cel = person.getField("addr").getRules().get(0).getExpr();
     assertEquals("this.zip > 0", cel);
   }
@@ -4002,7 +4002,7 @@ class CheckConstraintTest {
         + "  addr Address NOT NULL,"
         + "  CHECK (addr.zip > 0)"
         + ");";
-    Schema person = parseScript(script).getNamedTypes().get("Person");
+    Schema person = parseScript(script).getRootSchema();
     assertEquals("this.addr.zip > 0", person.getRules().get(0).getExpr());
   }
 
@@ -4131,7 +4131,7 @@ class CheckConstraintTest {
         + "zip INT,"
         + "CHECK (zip IS NULL)"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     String cel = schema.getRules().get(0).getExpr();
     assertTrue(cel.contains("== null"), "got: " + cel);
   }
@@ -4160,7 +4160,7 @@ class CheckConstraintTest {
         + "addr STRUCT(zip INT) NOT NULL,"
         + "CHECK (addr.zip IS NULL)"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     String cel = schema.getRules().get(0).getExpr();
     assertTrue(cel.contains("== null"), "got: " + cel);
   }
@@ -4173,7 +4173,7 @@ class CheckConstraintTest {
         + "addr STRUCT(zip INT NOT NULL),"
         + "CHECK (addr.zip IS NULL)"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     String cel = schema.getRules().get(0).getExpr();
     assertTrue(cel.contains("== null"), "got: " + cel);
   }
@@ -4186,7 +4186,7 @@ class CheckConstraintTest {
         + "tags STRING ARRAY,"
         + "CHECK (tags[1] IS NULL)"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     String cel = schema.getRules().get(0).getExpr();
     assertTrue(cel.contains("== null"), "got: " + cel);
   }
@@ -4234,7 +4234,7 @@ class CheckConstraintTest {
     String script = "STRUCT T ("
         + "addr STRUCT(zip INT) CHECK (addr.zip IS NULL)"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     String cel = schema.getField("addr").getRules().get(0).getExpr();
     assertTrue(cel.contains("== null"), "got: " + cel);
   }
@@ -4261,7 +4261,7 @@ class CheckConstraintTest {
     String script = "STRUCT T ("
         + "addr STRUCT(zip INT) CHECK (COALESCE(addr.zip, 0) > 0)"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     String cel = schema.getField("addr").getRules().get(0).getExpr();
     assertTrue(cel.contains("zip"), "got: " + cel);
   }
@@ -4273,7 +4273,7 @@ class CheckConstraintTest {
     String script = "STRUCT T ("
         + "x INT CHECK (NULLIF(x, 0) > 0)"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     String cel = schema.getField("x").getRules().get(0).getExpr();
     assertTrue(cel.contains("?") && cel.contains("dyn(null)"),
         "got: " + cel);
@@ -4287,7 +4287,7 @@ class CheckConstraintTest {
         + "x INT,"
         + "CHECK (x IS NULL)"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     String cel = schema.getRules().get(0).getExpr();
     assertTrue(cel.contains("has(this.x)"), "got: " + cel);
   }
@@ -4301,7 +4301,7 @@ class CheckConstraintTest {
     String script = "STRUCT T ("
         + "tags STRING ARRAY CHECK (EVERY(tags, t, t IS NULL))"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     String cel = schema.getField("tags").getRules().get(0).getExpr();
     assertTrue(cel.contains("dyn(t) == null"), "got: " + cel);
   }
@@ -4311,7 +4311,7 @@ class CheckConstraintTest {
     String script = "STRUCT T ("
         + "tags STRING ARRAY CHECK (EVERY(tags, t, t IS NOT NULL))"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     String cel = schema.getField("tags").getRules().get(0).getExpr();
     assertTrue(cel.contains("dyn(t) != null"), "got: " + cel);
   }
@@ -4324,7 +4324,7 @@ class CheckConstraintTest {
         + "tags STRING ARRAY CHECK ("
         + "EVERY(tags, t, COALESCE(t, 'x') = 'x'))"
         + ");";
-    Schema schema = parseScript(script).getNamedTypes().get("T");
+    Schema schema = parseScript(script).getRootSchema();
     String cel = schema.getField("tags").getRules().get(0).getExpr();
     assertTrue(cel.contains("(t)"), "got: " + cel);
   }
@@ -4476,7 +4476,7 @@ class CheckConstraintTest {
         + "TYPE Person";
     LogicalTypesSchemaVisitor v = new LogicalTypesSchemaVisitor();
     v.visit(LogicalTypesParserFactory.parse(script));
-    String cel = v.getNamedTypes().get("Person").getRules().get(0).getExpr();
+    String cel = v.getRootSchema().getRules().get(0).getExpr();
     assertEquals("this.addr.tags['home'] == 'x'", cel);
   }
 

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/json/JsonToLogicalTypeConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/json/JsonToLogicalTypeConverterTest.java
@@ -16,6 +16,7 @@
 
 package io.confluent.kafka.schemaregistry.type.logical.json;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
@@ -417,5 +418,17 @@ class JsonToLogicalTypeConverterTest {
 
   private static LogicalType convert(String jsonText) {
     return JsonToLogicalTypeConverter.toLogicalType(new JsonSchema(jsonText));
+  }
+
+  @Test
+  void rootObjectTitleCarriedAsName() {
+    // A root object is inline (no namedTypes key), so its `title` would be lost; carry it as the
+    // LogicalType root name.
+    LogicalType lt = convert(
+        "{\"type\":\"object\",\"title\":\"Order\","
+            + "\"properties\":{\"id\":{\"type\":\"string\"}}}");
+
+    assertThat(lt.getRootSchema().getType()).isEqualTo(Schema.Type.STRUCT);
+    assertThat(lt.getName()).isEqualTo("Order");
   }
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/json/JsonToLogicalTypeConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/json/JsonToLogicalTypeConverterTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
 import io.confluent.kafka.schemaregistry.type.logical.LogicalType;
+import io.confluent.kafka.schemaregistry.type.logical.LogicalTypeToDdlConverter;
 import io.confluent.kafka.schemaregistry.type.logical.Schema;
 import io.confluent.kafka.schemaregistry.type.logical.ValidationException;
 import io.confluent.kafka.schemaregistry.type.logical.common.LogicalTypeVersion;
@@ -42,6 +43,23 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JsonToLogicalTypeConverterTest {
+
+  @Test
+  void namedLeafRootTitleRoundTripsThroughJson() {
+    // JSON -> LT -> JSON: a root object with a title unwraps to a bare STRUCT carrying its name on
+    // read, and the writer re-emits that name as the root object's title.
+    String jsonSchema = "{\"type\":\"object\",\"title\":\"Order\","
+        + "\"properties\":{\"id\":{\"type\":\"integer\",\"connect.type\":\"int32\"}}}";
+    LogicalType lt = JsonToLogicalTypeConverter.toLogicalType(new JsonSchema(jsonSchema));
+    assertEquals(Schema.Type.STRUCT, lt.getRootSchema().getType());
+    assertEquals("Order", lt.getName());
+    JsonSchema out = LogicalTypeToJsonConverter.fromLogicalType(lt, "IGNORED");
+    assertEquals("Order", out.rawSchema().getTitle());
+
+    // The DDL projection declares the root as a named STRUCT.
+    String ddl = LogicalTypeToDdlConverter.toDdl(lt);
+    assertThat(ddl).contains("STRUCT Order (");
+  }
 
   @Test
   void testBooleanType() {

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/json/LogicalTypeToJsonConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/json/LogicalTypeToJsonConverterTest.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -130,6 +131,24 @@ class LogicalTypeToJsonConverterTest {
     assertEquals("a person record", roundTripped.getDoc());
     assertEquals(Arrays.asList("PII", "SENSITIVE"), roundTripped.getTags());
     assertEquals("2", roundTripped.getParams().get("version"));
+  }
+
+  @Test
+  void nullableNamedRootPreservesNameThroughJson() {
+    // A nullable named STRUCT root is wrapped in an outer combined schema on emit; the reader reads
+    // the OUTER title for the root name, so the name must be re-applied to the outer schema or it
+    // is lost. NOT NULL named roots put the title directly on the object; this pins the nullable
+    // case, which arises e.g. from an explicit DDL `TYPE Order` (nullable) round-tripped via JSON.
+    Schema struct = Schema.createStruct(Arrays.asList(
+        new Field("id", Schema.create(Schema.Type.INT).setNullable(false), 0)));  // nullable default
+    LogicalType lt = new LogicalType(
+        "Order", null, struct, Map.of(), Set.of(), Map.of(), List.of(), Map.of(), Map.of());
+
+    JsonSchema json = LogicalTypeToJsonConverter.fromLogicalType(lt, "row");
+    LogicalType roundTripped = JsonToLogicalTypeConverter.toLogicalType(json);
+
+    assertEquals("Order", roundTripped.getName());
+    assertTrue(roundTripped.getRootSchema().isNullable());
   }
 
   @Test

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ExternalRefsRoundTripTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ExternalRefsRoundTripTest.java
@@ -92,10 +92,11 @@ class ExternalRefsRoundTripTest {
 
     // Pin the DDL projection of the resulting LT — bare externals have no
     // syntactic marker (re-inferred from usage on read-back) and the file's
-    // package becomes a namespace.
+    // package becomes a namespace. The root message name ("Order") is carried
+    // on the LogicalType, so the root renders as a named STRUCT declaration.
     assertEquals(
         "NAMESPACE acme;\n"
-            + "TYPE STRUCT(a com.example.M1, b com.example.M2) NOT NULL;\n",
+            + "STRUCT Order (a com.example.M1, b com.example.M2);\n",
         LogicalTypeToDdlConverter.toDdl(lt));
 
     // Reverse: LT -> Proto. The result must be a valid (parseable) proto

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverterTest.java
@@ -657,4 +657,21 @@ class ProtoToLogicalTypeConverterTest {
     // The root (Bar) is declared before the peer (Foo) so first-wins picks it.
     assertThat(ddl.indexOf("STRUCT Bar (")).isLessThan(ddl.indexOf("STRUCT Foo ("));
   }
+
+  @Test
+  void namedInlineRootForcedWithExplicitTypeWhenPeerReferencesIt() {
+    // Root Order (first message) is referenced by peer Wrapper. First-wins inference would drop
+    // Order (it is referenced) and pick Wrapper, so the writer must force the root with an explicit
+    // trailing TYPE, preserving its NOT NULL.
+    String proto = "syntax = \"proto3\";\n"
+        + "message Order {\n  string id = 1;\n}\n"
+        + "message Wrapper {\n  Order order = 1;\n}\n";
+    LogicalType lt = ProtoToLogicalTypeConverter.toLogicalType(new ProtobufSchema(proto));
+
+    assertThat(lt.getName()).isEqualTo("Order");
+
+    String ddl = LogicalTypeToDdlConverter.toDdl(lt);
+    assertThat(ddl).contains("STRUCT Order (");
+    assertThat(ddl).contains("TYPE Order NOT NULL;");
+  }
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverterTest.java
@@ -659,19 +659,31 @@ class ProtoToLogicalTypeConverterTest {
   }
 
   @Test
-  void namedInlineRootForcedWithExplicitTypeWhenPeerReferencesIt() {
-    // Root Order (first message) is referenced by peer Wrapper. First-wins inference would drop
-    // Order (it is referenced) and pick Wrapper, so the writer must force the root with an explicit
-    // trailing TYPE, preserving its NOT NULL.
+  void peerReferencedRootStaysNamedRefAndForcesExplicitType() {
+    // Root Order (first message) is referenced by peer Wrapper. Unwrapping Order to a bare inline
+    // root would remove its body from namedTypes and dangle Wrapper.order (which every format
+    // writer resolves only through namedTypes), so the shared root stays a NAMED_TYPE_REF with
+    // Order kept as a named peer. First-wins inference would then pick Wrapper (Order is
+    // referenced), so the DDL writer forces the root with an explicit trailing TYPE, NOT NULL.
     String proto = "syntax = \"proto3\";\n"
         + "message Order {\n  string id = 1;\n}\n"
         + "message Wrapper {\n  Order order = 1;\n}\n";
     LogicalType lt = ProtoToLogicalTypeConverter.toLogicalType(new ProtobufSchema(proto));
 
-    assertThat(lt.getName()).isEqualTo("Order");
+    assertThat(lt.getName()).isNull();
+    assertThat(lt.getRootSchema().getType()).isEqualTo(Schema.Type.NAMED_TYPE_REF);
+    assertThat(lt.getRootSchema().getQualifiedName()).isEqualTo("Order");
+    assertThat(lt.getNamedTypes()).containsKey("Order").containsKey("Wrapper");
 
     String ddl = LogicalTypeToDdlConverter.toDdl(lt);
     assertThat(ddl).contains("STRUCT Order (");
     assertThat(ddl).contains("TYPE Order NOT NULL;");
+
+    // The format writer resolves Wrapper.order through namedTypes (Order kept there) instead of
+    // throwing "Unknown named type reference"; building the descriptor exercises that resolution.
+    Descriptor out = LogicalTypeToProtoConverter.fromLogicalType(lt, "Order").toDescriptor();
+    assertThat(out.findFieldByName("id")).isNotNull();
+    Descriptor wrapper = out.getFile().findMessageTypeByName("Wrapper");
+    assertThat(wrapper.findFieldByName("order").getMessageType()).isEqualTo(out);
   }
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverterTest.java
@@ -636,4 +636,25 @@ class ProtoToLogicalTypeConverterTest {
     assertThat(ddl).contains("STRUCT Order (");
     assertThat(ddl).doesNotContain("TYPE STRUCT");
   }
+
+  @Test
+  void namedInlineRootShownWithUnreferencedLocalPeer() {
+    // Two independent top-level messages: root is Bar (the first message), Foo is an unreferenced
+    // local peer. The root is emitted as a named declaration FIRST, so first-wins root inference
+    // picks Bar on read-back — the name is shown, no anonymous fallback and no spurious UNION.
+    String proto = "syntax = \"proto3\";\n"
+        + "message Bar {\n  string f2 = 1;\n}\n"
+        + "message Foo {\n  string f1 = 1;\n}\n";
+    LogicalType lt = ProtoToLogicalTypeConverter.toLogicalType(new ProtobufSchema(proto));
+
+    assertThat(lt.getName()).isEqualTo("Bar");
+    assertThat(lt.getRootSchema().getType()).isEqualTo(Schema.Type.STRUCT);
+
+    String ddl = LogicalTypeToDdlConverter.toDdl(lt);
+    assertThat(ddl).doesNotContain("TYPE STRUCT");
+    assertThat(ddl).contains("STRUCT Bar (");
+    assertThat(ddl).contains("STRUCT Foo (");
+    // The root (Bar) is declared before the peer (Foo) so first-wins picks it.
+    assertThat(ddl.indexOf("STRUCT Bar (")).isLessThan(ddl.indexOf("STRUCT Foo ("));
+  }
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverterTest.java
@@ -288,6 +288,77 @@ class ProtoToLogicalTypeConverterTest {
   }
 
   @Test
+  void namedLeafRootNameRoundTripsThroughProto() throws Exception {
+    // Proto -> LT -> Proto: a single non-recursive message root unwraps to a bare STRUCT carrying
+    // its name on read, and the writer re-emits it under the same message name.
+    DescriptorProto order = DescriptorProto.newBuilder()
+        .setName("Order")
+        .addField(FieldDescriptorProto.newBuilder()
+            .setName("id").setNumber(1).setType(Type.TYPE_INT32))
+        .build();
+    LogicalType lt = ProtoToLogicalTypeConverter.toLogicalType(
+        new ProtobufSchema(buildFileDescriptor(order)));
+    assertEquals(Schema.Type.STRUCT, lt.getRootSchema().getType());
+    assertEquals("Order", lt.getName());
+    ProtobufSchema out = LogicalTypeToProtoConverter.fromLogicalType(lt, "IGNORED");
+    assertEquals("Order", out.toDescriptor().getName());
+
+    // The DDL projection declares the root as a named STRUCT; a single unreferenced root needs no
+    // explicit trailing TYPE (first-wins inference recovers it).
+    String ddl = LogicalTypeToDdlConverter.toDdl(lt);
+    assertThat(ddl).contains("STRUCT Order (");
+    assertThat(ddl).doesNotContain("TYPE");
+  }
+
+  @Test
+  void twoIndependentMessagesRoundTripThroughProtoPreservingNames() throws Exception {
+    // Proto (2 independent top-level messages) -> LT -> Proto (2 messages). The first message is
+    // the root: it unwraps to a bare STRUCT carrying its name on LogicalType.name. The second is a
+    // peer named type (a STRUCT in namedTypes). Both message names survive the round-trip.
+    DescriptorProto order = DescriptorProto.newBuilder()
+        .setName("Order")
+        .addField(FieldDescriptorProto.newBuilder()
+            .setName("id").setNumber(1).setType(Type.TYPE_INT32))
+        .build();
+    DescriptorProto customer = DescriptorProto.newBuilder()
+        .setName("Customer")
+        .addField(FieldDescriptorProto.newBuilder()
+            .setName("name").setNumber(1).setType(Type.TYPE_STRING))
+        .build();
+    FileDescriptorProto fileProto = FileDescriptorProto.newBuilder()
+        .addMessageType(order)
+        .addMessageType(customer)
+        .setSyntax("proto3")
+        .build();
+    FileDescriptor fd = FileDescriptor.buildFrom(fileProto, new FileDescriptor[0]);
+
+    LogicalType lt = ProtoToLogicalTypeConverter.toLogicalType(new ProtobufSchema(fd));
+    // Root: bare STRUCT carrying its name.
+    assertEquals(Schema.Type.STRUCT, lt.getRootSchema().getType());
+    assertEquals("Order", lt.getName());
+    // Peer: a named STRUCT held in namedTypes (only the root goes bare + name).
+    Schema customerType = lt.getNamedTypes().get("Customer");
+    assertNotNull(customerType);
+    assertEquals(Schema.Type.STRUCT, customerType.getType());
+
+    // Back to Proto: both messages re-emitted under their original names, fields intact.
+    ProtobufSchema out = LogicalTypeToProtoConverter.fromLogicalType(lt, "IGNORED");
+    Descriptor rootOut = out.toDescriptor();
+    assertEquals("Order", rootOut.getName());
+    assertNotNull(rootOut.findFieldByName("id"));
+    Descriptor customerOut = rootOut.getFile().findMessageTypeByName("Customer");
+    assertNotNull(customerOut);
+    assertNotNull(customerOut.findFieldByName("name"));
+
+    // The DDL projection declares BOTH as named STRUCTs. No explicit trailing TYPE is needed:
+    // first-wins inference makes the first-declared unreferenced type (Order) the root.
+    String ddl = LogicalTypeToDdlConverter.toDdl(lt);
+    assertThat(ddl).contains("STRUCT Order (");
+    assertThat(ddl).contains("STRUCT Customer (");
+    assertThat(ddl).doesNotContain("TYPE Order");
+  }
+
+  @Test
   void testTypeMappings() {
     // Matrix-driven coverage. Each TypeMapping in CommonMappings goes
     // LT -> Proto -> LT and the result must equal the original. Adding a new

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ProtoToLogicalTypeConverterTest.java
@@ -19,6 +19,7 @@ package io.confluent.kafka.schemaregistry.type.logical.protobuf;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.confluent.kafka.schemaregistry.type.logical.LogicalType;
+import io.confluent.kafka.schemaregistry.type.logical.LogicalTypeToDdlConverter;
 import io.confluent.kafka.schemaregistry.type.logical.Schema;
 import com.google.protobuf.DescriptorProtos.DescriptorProto;
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
@@ -614,5 +615,25 @@ class ProtoToLogicalTypeConverterTest {
 
     assertThat(out.findFieldByName("a").getNumber()).isEqualTo(5);
     assertThat(out.findFieldByName("b").getNumber()).isEqualTo(2);
+  }
+
+  @Test
+  void simpleRootMessageNameCarriedAndRenderedInDdl() throws Exception {
+    // A simple (non-recursive, non-nested) root message is unwrapped to a bare STRUCT; its name
+    // would be lost, so it is carried on LogicalType.name and the DDL renders a named declaration.
+    DescriptorProto message = DescriptorProto.newBuilder()
+        .setName("Order")
+        .addField(FieldDescriptorProto.newBuilder()
+            .setName("id").setNumber(1).setType(Type.TYPE_STRING))
+        .build();
+
+    LogicalType lt = ProtoToLogicalTypeConverter.toLogicalType(
+        new ProtobufSchema(buildFileDescriptor(message)));
+
+    assertThat(lt.getRootSchema().getType()).isEqualTo(Schema.Type.STRUCT);
+    assertThat(lt.getName()).isEqualTo("Order");
+    String ddl = LogicalTypeToDdlConverter.toDdl(lt);
+    assertThat(ddl).contains("STRUCT Order (");
+    assertThat(ddl).doesNotContain("TYPE STRUCT");
   }
 }


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----

 A registered root type's own name (an Avro record / Protobuf message / JSON root                                                                                                  
  object, or a DDL `STRUCT`/`ENUM`) was only representable as a `NAMED_TYPE_REF` into                                                                                               
  `namedTypes`, or was dropped entirely on some paths. This makes bare-`STRUCT`/`ENUM`                                                                                            
  `LogicalType.name` the canonical named-root shape, so a leaf named root round-trips                                                                                           
  `LT → DDL → LT` and `LT → {Avro,Proto,JSON} → LT` without losing its name, while                                                                                                  
  `NAMED_TYPE_REF` is retained for the cases that genuinely need it (recursive, nested,                                                                                             
  shared, external).                                                                                                                                                                
                                                                                                                                                                                    
  ## Brief change log                                                                                                                                                               
                                                                                                                                                                                    
  - `LogicalType`: new shared `unwrapLeafNamedRoot(rootSchema, namedTypes, namespace)`                                                                                              
    helper + `RootUnwrap` result. Unwraps a leaf `NAMED_TYPE_REF` root to the bare body                                                                                             
    carrying its simple name; **gated** so external / cyclic / nested-named /                                                                                                       
    foreign-namespace roots stay `NAMED_TYPE_REF`.                                                                                                                                  
  - `LogicalTypesSchemaVisitor`: delegates root unwrap to the shared helper; first-wins                                                                                             
    multi-root inference (multi-root UNION *sugar* removed — a UNION-of-named-types root                                                                                            
    must be explicit `TYPE UNION(...)`).                                                                                                                                            
  - `LogicalTypeToDdlConverter`: emits the named root declaration first and round-trips it.                                                                                         
  - `AvroToLogicalTypeConverter`: unwraps a leaf root record/enum via the shared helper.                                                                                            
  - Writers `LogicalTypeTo{Avro,Proto,Json}Converter`: consume `lt.getName()` as the root                                                                                           
    name (record full-name / message name / JSON `title`), taking precedence over the                                                                                               
    caller's `rowName`.      

<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
