### PR TITLE
[Common BOM] Remove avro.version property references

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,11 +145,6 @@
                 <version>${kcache.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.avro</groupId>
-                <artifactId>avro</artifactId>
-                <version>${avro.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>commons-validator</groupId>
                 <artifactId>commons-validator</artifactId>
                 <version>${commons.validator.version}</version>
@@ -578,7 +573,7 @@
                 <plugin>
                     <groupId>org.apache.avro</groupId>
                     <artifactId>avro-maven-plugin</artifactId>
-                    <version>${avro.version}</version>
+                    <version>1.12.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
## Summary
Two GAVs referenced `${avro.version}`:
- The plain `dependencyManagement` entry for `org.apache.avro:avro` had no exclusions, so the whole block was simply deleted.
- The `avro-maven-plugin` `pluginManagement` entry **is actually consumed** — 5 submodules (`core`, `schema-rules`, `avro-data`, `avro-serde`, `avro-serializer`) invoke this plugin without their own version, relying on this entry as their only version source. `common` doesn't manage this plugin anywhere upstream (only the `avro.version` property and the `org.apache.avro:avro` *dependency* via `confluent-common-bom`), so the property reference was replaced with the current resolved literal (`1.12.1`) rather than removed outright — same pattern used for `ksql`/`ksql-internal`'s `avro-maven-plugin` usage.

`common` declares `avro.version = 1.12.1`, so this is a no-op version change.

## Tracking
Part of the `common` dependency-property cleanup effort: https://claude.ai/code/artifact/854856e4-47a3-4455-9e22-326715a12c82

## Test plan
- [x] `mvn -N validate` passes
- [x] `mvn help:effective-pom` confirms both the dependency and the plugin resolve unchanged at `1.12.1`
- [ ] CI green