### PR TITLE
DGS-25232 Fix USING TYPE for local aliases

### DIFF
--- a/logical-types/src/main/antlr4/io/confluent/kafka/schemaregistry/type/logical/generated/LogicalTypes.g4
+++ b/logical-types/src/main/antlr4/io/confluent/kafka/schemaregistry/type/logical/generated/LogicalTypes.g4
@@ -22,8 +22,11 @@ declareNamespaceStmt
 // reachable from the root or from a local body that isn't itself declared
 // locally is treated as external. There is no syntactic marker for it.
 //
-// `USING TYPE <name> FOR <qualifiedName>` is a local alias: source-text sugar
-// substituted during reference resolution, so nothing survives into the
+// Both forms are marker-led — the token after FOR decides which — so neither
+// depends on lookahead, and a further kind could be added the same way.
+//
+// `USING TYPE <name> FOR TYPE <qualifiedName>` is a local alias: source-text
+// sugar substituted during reference resolution, so nothing survives into the
 // LogicalType. That is why it works for every target format, and why aliases do
 // not round-trip — the DDL writer emits the resolved FQN inline. The target is
 // taken verbatim (never namespace-qualified), may be a local type, and must not
@@ -42,7 +45,7 @@ declareNamespaceStmt
 // body or by the root, and must not collide with a local STRUCT/ENUM.
 
 aliasStmt
-    : USING TYPE qualifiedName FOR qualifiedName        # typeAliasStmt
+    : USING TYPE qualifiedName FOR TYPE qualifiedName   # typeAliasStmt
     | USING TYPE qualifiedName FOR REF stringLiteral    # typeRefStmt
     ;
 

--- a/logical-types/src/main/antlr4/io/confluent/kafka/schemaregistry/type/logical/generated/LogicalTypes.g4
+++ b/logical-types/src/main/antlr4/io/confluent/kafka/schemaregistry/type/logical/generated/LogicalTypes.g4
@@ -22,10 +22,7 @@ declareNamespaceStmt
 // reachable from the root or from a local body that isn't itself declared
 // locally is treated as external. There is no syntactic marker for it.
 //
-// Both forms are marker-led — the token after FOR decides which — so neither
-// depends on lookahead, and a further kind could be added the same way.
-//
-// `USING TYPE <name> FOR TYPE <qualifiedName>` is a local alias: source-text
+// `USING TYPE <name> FOR <qualifiedName>` is a local alias: source-text
 // sugar substituted during reference resolution, so nothing survives into the
 // LogicalType. That is why it works for every target format, and why aliases do
 // not round-trip — the DDL writer emits the resolved FQN inline. The target is
@@ -45,7 +42,7 @@ declareNamespaceStmt
 // body or by the root, and must not collide with a local STRUCT/ENUM.
 
 aliasStmt
-    : USING TYPE qualifiedName FOR TYPE qualifiedName   # typeAliasStmt
+    : USING TYPE qualifiedName FOR qualifiedName        # typeAliasStmt
     | USING TYPE qualifiedName FOR REF stringLiteral    # typeRefStmt
     ;
 

--- a/logical-types/src/main/antlr4/io/confluent/kafka/schemaregistry/type/logical/generated/LogicalTypes.g4
+++ b/logical-types/src/main/antlr4/io/confluent/kafka/schemaregistry/type/logical/generated/LogicalTypes.g4
@@ -16,34 +16,34 @@ declareNamespaceStmt
     : NAMESPACE qualifiedName
     ;
 
-// ─── external aliases ────────────────────────────────────────────────────────
+// ─── USING TYPE ──────────────────────────────────────────────────────────────
 //
 // External-ness of a type is *inferred* by the visitor: any NAMED_TYPE_REF FQN
 // reachable from the root or from a local body that isn't itself declared
 // locally is treated as external. There is no syntactic marker for it.
 //
-// `USING TYPE <qualifiedName> FOR <stringLiteral>` optionally attaches a
-// synthetic-wrapper URI to a named external — used when the source isn't
-// addressable by FQN alone (whole-doc JSON refs, arbitrary JSON-Pointer refs,
-// etc.). Visitor records (qualifiedName -> URI) in the LT's externalImports;
-// writers emit the URI as the reference target. Without a USING TYPE, the external
-// is canonical and the writer discovers its source by walking
-// resolvedReferences.
+// `USING TYPE <name> FOR <qualifiedName>` is a local alias: source-text sugar
+// substituted during reference resolution, so nothing survives into the
+// LogicalType. That is why it works for every target format, and why aliases do
+// not round-trip — the DDL writer emits the resolved FQN inline. The target is
+// taken verbatim (never namespace-qualified), may be a local type, and must not
+// itself be an alias; chains are rejected.
 //
-// `USING TYPE` controls only the WIRE-FORMAT shape of the reference (the $ref URI
-// in JSON, the import string in Proto). It deliberately does NOT carry SR
-// coordinates (subject + version) — those are deployment metadata that vary
-// across environments and aren't expressible in DDL. To produce an
-// SR-publishable LT from DDL, the caller attaches a SchemaReference list
-// (with matching resolvedReferences content) to the LogicalType separately
-// after the visitor runs.
+// `USING TYPE <name> FOR REF <stringLiteral>` attaches a synthetic-wrapper URI
+// to a named external, for sources an FQN can't address (whole-doc JSON refs,
+// JSON-Pointer refs). Visitor records (name -> URI) in externalImports; writers
+// emit the URI as the reference target. It shapes only the wire-format
+// reference (the $ref URI in JSON), so it is JSON-only — Avro and Proto reject
+// a LogicalType carrying externalImports. It deliberately does NOT carry SR
+// coordinates (subject + version); the caller attaches a SchemaReference list
+// separately after the visitor runs.
 //
-// Validation: each USING TYPE's FQN must (a) actually be referenced by some local
-// body or by the root (no dangling aliases) and (b) not collide with a local
-// STRUCT/ENUM declaration of the same name (no shadowing).
+// Validation, both forms: the declared name must be referenced by some local
+// body or by the root, and must not collide with a local STRUCT/ENUM.
 
 aliasStmt
-    : USING TYPE qualifiedName FOR stringLiteral
+    : USING TYPE qualifiedName FOR qualifiedName        # typeAliasStmt
+    | USING TYPE qualifiedName FOR REF stringLiteral    # typeRefStmt
     ;
 
 // ─── named type declarations ──────────────────────────────────────────────────
@@ -458,6 +458,7 @@ nonReservedKeyword
     | INTERVAL
     | MAP
     | NAMESPACE
+    | REF
     | TAGS
     | TYPE
     | VARIANT
@@ -517,6 +518,7 @@ OR              : O R ;
 POSITION        : P O S I T I O N ;
 PRECISION       : P R E C I S I O N ;
 REAL            : R E A L ;
+REF             : R E F ;
 RETURNING       : R E T U R N I N G ;
 ROW             : R O W ;
 STRUCT          : S T R U C T ;

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverter.java
@@ -98,7 +98,7 @@ public final class LogicalTypeToDdlConverter {
           continue;
         }
         sb.append("USING TYPE ").append(qualifiedName(e.getKey()))
-            .append(" FOR ").append(stringLiteral(e.getValue()))
+            .append(" FOR REF ").append(stringLiteral(e.getValue()))
             .append(";\n");
       }
 

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverter.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverter.java
@@ -97,7 +97,9 @@ public final class LogicalTypeToDdlConverter {
         if (!externalRefs.contains(e.getKey())) {
           continue;
         }
-        sb.append("USING TYPE ").append(qualifiedName(e.getKey()))
+        // displayName so the key re-emits the way a type reference does: the visitor stores it
+        // namespace-qualified, and re-parsing applies the namespace again.
+        sb.append("USING TYPE ").append(qualifiedName(displayName(e.getKey())))
             .append(" FOR REF ").append(stringLiteral(e.getValue()))
             .append(";\n");
       }

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitor.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitor.java
@@ -425,7 +425,7 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
     String target = buildQualifiedName(ctx.qualifiedName(1));
     if (name.equals(target)) {
       throw error(ctx.qualifiedName(1),
-          "USING TYPE " + name + " FOR TYPE " + target + " aliases a name to itself");
+          "USING TYPE " + name + " FOR  " + target + " aliases a name to itself");
     }
     typeAliases.put(name, target);
     return null;

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitor.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitor.java
@@ -445,7 +445,17 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
     // Keyed namespace-qualified, unlike an alias: this name survives into the LogicalType, and
     // every consumer -- the dangling check, and the JSON writer's $defs synthesis and $ref
     // emission -- looks it up by the qualified name a body reference resolves to.
-    externalImports.put(qualifyWithNamespace(name), uri);
+    //
+    // Re-check for duplicates on the qualified key. declareAliasName only saw the name as written,
+    // and two spellings can collide here: under NAMESPACE n, both `Foo` and `n.Foo` qualify to
+    // n.Foo, and a plain put would let the second silently replace the first.
+    String qualified = qualifyWithNamespace(name);
+    if (externalImports.putIfAbsent(qualified, uri) != null) {
+      throw error(ctx.qualifiedName(),
+          "Duplicate USING TYPE: " + name + " resolves to " + qualified
+              + ", which is already bound (each name may be declared at most once, however "
+              + "it is spelled)");
+    }
     return null;
   }
 

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitor.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitor.java
@@ -200,8 +200,13 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
     Set<String> declared = new LinkedHashSet<>(externalImports.keySet());
     declared.addAll(typeAliases.keySet());
 
-    Set<String> shadowed = new LinkedHashSet<>(declared);
-    shadowed.retainAll(namedTypes.keySet());
+    // Compare against the namespace-qualified form: a USING TYPE name is written bare and stored
+    // verbatim, while a local declaration is keyed qualified, so the raw sets never intersect
+    // under a NAMESPACE even when both claim the same token.
+    Set<String> shadowed = declared.stream()
+        .map(this::qualifyWithNamespace)
+        .filter(namedTypes::containsKey)
+        .collect(Collectors.toCollection(LinkedHashSet::new));
     if (!shadowed.isEmpty()) {
       throw new ValidationException(
           "USING TYPE declared for name(s) that are also locally declared as "

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitor.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitor.java
@@ -143,9 +143,6 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
     if (ctx.declareNamespaceStmt() != null) {
       visit(ctx.declareNamespaceStmt());
     }
-    for (LogicalTypesParser.AliasStmtContext stmt : ctx.aliasStmt()) {
-      visit(stmt);
-    }
     // Pre-pass: register every named-type declaration's qualified name (with
     // an empty placeholder) before building any body. This lets a parent's
     // body reference its own nested children by name (e.g., `STRUCT Outer
@@ -154,6 +151,12 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
     // registered by previously-visited declarations in this same pre-pass.
     for (LogicalTypesParser.CreateTypeStmtContext stmt : ctx.createTypeStmt()) {
       preRegisterCreateTypeName(stmt);
+    }
+    // After the pre-pass, so a REF binding's key is qualified the same way the body reference to
+    // it will be: qualifyWithNamespace consults locally-declared names to decide whether a dotted
+    // name is nested under a local parent, and before the pre-pass it would see none.
+    for (LogicalTypesParser.AliasStmtContext stmt : ctx.aliasStmt()) {
+      visit(stmt);
     }
     for (LogicalTypesParser.CreateTypeStmtContext stmt : ctx.createTypeStmt()) {
       visit(stmt);
@@ -425,7 +428,7 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
     String target = buildQualifiedName(ctx.qualifiedName(1));
     if (name.equals(target)) {
       throw error(ctx.qualifiedName(1),
-          "USING TYPE " + name + " FOR  " + target + " aliases a name to itself");
+          "USING TYPE " + name + " FOR " + target + " aliases a name to itself");
     }
     typeAliases.put(name, target);
     return null;

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitor.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitor.java
@@ -69,6 +69,8 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
   private String name;
   private String namespace;
   private final Map<String, String> externalImports = new LinkedHashMap<>();
+  private final Map<String, String> typeAliases = new LinkedHashMap<>();
+  private final Set<String> usedAliases = new LinkedHashSet<>();
   private final Map<String, Schema> namedTypes = new LinkedHashMap<>();
   private Schema rootSchema;
 
@@ -192,25 +194,44 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
    * parse time rather than allowed to silently no-op.
    */
   private void validateAliases() {
-    if (externalImports.isEmpty()) {
+    if (externalImports.isEmpty() && typeAliases.isEmpty()) {
       return;
     }
-    Set<String> shadowed = new LinkedHashSet<>(externalImports.keySet());
+    Set<String> declared = new LinkedHashSet<>(externalImports.keySet());
+    declared.addAll(typeAliases.keySet());
+
+    Set<String> shadowed = new LinkedHashSet<>(declared);
     shadowed.retainAll(namedTypes.keySet());
     if (!shadowed.isEmpty()) {
       throw new ValidationException(
           "USING TYPE declared for name(s) that are also locally declared as "
-              + "STRUCT/ENUM — a USING TYPE attaches a URI to an external reference, "
+              + "STRUCT/ENUM — a USING TYPE names something resolved elsewhere, "
               + "so it must not collide with a local declaration: " + shadowed);
     }
-    Set<String> externals = inferExternalTypes();
+
+    // An alias target may be a local type, but must not be another alias: chains are rejected,
+    // which also rules out cycles.
+    Set<String> chained = new LinkedHashSet<>(typeAliases.values());
+    chained.retainAll(typeAliases.keySet());
+    if (!chained.isEmpty()) {
+      throw new ValidationException(
+          "USING TYPE alias targets that are themselves aliases — chains are not "
+              + "resolved, so each alias must name its type directly: " + chained);
+    }
+
+    // REF bindings are found by walking the built bodies, since the name they declare survives
+    // into them. Aliases can't be: substitution replaced them, so usage is recorded as it happens.
     Set<String> dangling = new LinkedHashSet<>(externalImports.keySet());
-    dangling.removeAll(externals);
+    dangling.removeAll(inferExternalTypes());
+    for (String alias : typeAliases.keySet()) {
+      if (!usedAliases.contains(alias)) {
+        dangling.add(alias);
+      }
+    }
     if (!dangling.isEmpty()) {
       throw new ValidationException(
           "USING TYPE declared for name(s) that aren't referenced by any local "
-              + "type or by the root — externals are inferred from usage, so "
-              + "an unused USING TYPE has no effect: " + dangling);
+              + "type or by the root — an unused USING TYPE has no effect: " + dangling);
     }
   }
 
@@ -392,20 +413,43 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
   }
 
   @Override
-  public Object visitAliasStmt(LogicalTypesParser.AliasStmtContext ctx) {
-    String name = buildQualifiedName(ctx.qualifiedName());
-    if (externalImports.containsKey(name)) {
-      throw error(ctx.qualifiedName(),
-          "Duplicate USING TYPE: " + name
-              + " (each alias FQN may be declared at most once)");
+  public Object visitTypeAliasStmt(LogicalTypesParser.TypeAliasStmtContext ctx) {
+    String name = declareAliasName(ctx.qualifiedName(0));
+    // Target is verbatim: never namespace-qualified, so a single-segment target
+    // names a top-level type.
+    String target = buildQualifiedName(ctx.qualifiedName(1));
+    if (name.equals(target)) {
+      throw error(ctx.qualifiedName(1),
+          "USING TYPE " + name + " FOR " + target + " aliases a name to itself");
     }
+    typeAliases.put(name, target);
+    return null;
+  }
+
+  @Override
+  public Object visitTypeRefStmt(LogicalTypesParser.TypeRefStmtContext ctx) {
+    String name = declareAliasName(ctx.qualifiedName());
     String uri = stripStringLiteral(ctx.stringLiteral().getText());
     if (uri.trim().isEmpty()) {
       throw error(ctx.stringLiteral(),
-          "USING TYPE " + name + " FOR clause must be a non-empty URI");
+          "USING TYPE " + name + " FOR REF clause must be a non-empty URI");
     }
     externalImports.put(name, uri);
     return null;
+  }
+
+  /**
+   * Qualifies and duplicate-checks the name a {@code USING TYPE} declares. The two forms share one
+   * namespace of declared names, so aliasing and REF-binding the same name is a duplicate.
+   */
+  private String declareAliasName(LogicalTypesParser.QualifiedNameContext ctx) {
+    String name = buildQualifiedName(ctx);
+    if (externalImports.containsKey(name) || typeAliases.containsKey(name)) {
+      throw error(ctx,
+          "Duplicate USING TYPE: " + name
+              + " (each alias FQN may be declared at most once)");
+    }
+    return name;
   }
 
   @Override
@@ -907,6 +951,14 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
    * reference and inherits the active namespace.
    */
   private String qualifyTypeRef(String name) {
+    // An alias resolves to its target verbatim, bypassing namespace qualification: the target is
+    // already the FQN the author meant, and substituting here is what keeps aliases out of the
+    // LogicalType entirely.
+    String target = typeAliases.get(name);
+    if (target != null) {
+      usedAliases.add(name);
+      return target;
+    }
     if (namespace == null || namespace.isEmpty()) {
       return name;
     }

--- a/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitor.java
+++ b/logical-types/src/main/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitor.java
@@ -70,6 +70,7 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
   private String namespace;
   private final Map<String, String> externalImports = new LinkedHashMap<>();
   private final Map<String, String> typeAliases = new LinkedHashMap<>();
+  private final Set<String> declaredUsingNames = new LinkedHashSet<>();
   private final Set<String> usedAliases = new LinkedHashSet<>();
   private final Map<String, Schema> namedTypes = new LinkedHashMap<>();
   private Schema rootSchema;
@@ -197,13 +198,10 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
     if (externalImports.isEmpty() && typeAliases.isEmpty()) {
       return;
     }
-    Set<String> declared = new LinkedHashSet<>(externalImports.keySet());
-    declared.addAll(typeAliases.keySet());
-
-    // Compare against the namespace-qualified form: a USING TYPE name is written bare and stored
-    // verbatim, while a local declaration is keyed qualified, so the raw sets never intersect
-    // under a NAMESPACE even when both claim the same token.
-    Set<String> shadowed = declared.stream()
+    // Compare against the namespace-qualified form: a USING TYPE name is written bare, while a
+    // local declaration is keyed qualified, so the raw sets never intersect under a NAMESPACE even
+    // when both claim the same token.
+    Set<String> shadowed = declaredUsingNames.stream()
         .map(this::qualifyWithNamespace)
         .filter(namedTypes::containsKey)
         .collect(Collectors.toCollection(LinkedHashSet::new));
@@ -419,13 +417,15 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
 
   @Override
   public Object visitTypeAliasStmt(LogicalTypesParser.TypeAliasStmtContext ctx) {
+    // Keyed by the source token, unqualified: substitution happens in qualifyTypeRef before the
+    // namespace is applied, so this must match what the author actually writes at the use site.
     String name = declareAliasName(ctx.qualifiedName(0));
     // Target is verbatim: never namespace-qualified, so a single-segment target
     // names a top-level type.
     String target = buildQualifiedName(ctx.qualifiedName(1));
     if (name.equals(target)) {
       throw error(ctx.qualifiedName(1),
-          "USING TYPE " + name + " FOR " + target + " aliases a name to itself");
+          "USING TYPE " + name + " FOR TYPE " + target + " aliases a name to itself");
     }
     typeAliases.put(name, target);
     return null;
@@ -439,17 +439,21 @@ public class LogicalTypesSchemaVisitor extends LogicalTypesBaseVisitor<Object> {
       throw error(ctx.stringLiteral(),
           "USING TYPE " + name + " FOR REF clause must be a non-empty URI");
     }
-    externalImports.put(name, uri);
+    // Keyed namespace-qualified, unlike an alias: this name survives into the LogicalType, and
+    // every consumer -- the dangling check, and the JSON writer's $defs synthesis and $ref
+    // emission -- looks it up by the qualified name a body reference resolves to.
+    externalImports.put(qualifyWithNamespace(name), uri);
     return null;
   }
 
   /**
-   * Qualifies and duplicate-checks the name a {@code USING TYPE} declares. The two forms share one
-   * namespace of declared names, so aliasing and REF-binding the same name is a duplicate.
+   * Duplicate-checks the name a {@code USING TYPE} declares. The two forms share one namespace of
+   * declared names, so aliasing and REF-binding the same name is a duplicate -- tracked on the
+   * name as written, since the two forms key their maps differently.
    */
   private String declareAliasName(LogicalTypesParser.QualifiedNameContext ctx) {
     String name = buildQualifiedName(ctx);
-    if (externalImports.containsKey(name) || typeAliases.containsKey(name)) {
+    if (!declaredUsingNames.add(name)) {
       throw error(ctx,
           "Duplicate USING TYPE: " + name
               + " (each alias FQN may be declared at most once)");

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/CrossFormatRoundTripTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/CrossFormatRoundTripTest.java
@@ -890,4 +890,33 @@ class CrossFormatRoundTripTest {
         ? java.util.Collections.emptyList()
         : (java.util.List<io.confluent.kafka.schemaregistry.type.logical.Rule>) out;
   }
+
+  @Test
+  void localAliasDocumentEmitsToEveryFormat() {
+    // A local alias is substituted during reference resolution and leaves nothing in the LT, so
+    // no writer has anything to reject. That is the whole reason the alias form works for every
+    // target format, unlike the `FOR REF` URI binding. One NAMESPACE throughout, since Proto
+    // requires all named types to share the file package.
+    LogicalType lt = parseDdl(
+        "NAMESPACE com.example;"
+            + "USING TYPE Addr FOR com.example.Address;"
+            + "STRUCT Address (street VARCHAR NOT NULL);"
+            + "STRUCT Employee (id BIGINT NOT NULL, home Addr NOT NULL);"
+            + "TYPE Employee");
+
+    assertTrue(lt.getExternalImports().isEmpty(), "an alias must not become an external import");
+
+    assertTrue(LogicalTypeToAvroConverter.fromLogicalType(lt, "Employee")
+        .canonicalString().contains("Address"));
+    assertTrue(LogicalTypeToProtoConverter.fromLogicalType(lt, "Employee")
+        .canonicalString().contains("Address"));
+    assertTrue(LogicalTypeToJsonConverter.fromLogicalType(lt, "Employee")
+        .canonicalString().contains("Address"));
+  }
+
+  private static LogicalType parseDdl(String ddl) {
+    LogicalTypesSchemaVisitor visitor = new LogicalTypesSchemaVisitor();
+    visitor.visit(LogicalTypesParserFactory.parse(ddl));
+    return visitor.toLogicalType();
+  }
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/CrossFormatRoundTripTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/CrossFormatRoundTripTest.java
@@ -899,7 +899,7 @@ class CrossFormatRoundTripTest {
     // requires all named types to share the file package.
     LogicalType lt = parseDdl(
         "NAMESPACE com.example;"
-            + "USING TYPE Addr FOR com.example.Address;"
+            + "USING TYPE Addr FOR TYPE com.example.Address;"
             + "STRUCT Address (street VARCHAR NOT NULL);"
             + "STRUCT Employee (id BIGINT NOT NULL, home Addr NOT NULL);"
             + "TYPE Employee");

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/CrossFormatRoundTripTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/CrossFormatRoundTripTest.java
@@ -899,7 +899,7 @@ class CrossFormatRoundTripTest {
     // requires all named types to share the file package.
     LogicalType lt = parseDdl(
         "NAMESPACE com.example;"
-            + "USING TYPE Addr FOR TYPE com.example.Address;"
+            + "USING TYPE Addr FOR com.example.Address;"
             + "STRUCT Address (street VARCHAR NOT NULL);"
             + "STRUCT Employee (id BIGINT NOT NULL, home Addr NOT NULL);"
             + "TYPE Employee");

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverterTest.java
@@ -309,7 +309,7 @@ class LogicalTypeToDdlConverterTest {
     // which does round-trip.
     LogicalType lt = parse(
         "NAMESPACE com.example;"
-            + "USING TYPE Addr FOR com.example.Address;"
+            + "USING TYPE Addr FOR TYPE com.example.Address;"
             + "STRUCT Address (street VARCHAR NOT NULL);"
             + "STRUCT Employee (id BIGINT NOT NULL, home Addr NOT NULL);"
             + "TYPE Employee");

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverterTest.java
@@ -256,7 +256,7 @@ class LogicalTypeToDdlConverterTest {
   @Test
   void aliasCarriesUriBinding() {
     // External Ref1 carries a synthetic-wrapper URI binding via externalImports.
-    // Emitter writes `USING TYPE Ref1 FOR '<uri>';` so the binding round-trips
+    // Emitter writes `USING TYPE Ref1 FOR REF '<uri>';` so the binding round-trips
     // through DDL → LT → DDL.
     Schema struct = Schema.createStruct(Arrays.asList(
         new Schema.Field("a",
@@ -273,7 +273,7 @@ class LogicalTypeToDdlConverterTest {
         java.util.Collections.emptyMap(),
         java.util.Collections.emptyMap());
     String ddl = LogicalTypeToDdlConverter.toDdl(lt);
-    assertTrue(ddl.contains("USING TYPE Ref1 FOR 'ext.Outer';"),
+    assertTrue(ddl.contains("USING TYPE Ref1 FOR REF 'ext.Outer';"),
         "expected USING TYPE with URI binding, got:\n" + ddl);
     assertRoundTrip(lt);
   }
@@ -297,9 +297,27 @@ class LogicalTypeToDdlConverterTest {
         java.util.Collections.emptyMap(),
         java.util.Collections.emptyMap());
     String ddl = LogicalTypeToDdlConverter.toDdl(lt);
-    assertTrue(ddl.contains("USING TYPE Ref1 FOR 'ext.O''Hare';"),
+    assertTrue(ddl.contains("USING TYPE Ref1 FOR REF 'ext.O''Hare';"),
         "expected escaped single-quote in USING TYPE URI, got:\n" + ddl);
     assertRoundTrip(lt);
+  }
+
+  @Test
+  void localAliasDoesNotSurviveRoundTrip() {
+    // A local alias is substituted at parse time and leaves nothing in the LT, so there is no
+    // binding to re-emit: the writer prints the resolved FQN inline. Contrast the REF form above,
+    // which does round-trip.
+    LogicalType lt = parse(
+        "NAMESPACE com.example;"
+            + "USING TYPE Addr FOR com.example.Address;"
+            + "STRUCT Address (street VARCHAR NOT NULL);"
+            + "STRUCT Employee (id BIGINT NOT NULL, home Addr NOT NULL);"
+            + "TYPE Employee");
+
+    String ddl = LogicalTypeToDdlConverter.toDdl(lt);
+    assertFalse(ddl.contains("USING TYPE"), ddl);
+    assertEquals(lt.getRootSchema().getFields().get(1).getSchema().getQualifiedName(),
+        parse(ddl).getRootSchema().getFields().get(1).getSchema().getQualifiedName());
   }
 
   // -----------------------------------------------------------------------

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverterTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypeToDdlConverterTest.java
@@ -309,7 +309,7 @@ class LogicalTypeToDdlConverterTest {
     // which does round-trip.
     LogicalType lt = parse(
         "NAMESPACE com.example;"
-            + "USING TYPE Addr FOR TYPE com.example.Address;"
+            + "USING TYPE Addr FOR com.example.Address;"
             + "STRUCT Address (street VARCHAR NOT NULL);"
             + "STRUCT Employee (id BIGINT NOT NULL, home Addr NOT NULL);"
             + "TYPE Employee");

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitorTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitorTest.java
@@ -804,6 +804,25 @@ class LogicalTypesSchemaVisitorTest {
   }
 
   @Test
+  void testNestedRefBindingUnderNamespaceIsKeyedQualified() {
+    // A dotted name is only qualified when a prefix names a local type, so the REF key can only be
+    // computed once the local declarations are known. Visiting USING TYPE before the pre-pass
+    // would key this "Outer.Child" while the body reference resolves to "n.Outer.Child",
+    // reporting a valid binding as dangling.
+    LogicalTypesSchemaVisitor v = parseScript(
+        "NAMESPACE n;"
+        + "USING TYPE Outer.Child FOR REF 'ext.Doc#/properties/foo/items';"
+        + "STRUCT Outer (x INT);"
+        + "STRUCT H (c Outer.Child);"
+        + "TYPE H"
+    );
+    LogicalType lt = v.toLogicalType();
+    assertEquals("ext.Doc#/properties/foo/items",
+        lt.getExternalImports().get("n.Outer.Child"));
+    assertTrue(lt.isExternal("n.Outer.Child"));
+  }
+
+  @Test
   void testShadowedLocalAliasRejectedUnderNamespace() {
     // The alias name is stored verbatim while the local declaration is keyed namespace-qualified,
     // so a naive set intersection misses this. Without the qualified comparison the alias would

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitorTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitorTest.java
@@ -804,6 +804,20 @@ class LogicalTypesSchemaVisitorTest {
   }
 
   @Test
+  void testRefBindingsThatQualifyToTheSameNameRejected() {
+    // Distinct spellings, one key: under NAMESPACE n both qualify to n.Foo. The as-written
+    // duplicate check can't see this, so without a second check on the qualified key the later
+    // binding would silently replace the earlier one.
+    assertThrows(ValidationException.class, () -> parseScript(
+        "NAMESPACE n;"
+        + "USING TYPE Foo FOR REF 'a';"
+        + "USING TYPE n.Foo FOR REF 'b';"
+        + "STRUCT H (f Foo);"
+        + "TYPE H"
+    ));
+  }
+
+  @Test
   void testNestedRefBindingUnderNamespaceIsKeyedQualified() {
     // A dotted name is only qualified when a prefix names a local type, so the REF key can only be
     // computed once the local declarations are known. Visiting USING TYPE before the pre-pass

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitorTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitorTest.java
@@ -787,6 +787,23 @@ class LogicalTypesSchemaVisitorTest {
   }
 
   @Test
+  void testRefBindingUnderNamespaceIsKeyedQualified() {
+    // The REF key must match the qualified name a body reference resolves to, or the binding is
+    // both reported dangling here and silently ignored by the JSON writer, which looks it up by
+    // that qualified name.
+    LogicalTypesSchemaVisitor v = parseScript(
+        "NAMESPACE n;"
+        + "USING TYPE Foo FOR REF 'ext.Doc#/properties/foo/items';"
+        + "STRUCT H (f Foo);"
+        + "TYPE H"
+    );
+    LogicalType lt = v.toLogicalType();
+    assertEquals("ext.Doc#/properties/foo/items", lt.getExternalImports().get("n.Foo"));
+    assertEquals("n.Foo", lt.getRootSchema().getField("f").getSchema().getQualifiedName());
+    assertTrue(lt.isExternal("n.Foo"));
+  }
+
+  @Test
   void testShadowedLocalAliasRejectedUnderNamespace() {
     // The alias name is stored verbatim while the local declaration is keyed namespace-qualified,
     // so a naive set intersection misses this. Without the qualified comparison the alias would

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitorTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitorTest.java
@@ -637,8 +637,8 @@ class LogicalTypesSchemaVisitorTest {
   void testAlias() {
     // USING TYPE attaches a URI binding to a (necessarily external) FQN.
     LogicalTypesSchemaVisitor v = parseScript(
-        "USING TYPE Ref1 FOR 'ext.Outer';"
-        + "USING TYPE Ref2 FOR 'https://example.com/foo#/properties/bar';"
+        "USING TYPE Ref1 FOR REF 'ext.Outer';"
+        + "USING TYPE Ref2 FOR REF 'https://example.com/foo#/properties/bar';"
         + "STRUCT Holder ("
         + "  i Inner,"
         + "  one Ref1,"
@@ -663,7 +663,7 @@ class LogicalTypesSchemaVisitorTest {
   @Test
   void testAliasEmptyStringRejected() {
     assertThrows(ValidationException.class, () -> parseScript(
-        "USING TYPE Ref1 FOR '';"
+        "USING TYPE Ref1 FOR REF '';"
         + "STRUCT H (one Ref1);"
         + "TYPE H"
     ));
@@ -674,8 +674,8 @@ class LogicalTypesSchemaVisitorTest {
     // Two USING TYPE declarations for the same name. Last-write-wins would hide
     // the user's mistake — reject explicitly.
     assertThrows(ValidationException.class, () -> parseScript(
-        "USING TYPE Foo FOR 'a';"
-        + "USING TYPE Foo FOR 'b';"
+        "USING TYPE Foo FOR REF 'a';"
+        + "USING TYPE Foo FOR REF 'b';"
         + "STRUCT H (f Foo);"
         + "TYPE H"
     ));
@@ -686,7 +686,7 @@ class LogicalTypesSchemaVisitorTest {
     // USING TYPE whose FQN isn't referenced anywhere — visitor rejects since
     // externals are inferred from usage and an unused alias has no effect.
     assertThrows(ValidationException.class, () -> parseScript(
-        "USING TYPE Foo FOR 'a';"
+        "USING TYPE Foo FOR REF 'a';"
         + "TYPE INT"
     ));
   }
@@ -696,10 +696,104 @@ class LogicalTypesSchemaVisitorTest {
     // USING TYPE for a name that's also a local STRUCT declaration. The USING TYPE's URI
     // binding can't apply to a local type; reject the collision.
     assertThrows(ValidationException.class, () -> parseScript(
-        "USING TYPE Foo FOR 'a';"
+        "USING TYPE Foo FOR REF 'a';"
         + "STRUCT Foo (x INT);"
         + "TYPE Foo"
     ));
+  }
+
+  @Test
+  void testLocalAliasResolvesToTargetAndLeavesNoTrace() {
+    LogicalTypesSchemaVisitor v = parseScript(
+        "NAMESPACE com.example.hr;"
+        + "USING TYPE Person FOR com.example.common.Person;"
+        + "STRUCT Employee (id BIGINT NOT NULL, person Person);"
+        + "TYPE Employee"
+    );
+    LogicalType lt = v.toLogicalType();
+
+    // The alias is sugar: the field resolves to the target FQN, and nothing about the alias
+    // survives -- which is what lets Avro and Proto emit an LT that used one.
+    assertEquals("com.example.common.Person",
+        lt.getRootSchema().getFields().get(1).getSchema().getQualifiedName());
+    assertTrue(lt.getExternalImports().isEmpty());
+    assertTrue(lt.isExternal("com.example.common.Person"));
+    assertFalse(lt.isExternal("com.example.hr.Person"),
+        "the alias name itself must not become a type");
+  }
+
+  @Test
+  void testLocalAliasTargetIsVerbatimNotNamespaceQualified() {
+    LogicalTypesSchemaVisitor v = parseScript(
+        "NAMESPACE com.example.hr;"
+        + "USING TYPE P FOR Person;"
+        + "STRUCT Employee (person P);"
+        + "TYPE Employee"
+    );
+    assertEquals("Person",
+        v.toLogicalType().getRootSchema().getFields().get(0).getSchema().getQualifiedName());
+  }
+
+  @Test
+  void testLocalAliasMayTargetALocalType() {
+    LogicalTypesSchemaVisitor v = parseScript(
+        "USING TYPE Inner FOR Outer.Inner;"
+        + "STRUCT Outer.Inner (x INT);"
+        + "STRUCT Holder (i Inner);"
+        + "TYPE Holder"
+    );
+    assertEquals("Outer.Inner",
+        v.toLogicalType().getRootSchema().getFields().get(0).getSchema().getQualifiedName());
+  }
+
+  @Test
+  void testAliasChainRejected() {
+    assertThrows(ValidationException.class, () -> parseScript(
+        "USING TYPE A FOR B;"
+        + "USING TYPE B FOR com.x.C;"
+        + "STRUCT H (a A, b B);"
+        + "TYPE H"
+    ));
+  }
+
+  @Test
+  void testSelfAliasRejected() {
+    assertThrows(ValidationException.class, () -> parseScript(
+        "USING TYPE Foo FOR Foo;"
+        + "STRUCT H (f Foo);"
+        + "TYPE H"
+    ));
+  }
+
+  @Test
+  void testDanglingLocalAliasRejected() {
+    // Substitution removes the alias name, so usage is tracked as it happens rather than
+    // inferred from the built bodies.
+    assertThrows(ValidationException.class, () -> parseScript(
+        "USING TYPE Foo FOR com.x.Foo;"
+        + "STRUCT H (x INT);"
+        + "TYPE H"
+    ));
+  }
+
+  @Test
+  void testAliasAndRefForSameNameRejected() {
+    assertThrows(ValidationException.class, () -> parseScript(
+        "USING TYPE Foo FOR com.x.Foo;"
+        + "USING TYPE Foo FOR REF 'a';"
+        + "STRUCT H (f Foo);"
+        + "TYPE H"
+    ));
+  }
+
+  @Test
+  void testRefIsUsableAsAnOrdinaryName() {
+    // REF is non-reserved: it marks the URI form of USING TYPE and nothing else.
+    LogicalTypesSchemaVisitor v = parseScript(
+        "STRUCT H (ref INT NOT NULL);"
+        + "TYPE H"
+    );
+    assertNotNull(v.toLogicalType().getRootSchema().getField("ref"));
   }
 
   @Test

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitorTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitorTest.java
@@ -706,7 +706,7 @@ class LogicalTypesSchemaVisitorTest {
   void testLocalAliasResolvesToTargetAndLeavesNoTrace() {
     LogicalTypesSchemaVisitor v = parseScript(
         "NAMESPACE com.example.hr;"
-        + "USING TYPE Person FOR TYPE com.example.common.Person;"
+        + "USING TYPE Person FOR com.example.common.Person;"
         + "STRUCT Employee (id BIGINT NOT NULL, person Person);"
         + "TYPE Employee"
     );
@@ -726,7 +726,7 @@ class LogicalTypesSchemaVisitorTest {
   void testLocalAliasTargetIsVerbatimNotNamespaceQualified() {
     LogicalTypesSchemaVisitor v = parseScript(
         "NAMESPACE com.example.hr;"
-        + "USING TYPE P FOR TYPE Person;"
+        + "USING TYPE P FOR Person;"
         + "STRUCT Employee (person P);"
         + "TYPE Employee"
     );
@@ -737,7 +737,7 @@ class LogicalTypesSchemaVisitorTest {
   @Test
   void testLocalAliasMayTargetALocalType() {
     LogicalTypesSchemaVisitor v = parseScript(
-        "USING TYPE Inner FOR TYPE Outer.Inner;"
+        "USING TYPE Inner FOR Outer.Inner;"
         + "STRUCT Outer.Inner (x INT);"
         + "STRUCT Holder (i Inner);"
         + "TYPE Holder"
@@ -749,8 +749,8 @@ class LogicalTypesSchemaVisitorTest {
   @Test
   void testAliasChainRejected() {
     assertThrows(ValidationException.class, () -> parseScript(
-        "USING TYPE A FOR TYPE B;"
-        + "USING TYPE B FOR TYPE com.x.C;"
+        "USING TYPE A FOR B;"
+        + "USING TYPE B FOR com.x.C;"
         + "STRUCT H (a A, b B);"
         + "TYPE H"
     ));
@@ -759,7 +759,7 @@ class LogicalTypesSchemaVisitorTest {
   @Test
   void testSelfAliasRejected() {
     assertThrows(ValidationException.class, () -> parseScript(
-        "USING TYPE Foo FOR TYPE Foo;"
+        "USING TYPE Foo FOR Foo;"
         + "STRUCT H (f Foo);"
         + "TYPE H"
     ));
@@ -770,7 +770,7 @@ class LogicalTypesSchemaVisitorTest {
     // Substitution removes the alias name, so usage is tracked as it happens rather than
     // inferred from the built bodies.
     assertThrows(ValidationException.class, () -> parseScript(
-        "USING TYPE Foo FOR TYPE com.x.Foo;"
+        "USING TYPE Foo FOR com.x.Foo;"
         + "STRUCT H (x INT);"
         + "TYPE H"
     ));
@@ -779,7 +779,7 @@ class LogicalTypesSchemaVisitorTest {
   @Test
   void testAliasAndRefForSameNameRejected() {
     assertThrows(ValidationException.class, () -> parseScript(
-        "USING TYPE Foo FOR TYPE com.x.Foo;"
+        "USING TYPE Foo FOR com.x.Foo;"
         + "USING TYPE Foo FOR REF 'a';"
         + "STRUCT H (f Foo);"
         + "TYPE H"
@@ -810,7 +810,7 @@ class LogicalTypesSchemaVisitorTest {
     // silently win over the local STRUCT, since substitution happens before qualification.
     assertThrows(ValidationException.class, () -> parseScript(
         "NAMESPACE n;"
-        + "USING TYPE Foo FOR TYPE ext.Foo;"
+        + "USING TYPE Foo FOR ext.Foo;"
         + "STRUCT Foo (x INT);"
         + "STRUCT H (f Foo);"
         + "TYPE H"

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitorTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/LogicalTypesSchemaVisitorTest.java
@@ -706,7 +706,7 @@ class LogicalTypesSchemaVisitorTest {
   void testLocalAliasResolvesToTargetAndLeavesNoTrace() {
     LogicalTypesSchemaVisitor v = parseScript(
         "NAMESPACE com.example.hr;"
-        + "USING TYPE Person FOR com.example.common.Person;"
+        + "USING TYPE Person FOR TYPE com.example.common.Person;"
         + "STRUCT Employee (id BIGINT NOT NULL, person Person);"
         + "TYPE Employee"
     );
@@ -726,7 +726,7 @@ class LogicalTypesSchemaVisitorTest {
   void testLocalAliasTargetIsVerbatimNotNamespaceQualified() {
     LogicalTypesSchemaVisitor v = parseScript(
         "NAMESPACE com.example.hr;"
-        + "USING TYPE P FOR Person;"
+        + "USING TYPE P FOR TYPE Person;"
         + "STRUCT Employee (person P);"
         + "TYPE Employee"
     );
@@ -737,7 +737,7 @@ class LogicalTypesSchemaVisitorTest {
   @Test
   void testLocalAliasMayTargetALocalType() {
     LogicalTypesSchemaVisitor v = parseScript(
-        "USING TYPE Inner FOR Outer.Inner;"
+        "USING TYPE Inner FOR TYPE Outer.Inner;"
         + "STRUCT Outer.Inner (x INT);"
         + "STRUCT Holder (i Inner);"
         + "TYPE Holder"
@@ -749,8 +749,8 @@ class LogicalTypesSchemaVisitorTest {
   @Test
   void testAliasChainRejected() {
     assertThrows(ValidationException.class, () -> parseScript(
-        "USING TYPE A FOR B;"
-        + "USING TYPE B FOR com.x.C;"
+        "USING TYPE A FOR TYPE B;"
+        + "USING TYPE B FOR TYPE com.x.C;"
         + "STRUCT H (a A, b B);"
         + "TYPE H"
     ));
@@ -759,7 +759,7 @@ class LogicalTypesSchemaVisitorTest {
   @Test
   void testSelfAliasRejected() {
     assertThrows(ValidationException.class, () -> parseScript(
-        "USING TYPE Foo FOR Foo;"
+        "USING TYPE Foo FOR TYPE Foo;"
         + "STRUCT H (f Foo);"
         + "TYPE H"
     ));
@@ -770,7 +770,7 @@ class LogicalTypesSchemaVisitorTest {
     // Substitution removes the alias name, so usage is tracked as it happens rather than
     // inferred from the built bodies.
     assertThrows(ValidationException.class, () -> parseScript(
-        "USING TYPE Foo FOR com.x.Foo;"
+        "USING TYPE Foo FOR TYPE com.x.Foo;"
         + "STRUCT H (x INT);"
         + "TYPE H"
     ));
@@ -779,8 +779,22 @@ class LogicalTypesSchemaVisitorTest {
   @Test
   void testAliasAndRefForSameNameRejected() {
     assertThrows(ValidationException.class, () -> parseScript(
-        "USING TYPE Foo FOR com.x.Foo;"
+        "USING TYPE Foo FOR TYPE com.x.Foo;"
         + "USING TYPE Foo FOR REF 'a';"
+        + "STRUCT H (f Foo);"
+        + "TYPE H"
+    ));
+  }
+
+  @Test
+  void testShadowedLocalAliasRejectedUnderNamespace() {
+    // The alias name is stored verbatim while the local declaration is keyed namespace-qualified,
+    // so a naive set intersection misses this. Without the qualified comparison the alias would
+    // silently win over the local STRUCT, since substitution happens before qualification.
+    assertThrows(ValidationException.class, () -> parseScript(
+        "NAMESPACE n;"
+        + "USING TYPE Foo FOR TYPE ext.Foo;"
+        + "STRUCT Foo (x INT);"
         + "STRUCT H (f Foo);"
         + "TYPE H"
     ));

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/ExternalRefsRoundTripTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/ExternalRefsRoundTripTest.java
@@ -205,7 +205,8 @@ class ExternalRefsRoundTripTest {
 
   @Test
   void externalImportsRejectedByAvro() {
-    // A `USING TYPE x FOR REF '<uri>'` binding shapes a JSON $ref; Avro references types by name only -- there is no location for a URI to become.
+    // A `USING TYPE x FOR REF '<uri>'` binding shapes a JSON $ref; Avro references
+    // types by name only, so there is no location for a URI to become.
     // Reject rather than silently emit something meaningless.
     Schema rootSchema = Schema.createStruct(Arrays.asList(
         new Field("home",

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/ExternalRefsRoundTripTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/avro/ExternalRefsRoundTripTest.java
@@ -21,6 +21,7 @@ import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.type.logical.LogicalType;
 import io.confluent.kafka.schemaregistry.type.logical.LogicalTypeToDdlConverter;
 import io.confluent.kafka.schemaregistry.type.logical.Schema;
+import io.confluent.kafka.schemaregistry.type.logical.ValidationException;
 import io.confluent.kafka.schemaregistry.type.logical.Schema.Field;
 import org.junit.jupiter.api.Test;
 
@@ -32,6 +33,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -199,5 +201,29 @@ class ExternalRefsRoundTripTest {
     // No synthetic-wrapper externals (Avro doesn't have that mechanism).
     assertTrue(roundTripped.getExternalImports().isEmpty(),
         "Avro round-trip should not produce externalImports");
+  }
+
+  @Test
+  void externalImportsRejectedByAvro() {
+    // A `USING TYPE x FOR REF '<uri>'` binding shapes a JSON $ref; Avro references types by name only -- there is no location for a URI to become.
+    // Reject rather than silently emit something meaningless.
+    Schema rootSchema = Schema.createStruct(Arrays.asList(
+        new Field("home",
+            Schema.createNamedTypeRef("Ref1").setNullable(false), 0)))
+        .setNullable(false);
+    Map<String, String> imports = new LinkedHashMap<>();
+    imports.put("Ref1", "https://example.com/common.json#/$defs/Address");
+    LogicalType lt = new LogicalType(
+        null,
+        rootSchema,
+        java.util.Collections.emptyMap(),
+        java.util.Set.of("Ref1"),
+        imports,
+        java.util.Collections.emptyList(),
+        java.util.Collections.emptyMap(),
+        java.util.Collections.emptyMap());
+
+    assertThrows(ValidationException.class,
+        () -> LogicalTypeToAvroConverter.fromLogicalType(lt, "Person"));
   }
 }

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/json/ExternalRefsRoundTripTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/json/ExternalRefsRoundTripTest.java
@@ -103,7 +103,7 @@ class ExternalRefsRoundTripTest {
     // Inner extracted from the canonical /$defs/Inner ref needs no USING TYPE
     // (its source is discoverable via resolvedReferences).
     assertEquals(
-        "USING TYPE Ref1 FOR 'ext.Outer';\n"
+        "USING TYPE Ref1 FOR REF 'ext.Outer';\n"
             + "TYPE STRUCT(inner Inner, outer Ref1) NOT NULL;\n",
         LogicalTypeToDdlConverter.toDdl(lt));
 
@@ -223,11 +223,11 @@ class ExternalRefsRoundTripTest {
     // statements carrying their URI bindings.
     String ddl = LogicalTypeToDdlConverter.toDdl(lt);
     assertTrue(
-        ddl.contains("USING TYPE " + wholeName + " FOR 'ext.Doc';"),
+        ddl.contains("USING TYPE " + wholeName + " FOR REF 'ext.Doc';"),
         ddl);
     assertTrue(
         ddl.contains("USING TYPE " + subName
-            + " FOR 'ext.Doc#/properties/foo/items';"),
+            + " FOR REF 'ext.Doc#/properties/foo/items';"),
         ddl);
     assertTrue(ddl.contains("STRUCT `Local` ("), ddl);
 

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ExternalRefsRoundTripTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ExternalRefsRoundTripTest.java
@@ -193,7 +193,8 @@ class ExternalRefsRoundTripTest {
 
   @Test
   void externalImportsRejectedByProto() {
-    // A `USING TYPE x FOR REF '<uri>'` binding shapes a JSON $ref; Proto has no $ref mechanism, so the synthetic-wrapper URI has nothing to emit into.
+    // A `USING TYPE x FOR REF '<uri>'` binding shapes a JSON $ref; Proto has no
+    // $ref mechanism, so the synthetic-wrapper URI has nothing to emit into.
     // Reject rather than silently emit something meaningless.
     Schema rootSchema = Schema.createStruct(Arrays.asList(
         new Field("home",

--- a/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ExternalRefsRoundTripTest.java
+++ b/logical-types/src/test/java/io/confluent/kafka/schemaregistry/type/logical/protobuf/ExternalRefsRoundTripTest.java
@@ -21,6 +21,7 @@ import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.confluent.kafka.schemaregistry.type.logical.LogicalType;
 import io.confluent.kafka.schemaregistry.type.logical.LogicalTypeToDdlConverter;
 import io.confluent.kafka.schemaregistry.type.logical.Schema;
+import io.confluent.kafka.schemaregistry.type.logical.ValidationException;
 import io.confluent.kafka.schemaregistry.type.logical.Schema.Field;
 import org.junit.jupiter.api.Test;
 
@@ -32,6 +33,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -187,5 +189,29 @@ class ExternalRefsRoundTripTest {
     // Proto doesn't use synthetic-wrapper externals.
     assertTrue(roundTripped.getExternalImports().isEmpty(),
         "Proto round-trip should not produce externalImports");
+  }
+
+  @Test
+  void externalImportsRejectedByProto() {
+    // A `USING TYPE x FOR REF '<uri>'` binding shapes a JSON $ref; Proto has no $ref mechanism, so the synthetic-wrapper URI has nothing to emit into.
+    // Reject rather than silently emit something meaningless.
+    Schema rootSchema = Schema.createStruct(Arrays.asList(
+        new Field("home",
+            Schema.createNamedTypeRef("Ref1").setNullable(false), 0)))
+        .setNullable(false);
+    Map<String, String> imports = new LinkedHashMap<>();
+    imports.put("Ref1", "https://example.com/common.json#/$defs/Address");
+    LogicalType lt = new LogicalType(
+        null,
+        rootSchema,
+        java.util.Collections.emptyMap(),
+        java.util.Set.of("Ref1"),
+        imports,
+        java.util.Collections.emptyList(),
+        java.util.Collections.emptyMap(),
+        java.util.Collections.emptyMap());
+
+    assertThrows(ValidationException.class,
+        () -> LogicalTypeToProtoConverter.fromLogicalType(lt, "Person"));
   }
 }


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----

`USING TYPE` is documented as declaring a **local alias** but what it actually did was bind a wire-format URI to an external reference. The alias name was recorded in `LogicalType.externalImports`, and both non-JSON writers reject that outright.                                                                                  
                                                                                                                                                                                    
                                                                                                                                                                                     
  So the natural reading of the feature                                                                                                                                          
           
```                                                                                                                                                                         
  NAMESPACE com.example.hr;                                                                                                                                                         
  USING TYPE Person FOR 'com.example.common.Person';                                                                                                                                
  STRUCT Employee (id BIGINT NOT NULL, person Person)      
```                                                                                                                         
                                                                                                                                                                                    
  failed for AVRO and PROTOBUF, and for JSON silently emitted a                                                                                           
  `$ref` to the literal string `com.example.common.Person`, which resolves to nothing.        

### The model                                                                                                                                                                         
                                                                                                                                                                                    
  Referencing a type from another schema. Write its fully-qualified name inline; the reference                                                                                      
  itself is supplied out-of-band. All three formats resolve references by name — Avro by FQN,                                                                                       
  Protobuf by qualified name (with an import path), JSON Schema by a name found under $defs or                                                                                      
  definitions in the referenced document. No USING TYPE is needed for this.                                                                                                         
                                                                                                                                                                                    
  FOR REF exists because JSON Schema also allows references that have no name. A JSON Pointer                                                                                       
  into an arbitrary location (#/properties/foo/items), or a whole-document reference, addresses                                                                                     
  something that isn't a named entry — there's nothing for the writer to discover, so you state the                                                                                 
  URI explicitly. Avro and Protobuf have no equivalent, which is why they reject a schema carrying                                                                                  
  one.                                                                                                                                                                              
                                                                                                                                                                                    
  > Rule of thumb: use FOR REF only when the target is not a named entry under                                                                                                      
  > $defs/definitions in the referenced document. Otherwise use the bare FQN.                                                                                                       
                                                                                                                                                                                    
  The alias form is a separate concern: readability. It gives a long FQN a short local name for                                                                                     
  the rest of the document. It's resolved while parsing and leaves no trace in the LogicalType —                                                                                    
  which is exactly why it works for every target format, and why it does not survive a round trip                                                                                   
  (the emitted DDL shows the resolved FQN).                                                                                                                                         
                                                                                                                                                                                    
  
<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
