### PR TITLE
Simplify namespaced names when going from formats to LT

### DIFF
--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverter.java
@@ -162,11 +162,11 @@ public final class LogicalTypeToDdlConverter {
     private void printCreateType(String name, Schema body) {
       switch (body.getType()) {
         case STRUCT:
-          sb.append("STRUCT ").append(qualifiedName(name)).append(" ");
+          sb.append("STRUCT ").append(qualifiedName(displayName(name))).append(" ");
           appendStructBody(body, /*indent=*/"");
           break;
         case ENUM:
-          sb.append("ENUM ").append(qualifiedName(name)).append(" ");
+          sb.append("ENUM ").append(qualifiedName(displayName(name))).append(" ");
           appendEnumBody(body);
           break;
         default:
@@ -357,7 +357,7 @@ public final class LogicalTypeToDdlConverter {
           // Schema.toDdl returns the bare qualified name without identifier
           // quoting — collides with reserved words (e.g., a type literally
           // named "Row" would lex as the ROW keyword). Quote per-segment.
-          return wrapNullable(qualifiedName(schema.getQualifiedName()), schema);
+          return wrapNullable(qualifiedName(displayName(schema.getQualifiedName())), schema);
         default:
           // Primitive / decimal / parametric / ENUM — Schema.toDdl already
           // emits the right syntax including the " NOT NULL" suffix when
@@ -571,6 +571,22 @@ public final class LogicalTypeToDdlConverter {
     // ---------------------------------------------------------------------
     // Names and literals
     // ---------------------------------------------------------------------
+
+    /**
+     * Strip the document namespace prefix from a fully-qualified name so names under the active
+     * {@code NAMESPACE} render simplified (e.g. {@code com.example.demo.Address} → {@code Address}
+     * when the namespace is {@code com.example.demo}). Foreign-namespace names pass through
+     * unchanged, and a nested type's nesting portion is preserved
+     * ({@code com.example.demo.Outer.Inner} → {@code Outer.Inner}) — the visitor re-qualifies it on
+     * read-back via its local-parent-prefix rule.
+     */
+    private String displayName(String fqn) {
+      String ns = lt.getNamespace();
+      if (ns != null && !ns.isEmpty() && fqn != null && fqn.startsWith(ns + ".")) {
+        return fqn.substring(ns.length() + 1);
+      }
+      return fqn;
+    }
 
     private static String qualifiedName(String dotted) {
       String[] parts = dotted.split("\\.");

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverter.java
@@ -575,17 +575,47 @@ public final class LogicalTypeToDdlConverter {
     /**
      * Strip the document namespace prefix from a fully-qualified name so names under the active
      * {@code NAMESPACE} render simplified (e.g. {@code com.example.demo.Address} → {@code Address}
-     * when the namespace is {@code com.example.demo}). Foreign-namespace names pass through
-     * unchanged, and a nested type's nesting portion is preserved
-     * ({@code com.example.demo.Outer.Inner} → {@code Outer.Inner}) — the visitor re-qualifies it on
-     * read-back via its local-parent-prefix rule.
+     * when the namespace is {@code com.example.demo}). Only simplifies when the visitor can reverse
+     * it on read-back:
+     * <ul>
+     *   <li>a bare (dot-free) remainder is always re-qualified with the namespace;</li>
+     *   <li>a dotted remainder is re-qualified only when a prefix of it names a locally-declared
+     *       parent type — i.e. it denotes nesting ({@code Outer.Inner}).</li>
+     * </ul>
+     * Otherwise the name is left fully qualified: foreign-namespace names, and a type in a
+     * sub-namespace of the document namespace with no local parent (e.g.
+     * {@code com.example.sub.Address}), would be read back as an unrelated FQN if simplified.
      */
     private String displayName(String fqn) {
       String ns = lt.getNamespace();
-      if (ns != null && !ns.isEmpty() && fqn != null && fqn.startsWith(ns + ".")) {
-        return fqn.substring(ns.length() + 1);
+      if (ns == null || ns.isEmpty() || fqn == null || !fqn.startsWith(ns + ".")) {
+        return fqn;
+      }
+      String relative = fqn.substring(ns.length() + 1);
+      if (!relative.contains(".") || hasLocalParentPrefix(relative, ns)) {
+        return relative;
       }
       return fqn;
+    }
+
+    /**
+     * Mirror of {@code LogicalTypesSchemaVisitor#hasLocalParentPrefix} over the local named types:
+     * true iff a dotted prefix of {@code name} (as written, or namespace-prepended) names a
+     * locally-declared type — which is exactly when the visitor treats the dots as nesting and
+     * re-applies the namespace on read-back.
+     */
+    private boolean hasLocalParentPrefix(String name, String ns) {
+      Set<String> declared = lt.getLocalNamedTypes().keySet();
+      int dot = name.lastIndexOf('.');
+      while (dot > 0) {
+        String prefix = name.substring(0, dot);
+        if (declared.contains(prefix)
+            || (ns != null && !ns.isEmpty() && declared.contains(ns + "." + prefix))) {
+          return true;
+        }
+        dot = name.lastIndexOf('.', dot - 1);
+      }
+      return false;
     }
 
     private static String qualifiedName(String dotted) {

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
@@ -143,8 +143,12 @@ public class AvroToLogicalTypeConverter {
     // type's full name instead. Fall back to the root named type's own namespace so the recovered
     // LogicalType has a document namespace (a NAMESPACE declaration + simplified names in DDL),
     // matching what the Proto (file package) and JSON (confluent:namespace) readers produce.
+    // Skip an anonymous root: the V2 writer marks a synthetic STRUCT/ENUM root with
+    // logical.anonymous=true and names it after the caller's rowName. If that rowName was qualified
+    // (e.g. acme.Row), its namespace is synthetic — not a document namespace — so it must not be
+    // inferred (that would add a spurious NAMESPACE on read-back).
     org.apache.avro.Schema root = rootNamedType(avroSchema.rawSchema());
-    if (root != null) {
+    if (root != null && !isAnonymous(root)) {
       String ns = root.getNamespace();
       return ns == null || ns.isEmpty() ? null : ns;
     }

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
@@ -143,10 +143,41 @@ public class AvroToLogicalTypeConverter {
     // type's full name instead. Fall back to the root named type's own namespace so the recovered
     // LogicalType has a document namespace (a NAMESPACE declaration + simplified names in DDL),
     // matching what the Proto (file package) and JSON (confluent:namespace) readers produce.
-    org.apache.avro.Schema raw = avroSchema.rawSchema();
-    if (raw != null && isNamedAvroType(raw.getType())) {
-      String ns = raw.getNamespace();
+    org.apache.avro.Schema root = rootNamedType(avroSchema.rawSchema());
+    if (root != null) {
+      String ns = root.getNamespace();
       return ns == null || ns.isEmpty() ? null : ns;
+    }
+    return null;
+  }
+
+  /**
+   * The effective named root type: the schema itself if it is a RECORD/ENUM/FIXED, or the single
+   * non-null branch of a nullable {@code ["null", T]} union when {@code T} is a named type (which
+   * the converter unwraps to a nullable STRUCT/ENUM root). Returns {@code null} for anything else
+   * (primitives, arrays/maps, or a genuine multi-branch union with no single named type).
+   */
+  private static org.apache.avro.Schema rootNamedType(org.apache.avro.Schema raw) {
+    if (raw == null) {
+      return null;
+    }
+    if (isNamedAvroType(raw.getType())) {
+      return raw;
+    }
+    if (raw.getType() == org.apache.avro.Schema.Type.UNION) {
+      org.apache.avro.Schema named = null;
+      for (org.apache.avro.Schema member : raw.getTypes()) {
+        if (member.getType() == org.apache.avro.Schema.Type.NULL) {
+          continue;
+        }
+        if (named != null) {
+          return null; // more than one non-null branch — not a simple nullable named root
+        }
+        named = member;
+      }
+      if (named != null && isNamedAvroType(named.getType())) {
+        return named;
+      }
     }
     return null;
   }

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
@@ -115,6 +115,9 @@ public class AvroToLogicalTypeConverter {
    * stripped), yet must still map to VARIANT.
    */
   private static boolean isVariantRecord(org.apache.avro.Schema avroSchema) {
+    if (avroSchema.getType() != org.apache.avro.Schema.Type.RECORD) {
+      return false;
+    }
     org.apache.avro.LogicalType logicalType = avroSchema.getLogicalType();
     if (logicalType != null && VariantLogicalType.NAME.equals(logicalType.getName())) {
       return true;

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
@@ -133,10 +133,28 @@ public class AvroToLogicalTypeConverter {
 
   private static String extractNamespace(AvroSchema avroSchema) {
     Metadata metadata = avroSchema.metadata();
-    if (metadata == null || metadata.getProperties() == null) {
-      return null;
+    if (metadata != null && metadata.getProperties() != null) {
+      String ns = metadata.getProperties().get(CONFLUENT_NAMESPACE_PROP);
+      if (ns != null) {
+        return ns;
+      }
     }
-    return metadata.getProperties().get(CONFLUENT_NAMESPACE_PROP);
+    // Natural Avro carries no confluent:namespace metadata; the namespace lives on each named
+    // type's full name instead. Fall back to the root named type's own namespace so the recovered
+    // LogicalType has a document namespace (a NAMESPACE declaration + simplified names in DDL),
+    // matching what the Proto (file package) and JSON (confluent:namespace) readers produce.
+    org.apache.avro.Schema raw = avroSchema.rawSchema();
+    if (raw != null && isNamedAvroType(raw.getType())) {
+      String ns = raw.getNamespace();
+      return ns == null || ns.isEmpty() ? null : ns;
+    }
+    return null;
+  }
+
+  private static boolean isNamedAvroType(org.apache.avro.Schema.Type type) {
+    return type == org.apache.avro.Schema.Type.RECORD
+        || type == org.apache.avro.Schema.Type.ENUM
+        || type == org.apache.avro.Schema.Type.FIXED;
   }
 
   private static Map<String, Object> extractUnionMetadata(AvroSchema avroSchema) {

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverter.java
@@ -143,12 +143,17 @@ public class AvroToLogicalTypeConverter {
     // type's full name instead. Fall back to the root named type's own namespace so the recovered
     // LogicalType has a document namespace (a NAMESPACE declaration + simplified names in DDL),
     // matching what the Proto (file package) and JSON (confluent:namespace) readers produce.
-    // Skip an anonymous root: the V2 writer marks a synthetic STRUCT/ENUM root with
-    // logical.anonymous=true and names it after the caller's rowName. If that rowName was qualified
-    // (e.g. acme.Row), its namespace is synthetic — not a document namespace — so it must not be
-    // inferred (that would add a spurious NAMESPACE on read-back).
+    // Only infer a namespace from a root whose IDENTITY survives conversion — i.e. a RECORD → named
+    // STRUCT or ENUM → named ENUM. Exclude roots whose name is synthetic or encoding-only, since
+    // their (possibly qualified) name would leak a spurious NAMESPACE on read-back:
+    //   - anonymous roots (logical.anonymous=true, named after the caller's rowName);
+    //   - FIXED, which converts to unnamed BINARY;
+    //   - the canonical confluent.type.Variant record, which converts to unnamed VARIANT.
     org.apache.avro.Schema root = rootNamedType(avroSchema.rawSchema());
-    if (root != null && !isAnonymous(root)) {
+    if (root != null
+        && root.getType() != org.apache.avro.Schema.Type.FIXED
+        && !isAnonymous(root)
+        && !isVariantRecord(root)) {
       String ns = root.getNamespace();
       return ns == null || ns.isEmpty() ? null : ns;
     }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverterTest.java
@@ -62,6 +62,31 @@ class LogicalTypeToDdlConverterTest {
   // -----------------------------------------------------------------------
 
   @Test
+  void namespacedNamesSimplifyInDdlIncludingNestedTypes() {
+    // Names under the document NAMESPACE render simplified (the com.example.demo prefix is
+    // stripped), including nested types whose nesting portion (Outer.Inner) is preserved.
+    // A foreign-namespace reference stays fully qualified.
+    LogicalType lt = parse(
+        "NAMESPACE com.example.demo;\n"
+        + "STRUCT Outer (inner Outer.Inner NOT NULL, addr Address, ext other.ns.Thing);\n"
+        + "STRUCT Outer.Inner (x INT NOT NULL);\n"
+        + "STRUCT Address (city STRING NOT NULL);\n");
+    String ddl = LogicalTypeToDdlConverter.toDdl(lt);
+    assertTrue(ddl.contains("NAMESPACE com.example.demo;"), ddl);
+    assertTrue(ddl.contains("STRUCT Outer ("), ddl);
+    assertTrue(ddl.contains("STRUCT Outer.Inner ("), ddl);
+    assertTrue(ddl.contains("STRUCT Address ("), ddl);
+    assertTrue(ddl.contains("inner Outer.Inner NOT NULL"), ddl);
+    assertTrue(ddl.contains("addr Address"), ddl);
+    // Foreign-namespace reference is not stripped.
+    assertTrue(ddl.contains("ext other.ns.Thing"), ddl);
+    // The document namespace prefix never appears on a local name.
+    assertTrue(!ddl.contains("com.example.demo.Outer")
+        && !ddl.contains("com.example.demo.Address"), ddl);
+    assertRoundTrip(lt);
+  }
+
+  @Test
   void primitives() {
     // Named-type (STRUCT/ENUM) bodies are parsed as nullable (the body's own nullability
     // is "ambient"; the use site sets nullability via the NAMED_TYPE_REF

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverterTest.java
@@ -87,6 +87,23 @@ class LogicalTypeToDdlConverterTest {
   }
 
   @Test
+  void subNamespaceNamesAreNotOverSimplified() {
+    // A type in a sub-namespace of the document namespace with NO local parent must stay fully
+    // qualified: stripping com.example.sub.Address -> sub.Address would re-read as an unrelated
+    // FQN, since the visitor only re-qualifies a dotted name when a prefix names a local parent.
+    LogicalType lt = parse(
+        "NAMESPACE com.example;\n"
+        + "STRUCT Order (addr com.example.sub.Address NOT NULL);\n"
+        + "STRUCT com.example.sub.Address (city STRING NOT NULL);\n");
+    String ddl = LogicalTypeToDdlConverter.toDdl(lt);
+    assertTrue(ddl.contains("STRUCT com.example.sub.Address ("), ddl);
+    assertTrue(ddl.contains("addr com.example.sub.Address NOT NULL"), ddl);
+    // Type identity must survive the projection. String idempotence alone would NOT catch
+    // over-stripping (sub.Address re-emits as sub.Address), so assert the FQN key round-trips.
+    assertTrue(parse(ddl).getNamedTypes().containsKey("com.example.sub.Address"), ddl);
+  }
+
+  @Test
   void primitives() {
     // Named-type (STRUCT/ENUM) bodies are parsed as nullable (the body's own nullability
     // is "ambient"; the use site sets nullability via the NAMED_TYPE_REF

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverterTest.java
@@ -181,6 +181,29 @@ class AvroToLogicalTypeConverterTest {
   }
 
   @Test
+  void fixedRootDoesNotInferNamespace() {
+    // A FIXED root converts to unnamed BINARY, so its (qualified) name must not seed a namespace.
+    String json = "{\"type\":\"fixed\",\"name\":\"Hash\",\"namespace\":\"acme\",\"size\":16}";
+    io.confluent.kafka.schemaregistry.type.logical.LogicalType lt =
+        AvroToLogicalTypeConverter.toLogicalType(new AvroSchema(json));
+    assertNull(lt.getNamespace());
+    assertNull(lt.getName());
+    assertEquals(Schema.Type.BINARY, lt.getRootSchema().getType());
+  }
+
+  @Test
+  void variantRootDoesNotInferNamespace() {
+    // A confluent.type.Variant record converts to unnamed VARIANT, so its namespace must not leak.
+    String json = "{\"type\":\"record\",\"name\":\"Variant\",\"namespace\":\"confluent.type\","
+        + "\"fields\":[{\"name\":\"metadata\",\"type\":\"bytes\"},"
+        + "{\"name\":\"value\",\"type\":\"bytes\"}]}";
+    io.confluent.kafka.schemaregistry.type.logical.LogicalType lt =
+        AvroToLogicalTypeConverter.toLogicalType(new AvroSchema(json));
+    assertNull(lt.getNamespace());
+    assertEquals(Schema.Type.VARIANT, lt.getRootSchema().getType());
+  }
+
+  @Test
   void testProperUnionConversion() {
     org.apache.avro.Schema unionSchema = org.apache.avro.Schema.createUnion(
         SchemaBuilder.builder().intType(),

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverterTest.java
@@ -166,6 +166,21 @@ class AvroToLogicalTypeConverterTest {
   }
 
   @Test
+  void anonymousRootDoesNotInferNamespace() {
+    // An anonymous root (logical.anonymous=true) named after a qualified rowName must NOT contribute
+    // a document namespace — its name/namespace are synthetic, so inferring one would add a spurious
+    // NAMESPACE on read-back.
+    String json = "{\"type\":\"record\",\"name\":\"Row\",\"namespace\":\"acme\","
+        + "\"logical.anonymous\":\"true\","
+        + "\"fields\":[{\"name\":\"id\",\"type\":\"int\"}]}";
+    io.confluent.kafka.schemaregistry.type.logical.LogicalType lt =
+        AvroToLogicalTypeConverter.toLogicalType(new AvroSchema(json));
+    assertNull(lt.getNamespace());
+    assertNull(lt.getName());
+    assertEquals(Schema.Type.STRUCT, lt.getRootSchema().getType());
+  }
+
+  @Test
   void testProperUnionConversion() {
     org.apache.avro.Schema unionSchema = org.apache.avro.Schema.createUnion(
         SchemaBuilder.builder().intType(),

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/AvroToLogicalTypeConverterTest.java
@@ -151,6 +151,21 @@ class AvroToLogicalTypeConverterTest {
   }
 
   @Test
+  void nullableNamespacedRootInfersNamespace() {
+    // A natural nullable Avro root is a top-level ["null", record] union; the namespace fallback
+    // must still infer the record's namespace (matching the NOT NULL case and the Proto/JSON
+    // readers) rather than seeing UNION and giving up.
+    String json = "[\"null\",{\"type\":\"record\",\"name\":\"Order\",\"namespace\":\"acme\","
+        + "\"fields\":[{\"name\":\"id\",\"type\":\"int\"}]}]";
+    io.confluent.kafka.schemaregistry.type.logical.LogicalType lt =
+        AvroToLogicalTypeConverter.toLogicalType(new AvroSchema(json));
+    assertEquals("acme", lt.getNamespace());
+    assertEquals(Schema.Type.STRUCT, lt.getRootSchema().getType());
+    assertEquals("Order", lt.getName());
+    assertTrue(lt.getRootSchema().isNullable());
+  }
+
+  @Test
   void testProperUnionConversion() {
     org.apache.avro.Schema unionSchema = org.apache.avro.Schema.createUnion(
         SchemaBuilder.builder().intType(),

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/ExternalRefsRoundTripTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/ExternalRefsRoundTripTest.java
@@ -80,14 +80,15 @@ class ExternalRefsRoundTripTest {
 
     AvroSchema legacy = new AvroSchema(mainAvro, refs, resolved, null);
 
-    // Forward: legacy Avro -> LT. The Avro reader body-promotes every named
-    // record into namedTypes, so the root is a NAMED_TYPE_REF to acme.Person.
+    // Forward: legacy Avro -> LT. The namespaced root record acme.Person unwraps to a bare STRUCT
+    // carrying its name, and its own namespace (acme) becomes the document namespace; the externals
+    // it references are body-promoted into namedTypes and flagged external.
     LogicalType lt = AvroToLogicalTypeConverter.toLogicalType(legacy);
 
-    assertEquals(Schema.Type.NAMED_TYPE_REF, lt.getRootSchema().getType());
-    assertEquals("acme.Person", lt.getRootSchema().getQualifiedName());
-    Schema personBody = lt.getNamedTypes().get("acme.Person");
-    assertNotNull(personBody, "Person body should live in namedTypes");
+    assertEquals(Schema.Type.STRUCT, lt.getRootSchema().getType());
+    assertEquals("Person", lt.getName());
+    assertEquals("acme", lt.getNamespace());
+    Schema personBody = lt.getRootSchema();
 
     Schema home = personBody.getField("home").getSchema();
     Schema thing = personBody.getField("thing").getSchema();
@@ -100,11 +101,12 @@ class ExternalRefsRoundTripTest {
     assertTrue(lt.isExternal("com.example.Stuff"),
         "Stuff should be flagged as external");
 
-    // Pin the DDL projection of the resulting LT — bare externals have no
-    // syntactic marker (re-inferred from usage on read-back) and Person
-    // becomes the registered root.
+    // Pin the DDL projection: the root's namespace becomes a NAMESPACE header and its own name is
+    // simplified (acme.Person -> Person); the foreign-namespace externals stay fully qualified and
+    // carry no syntactic marker (re-inferred from usage on read-back).
     assertEquals(
-        "STRUCT acme.Person (home com.example.Outer NOT NULL,"
+        "NAMESPACE acme;\n"
+            + "STRUCT Person (home com.example.Outer NOT NULL,"
             + " thing com.example.Stuff NOT NULL);\n",
         LogicalTypeToDdlConverter.toDdl(lt));
 
@@ -119,8 +121,9 @@ class ExternalRefsRoundTripTest {
     // Re-read the rebuilt schema as a final validity check: the field types
     // must still resolve as NAMED_TYPE_REFs to the same FQNs.
     LogicalType rt = AvroToLogicalTypeConverter.toLogicalType(rebuilt);
-    Schema personBody2 = rt.getNamedTypes().get("acme.Person");
-    assertNotNull(personBody2, "Person body should survive the round trip");
+    Schema personBody2 = rt.getRootSchema();
+    assertEquals(Schema.Type.STRUCT, personBody2.getType(),
+        "Person body should survive the round trip as the bare named root");
     Schema home2 = personBody2.getField("home").getSchema();
     Schema thing2 = personBody2.getField("thing").getSchema();
     assertEquals(Schema.Type.NAMED_TYPE_REF, home2.getType());


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----

Makes the `format → LogicalType → DDL` direction consistent across Avro, Protobuf,                                                                                                
  and JSON for schemas that use a namespace. Two related changes:                                                                                                                   
                                                                                                                                                                                    
  1. **Avro reader — infer the document namespace.** `AvroToLogicalTypeConverter`                                                                                                   
     previously read the namespace only from a `confluent:namespace` metadata prop, so a                                                                                            
     natural Avro schema (whose namespace lives on each record's full name) produced a                                                                                              
     `LogicalType` with a null namespace. It now falls back to the root named type's own                                                                                            
     Avro namespace, matching what the Proto reader (file `package`) and JSON reader                                                                                                
     (`confluent:namespace`) already do.                                                                                                                                            
                                                                                                                                                                                    
  2. **DDL writer — simplify names under the namespace.** `LogicalTypeToDdlConverter`                                                                                               
     always emitted fully-qualified type names, so even with a `NAMESPACE` declaration the                                                                                          
     peer declarations and type references stayed fully qualified                                                                                                                   
     (`STRUCT com.example.demo.Address`, `status com.example.demo.Status`). It now strips                                                                                           
     the document-namespace prefix (`com.example.demo.Address` → `Address`), preserving the                                                                                         
     nesting portion of nested types (`com.example.demo.Outer.Inner` → `Outer.Inner`) and                                                                                           
     leaving foreign-namespace names fully qualified.

<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
