### PR TITLE
DGS-25204 Handle empty/invalid encryptedKeyMaterial on createDek

### DIFF
--- a/dek-registry/src/main/java/io/confluent/dekregistry/storage/AbstractDekRegistry.java
+++ b/dek-registry/src/main/java/io/confluent/dekregistry/storage/AbstractDekRegistry.java
@@ -794,8 +794,15 @@ public abstract class AbstractDekRegistry implements Closeable {
         ? request.getAlgorithm()
         : DekFormat.AES256_GCM;
     int version = request.getVersion() != null ? request.getVersion() : MIN_VERSION;
+    // Treat empty/blank caller-supplied key material as absent, so that a shared KEK generates a
+    // new DEK instead of trying to unwrap empty ciphertext (which the KMS rejects). Some older
+    // clients send an empty string rather than omitting the field when no key material is provided.
+    String encryptedKeyMaterial = request.getEncryptedKeyMaterial();
+    if (encryptedKeyMaterial != null && encryptedKeyMaterial.trim().isEmpty()) {
+      encryptedKeyMaterial = null;
+    }
     DataEncryptionKey key = new DataEncryptionKey(kekName, request.getSubject(),
-        algorithm, version, request.getEncryptedKeyMaterial(), request.isDeleted());
+        algorithm, version, encryptedKeyMaterial, request.isDeleted());
     KeyEncryptionKey kek = getKek(key.getKekName(), true);
     DataEncryptionKeyId keyId = new DataEncryptionKeyId(
         tenant, kekName, request.getSubject(), algorithm, version);
@@ -805,7 +812,8 @@ public abstract class AbstractDekRegistry implements Closeable {
         && (request.isDeleted() == oldKey.isDeleted() || !oldKey.isEquivalent(key))) {
       throw new AlreadyExistsException(request.getSubject());
     }
-    if (key.getEncryptedKeyMaterial() != null) {
+    boolean callerSuppliedKeyMaterial = key.getEncryptedKeyMaterial() != null;
+    if (callerSuppliedKeyMaterial) {
       if (kek.isShared() && oldKey != null) {
         throw new AlreadyExistsException(request.getSubject());
       }
@@ -821,7 +829,19 @@ public abstract class AbstractDekRegistry implements Closeable {
     // Verify the DEK round-trip before persisting
     String rawKeyMaterial = null;
     if (kek.isShared() && schemaRegistry.getModeInScope(request.getSubject()) != Mode.IMPORT) {
-      rawKeyMaterial = generateRawDek(kek, key).getKeyMaterial();
+      try {
+        rawKeyMaterial = generateRawDek(kek, key).getKeyMaterial();
+      } catch (DekGenerationException e) {
+        // If the caller supplied the encrypted key material, a failed round-trip means the
+        // supplied ciphertext is unusable (e.g. the KMS rejected it as malformed) -- a client
+        // error, so surface it as an invalid-key (422) rather than a server error (500). An
+        // access-denied failure stays a DekGenerationException so it still maps to 403, and a
+        // failure on freshly generated material is a genuine server-side problem.
+        if (callerSuppliedKeyMaterial && !e.isAccessDenied()) {
+          throw new InvalidKeyException("encryptedKeyMaterial", e);
+        }
+        throw e;
+      }
     }
     putKey(keyId, key);
     // Retrieve key with ts set

--- a/dek-registry/src/test/java/io/confluent/dekregistry/storage/DekRegistryTest.java
+++ b/dek-registry/src/test/java/io/confluent/dekregistry/storage/DekRegistryTest.java
@@ -156,6 +156,29 @@ public class DekRegistryTest extends ClusterTestHarness {
     }
 
     @Test
+    public void testCreateDekWithEmptyKeyMaterialGeneratesDek() throws Exception {
+        // An empty encryptedKeyMaterial must be treated as absent, so that a shared KEK generates
+        // a new DEK instead of trying to unwrap empty ciphertext (which the KMS rejects, producing
+        // a spurious 500). kek (kekName1) from setUp is shared.
+        CreateDekRequest dekRequest = CreateDekRequest.fromJson(
+            "{\"subject\": \"emptyMaterialSubject\", \"version\": \"1\", \"algorithm\": \"AES256_GCM\", \"encryptedKeyMaterial\": \"\", \"deleted\": false}");
+        DataEncryptionKey dek = dekRegistry.createDek(kek.getName(), false, dekRequest);
+        assertNotNull(dek.getEncryptedKeyMaterial());
+        assertFalse(dek.getEncryptedKeyMaterial().isEmpty());
+    }
+
+    @Test
+    public void testCreateDekWithInvalidKeyMaterialThrowsInvalidKey() throws Exception {
+        // Caller-supplied ciphertext that the KMS cannot unwrap is a client error (422/invalid
+        // key), not a server error (500).
+        String garbage = Base64.getEncoder().encodeToString("not-real-ciphertext".getBytes());
+        CreateDekRequest dekRequest = CreateDekRequest.fromJson(String.format(
+            "{\"subject\": \"badMaterialSubject\", \"version\": \"1\", \"algorithm\": \"AES256_GCM\", \"encryptedKeyMaterial\": \"%s\", \"deleted\": false}", garbage));
+        assertThrows(InvalidKeyException.class,
+            () -> dekRegistry.createDek(kek.getName(), false, dekRequest));
+    }
+
+    @Test
     public void testDeleteKek() throws SchemaRegistryException  {
         // First soft delete.
         dekRegistry.deleteKek("kekName1", false);


### PR DESCRIPTION
What
----
Treat empty or blank caller-supplied encryptedKeyMaterial as absent so a shared KEK generates a new DEK instead of trying to unwrap empty ciphertext, which the KMS rejects and surfaces as a spurious 500. Also classify a failed round-trip on caller-supplied ciphertext as an invalid-key (422) rather than a DEK generation error (500); access-denied still maps to 403 and failures on freshly generated material stay 500.

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
https://confluentinc.atlassian.net/browse/DGS-25204

Test & Review
------------
Unit tests