### PR TITLE
DGS-23963 Support format=logical output across schema APIs

### DIFF
--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -150,7 +150,7 @@ public class CompatibilityResource {
       // Auto-detect a logical-types DDL body (native-first) and convert it to the requested native
       // schemaType before the check, mirroring register and lookUpSchemaUnderSubject.
       if (LogicalFormat.looksLogical(schemaRegistry, new Schema(subject, request))) {
-        LogicalFormat.convertToNative(schemaRegistry, subject, request, true);
+        LogicalFormat.convertToNative(schemaRegistry, subject, request);
       }
       Schema schema = new Schema(subject, request);
       if (!normalize) {
@@ -243,7 +243,7 @@ public class CompatibilityResource {
       // Auto-detect a logical-types DDL body (native-first) and convert it to the requested native
       // schemaType before the check, mirroring register and lookUpSchemaUnderSubject.
       if (LogicalFormat.looksLogical(schemaRegistry, new Schema(subject, request))) {
-        LogicalFormat.convertToNative(schemaRegistry, subject, request, true);
+        LogicalFormat.convertToNative(schemaRegistry, subject, request);
       }
       Schema schema = new Schema(subject, request);
       if (!normalize) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -146,8 +146,13 @@ public class CompatibilityResource {
     if (schemaForSpecifiedVersion == null && !versionId.isLatest()) {
       throw Errors.versionNotFoundException(versionId.getVersionId());
     }
-    Schema schema = new Schema(subject, request);
     try {
+      // Auto-detect a logical-types DDL body (native-first) and convert it to the requested native
+      // schemaType before the check, mirroring register and lookUpSchemaUnderSubject.
+      if (LogicalFormat.looksLogical(schemaRegistry, new Schema(subject, request))) {
+        LogicalFormat.convertToNative(schemaRegistry, subject, request, true);
+      }
+      Schema schema = new Schema(subject, request);
       if (!normalize) {
         normalize = Boolean.TRUE.equals(schemaRegistry.getConfigInScope(subject).isNormalize());
       }
@@ -234,8 +239,13 @@ public class CompatibilityResource {
       throw Errors.storeException("Error while retrieving schema for subject "
           + subject, e);
     }
-    Schema schema = new Schema(subject, request);
     try {
+      // Auto-detect a logical-types DDL body (native-first) and convert it to the requested native
+      // schemaType before the check, mirroring register and lookUpSchemaUnderSubject.
+      if (LogicalFormat.looksLogical(schemaRegistry, new Schema(subject, request))) {
+        LogicalFormat.convertToNative(schemaRegistry, subject, request, true);
+      }
+      Schema schema = new Schema(subject, request);
       if (!normalize) {
         normalize = Boolean.TRUE.equals(schemaRegistry.getConfigInScope(subject).isNormalize());
       }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/CompatibilityResource.java
@@ -148,10 +148,8 @@ public class CompatibilityResource {
     }
     try {
       // Auto-detect a logical-types DDL body (native-first) and convert it to the requested native
-      // schemaType before the check, mirroring register and lookUpSchemaUnderSubject.
-      if (LogicalFormat.looksLogical(schemaRegistry, new Schema(subject, request))) {
-        LogicalFormat.convertToNative(schemaRegistry, subject, request);
-      }
+      // schemaType before the check.
+      LogicalFormat.tryConvertToNative(schemaRegistry, subject, request);
       Schema schema = new Schema(subject, request);
       if (!normalize) {
         normalize = Boolean.TRUE.equals(schemaRegistry.getConfigInScope(subject).isNormalize());
@@ -241,10 +239,8 @@ public class CompatibilityResource {
     }
     try {
       // Auto-detect a logical-types DDL body (native-first) and convert it to the requested native
-      // schemaType before the check, mirroring register and lookUpSchemaUnderSubject.
-      if (LogicalFormat.looksLogical(schemaRegistry, new Schema(subject, request))) {
-        LogicalFormat.convertToNative(schemaRegistry, subject, request);
-      }
+      // schemaType before the check.
+      LogicalFormat.tryConvertToNative(schemaRegistry, subject, request);
       Schema schema = new Schema(subject, request);
       if (!normalize) {
         normalize = Boolean.TRUE.equals(schemaRegistry.getConfigInScope(subject).isNormalize());

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
@@ -101,19 +101,11 @@ final class LogicalFormat {
    *
    * <p>{@code schemaType} is required here. Unlike a native registration, a logical DDL body never
    * implies a target format, so there is no default to fall back to.
-   *
-   * @param validateAsNew whether the body is a candidate new schema, as on register and
-   *                      compatibility checks, or an existing one being looked up. It governs
-   *                      whether references to soft-deleted versions resolve, and must match what
-   *                      the caller's native path does so a logical body and its native equivalent
-   *                      behave identically -- lookup canonicalizes with {@code false}, while
-   *                      register and the compatibility checks treat the body as new.
    */
   static void convertToNative(
       final SchemaRegistry schemaRegistry,
       final String subject,
-      final RegisterSchemaRequest request,
-      final boolean validateAsNew)
+      final RegisterSchemaRequest request)
       throws SchemaRegistryException {
     String schemaType = request.getSchemaType();
     if (schemaType == null || schemaType.trim().isEmpty()) {
@@ -134,8 +126,8 @@ final class LogicalFormat {
       throw new InvalidSchemaException("Invalid logical type schema: " + e.getMessage(), e);
     }
 
-    LogicalType logicalType = attachReferences(
-        schemaRegistry, subject, parsed, request.getReferences(), validateAsNew);
+    LogicalType logicalType =
+        attachReferences(schemaRegistry, subject, parsed, request.getReferences());
     String rowName = rowNameFor(subject);
 
     ParsedSchema nativeSchema;
@@ -195,21 +187,23 @@ final class LogicalFormat {
       final SchemaRegistry schemaRegistry,
       final String subject,
       final LogicalType parsed,
-      final List<SchemaReference> references,
-      final boolean validateAsNew)
+      final List<SchemaReference> references)
       throws SchemaRegistryException {
     if (references == null || references.isEmpty()) {
       return parsed;
     }
-    // validateAsNew is the caller's: it decides whether references to soft-deleted versions
-    // resolve, and mirrors the validateAsNew the caller's native path passes to canonicalizeSchema.
-    // referenceVersionsStrict is false here because it is a per-provider setting this path cannot
-    // reach; it is still enforced, since the converted native schema is re-parsed downstream by the
-    // provider, which resolves the same references with its configured value.
+    // Both flags are deliberately permissive, because this resolution is not a validation gate --
+    // it only supplies the referenced definitions the conversion needs to emit a native schema.
+    // Every caller feeds that native schema straight into a path that re-resolves the same
+    // references and enforces the configured mode: validateAsNew is derived per-caller
+    // (schemaId < 0 && schema.validate.new.schemas on register, the config alone on a
+    // compatibility check, false on lookup), and referenceVersionsStrict comes from the provider.
+    // Resolving strictly here would reject a soft-deleted reference that the equivalent native
+    // request accepts whenever the caller's own flag works out to false.
     Map<String, String> resolvedReferences;
     try {
       resolvedReferences = AbstractSchemaProvider.resolveReferences(
-          schemaRegistry, subject, references, validateAsNew, false);
+          schemaRegistry, subject, references, false, false);
     } catch (IllegalArgumentException | IllegalStateException e) {
       // resolveReferences throws IllegalArgument/IllegalState on a missing or conflicting
       // reference; surface it as a clean InvalidSchemaException (422), the same way the native

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
@@ -101,11 +101,19 @@ final class LogicalFormat {
    *
    * <p>{@code schemaType} is required here. Unlike a native registration, a logical DDL body never
    * implies a target format, so there is no default to fall back to.
+   *
+   * @param validateAsNew whether the body is a candidate new schema, as on register and
+   *                      compatibility checks, or an existing one being looked up. It governs
+   *                      whether references to soft-deleted versions resolve, and must match what
+   *                      the caller's native path does so a logical body and its native equivalent
+   *                      behave identically -- lookup canonicalizes with {@code false}, while
+   *                      register and the compatibility checks treat the body as new.
    */
   static void convertToNative(
       final SchemaRegistry schemaRegistry,
       final String subject,
-      final RegisterSchemaRequest request)
+      final RegisterSchemaRequest request,
+      final boolean validateAsNew)
       throws SchemaRegistryException {
     String schemaType = request.getSchemaType();
     if (schemaType == null || schemaType.trim().isEmpty()) {
@@ -126,8 +134,8 @@ final class LogicalFormat {
       throw new InvalidSchemaException("Invalid logical type schema: " + e.getMessage(), e);
     }
 
-    LogicalType logicalType =
-        attachReferences(schemaRegistry, subject, parsed, request.getReferences());
+    LogicalType logicalType = attachReferences(
+        schemaRegistry, subject, parsed, request.getReferences(), validateAsNew);
     String rowName = rowNameFor(subject);
 
     ParsedSchema nativeSchema;
@@ -187,19 +195,21 @@ final class LogicalFormat {
       final SchemaRegistry schemaRegistry,
       final String subject,
       final LogicalType parsed,
-      final List<SchemaReference> references)
+      final List<SchemaReference> references,
+      final boolean validateAsNew)
       throws SchemaRegistryException {
     if (references == null || references.isEmpty()) {
       return parsed;
     }
-    // validateAsNew=true: this is a new registration, so references to deleted versions must not
-    // resolve, matching what the native register path does via canonicalizeSchema.
-    // referenceVersionsStrict defaults to false: it is a per-provider setting configured on the
-    // native SchemaProvider instances, which the logical registration path does not reach.
+    // validateAsNew is the caller's: it decides whether references to soft-deleted versions
+    // resolve, and mirrors the validateAsNew the caller's native path passes to canonicalizeSchema.
+    // referenceVersionsStrict is false here because it is a per-provider setting this path cannot
+    // reach; it is still enforced, since the converted native schema is re-parsed downstream by the
+    // provider, which resolves the same references with its configured value.
     Map<String, String> resolvedReferences;
     try {
       resolvedReferences = AbstractSchemaProvider.resolveReferences(
-          schemaRegistry, subject, references, true, false);
+          schemaRegistry, subject, references, validateAsNew, false);
     } catch (IllegalArgumentException | IllegalStateException e) {
       // resolveReferences throws IllegalArgument/IllegalState on a missing or conflicting
       // reference; surface it as a clean InvalidSchemaException (422), the same way the native

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
@@ -55,22 +55,29 @@ final class LogicalFormat {
    * Auto-detects whether a request-body schema is a logical-types DDL rather than a native
    * Avro/JSON/Protobuf schema, so callers don't need to pass {@code format=logical} on input.
    *
-   * <p>Native-first: the body is parsed as its declared {@code schemaType}; if that succeeds it is
-   * a native schema. Only when the native parse fails is the logical DDL parse attempted, so common
-   * native traffic never pays for a DDL parse, a native schema (which is never valid DDL) is never
-   * misread as logical, and unparseable garbage stays native so its native error is what surfaces.
-   * {@code parseSchema} resolves references, so a referenced native schema still classifies
-   * correctly.
+   * <p>The cheap, registry-free DDL parse is the gate: a body that does not even parse as logical
+   * DDL is native, and the overwhelmingly common native traffic stops here having paid only for a
+   * fast failed DDL parse -- it is not parsed against the registry at all, so it is parsed exactly
+   * once, downstream, on the register/lookup path itself.
+   *
+   * <p>Native-first only where it matters: a body that <em>does</em> parse as DDL could still be a
+   * native schema that happens to be valid DDL, so it is disambiguated by a native parse and native
+   * wins if that succeeds. {@code parseSchema} resolves references, so a referenced native schema
+   * still classifies correctly. Only a genuine logical body reaches -- and pays for -- this parse.
    */
   static boolean looksLogical(SchemaRegistry schemaRegistry, Schema schema) {
     if (schema == null || schema.getSchema() == null || schema.getSchema().isBlank()) {
       return false;
     }
+    if (!parsesAsLogical(schema.getSchema())) {
+      return false; // not DDL at all -> native; no registry parse spent on the common case
+    }
+    // Parses as DDL, but might be a native schema that is also valid DDL: native wins if it parses.
     try {
       schemaRegistry.parseSchema(schema, false, false);
-      return false; // parses as its declared native schemaType
+      return false;
     } catch (RuntimeException | SchemaRegistryException e) {
-      return parsesAsLogical(schema.getSchema()); // not native — logical iff it parses as DDL
+      return true;
     }
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
@@ -28,6 +28,7 @@ import io.confluent.kafka.schemaregistry.type.logical.LogicalType;
 import io.confluent.kafka.schemaregistry.type.logical.LogicalTypeToDdlConverter;
 import io.confluent.kafka.schemaregistry.type.logical.LogicalTypesParserFactory;
 import io.confluent.kafka.schemaregistry.type.logical.LogicalTypesSchemaVisitor;
+import io.confluent.kafka.schemaregistry.type.logical.generated.LogicalTypesParser;
 import io.confluent.kafka.schemaregistry.type.logical.ValidationException;
 import io.confluent.kafka.schemaregistry.type.logical.avro.LogicalTypeToAvroConverter;
 import io.confluent.kafka.schemaregistry.type.logical.json.LogicalTypeToJsonConverter;
@@ -52,14 +53,18 @@ final class LogicalFormat {
   }
 
   /**
-   * Auto-detects whether a request-body schema is a logical-types DDL rather than a native
-   * Avro/JSON/Protobuf schema, so callers don't need to pass {@code format=logical} on input.
+   * Auto-detects whether {@code request}'s body is a logical-types DDL rather than a native
+   * Avro/JSON/Protobuf schema and, if it is, converts it to the requested native
+   * {@code schemaType} in place -- so callers don't need to pass {@code format=logical} on input.
+   *
+   * <p>Detection and conversion are one method because they share the DDL parse: splitting them
+   * would parse a logical body twice, once to classify it and once to convert it.
    *
    * <p>Native-first: the body is parsed as its declared {@code schemaType}, and only if that fails
    * is the logical DDL parse attempted. So a native schema always wins, and a body is logical only
    * once it has been ruled out as native. {@code parseSchema} resolves references, so a referenced
    * native schema still classifies correctly, and unparseable garbage stays native so its native
-   * error is what surfaces.
+   * error is what surfaces rather than a misleading DDL one.
    *
    * <p>The native parse is not extra work in the common case: it goes through the registry's
    * {@code oldSchemaCache} under the same key that the {@code lookUpSchemaUnderSubject} performed
@@ -70,42 +75,50 @@ final class LogicalFormat {
    * <p>Only {@code InvalidSchemaException} means "not native" -- the registry funnels every parse
    * failure into it. Catching it alone keeps unrelated runtime failures from being misclassified
    * as logical input.
+   *
+   * @return whether the body was logical and has been replaced by its native equivalent
    */
-  static boolean looksLogical(SchemaRegistry schemaRegistry, Schema schema) {
-    if (schema == null || schema.getSchema() == null || schema.getSchema().isBlank()) {
+  static boolean tryConvertToNative(
+      final SchemaRegistry schemaRegistry,
+      final String subject,
+      final RegisterSchemaRequest request)
+      throws SchemaRegistryException {
+    if (request == null || request.getSchema() == null || request.getSchema().isBlank()) {
       return false;
     }
     try {
-      schemaRegistry.parseSchema(schema, false, false);
+      schemaRegistry.parseSchema(new Schema(subject, request), false, false);
       return false; // parses as its declared native schemaType
     } catch (InvalidSchemaException e) {
-      return parsesAsLogical(schema.getSchema()); // not native -- logical iff it parses as DDL
+      // Not native. Fall through: logical iff it parses as DDL.
     }
-  }
 
-  static boolean parsesAsLogical(String schema) {
-    if (schema == null || schema.isBlank()) {
-      return false;
-    }
+    // Syntax decides logical-vs-native; semantics decides valid-vs-invalid. A body that does not
+    // even parse as DDL is native, but one that parses and then fails the visitor is a bad logical
+    // schema and must say so, rather than falling through to a confusing native error.
+    LogicalTypesParser.ScriptContext script;
     try {
-      new LogicalTypesSchemaVisitor().visit(LogicalTypesParserFactory.parse(schema));
-      return true;
+      script = LogicalTypesParserFactory.parse(request.getSchema());
     } catch (RuntimeException e) {
-      return false;
+      return false; // neither native nor DDL -- leave it native so its native error surfaces
     }
+
+    convertToNative(schemaRegistry, subject, request, script);
+    return true;
   }
 
   /**
-   * Converts the Logical Type in {@code request}'s schema field into {@code request}'s declared
-   * {@code schemaType}, replacing it in place.
+   * Converts an already-parsed logical type into {@code request}'s declared {@code schemaType},
+   * replacing the request's schema in place.
    *
    * <p>{@code schemaType} is required here. Unlike a native registration, a logical DDL body never
    * implies a target format, so there is no default to fall back to.
    */
-  static void convertToNative(
+  private static void convertToNative(
       final SchemaRegistry schemaRegistry,
       final String subject,
-      final RegisterSchemaRequest request)
+      final RegisterSchemaRequest request,
+      final LogicalTypesParser.ScriptContext script)
       throws SchemaRegistryException {
     String schemaType = request.getSchemaType();
     if (schemaType == null || schemaType.trim().isEmpty()) {
@@ -115,12 +128,9 @@ final class LogicalFormat {
     }
 
     LogicalType parsed;
-    if (request.getSchema() == null || request.getSchema().trim().isEmpty()) {
-      throw new InvalidSchemaException("Schema is required for a logical type schema");
-    }
     try {
       LogicalTypesSchemaVisitor visitor = new LogicalTypesSchemaVisitor();
-      visitor.visit(LogicalTypesParserFactory.parse(request.getSchema()));
+      visitor.visit(script);
       parsed = visitor.toLogicalType();
     } catch (RuntimeException e) {
       throw new InvalidSchemaException("Invalid logical type schema: " + e.getMessage(), e);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
@@ -52,6 +52,41 @@ final class LogicalFormat {
   }
 
   /**
+   * Auto-detects whether a request-body schema is a logical-types DDL rather than a native
+   * Avro/JSON/Protobuf schema, so callers don't need to pass {@code format=logical} on input.
+   *
+   * <p>Native-first: the body is parsed as its declared {@code schemaType}; if that succeeds it is
+   * a native schema. Only when the native parse fails is the logical DDL parse attempted, so common
+   * native traffic never pays for a DDL parse, a native schema (which is never valid DDL) is never
+   * misread as logical, and unparseable garbage stays native so its native error is what surfaces.
+   * {@code parseSchema} resolves references, so a referenced native schema still classifies
+   * correctly.
+   */
+  static boolean looksLogical(SchemaRegistry schemaRegistry, Schema schema) {
+    if (schema == null || schema.getSchema() == null || schema.getSchema().isBlank()) {
+      return false;
+    }
+    try {
+      schemaRegistry.parseSchema(schema, false, false);
+      return false; // parses as its declared native schemaType
+    } catch (RuntimeException | SchemaRegistryException e) {
+      return parsesAsLogical(schema.getSchema()); // not native — logical iff it parses as DDL
+    }
+  }
+
+  static boolean parsesAsLogical(String schema) {
+    if (schema == null || schema.isBlank()) {
+      return false;
+    }
+    try {
+      new LogicalTypesSchemaVisitor().visit(LogicalTypesParserFactory.parse(schema));
+      return true;
+    } catch (RuntimeException e) {
+      return false;
+    }
+  }
+
+  /**
    * Converts the Logical Type in {@code request}'s schema field into {@code request}'s declared
    * {@code schemaType}, replacing it in place.
    *

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormat.java
@@ -55,29 +55,31 @@ final class LogicalFormat {
    * Auto-detects whether a request-body schema is a logical-types DDL rather than a native
    * Avro/JSON/Protobuf schema, so callers don't need to pass {@code format=logical} on input.
    *
-   * <p>The cheap, registry-free DDL parse is the gate: a body that does not even parse as logical
-   * DDL is native, and the overwhelmingly common native traffic stops here having paid only for a
-   * fast failed DDL parse -- it is not parsed against the registry at all, so it is parsed exactly
-   * once, downstream, on the register/lookup path itself.
+   * <p>Native-first: the body is parsed as its declared {@code schemaType}, and only if that fails
+   * is the logical DDL parse attempted. So a native schema always wins, and a body is logical only
+   * once it has been ruled out as native. {@code parseSchema} resolves references, so a referenced
+   * native schema still classifies correctly, and unparseable garbage stays native so its native
+   * error is what surfaces.
    *
-   * <p>Native-first only where it matters: a body that <em>does</em> parse as DDL could still be a
-   * native schema that happens to be valid DDL, so it is disambiguated by a native parse and native
-   * wins if that succeeds. {@code parseSchema} resolves references, so a referenced native schema
-   * still classifies correctly. Only a genuine logical body reaches -- and pays for -- this parse.
+   * <p>The native parse is not extra work in the common case: it goes through the registry's
+   * {@code oldSchemaCache} under the same key that the {@code lookUpSchemaUnderSubject} performed
+   * moments later on the register/lookup path uses, so that call is served from the cache. (The
+   * key includes {@code normalize}, so a {@code normalize=true} request does pay for one extra
+   * parse.)
+   *
+   * <p>Only {@code InvalidSchemaException} means "not native" -- the registry funnels every parse
+   * failure into it. Catching it alone keeps unrelated runtime failures from being misclassified
+   * as logical input.
    */
   static boolean looksLogical(SchemaRegistry schemaRegistry, Schema schema) {
     if (schema == null || schema.getSchema() == null || schema.getSchema().isBlank()) {
       return false;
     }
-    if (!parsesAsLogical(schema.getSchema())) {
-      return false; // not DDL at all -> native; no registry parse spent on the common case
-    }
-    // Parses as DDL, but might be a native schema that is also valid DDL: native wins if it parses.
     try {
       schemaRegistry.parseSchema(schema, false, false);
-      return false;
-    } catch (RuntimeException | SchemaRegistryException e) {
-      return true;
+      return false; // parses as its declared native schemaType
+    } catch (InvalidSchemaException e) {
+      return parsesAsLogical(schema.getSchema()); // not native -- logical iff it parses as DDL
     }
   }
 
@@ -97,8 +99,8 @@ final class LogicalFormat {
    * Converts the Logical Type in {@code request}'s schema field into {@code request}'s declared
    * {@code schemaType}, replacing it in place.
    *
-   * <p>{@code schemaType} is required here. Unlike a native registration, the request body under
-   * {@code format=logical} never implies a target format, so there is no default to fall back to.
+   * <p>{@code schemaType} is required here. Unlike a native registration, a logical DDL body never
+   * implies a target format, so there is no default to fall back to.
    */
   static void convertToNative(
       final SchemaRegistry schemaRegistry,
@@ -108,13 +110,13 @@ final class LogicalFormat {
     String schemaType = request.getSchemaType();
     if (schemaType == null || schemaType.trim().isEmpty()) {
       throw new InvalidSchemaException(
-          "schemaType is required when format=logical, and must be one of "
+          "schemaType is required for a logical type schema, and must be one of "
               + "AVRO, JSON, PROTOBUF");
     }
 
     LogicalType parsed;
     if (request.getSchema() == null || request.getSchema().trim().isEmpty()) {
-      throw new InvalidSchemaException("Schema is required when format=logical");
+      throw new InvalidSchemaException("Schema is required for a logical type schema");
     }
     try {
       LogicalTypesSchemaVisitor visitor = new LogicalTypesSchemaVisitor();
@@ -142,7 +144,7 @@ final class LogicalFormat {
           break;
         default:
           throw new InvalidSchemaException(
-              "Unsupported schemaType '" + schemaType + "' for format=logical; "
+              "Unsupported schemaType '" + schemaType + "' for a logical type schema; "
                   + "must be one of AVRO, JSON, PROTOBUF");
       }
     } catch (RuntimeException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
@@ -501,7 +501,9 @@ public class SchemasResource {
     if (!hasReferences(schema)) {
       return null;
     }
-    Set<String> subjects = schemaRegistry.listSubjectsForId(id, subject);
+    // returnDeleted=true: fetching by id does not filter soft-deleted schemas, so the id's only
+    // subject versions may be deleted ones -- excluding them would lose the context entirely.
+    Set<String> subjects = schemaRegistry.listSubjectsForId(id, subject, true);
     return subjects == null || subjects.isEmpty() ? null : subjects.iterator().next();
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
@@ -233,7 +233,7 @@ public class SchemasResource {
       if (LogicalFormat.isLogical(format)) {
         // Convert with the stored subject so unqualified references resolve in their own context.
         schema.setSchemaString(LogicalFormat.convertToLogical(schemaRegistry,
-            new Schema(schema.getSubject(), schema.getVersion(), id, schema)));
+            new Schema(refParentForId(id, subject, schema), schema.getVersion(), id, schema)));
       }
       QualifiedSubject qs = QualifiedSubject.create(schemaRegistry.tenant(), schema.getSubject());
       boolean isQualifiedSubject = qs != null && !DEFAULT_CONTEXT.equals(qs.getContext());
@@ -412,7 +412,7 @@ public class SchemasResource {
         SchemaString ss = schemaRegistry.get(id, subject, "", false);
         // A missing id yields null; let the not-found check below handle it rather than NPE.
         schema = ss == null ? null : LogicalFormat.convertToLogical(
-            schemaRegistry, new Schema(ss.getSubject(), null, id, ss));
+            schemaRegistry, new Schema(refParentForId(id, subject, ss), null, id, ss));
       } else {
         schema = schemaRegistry.get(id, subject, format, false).getSchemaString();
       }
@@ -486,6 +486,31 @@ public class SchemasResource {
   }
 
   /**
+   * Returns the subject to use as the parent when resolving the references of a schema fetched by
+   * id. When the caller omits {@code subject}, storage deliberately returns a {@link SchemaString}
+   * with a null subject, but unqualified reference subjects are qualified against their parent's
+   * context -- so an id selected from a non-default context would otherwise resolve its references
+   * in the default context. Recovers a stored subject for the id in that case. Returns
+   * {@code null} when the schema has no references, since the parent is then unused.
+   */
+  private String refParentForId(int id, String subject, SchemaString schema)
+      throws SchemaRegistryException {
+    if (schema.getSubject() != null) {
+      return schema.getSubject();
+    }
+    if (!hasReferences(schema)) {
+      return null;
+    }
+    Set<String> subjects = schemaRegistry.listSubjectsForId(id, subject);
+    return subjects == null || subjects.isEmpty() ? null : subjects.iterator().next();
+  }
+
+  private static boolean hasReferences(SchemaString schema) {
+    List<SchemaReference> refs = schema.getReferences();
+    return refs != null && !refs.isEmpty();
+  }
+
+  /**
    * Returns a qualified-context subject standing in for the context the given guid lives in, to be
    * used as the parent when resolving the schema's references. A schema fetched by guid has had its
    * subject stripped, but unqualified reference subjects are qualified against their parent's
@@ -494,8 +519,7 @@ public class SchemasResource {
    */
   private String contextForGuid(String guid, SchemaString schema)
       throws SchemaRegistryException {
-    List<SchemaReference> refs = schema.getReferences();
-    if (refs == null || refs.isEmpty()) {
+    if (!hasReferences(schema)) {
       return null;
     }
     List<ContextId> ids = schemaRegistry.listIdsForGuid(guid);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
@@ -218,16 +218,10 @@ public class SchemasResource {
     String errorMessage = "Error while retrieving schema with id " + id + " from the schema "
                           + "registry";
     try {
-      if (LogicalFormat.isLogical(format)) {
-        // Storage renders native formats only; fetch natively and convert to logical DDL here.
-        schema = schemaRegistry.get(id, subject, "", fetchMaxId);
-        if (schema != null) {
-          schema.setSchemaString(LogicalFormat.convertToLogical(
-              schemaRegistry, new Schema(subject, null, id, schema)));
-        }
-      } else {
-        schema = schemaRegistry.get(id, subject, format, fetchMaxId);
-      }
+      // Storage renders native formats only; for logical DDL, fetch natively and convert further
+      // below -- after extractSchemaTags, which reparses the schema string as its native type.
+      schema = schemaRegistry.get(
+          id, subject, LogicalFormat.isLogical(format) ? "" : format, fetchMaxId);
       if (schema == null) {
         throw Errors.schemaNotFoundException(id);
       }
@@ -235,6 +229,11 @@ public class SchemasResource {
         Schema s = new Schema(schema.getSubject(), schema.getVersion(), id, schema);
         schemaRegistry.extractSchemaTags(s, tags);
         schema.setSchemaTags(s.getSchemaTags());
+      }
+      if (LogicalFormat.isLogical(format)) {
+        // Convert with the stored subject so unqualified references resolve in their own context.
+        schema.setSchemaString(LogicalFormat.convertToLogical(schemaRegistry,
+            new Schema(schema.getSubject(), schema.getVersion(), id, schema)));
       }
       QualifiedSubject qs = QualifiedSubject.create(schemaRegistry.tenant(), schema.getSubject());
       boolean isQualifiedSubject = qs != null && !DEFAULT_CONTEXT.equals(qs.getContext());
@@ -411,7 +410,9 @@ public class SchemasResource {
     try {
       if (LogicalFormat.isLogical(format)) {
         SchemaString ss = schemaRegistry.get(id, subject, "", false);
-        schema = LogicalFormat.convertToLogical(schemaRegistry, new Schema(subject, null, id, ss));
+        // A missing id yields null; let the not-found check below handle it rather than NPE.
+        schema = ss == null ? null : LogicalFormat.convertToLogical(
+            schemaRegistry, new Schema(ss.getSubject(), null, id, ss));
       } else {
         schema = schemaRegistry.get(id, subject, format, false).getSchemaString();
       }
@@ -461,8 +462,11 @@ public class SchemasResource {
       if (LogicalFormat.isLogical(format)) {
         schema = schemaRegistry.getByGuid(guid, "");
         if (schema != null) {
+          // getByGuid strips subject/version, but unqualified reference subjects resolve against
+          // their parent's context -- so recover the guid's own context as the conversion parent.
+          // Only needed when the schema actually has references.
           schema.setSchemaString(LogicalFormat.convertToLogical(
-              schemaRegistry, new Schema(null, null, null, schema)));
+              schemaRegistry, new Schema(contextForGuid(guid, schema), null, null, schema)));
         }
       } else {
         schema = schemaRegistry.getByGuid(guid, format);
@@ -479,6 +483,27 @@ public class SchemasResource {
       throw Errors.schemaRegistryException(errorMessage, e);
     }
     return schema;
+  }
+
+  /**
+   * Returns a qualified-context subject standing in for the context the given guid lives in, to be
+   * used as the parent when resolving the schema's references. A schema fetched by guid has had its
+   * subject stripped, but unqualified reference subjects are qualified against their parent's
+   * context, so without this a referenced schema in a non-default context would not be found.
+   * Returns {@code null} when the schema has no references, since the parent is then unused.
+   */
+  private String contextForGuid(String guid, SchemaString schema)
+      throws SchemaRegistryException {
+    List<SchemaReference> refs = schema.getReferences();
+    if (refs == null || refs.isEmpty()) {
+      return null;
+    }
+    List<ContextId> ids = schemaRegistry.listIdsForGuid(guid);
+    if (ids.isEmpty()) {
+      return null;
+    }
+    return new QualifiedSubject(schemaRegistry.tenant(), ids.get(0).getContext(), null)
+        .toQualifiedContext();
   }
 
   @GET

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
@@ -218,7 +218,16 @@ public class SchemasResource {
     String errorMessage = "Error while retrieving schema with id " + id + " from the schema "
                           + "registry";
     try {
-      schema = schemaRegistry.get(id, subject, format, fetchMaxId);
+      if (LogicalFormat.isLogical(format)) {
+        // Storage renders native formats only; fetch natively and convert to logical DDL here.
+        schema = schemaRegistry.get(id, subject, "", fetchMaxId);
+        if (schema != null) {
+          schema.setSchemaString(LogicalFormat.convertToLogical(
+              schemaRegistry, new Schema(subject, null, id, schema)));
+        }
+      } else {
+        schema = schemaRegistry.get(id, subject, format, fetchMaxId);
+      }
       if (schema == null) {
         throw Errors.schemaNotFoundException(id);
       }
@@ -400,7 +409,12 @@ public class SchemasResource {
             + "schema with id " + id + " from the schema registry";
     String schema ;
     try {
-      schema = schemaRegistry.get(id, subject, format, false).getSchemaString();
+      if (LogicalFormat.isLogical(format)) {
+        SchemaString ss = schemaRegistry.get(id, subject, "", false);
+        schema = LogicalFormat.convertToLogical(schemaRegistry, new Schema(subject, null, id, ss));
+      } else {
+        schema = schemaRegistry.get(id, subject, format, false).getSchemaString();
+      }
     } catch (InvalidSchemaException e) {
       throw Errors.invalidSchemaException(e);
     } catch (SchemaRegistryStoreException e) {
@@ -444,7 +458,15 @@ public class SchemasResource {
     String errorMessage = "Error while retrieving schema with guid " + guid + " from the schema "
         + "registry";
     try {
-      schema = schemaRegistry.getByGuid(guid, format);
+      if (LogicalFormat.isLogical(format)) {
+        schema = schemaRegistry.getByGuid(guid, "");
+        if (schema != null) {
+          schema.setSchemaString(LogicalFormat.convertToLogical(
+              schemaRegistry, new Schema(null, null, null, schema)));
+        }
+      } else {
+        schema = schemaRegistry.getByGuid(guid, format);
+      }
       if (schema == null) {
         throw Errors.schemaNotFoundException(guid);
       }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SchemasResource.java
@@ -233,7 +233,7 @@ public class SchemasResource {
       if (LogicalFormat.isLogical(format)) {
         // Convert with the stored subject so unqualified references resolve in their own context.
         schema.setSchemaString(LogicalFormat.convertToLogical(schemaRegistry,
-            new Schema(refParentForId(id, subject, schema), schema.getVersion(), id, schema)));
+            new Schema(subjectForId(id, subject, schema), schema.getVersion(), id, schema)));
       }
       QualifiedSubject qs = QualifiedSubject.create(schemaRegistry.tenant(), schema.getSubject());
       boolean isQualifiedSubject = qs != null && !DEFAULT_CONTEXT.equals(qs.getContext());
@@ -412,7 +412,7 @@ public class SchemasResource {
         SchemaString ss = schemaRegistry.get(id, subject, "", false);
         // A missing id yields null; let the not-found check below handle it rather than NPE.
         schema = ss == null ? null : LogicalFormat.convertToLogical(
-            schemaRegistry, new Schema(refParentForId(id, subject, ss), null, id, ss));
+            schemaRegistry, new Schema(subjectForId(id, subject, ss), null, id, ss));
       } else {
         schema = schemaRegistry.get(id, subject, format, false).getSchemaString();
       }
@@ -485,6 +485,11 @@ public class SchemasResource {
     return schema;
   }
 
+  private static boolean hasReferences(SchemaString schema) {
+    List<SchemaReference> refs = schema.getReferences();
+    return refs != null && !refs.isEmpty();
+  }
+
   /**
    * Returns the subject to use as the parent when resolving the references of a schema fetched by
    * id. When the caller omits {@code subject}, storage deliberately returns a {@link SchemaString}
@@ -493,7 +498,7 @@ public class SchemasResource {
    * in the default context. Recovers a stored subject for the id in that case. Returns
    * {@code null} when the schema has no references, since the parent is then unused.
    */
-  private String refParentForId(int id, String subject, SchemaString schema)
+  private String subjectForId(int id, String subject, SchemaString schema)
       throws SchemaRegistryException {
     if (schema.getSubject() != null) {
       return schema.getSubject();
@@ -505,11 +510,6 @@ public class SchemasResource {
     // subject versions may be deleted ones -- excluding them would lose the context entirely.
     Set<String> subjects = schemaRegistry.listSubjectsForId(id, subject, true);
     return subjects == null || subjects.isEmpty() ? null : subjects.iterator().next();
-  }
-
-  private static boolean hasReferences(SchemaString schema) {
-    List<SchemaReference> refs = schema.getReferences();
-    return refs != null && !refs.isEmpty();
   }
 
   /**

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -493,7 +493,11 @@ public class SubjectVersionsResource {
 
     RegisterSchemaResponse registerSchemaResponse;
     try {
-      if (LogicalFormat.isLogical(format)) {
+      // Input format is auto-detected from the body (native-first: only a body that fails to parse
+      // as its declared native schemaType and then parses as logical DDL is treated as logical).
+      // A logical body is converted to the requested native schemaType before registration. The
+      // `format` query param is not consulted for input; it only renders the response (below).
+      if (LogicalFormat.looksLogical(schemaRegistry, new Schema(subjectName, request))) {
         LogicalFormat.convertToNative(schemaRegistry, subjectName, request);
       }
       if (!normalize) {
@@ -501,14 +505,17 @@ public class SubjectVersionsResource {
       }
       Schema result = schemaRegistry.registerOrForward(
           subjectName, request, normalize, force, headerProperties);
-      // format=logical governs how the request body is interpreted, not how the response is
-      // rendered -- the response always reflects the stored native schema.
-      if (result.getSchema() != null && format != null && !format.trim().isEmpty()
-          && !LogicalFormat.isLogical(format)) {
-        ParsedSchema parsedSchema = schemaRegistry.parseSchema(result, false, false);
-        String originalGuid = result.getGuid();
-        result.setSchema(parsedSchema.formattedString(format));
-        result.setGuid(originalGuid);
+      // `format` renders the response: `logical` emits the stored native schema as logical-types
+      // DDL, any other value applies the native formatter.
+      if (result.getSchema() != null && format != null && !format.trim().isEmpty()) {
+        if (LogicalFormat.isLogical(format)) {
+          result.setSchema(LogicalFormat.convertToLogical(schemaRegistry, result));
+        } else {
+          ParsedSchema parsedSchema = schemaRegistry.parseSchema(result, false, false);
+          String originalGuid = result.getGuid();
+          result.setSchema(parsedSchema.formattedString(format));
+          result.setGuid(originalGuid);
+        }
       }
       registerSchemaResponse = new RegisterSchemaResponse(result);
     } catch (IdDoesNotMatchException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -498,7 +498,7 @@ public class SubjectVersionsResource {
       // A logical body is converted to the requested native schemaType before registration. The
       // `format` query param is not consulted for input; it only renders the response (below).
       if (LogicalFormat.looksLogical(schemaRegistry, new Schema(subjectName, request))) {
-        LogicalFormat.convertToNative(schemaRegistry, subjectName, request, true);
+        LogicalFormat.convertToNative(schemaRegistry, subjectName, request);
       }
       if (!normalize) {
         normalize = Boolean.TRUE.equals(schemaRegistry.getConfigInScope(subjectName).isNormalize());

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -508,14 +508,17 @@ public class SubjectVersionsResource {
       // `format` renders the response: `logical` emits the stored native schema as logical-types
       // DDL, any other value applies the native formatter.
       if (result.getSchema() != null && format != null && !format.trim().isEmpty()) {
+        // Schema.setSchema(...) nulls the guid, and getGuid() then recomputes it as an MD5 of the
+        // new schema string -- so capture the real (native) guid up front and restore it after
+        // rendering, whether the body is logical DDL or a native-formatter output.
+        String originalGuid = result.getGuid();
         if (LogicalFormat.isLogical(format)) {
           result.setSchema(LogicalFormat.convertToLogical(schemaRegistry, result));
         } else {
           ParsedSchema parsedSchema = schemaRegistry.parseSchema(result, false, false);
-          String originalGuid = result.getGuid();
           result.setSchema(parsedSchema.formattedString(format));
-          result.setGuid(originalGuid);
         }
+        result.setGuid(originalGuid);
       }
       registerSchemaResponse = new RegisterSchemaResponse(result);
     } catch (IdDoesNotMatchException e) {

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -498,7 +498,7 @@ public class SubjectVersionsResource {
       // A logical body is converted to the requested native schemaType before registration. The
       // `format` query param is not consulted for input; it only renders the response (below).
       if (LogicalFormat.looksLogical(schemaRegistry, new Schema(subjectName, request))) {
-        LogicalFormat.convertToNative(schemaRegistry, subjectName, request);
+        LogicalFormat.convertToNative(schemaRegistry, subjectName, request, true);
       }
       if (!normalize) {
         normalize = Boolean.TRUE.equals(schemaRegistry.getConfigInScope(subjectName).isNormalize());

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectVersionsResource.java
@@ -497,9 +497,7 @@ public class SubjectVersionsResource {
       // as its declared native schemaType and then parses as logical DDL is treated as logical).
       // A logical body is converted to the requested native schemaType before registration. The
       // `format` query param is not consulted for input; it only renders the response (below).
-      if (LogicalFormat.looksLogical(schemaRegistry, new Schema(subjectName, request))) {
-        LogicalFormat.convertToNative(schemaRegistry, subjectName, request);
-      }
+      LogicalFormat.tryConvertToNative(schemaRegistry, subjectName, request);
       if (!normalize) {
         normalize = Boolean.TRUE.equals(schemaRegistry.getConfigInScope(subjectName).isNormalize());
       }

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -132,10 +132,8 @@ public class SubjectsResource {
     try {
       // Auto-detect a logical-types DDL body (native-first) and convert it to the requested native
       // schemaType before lookup, mirroring register (the `format` param is not read for input).
-      // validateAsNew=false: this looks up an existing schema, so references to soft-deleted
-      // versions must still resolve, as they do for an equivalent native lookup.
       if (LogicalFormat.looksLogical(schemaRegistry, new Schema(subject, request))) {
-        LogicalFormat.convertToNative(schemaRegistry, subject, request, false);
+        LogicalFormat.convertToNative(schemaRegistry, subject, request);
       }
       // returns version if the schema exists. Otherwise returns 404
       Schema schema = new Schema(subject, request);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -150,14 +150,17 @@ public class SubjectsResource {
         }
       }
       if (format != null && !format.trim().isEmpty()) {
+        // Schema.setSchema(...) nulls the guid, and getGuid() then recomputes it as an MD5 of the
+        // new schema string -- so capture the real guid up front and restore it after rendering,
+        // whether the body is logical DDL or a native-formatter output.
+        String originalGuid = matchingSchema.getGuid();
         if (LogicalFormat.isLogical(format)) {
           matchingSchema.setSchema(LogicalFormat.convertToLogical(schemaRegistry, matchingSchema));
         } else {
           ParsedSchema parsedSchema = schemaRegistry.parseSchema(matchingSchema, false, false);
-          String originalGuid = matchingSchema.getGuid();
           matchingSchema.setSchema(parsedSchema.formattedString(format));
-          matchingSchema.setGuid(originalGuid);
         }
+        matchingSchema.setGuid(originalGuid);
       }
     } catch (InvalidSchemaException e) {
       throw Errors.invalidSchemaException(e);
@@ -215,14 +218,17 @@ public class SubjectsResource {
         }
       }
       if (format != null && !format.trim().isEmpty()) {
+        // Schema.setSchema(...) nulls the guid, and getGuid() then recomputes it as an MD5 of the
+        // new schema string -- so capture the real guid up front and restore it after rendering,
+        // whether the body is logical DDL or a native-formatter output.
+        String originalGuid = matchingSchema.getGuid();
         if (LogicalFormat.isLogical(format)) {
           matchingSchema.setSchema(LogicalFormat.convertToLogical(schemaRegistry, matchingSchema));
         } else {
           ParsedSchema parsedSchema = schemaRegistry.parseSchema(matchingSchema, false, false);
-          String originalGuid = matchingSchema.getGuid();
           matchingSchema.setSchema(parsedSchema.formattedString(format));
-          matchingSchema.setGuid(originalGuid);
         }
+        matchingSchema.setGuid(originalGuid);
       }
     } catch (InvalidSchemaException e) {
       throw Errors.invalidSchemaException(e);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -132,8 +132,10 @@ public class SubjectsResource {
     try {
       // Auto-detect a logical-types DDL body (native-first) and convert it to the requested native
       // schemaType before lookup, mirroring register (the `format` param is not read for input).
+      // validateAsNew=false: this looks up an existing schema, so references to soft-deleted
+      // versions must still resolve, as they do for an equivalent native lookup.
       if (LogicalFormat.looksLogical(schemaRegistry, new Schema(subject, request))) {
-        LogicalFormat.convertToNative(schemaRegistry, subject, request);
+        LogicalFormat.convertToNative(schemaRegistry, subject, request, false);
       }
       // returns version if the schema exists. Otherwise returns 404
       Schema schema = new Schema(subject, request);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -128,10 +128,15 @@ public class SubjectsResource {
 
     subject = QualifiedSubject.normalize(schemaRegistry.tenant(), subject);
 
-    // returns version if the schema exists. Otherwise returns 404
-    Schema schema = new Schema(subject, request);
     io.confluent.kafka.schemaregistry.client.rest.entities.Schema matchingSchema;
     try {
+      // Auto-detect a logical-types DDL body (native-first) and convert it to the requested native
+      // schemaType before lookup, mirroring register (the `format` param is not read for input).
+      if (LogicalFormat.looksLogical(schemaRegistry, new Schema(subject, request))) {
+        LogicalFormat.convertToNative(schemaRegistry, subject, request);
+      }
+      // returns version if the schema exists. Otherwise returns 404
+      Schema schema = new Schema(subject, request);
       if (!normalize) {
         normalize = Boolean.TRUE.equals(schemaRegistry.getConfigInScope(subject).isNormalize());
       }
@@ -145,10 +150,14 @@ public class SubjectsResource {
         }
       }
       if (format != null && !format.trim().isEmpty()) {
-        ParsedSchema parsedSchema = schemaRegistry.parseSchema(matchingSchema, false, false);
-        String originalGuid = matchingSchema.getGuid();
-        matchingSchema.setSchema(parsedSchema.formattedString(format));
-        matchingSchema.setGuid(originalGuid);
+        if (LogicalFormat.isLogical(format)) {
+          matchingSchema.setSchema(LogicalFormat.convertToLogical(schemaRegistry, matchingSchema));
+        } else {
+          ParsedSchema parsedSchema = schemaRegistry.parseSchema(matchingSchema, false, false);
+          String originalGuid = matchingSchema.getGuid();
+          matchingSchema.setSchema(parsedSchema.formattedString(format));
+          matchingSchema.setGuid(originalGuid);
+        }
       }
     } catch (InvalidSchemaException e) {
       throw Errors.invalidSchemaException(e);
@@ -206,10 +215,14 @@ public class SubjectsResource {
         }
       }
       if (format != null && !format.trim().isEmpty()) {
-        ParsedSchema parsedSchema = schemaRegistry.parseSchema(matchingSchema, false, false);
-        String originalGuid = matchingSchema.getGuid();
-        matchingSchema.setSchema(parsedSchema.formattedString(format));
-        matchingSchema.setGuid(originalGuid);
+        if (LogicalFormat.isLogical(format)) {
+          matchingSchema.setSchema(LogicalFormat.convertToLogical(schemaRegistry, matchingSchema));
+        } else {
+          ParsedSchema parsedSchema = schemaRegistry.parseSchema(matchingSchema, false, false);
+          String originalGuid = matchingSchema.getGuid();
+          matchingSchema.setSchema(parsedSchema.formattedString(format));
+          matchingSchema.setGuid(originalGuid);
+        }
       }
     } catch (InvalidSchemaException e) {
       throw Errors.invalidSchemaException(e);

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/resources/SubjectsResource.java
@@ -131,10 +131,8 @@ public class SubjectsResource {
     io.confluent.kafka.schemaregistry.client.rest.entities.Schema matchingSchema;
     try {
       // Auto-detect a logical-types DDL body (native-first) and convert it to the requested native
-      // schemaType before lookup, mirroring register (the `format` param is not read for input).
-      if (LogicalFormat.looksLogical(schemaRegistry, new Schema(subject, request))) {
-        LogicalFormat.convertToNative(schemaRegistry, subject, request);
-      }
+      // schemaType before lookup.
+      LogicalFormat.tryConvertToNative(schemaRegistry, subject, request);
       // returns version if the schema exists. Otherwise returns 404
       Schema schema = new Schema(subject, request);
       if (!normalize) {

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormatTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormatTest.java
@@ -126,7 +126,7 @@ class LogicalFormatTest {
     RegisterSchemaRequest request = requestFor("AVRO", STRUCT_DDL);
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
-    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
+    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true);
 
     AvroSchema avroSchema = new AvroSchema(request.getSchema());
     assertNotNull(avroSchema.rawSchema().getField("id"));
@@ -139,7 +139,7 @@ class LogicalFormatTest {
     RegisterSchemaRequest request = requestFor("JSON", STRUCT_DDL);
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
-    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
+    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true);
 
     JsonSchema jsonSchema = new JsonSchema(request.getSchema());
     assertNotNull(jsonSchema.rawSchema());
@@ -152,7 +152,7 @@ class LogicalFormatTest {
     RegisterSchemaRequest request = requestFor("PROTOBUF", STRUCT_DDL);
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
-    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
+    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true);
 
     ProtobufSchema protobufSchema = new ProtobufSchema(request.getSchema());
     assertNotNull(protobufSchema.toDescriptor().findFieldByName("id"));
@@ -164,7 +164,7 @@ class LogicalFormatTest {
     RegisterSchemaRequest request = requestFor("avro", STRUCT_DDL);
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
-    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
+    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true);
 
     assertEquals(2, new AvroSchema(request.getSchema()).rawSchema().getFields().size());
   }
@@ -177,7 +177,7 @@ class LogicalFormatTest {
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true));
     assertTrue(e.getMessage().contains("schemaType is required"));
   }
 
@@ -187,7 +187,7 @@ class LogicalFormatTest {
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true));
     assertTrue(e.getMessage().contains("schemaType is required"));
   }
 
@@ -197,7 +197,7 @@ class LogicalFormatTest {
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true));
     assertTrue(e.getMessage().contains("Unsupported schemaType"));
   }
 
@@ -211,7 +211,7 @@ class LogicalFormatTest {
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true));
     assertTrue(e.getMessage().contains("Invalid logical type schema"));
   }
 
@@ -221,7 +221,7 @@ class LogicalFormatTest {
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true));
     assertTrue(e.getMessage().contains("Invalid logical type schema"));
   }
 
@@ -235,7 +235,7 @@ class LogicalFormatTest {
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true));
     assertTrue(e.getMessage().contains("cannot be represented as AVRO"),
         "expected the conversion-failure message, got: " + e.getMessage());
   }
@@ -263,7 +263,7 @@ class LogicalFormatTest {
     when(schemaRegistry.getByVersion("address-value", 1, false))
         .thenReturn(schemaEntityFor("AVRO", addressSchema));
 
-    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
+    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true);
 
     // The emitted schema legitimately leaves "addr" as a cross-schema pointer to
     // com.example.Address rather than inlining it -- matching how Avro schema references work in
@@ -289,7 +289,7 @@ class LogicalFormatTest {
     when(schemaRegistry.getByVersion("address-value", 1, false)).thenReturn(null);
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true));
     assertTrue(e.getMessage().contains("Could not resolve schema references"));
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormatTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormatTest.java
@@ -126,7 +126,7 @@ class LogicalFormatTest {
     RegisterSchemaRequest request = requestFor("AVRO", STRUCT_DDL);
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
-    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true);
+    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
 
     AvroSchema avroSchema = new AvroSchema(request.getSchema());
     assertNotNull(avroSchema.rawSchema().getField("id"));
@@ -139,7 +139,7 @@ class LogicalFormatTest {
     RegisterSchemaRequest request = requestFor("JSON", STRUCT_DDL);
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
-    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true);
+    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
 
     JsonSchema jsonSchema = new JsonSchema(request.getSchema());
     assertNotNull(jsonSchema.rawSchema());
@@ -152,7 +152,7 @@ class LogicalFormatTest {
     RegisterSchemaRequest request = requestFor("PROTOBUF", STRUCT_DDL);
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
-    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true);
+    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
 
     ProtobufSchema protobufSchema = new ProtobufSchema(request.getSchema());
     assertNotNull(protobufSchema.toDescriptor().findFieldByName("id"));
@@ -164,7 +164,7 @@ class LogicalFormatTest {
     RegisterSchemaRequest request = requestFor("avro", STRUCT_DDL);
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
-    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true);
+    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
 
     assertEquals(2, new AvroSchema(request.getSchema()).rawSchema().getFields().size());
   }
@@ -177,7 +177,7 @@ class LogicalFormatTest {
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true));
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
     assertTrue(e.getMessage().contains("schemaType is required"));
   }
 
@@ -187,7 +187,7 @@ class LogicalFormatTest {
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true));
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
     assertTrue(e.getMessage().contains("schemaType is required"));
   }
 
@@ -197,7 +197,7 @@ class LogicalFormatTest {
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true));
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
     assertTrue(e.getMessage().contains("Unsupported schemaType"));
   }
 
@@ -211,7 +211,7 @@ class LogicalFormatTest {
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true));
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
     assertTrue(e.getMessage().contains("Invalid logical type schema"));
   }
 
@@ -221,7 +221,7 @@ class LogicalFormatTest {
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true));
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
     assertTrue(e.getMessage().contains("Invalid logical type schema"));
   }
 
@@ -235,7 +235,7 @@ class LogicalFormatTest {
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true));
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
     assertTrue(e.getMessage().contains("cannot be represented as AVRO"),
         "expected the conversion-failure message, got: " + e.getMessage());
   }
@@ -257,13 +257,14 @@ class LogicalFormatTest {
     String addressSchema =
         "{\"type\":\"record\",\"name\":\"Address\",\"namespace\":\"com.example\","
             + "\"fields\":[{\"name\":\"street\",\"type\":\"string\"}]}";
-    // Reference resolution now routes through AbstractSchemaProvider.resolveReferences, which
+    // Reference resolution routes through AbstractSchemaProvider.resolveReferences, which
     // qualifies the subject against the parent context and fetches via getByVersion with
-    // lookupDeletedSchema=false (validateAsNew=true for a new registration).
-    when(schemaRegistry.getByVersion("address-value", 1, false))
+    // lookupDeletedSchema=true: conversion resolves permissively and leaves enforcement of the
+    // caller's configured validation mode to the native path that re-resolves downstream.
+    when(schemaRegistry.getByVersion("address-value", 1, true))
         .thenReturn(schemaEntityFor("AVRO", addressSchema));
 
-    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true);
+    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
 
     // The emitted schema legitimately leaves "addr" as a cross-schema pointer to
     // com.example.Address rather than inlining it -- matching how Avro schema references work in
@@ -286,10 +287,10 @@ class LogicalFormatTest {
 
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
     when(schemaRegistry.tenant()).thenReturn(QualifiedSubject.DEFAULT_TENANT);
-    when(schemaRegistry.getByVersion("address-value", 1, false)).thenReturn(null);
+    when(schemaRegistry.getByVersion("address-value", 1, true)).thenReturn(null);
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request, true));
+        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
     assertTrue(e.getMessage().contains("Could not resolve schema references"));
   }
 

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormatTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormatTest.java
@@ -62,61 +62,64 @@ class LogicalFormatTest {
     assertEquals(false, LogicalFormat.isLogical(null));
   }
 
-  // -- parsesAsLogical: the pure DDL-vs-not classifier -------------------------------------------
+  // -- tryConvertToNative: native-first input auto-detection --------------------------------------
 
   @Test
-  void parsesAsLogicalDetectsDdl() {
-    assertTrue(LogicalFormat.parsesAsLogical(
-        "STRUCT Widget (id INT NOT NULL, name VARCHAR NOT NULL)"));
-    assertTrue(LogicalFormat.parsesAsLogical("NAMESPACE com.example;\nSTRUCT W (id INT NOT NULL)"));
-    // ENUM is also a Protobuf keyword, so this exercises the parse itself, not a keyword sniff.
-    assertTrue(LogicalFormat.parsesAsLogical("ENUM Color ('RED', 'GREEN', 'BLUE')"));
-  }
-
-  @Test
-  void parsesAsLogicalRejectsNativeSchemas() {
-    assertEquals(false, LogicalFormat.parsesAsLogical(
-        "{\"type\":\"record\",\"name\":\"W\",\"fields\":[]}"));       // Avro
-    assertEquals(false, LogicalFormat.parsesAsLogical(
-        "{\"type\":\"object\",\"properties\":{}}"));                   // JSON Schema
-    assertEquals(false, LogicalFormat.parsesAsLogical(
-        "syntax = \"proto3\"; message W { string id = 1; }"));        // Protobuf
-    assertEquals(false, LogicalFormat.parsesAsLogical("enum E { A = 0; }")); // Proto enum, not DDL
-    assertEquals(false, LogicalFormat.parsesAsLogical(""));
-    assertEquals(false, LogicalFormat.parsesAsLogical("   "));
-    assertEquals(false, LogicalFormat.parsesAsLogical(null));
-  }
-
-  // -- looksLogical: native-first input auto-detection -------------------------------------------
-
-  @Test
-  void looksLogicalTreatsNativeParseSuccessAsNotLogical() throws Exception {
+  void tryConvertToNativeLeavesABodyThatParsesAsNativeAlone() throws Exception {
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
     // Body parses as its declared native schemaType -> not logical, whatever the body text is.
     when(schemaRegistry.parseSchema(any(Schema.class), anyBoolean(), anyBoolean()))
         .thenReturn(mock(ParsedSchema.class));
-    assertEquals(false, LogicalFormat.looksLogical(schemaRegistry,
-        schemaEntityFor("AVRO", "STRUCT Widget (id INT NOT NULL)")));
+    RegisterSchemaRequest request = requestFor("AVRO", STRUCT_DDL);
+
+    assertEquals(false, LogicalFormat.tryConvertToNative(schemaRegistry, "widgets-value", request));
+    assertEquals(STRUCT_DDL, request.getSchema(), "a native body must not be rewritten");
   }
 
   @Test
-  void looksLogicalFallsBackToDdlWhenNativeParseFails() throws Exception {
-    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
-    // Native parse fails -> logical iff the body parses as DDL.
-    when(schemaRegistry.parseSchema(any(Schema.class), anyBoolean(), anyBoolean()))
-        .thenThrow(new InvalidSchemaException("not native"));
-    assertTrue(LogicalFormat.looksLogical(schemaRegistry,
-        schemaEntityFor("AVRO", "STRUCT Widget (id INT NOT NULL)")));
-    assertEquals(false, LogicalFormat.looksLogical(schemaRegistry,
-        schemaEntityFor("AVRO", "not a schema at all {{{")));
+  void tryConvertToNativeConvertsDdlOnceNativeParseFails() throws Exception {
+    RegisterSchemaRequest request = requestFor("AVRO", STRUCT_DDL);
+
+    assertTrue(LogicalFormat.tryConvertToNative(
+        registryRejectingNative(), "widgets-value", request));
+    assertEquals(AvroSchema.TYPE, request.getSchemaType());
   }
 
   @Test
-  void looksLogicalRejectsBlankAndNull() throws Exception {
+  void tryConvertToNativeLeavesBodyThatIsNeitherNativeNorDdl() throws Exception {
+    // Parses as neither, so it stays native and the native error surfaces downstream.
+    RegisterSchemaRequest request = requestFor("AVRO", "not a schema at all {{{");
+
+    assertEquals(false, LogicalFormat.tryConvertToNative(
+        registryRejectingNative(), "widgets-value", request));
+    assertEquals("not a schema at all {{{", request.getSchema());
+  }
+
+  @Test
+  void tryConvertToNativeRejectsNativeSchemaTextAsLogical() throws Exception {
+    // Even with the native parse failing, real native schema text is not valid DDL, so it is
+    // never misread as logical input.
+    for (String nativeText : List.of(
+        "{\"type\":\"record\",\"name\":\"W\",\"fields\":[]}",     // Avro
+        "{\"type\":\"object\",\"properties\":{}}",                 // JSON Schema
+        "syntax = \"proto3\"; message W { string id = 1; }",      // Protobuf
+        "enum E { A = 0; }")) {                                   // Protobuf enum, not DDL
+      RegisterSchemaRequest request = requestFor("AVRO", nativeText);
+      assertEquals(false,
+          LogicalFormat.tryConvertToNative(registryRejectingNative(), "widgets-value", request),
+          "should not be treated as logical: " + nativeText);
+      assertEquals(nativeText, request.getSchema());
+    }
+  }
+
+  @Test
+  void tryConvertToNativeRejectsBlankAndNull() throws Exception {
     SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
-    assertEquals(false, LogicalFormat.looksLogical(schemaRegistry, null));
-    assertEquals(false, LogicalFormat.looksLogical(schemaRegistry, schemaEntityFor("AVRO", "")));
-    assertEquals(false, LogicalFormat.looksLogical(schemaRegistry, schemaEntityFor("AVRO", "   ")));
+    assertEquals(false, LogicalFormat.tryConvertToNative(schemaRegistry, "widgets-value", null));
+    assertEquals(false, LogicalFormat.tryConvertToNative(
+        schemaRegistry, "widgets-value", requestFor("AVRO", "")));
+    assertEquals(false, LogicalFormat.tryConvertToNative(
+        schemaRegistry, "widgets-value", requestFor("AVRO", "   ")));
   }
 
   // -- convertToNative: happy path, one per schemaType -------------------------------------------
@@ -124,9 +127,9 @@ class LogicalFormatTest {
   @Test
   void convertToNativeProducesAvro() throws Exception {
     RegisterSchemaRequest request = requestFor("AVRO", STRUCT_DDL);
-    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    SchemaRegistry schemaRegistry = registryRejectingNative();
 
-    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
+    LogicalFormat.tryConvertToNative(schemaRegistry, "widgets-value", request);
 
     AvroSchema avroSchema = new AvroSchema(request.getSchema());
     assertNotNull(avroSchema.rawSchema().getField("id"));
@@ -137,9 +140,9 @@ class LogicalFormatTest {
   @Test
   void convertToNativeProducesJson() throws Exception {
     RegisterSchemaRequest request = requestFor("JSON", STRUCT_DDL);
-    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    SchemaRegistry schemaRegistry = registryRejectingNative();
 
-    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
+    LogicalFormat.tryConvertToNative(schemaRegistry, "widgets-value", request);
 
     JsonSchema jsonSchema = new JsonSchema(request.getSchema());
     assertNotNull(jsonSchema.rawSchema());
@@ -150,9 +153,9 @@ class LogicalFormatTest {
   @Test
   void convertToNativeProducesProtobuf() throws Exception {
     RegisterSchemaRequest request = requestFor("PROTOBUF", STRUCT_DDL);
-    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    SchemaRegistry schemaRegistry = registryRejectingNative();
 
-    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
+    LogicalFormat.tryConvertToNative(schemaRegistry, "widgets-value", request);
 
     ProtobufSchema protobufSchema = new ProtobufSchema(request.getSchema());
     assertNotNull(protobufSchema.toDescriptor().findFieldByName("id"));
@@ -162,9 +165,9 @@ class LogicalFormatTest {
   @Test
   void convertToNativeIsCaseInsensitiveOnSchemaType() throws Exception {
     RegisterSchemaRequest request = requestFor("avro", STRUCT_DDL);
-    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    SchemaRegistry schemaRegistry = registryRejectingNative();
 
-    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
+    LogicalFormat.tryConvertToNative(schemaRegistry, "widgets-value", request);
 
     assertEquals(2, new AvroSchema(request.getSchema()).rawSchema().getFields().size());
   }
@@ -174,30 +177,30 @@ class LogicalFormatTest {
   @Test
   void convertToNativeRequiresSchemaType() {
     RegisterSchemaRequest request = requestFor(null, STRUCT_DDL);
-    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    SchemaRegistry schemaRegistry = registryRejectingNative();
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
+        LogicalFormat.tryConvertToNative(schemaRegistry, "widgets-value", request));
     assertTrue(e.getMessage().contains("schemaType is required"));
   }
 
   @Test
   void convertToNativeRejectsBlankSchemaType() {
     RegisterSchemaRequest request = requestFor("   ", STRUCT_DDL);
-    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    SchemaRegistry schemaRegistry = registryRejectingNative();
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
+        LogicalFormat.tryConvertToNative(schemaRegistry, "widgets-value", request));
     assertTrue(e.getMessage().contains("schemaType is required"));
   }
 
   @Test
   void convertToNativeRejectsUnsupportedSchemaType() {
     RegisterSchemaRequest request = requestFor("XML", STRUCT_DDL);
-    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    SchemaRegistry schemaRegistry = registryRejectingNative();
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
+        LogicalFormat.tryConvertToNative(schemaRegistry, "widgets-value", request));
     assertTrue(e.getMessage().contains("Unsupported schemaType"));
   }
 
@@ -208,21 +211,23 @@ class LogicalFormatTest {
     // error instead.
     RegisterSchemaRequest request = requestFor(
         "AVRO", "STRUCT Widget (id INT NOT NULL, id VARCHAR NOT NULL)");
-    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    SchemaRegistry schemaRegistry = registryRejectingNative();
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
+        LogicalFormat.tryConvertToNative(schemaRegistry, "widgets-value", request));
     assertTrue(e.getMessage().contains("Invalid logical type schema"));
   }
 
   @Test
-  void convertToNativeRejectsUnparsableDdl() {
+  void convertToNativeIgnoresUnparsableDdl() throws Exception {
+    // A DDL *syntax* error means "not logical", not "bad logical": the body is left alone so the
+    // native path reports it in its own terms. Contrast convertToNativeRejectsMalformedDdl, where
+    // the body parses and so is held to logical-schema rules.
     RegisterSchemaRequest request = requestFor("AVRO", "not valid ddl at all {{{");
-    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
 
-    InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
-    assertTrue(e.getMessage().contains("Invalid logical type schema"));
+    assertEquals(false, LogicalFormat.tryConvertToNative(
+        registryRejectingNative(), "widgets-value", request));
+    assertEquals("not valid ddl at all {{{", request.getSchema());
   }
 
   @Test
@@ -232,10 +237,10 @@ class LogicalFormatTest {
     // input, so it must surface as InvalidSchemaException (422) via the conversion catch, not as an
     // uncaught RuntimeException (500).
     RegisterSchemaRequest request = requestFor("AVRO", "STRUCT `bad name` (id INT NOT NULL)");
-    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    SchemaRegistry schemaRegistry = registryRejectingNative();
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
+        LogicalFormat.tryConvertToNative(schemaRegistry, "widgets-value", request));
     assertTrue(e.getMessage().contains("cannot be represented as AVRO"),
         "expected the conversion-failure message, got: " + e.getMessage());
   }
@@ -252,7 +257,7 @@ class LogicalFormatTest {
     request.setReferences(List.of(
         new SchemaReference("com.example.Address", "address-value", 1)));
 
-    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    SchemaRegistry schemaRegistry = registryRejectingNative();
     when(schemaRegistry.tenant()).thenReturn(QualifiedSubject.DEFAULT_TENANT);
     String addressSchema =
         "{\"type\":\"record\",\"name\":\"Address\",\"namespace\":\"com.example\","
@@ -264,7 +269,7 @@ class LogicalFormatTest {
     when(schemaRegistry.getByVersion("address-value", 1, true))
         .thenReturn(schemaEntityFor("AVRO", addressSchema));
 
-    LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request);
+    LogicalFormat.tryConvertToNative(schemaRegistry, "widgets-value", request);
 
     // The emitted schema legitimately leaves "addr" as a cross-schema pointer to
     // com.example.Address rather than inlining it -- matching how Avro schema references work in
@@ -285,12 +290,12 @@ class LogicalFormatTest {
     request.setReferences(List.of(
         new SchemaReference("com.example.Address", "address-value", 1)));
 
-    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    SchemaRegistry schemaRegistry = registryRejectingNative();
     when(schemaRegistry.tenant()).thenReturn(QualifiedSubject.DEFAULT_TENANT);
     when(schemaRegistry.getByVersion("address-value", 1, true)).thenReturn(null);
 
     InvalidSchemaException e = assertThrows(InvalidSchemaException.class, () ->
-        LogicalFormat.convertToNative(schemaRegistry, "widgets-value", request));
+        LogicalFormat.tryConvertToNative(schemaRegistry, "widgets-value", request));
     assertTrue(e.getMessage().contains("Could not resolve schema references"));
   }
 
@@ -362,6 +367,22 @@ class LogicalFormatTest {
   }
 
   // -- helpers ------------------------------------------------------------------------------
+
+  /**
+   * A registry whose native parse always fails, which is what a real one does for a DDL body.
+   * {@code tryConvertToNative} is native-first, so a bare mock -- whose {@code parseSchema} returns
+   * null rather than throwing -- would classify every body as native and convert nothing.
+   */
+  private static SchemaRegistry registryRejectingNative() {
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    try {
+      when(schemaRegistry.parseSchema(any(Schema.class), anyBoolean(), anyBoolean()))
+          .thenThrow(new InvalidSchemaException("not a native schema"));
+    } catch (InvalidSchemaException e) {
+      throw new AssertionError(e); // unreachable: stubbing, not invoking
+    }
+    return schemaRegistry;
+  }
 
   private static RegisterSchemaRequest requestFor(String schemaType, String ddl) {
     RegisterSchemaRequest request = new RegisterSchemaRequest();

--- a/core/src/test/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormatTest.java
+++ b/core/src/test/java/io/confluent/kafka/schemaregistry/rest/resources/LogicalFormatTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.Schema;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
@@ -59,6 +60,63 @@ class LogicalFormatTest {
     assertEquals(false, LogicalFormat.isLogical("resolved"));
     assertEquals(false, LogicalFormat.isLogical(""));
     assertEquals(false, LogicalFormat.isLogical(null));
+  }
+
+  // -- parsesAsLogical: the pure DDL-vs-not classifier -------------------------------------------
+
+  @Test
+  void parsesAsLogicalDetectsDdl() {
+    assertTrue(LogicalFormat.parsesAsLogical(
+        "STRUCT Widget (id INT NOT NULL, name VARCHAR NOT NULL)"));
+    assertTrue(LogicalFormat.parsesAsLogical("NAMESPACE com.example;\nSTRUCT W (id INT NOT NULL)"));
+    // ENUM is also a Protobuf keyword, so this exercises the parse itself, not a keyword sniff.
+    assertTrue(LogicalFormat.parsesAsLogical("ENUM Color ('RED', 'GREEN', 'BLUE')"));
+  }
+
+  @Test
+  void parsesAsLogicalRejectsNativeSchemas() {
+    assertEquals(false, LogicalFormat.parsesAsLogical(
+        "{\"type\":\"record\",\"name\":\"W\",\"fields\":[]}"));       // Avro
+    assertEquals(false, LogicalFormat.parsesAsLogical(
+        "{\"type\":\"object\",\"properties\":{}}"));                   // JSON Schema
+    assertEquals(false, LogicalFormat.parsesAsLogical(
+        "syntax = \"proto3\"; message W { string id = 1; }"));        // Protobuf
+    assertEquals(false, LogicalFormat.parsesAsLogical("enum E { A = 0; }")); // Proto enum, not DDL
+    assertEquals(false, LogicalFormat.parsesAsLogical(""));
+    assertEquals(false, LogicalFormat.parsesAsLogical("   "));
+    assertEquals(false, LogicalFormat.parsesAsLogical(null));
+  }
+
+  // -- looksLogical: native-first input auto-detection -------------------------------------------
+
+  @Test
+  void looksLogicalTreatsNativeParseSuccessAsNotLogical() throws Exception {
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    // Body parses as its declared native schemaType -> not logical, whatever the body text is.
+    when(schemaRegistry.parseSchema(any(Schema.class), anyBoolean(), anyBoolean()))
+        .thenReturn(mock(ParsedSchema.class));
+    assertEquals(false, LogicalFormat.looksLogical(schemaRegistry,
+        schemaEntityFor("AVRO", "STRUCT Widget (id INT NOT NULL)")));
+  }
+
+  @Test
+  void looksLogicalFallsBackToDdlWhenNativeParseFails() throws Exception {
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    // Native parse fails -> logical iff the body parses as DDL.
+    when(schemaRegistry.parseSchema(any(Schema.class), anyBoolean(), anyBoolean()))
+        .thenThrow(new InvalidSchemaException("not native"));
+    assertTrue(LogicalFormat.looksLogical(schemaRegistry,
+        schemaEntityFor("AVRO", "STRUCT Widget (id INT NOT NULL)")));
+    assertEquals(false, LogicalFormat.looksLogical(schemaRegistry,
+        schemaEntityFor("AVRO", "not a schema at all {{{")));
+  }
+
+  @Test
+  void looksLogicalRejectsBlankAndNull() throws Exception {
+    SchemaRegistry schemaRegistry = mock(SchemaRegistry.class);
+    assertEquals(false, LogicalFormat.looksLogical(schemaRegistry, null));
+    assertEquals(false, LogicalFormat.looksLogical(schemaRegistry, schemaEntityFor("AVRO", "")));
+    assertEquals(false, LogicalFormat.looksLogical(schemaRegistry, schemaEntityFor("AVRO", "   ")));
   }
 
   // -- convertToNative: happy path, one per schemaType -------------------------------------------


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----                                                                                                                                                                       
                                                                                                                                                                                    
  Makes logical-types (DDL) handling content-driven on input and consistent on output across the                                                                                    
  schema APIs.                                                                                                                                                                      
                                                                                                                                                                                                                                            
                                                                                                                                                                                    
  - **Input is auto-detected from the body**, so `format` is never read for input.                                                                                                  
  - **`format` selects the response rendering only**, uniformly, on every endpoint that has it.                                                                                     
                                                                                                                                                                                    
  ### Input: native-first auto-detection                                                                                                                                            
                                                                                                                                                                                    
  `LogicalFormat.tryConvertToNative(...)` detects and converts in one step:                                                                                                         
                                                                                                                                                                                    
  1. Parse the body as its declared `schemaType`. If that succeeds it is native — done.                                                                                             
  2. Otherwise parse it as logical DDL. A DDL *syntax* error means "not logical", so the body is left                                                                               
     alone and the native error surfaces rather than a misleading DDL one.                                                                                                          
  3. If it parses as DDL, convert it to the requested native `schemaType` in place. Failures past this                                                                              
     point are bad-logical-schema errors (422), not misclassifications.                                                                                                             
                                                                                                                                                                                    
  Native schemas always win, so a native body is never misread as logical. Detection and conversion                                                                                 
  share the one DDL parse rather than parsing it twice. The native parse is not extra work in the                                                                                   
  common case: it goes through `oldSchemaCache` under the same key the following                                                                                                    
  `lookUpSchemaUnderSubject` uses, so that call is a cache hit (a `normalize=true` request pays for                                                                                 
  one extra parse, since `normalize` is part of the key).                                                                                                                           
                                                                                                                                                                                    
  Applied to **every** endpoint that accepts a schema body — `register`, `lookUpSchemaUnderSubject`,                                                                                
  and both `/compatibility` checks. Lookup and the compatibility checks could not accept DDL before.                                                                                
                                                                                                                                                                                    
  ### Output: `format=logical` everywhere `format` is honored                                                                                                                       
                                                                                                                                                                                    
  Extended from version reads to `register`'s response, `lookUpSchemaUnderSubject`,                                                                                                 
  `getLatestWithMetadata`, and the by-id / by-guid endpoints in `SchemasResource`.         


<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
