### PR TITLE
MINOR refactoring of Avro LogicalTypeFactories

### DIFF
--- a/avro-types/src/main/java/io/confluent/avro/type/LogicalMapFactory.java
+++ b/avro-types/src/main/java/io/confluent/avro/type/LogicalMapFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.avro.type;
+
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+
+/**
+ * Registers {@link LogicalMap} with Avro's global logical type registry.
+ *
+ * <p>See {@link VariantLogicalTypeFactory} for why registration is a precondition for the
+ * conversion to be applied at all, and why this is a named public class rather than a lambda.
+ */
+public class LogicalMapFactory implements LogicalTypes.LogicalTypeFactory {
+
+  @Override
+  public LogicalType fromSchema(Schema schema) {
+    return LogicalMap.get();
+  }
+
+  /**
+   * Must be overridden: the interface default throws, and Avro calls this to key the registry.
+   */
+  @Override
+  public String getTypeName() {
+    return LogicalMap.NAME;
+  }
+}

--- a/avro-types/src/main/java/io/confluent/avro/type/LogicalMapFactory.java
+++ b/avro-types/src/main/java/io/confluent/avro/type/LogicalMapFactory.java
@@ -22,9 +22,6 @@ import org.apache.avro.Schema;
 
 /**
  * Registers {@link LogicalMap} with Avro's global logical type registry.
- *
- * <p>See {@link VariantLogicalTypeFactory} for why registration is a precondition for the
- * conversion to be applied at all, and why this is a named public class rather than a lambda.
  */
 public class LogicalMapFactory implements LogicalTypes.LogicalTypeFactory {
 

--- a/avro-types/src/main/java/io/confluent/avro/type/VariantLogicalTypeFactory.java
+++ b/avro-types/src/main/java/io/confluent/avro/type/VariantLogicalTypeFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.avro.type;
+
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
+import org.apache.avro.Schema;
+
+/**
+ * Registers {@link VariantLogicalType} with Avro's global logical type registry.
+ *
+ * <p>Avro's parser silently ignores a {@code logicalType} property it does not recognize, leaving
+ * {@link Schema#getLogicalType()} null -- and since a conversion is looked up by its
+ * {@code LogicalType}, an unregistered variant also gets no conversion applied. Registration is
+ * therefore a precondition for reading or writing variants, not just a convenience.
+ *
+ * <p>This exists as a named public class with a public no-arg constructor so it can be used
+ * wherever Avro accepts a factory by class name rather than instance -- notably
+ * avro-maven-plugin's {@code customLogicalTypeFactories}, which runs codegen in its own JVM where
+ * no Confluent registration code has executed.
+ */
+public class VariantLogicalTypeFactory implements LogicalTypes.LogicalTypeFactory {
+
+  @Override
+  public LogicalType fromSchema(Schema schema) {
+    return VariantLogicalType.get();
+  }
+
+  /**
+   * Must be overridden: the interface default throws, and Avro calls this to key the registry.
+   */
+  @Override
+  public String getTypeName() {
+    return VariantLogicalType.NAME;
+  }
+}

--- a/avro-types/src/main/java/io/confluent/avro/type/VariantLogicalTypeFactory.java
+++ b/avro-types/src/main/java/io/confluent/avro/type/VariantLogicalTypeFactory.java
@@ -23,15 +23,6 @@ import org.apache.avro.Schema;
 /**
  * Registers {@link VariantLogicalType} with Avro's global logical type registry.
  *
- * <p>Avro's parser silently ignores a {@code logicalType} property it does not recognize, leaving
- * {@link Schema#getLogicalType()} null -- and since a conversion is looked up by its
- * {@code LogicalType}, an unregistered variant also gets no conversion applied. Registration is
- * therefore a precondition for reading or writing variants, not just a convenience.
- *
- * <p>This exists as a named public class with a public no-arg constructor so it can be used
- * wherever Avro accepts a factory by class name rather than instance -- notably
- * avro-maven-plugin's {@code customLogicalTypeFactories}, which runs codegen in its own JVM where
- * no Confluent registration code has executed.
  */
 public class VariantLogicalTypeFactory implements LogicalTypes.LogicalTypeFactory {
 

--- a/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaUtils.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/avro/AvroSchemaUtils.java
@@ -26,10 +26,10 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.util.TokenBuffer;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import io.confluent.avro.type.LogicalMap;
 import io.confluent.avro.type.LogicalMapConversion;
+import io.confluent.avro.type.LogicalMapFactory;
 import io.confluent.avro.type.VariantConversion;
-import io.confluent.avro.type.VariantLogicalType;
+import io.confluent.avro.type.VariantLogicalTypeFactory;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaEntity;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -98,8 +98,8 @@ public class AvroSchemaUtils {
   private static final SpecificData SPECIFIC_DATA_INSTANCE_WITH_LOGICAL = new SpecificData();
 
   static {
-    registerLogicalTypeIfAbsent(LogicalMap.NAME, schema -> LogicalMap.get());
-    registerLogicalTypeIfAbsent(VariantLogicalType.NAME, schema -> VariantLogicalType.get());
+    registerLogicalTypeIfAbsent(new LogicalMapFactory());
+    registerLogicalTypeIfAbsent(new VariantLogicalTypeFactory());
     addLogicalTypeConversion(GENERIC_DATA_INSTANCE_WITH_LOGICAL);
     addLogicalTypeConversion(REFLECT_DATA_INSTANCE_WITH_LOGICAL);
     addLogicalTypeConversion(REFLECT_DATA_ALLOW_NULL_INSTANCE_WITH_LOGICAL);
@@ -111,10 +111,9 @@ public class AvroSchemaUtils {
   // (e.g. Apache Iceberg also registers "map" and "variant"). Iceberg's own registration is
   // unconditional, so leaving ours conditional lets whichever library claimed the name first
   // keep owning it, while still registering when no other library has.
-  private static void registerLogicalTypeIfAbsent(
-      String name, LogicalTypes.LogicalTypeFactory factory) {
-    if (!LogicalTypes.getCustomRegisteredTypes().containsKey(name)) {
-      LogicalTypes.register(name, factory);
+  private static void registerLogicalTypeIfAbsent(LogicalTypes.LogicalTypeFactory factory) {
+    if (!LogicalTypes.getCustomRegisteredTypes().containsKey(factory.getTypeName())) {
+      LogicalTypes.register(factory);
     }
   }
 


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----

Extracts the two Confluent Avro logical types' registration lambdas into named public                                                                                             
  `LogicalTypeFactory` classes, so they can be referenced by class name.                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                        
  Today that registration exists only as lambdas inside `AvroSchemaUtils`' static initializer, which                                                                                
  means it is only available to code that has class-loaded `AvroSchemaUtils`. Anything that consumes                                                                                
  `avro-types` without going through the SR client — most notably **avro-maven-plugin codegen, which                                                                                
  runs in its own JVM** — has no way to register these types, because there is no class to name.                                                                                    
                                                                                                                                                                                    
  With this change, users can point the plugin at them:                                                                                                                             
                                                                                                                                                                                    
  ```xml                                                                                                                                                                            
  <configuration>                                                                                                                                                                   
    <customLogicalTypeFactories>                                                                                                                                                    
      <customLogicalTypeFactory>io.confluent.avro.type.VariantLogicalTypeFactory</customLogicalTypeFactory>                                                                                                                                                     
    </customLogicalTypeFactories>                                                                                                                                                   
    <customConversions>                                                                                                                                                             
      <customConversion>io.confluent.avro.type.VariantConversion</customConversion>                                                                                                                                                                                          
    </customConversions>                                                                                                                                                            
  </configuration>                                                                                                                                                                  
                                        
```                             


<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[N]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - Covered by existing tests
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
