### PR TITLE
Return 422 instead of 500 for invalid logical-format schemas

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
@@ -78,7 +78,7 @@ final class LogicalFormat {
       LogicalTypesSchemaVisitor visitor = new LogicalTypesSchemaVisitor();
       visitor.visit(LogicalTypesParserFactory.parse(request.getSchema()));
       parsed = visitor.toLogicalType();
-    } catch (ValidationException e) {
+    } catch (RuntimeException e) {
       throw new InvalidSchemaException("Invalid logical type schema: " + e.getMessage(), e);
     }
 
@@ -103,7 +103,7 @@ final class LogicalFormat {
               "Unsupported schemaType '" + schemaType + "' for format=logical; "
                   + "must be one of AVRO, JSON, PROTOBUF");
       }
-    } catch (ValidationException e) {
+    } catch (RuntimeException e) {
       throw new InvalidSchemaException(
           "Logical type schema cannot be represented as " + schemaType + ": "
               + e.getMessage(), e);

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormatTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormatTest.java
@@ -167,6 +167,21 @@ class LogicalFormatTest {
     assertTrue(e.getMessage().contains("Invalid logical type schema"));
   }
 
+  @Test
+  void convertToNativeMapsIllegalTargetNameToInvalidSchema() {
+    // A root name that is legal DDL (backtick-quoted) but illegal for the target format: Avro's
+    // Schema.createRecord rejects the space, throwing SchemaParseException. That is invalid client
+    // input, so it must surface as InvalidSchemaException (422) via the conversion catch, not as an
+    // uncaught RuntimeException (500).
+    RegisterSchemaRequest request = requestFor("AVRO", "STRUCT `bad name` (id INT NOT NULL)");
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+
+    InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
+    assertTrue(e.getMessage().contains("cannot be represented as AVRO"),
+        "expected the conversion-failure message, got: " + e.getMessage());
+  }
+
   // -- convertToNative: external references --------------------------------------------------
 
   @Test


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----

When registering a `format=logical` schema, `LogicalFormat.convertToNative` parses the                                                                                            
  DDL into a `LogicalType` and converts it to the requested native format (Avro / JSON /                                                                                            
  Protobuf). Both steps caught only our own `ValidationException`, so any other                                                                                                     
  `RuntimeException` thrown while processing the client-supplied schema escaped uncaught                                                                                            
  and surfaced as a **500 Internal Server Error** instead of a **422**.                                                                                                             
                                                                                                                                                                                    
  The concrete case: a root name that is legal DDL (e.g. a backtick-quoted `` `bad name` ``)                                                                                        
  but illegal for the target format reaches Avro's `Schema.createRecord`, which throws                                                                                              
  `SchemaParseException` — not a `ValidationException` — so it was a 500.   

 Chose the broad `RuntimeException` over a narrow `ValidationException | SchemaParseException`                                                                                     
  because `SchemaParseException` is Avro-only; Protobuf and JSON throw different types, so a                                                                                        
  narrow union would leave those formats 500-ing and couple this class to three libraries'                                                                                          
  exception internals.     
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
