### PR TITLE
DGS-25243: Retry leader-forwarding requests on transient connection failures

### DIFF
--- a/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
+++ b/client/src/main/java/io/confluent/kafka/schemaregistry/client/rest/RestService.java
@@ -94,6 +94,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 import java.util.Set;
 
 import javax.net.ssl.HostnameVerifier;
@@ -414,6 +415,24 @@ public class RestService implements Closeable, Configurable {
   public void setHttpReadTimeoutMs(int httpReadTimeoutMs) {
     this.httpReadTimeoutMs = httpReadTimeoutMs;
     closeHttpClient();
+  }
+
+  /**
+   * Installs a retry policy for requests issued by this service. Only connection-level failures
+   * (an {@link IOException} such as connect timed out or connection refused) are retried, up to
+   * {@code maxRetries} times with exponential backoff and jitter between {@code retriesWaitMs} and
+   * {@code retriesMaxWaitMs}. HTTP error responses ({@link RestClientException}, e.g. 5xx) are
+   * never retried. Set {@code maxRetries} to 0 to disable retries.
+   *
+   * <p>Used for the leader-forwarding client so that a transient connection failure to the leader
+   * (such as during a rolling restart) is retried rather than immediately failing the request,
+   * while a request that reached the leader and returned an error is surfaced without replay.
+   */
+  public void setRetries(int maxRetries, int retriesWaitMs, int retriesMaxWaitMs) {
+    // Predicate is always false so RestClientException (any status) is not retried; IOExceptions
+    // are retried independently of the predicate by RetryExecutor.
+    this.retryExecutor = new RetryExecutor(
+        maxRetries, retriesWaitMs, retriesMaxWaitMs, new Random(), e -> false);
   }
 
   /**

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/RestServiceTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/RestServiceTest.java
@@ -116,6 +116,91 @@ public class RestServiceTest {
   }
 
   /*
+   * A transient connection failure (e.g. connect timed out during a rolling restart) is retried
+   * when a retry policy is configured, so the request ultimately succeeds.
+   */
+  @Test
+  public void testRetriesTransientConnectFailure() throws Exception {
+    RestService restService = new RestService("http://localhost:8081", true);
+    restService.setRetries(1, 0, 0); // one retry, no backoff
+    RestService restServiceSpy = spy(restService);
+
+    HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
+    InputStream inputStream = mock(InputStream.class);
+
+    doReturn(url).when(restServiceSpy).url(anyString());
+    when(url.openConnection()).thenReturn(httpURLConnection);
+    // First attempt fails at connect; the retry succeeds.
+    when(httpURLConnection.getResponseCode())
+        .thenThrow(new SocketTimeoutException("Connect timed out"))
+        .thenReturn(HttpURLConnection.HTTP_OK);
+    when(httpURLConnection.getInputStream()).thenReturn(inputStream);
+    when(inputStream.read(any(), anyInt(), anyInt())).thenAnswer(invocationOnMock -> {
+      byte[] b = invocationOnMock.getArgument(0);
+      byte[] json = "[\"abc\"]".getBytes(StandardCharsets.UTF_8);
+      System.arraycopy(json, 0, b, 0, json.length);
+      return json.length;
+    });
+
+    assertEquals(Arrays.asList("abc"), restServiceSpy.getAllSubjects());
+    // Connect was attempted twice: the initial failure plus one retry.
+    verify(httpURLConnection, Mockito.times(2)).getResponseCode();
+  }
+
+  /*
+   * Without a retry policy (the default for the forwarding constructor), a transient connect
+   * failure is not retried and propagates immediately.
+   */
+  @Test
+  public void testNoRetriesFailsOnTransientConnectFailure() throws Exception {
+    RestService restService = new RestService("http://localhost:8081", true);
+    RestService restServiceSpy = spy(restService);
+
+    HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
+
+    doReturn(url).when(restServiceSpy).url(anyString());
+    when(url.openConnection()).thenReturn(httpURLConnection);
+    when(httpURLConnection.getResponseCode())
+        .thenThrow(new SocketTimeoutException("Connect timed out"));
+
+    try {
+      restServiceSpy.getAllSubjects();
+      fail("Expected the request to fail without retries");
+    } catch (java.io.IOException expected) {
+      // expected
+    }
+    // Connect was attempted exactly once, i.e. no retry.
+    verify(httpURLConnection, Mockito.times(1)).getResponseCode();
+  }
+
+  /*
+   * With a retry policy configured, an HTTP error response (RestClientException) is NOT retried,
+   * even for a status that is retriable by default (503) -- only connection-level IOExceptions are
+   * retried on the leader-forwarding path, so a request that reached the leader is not replayed.
+   */
+  @Test
+  public void testRetriesDoNotApplyToHttpErrorResponse() throws Exception {
+    RestService restService = new RestService("http://localhost:8081", true);
+    restService.setRetries(1, 0, 0); // retries enabled, but must not apply to RestClientException
+    RestService restServiceSpy = spy(restService);
+
+    HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
+
+    doReturn(url).when(restServiceSpy).url(anyString());
+    when(url.openConnection()).thenReturn(httpURLConnection);
+    when(httpURLConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_UNAVAILABLE);
+
+    try {
+      restServiceSpy.getAllSubjects();
+      fail("Expected the request to fail without retrying the HTTP error response");
+    } catch (RestClientException expected) {
+      assertEquals(HttpURLConnection.HTTP_UNAVAILABLE, expected.getStatus());
+    }
+    // The 503 was returned only once: no retry despite retries being enabled.
+    verify(httpURLConnection, Mockito.times(1)).getResponseCode();
+  }
+
+  /*
    * Test setBasicAuthRequestHeader (private method) indirectly through getAllSubjects.
    */
   @Test

--- a/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/RetryExecutorTest.java
+++ b/client/src/test/java/io/confluent/kafka/schemaregistry/client/rest/RetryExecutorTest.java
@@ -19,6 +19,7 @@ package io.confluent.kafka.schemaregistry.client.rest;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import java.io.IOException;
 import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.function.Predicate;
@@ -41,6 +42,24 @@ public class RetryExecutorTest {
     TestCallableIO testCallable = new TestCallableIO();
     int result = retryExecutor.retry(testCallable);
     Assert.assertEquals(3, result);
+  }
+
+  @Test
+  public void testRetryExecutorConnectTimeoutRetried() throws IOException, RestClientException {
+    // Mirrors the leader-forwarding case: a transient "Connect timed out" is retried once.
+    RetryExecutor retryExecutor = new RetryExecutor(1, 0, 0);
+    TestCallableConnectTimeout testCallable = new TestCallableConnectTimeout(1);
+    int result = retryExecutor.retry(testCallable);
+    Assert.assertEquals(2, result);
+  }
+
+  @Test
+  public void testRetryExecutorConnectTimeoutNotRetriedWhenDisabled() {
+    // With retries disabled (maxRetries == 0) the connect failure propagates immediately.
+    RetryExecutor retryExecutor = new RetryExecutor(0, 0, 0);
+    TestCallableConnectTimeout testCallable = new TestCallableConnectTimeout(1);
+    Assert.assertThrows(SocketTimeoutException.class, () -> retryExecutor.retry(testCallable));
+    Assert.assertEquals(1, testCallable.count);
   }
 
   @Test
@@ -171,6 +190,25 @@ public class RetryExecutorTest {
         throw new SocketException("test");
       }
       return count;
+    }
+  }
+
+  /** Throws a connect timeout until {@code failures} attempts have been made. */
+  static class TestCallableConnectTimeout implements Callable<Integer> {
+    private final int failures;
+    private int count = 0;
+
+    TestCallableConnectTimeout(int failures) {
+      this.failures = failures;
+    }
+
+    @Override
+    public Integer call() throws IOException {
+      if (count < failures) {
+        count++;
+        throw new SocketTimeoutException("Connect timed out");
+      }
+      return count + 1;
     }
   }
 

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/rest/SchemaRegistryConfig.java
@@ -155,6 +155,21 @@ public class SchemaRegistryConfig extends RestConfig {
   public static final String LEADER_READ_TIMEOUT_MS = "leader.read.timeout.ms";
   public static final int DEFAULT_LEADER_READ_TIMEOUT_MS = 60000;
   /**
+   * <code>leader.connect.retries</code>*
+   */
+  public static final String LEADER_CONNECT_RETRIES = "leader.connect.retries";
+  public static final int DEFAULT_LEADER_CONNECT_RETRIES = 0;
+  /**
+   * <code>leader.retries.wait.ms</code>*
+   */
+  public static final String LEADER_RETRIES_WAIT_MS = "leader.retries.wait.ms";
+  public static final int DEFAULT_LEADER_RETRIES_WAIT_MS = 100;
+  /**
+   * <code>leader.retries.max.wait.ms</code>*
+   */
+  public static final String LEADER_RETRIES_MAX_WAIT_MS = "leader.retries.max.wait.ms";
+  public static final int DEFAULT_LEADER_RETRIES_MAX_WAIT_MS = 1000;
+  /**
    * <code>leader.election.delay</code>*
    */
   public static final String LEADER_ELECTION_DELAY = "leader.election.delay";
@@ -507,6 +522,17 @@ public class SchemaRegistryConfig extends RestConfig {
       "The timeout for connections when forwarding requests to the leader.";
   protected static final String LEADER_READ_TIMEOUT_MS_DOC =
       "The timeout for reading responses after forwarding requests to the leader.";
+  protected static final String LEADER_CONNECT_RETRIES_DOC =
+      "The maximum number of times a request forwarded to the leader is retried on a transient "
+      + "connection failure (e.g. connection refused or connect timed out), such as during a "
+      + "rolling restart when the leader is briefly unreachable. Defaults to 0 (disabled); set to "
+      + "a positive value to enable retries.";
+  protected static final String LEADER_RETRIES_WAIT_MS_DOC =
+      "The initial wait, in milliseconds, before retrying a request forwarded to the leader. "
+      + "Subsequent retries back off exponentially with jitter up to " + LEADER_RETRIES_MAX_WAIT_MS
+      + ".";
+  protected static final String LEADER_RETRIES_MAX_WAIT_MS_DOC =
+      "The maximum wait, in milliseconds, between retries of a request forwarded to the leader.";
   protected static final String LEADER_ELECTION_DELAY_DOC =
       "Whether to delay leader election until after initialization.";
   protected static final String LEADER_ELECTION_STICKY_DOC =
@@ -807,6 +833,15 @@ public class SchemaRegistryConfig extends RestConfig {
     )
     .define(LEADER_READ_TIMEOUT_MS, ConfigDef.Type.INT, DEFAULT_LEADER_READ_TIMEOUT_MS,
         ConfigDef.Importance.LOW, LEADER_READ_TIMEOUT_MS_DOC
+    )
+    .define(LEADER_CONNECT_RETRIES, ConfigDef.Type.INT, DEFAULT_LEADER_CONNECT_RETRIES,
+        ConfigDef.Importance.LOW, LEADER_CONNECT_RETRIES_DOC
+    )
+    .define(LEADER_RETRIES_WAIT_MS, ConfigDef.Type.INT, DEFAULT_LEADER_RETRIES_WAIT_MS,
+        ConfigDef.Importance.LOW, LEADER_RETRIES_WAIT_MS_DOC
+    )
+    .define(LEADER_RETRIES_MAX_WAIT_MS, ConfigDef.Type.INT, DEFAULT_LEADER_RETRIES_MAX_WAIT_MS,
+        ConfigDef.Importance.LOW, LEADER_RETRIES_MAX_WAIT_MS_DOC
     )
     .define(LEADER_ELECTION_DELAY, ConfigDef.Type.BOOLEAN, DEFAULT_LEADER_ELECTION_DELAY,
         ConfigDef.Importance.LOW, LEADER_ELECTION_DELAY_DOC

--- a/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
+++ b/core/src/main/java/io/confluent/kafka/schemaregistry/storage/KafkaSchemaRegistry.java
@@ -113,6 +113,9 @@ public class KafkaSchemaRegistry extends AbstractSchemaRegistry implements
   private RestService leaderRestService;
   private final int leaderConnectTimeoutMs;
   private final int leaderReadTimeoutMs;
+  private final int leaderConnectRetries;
+  private final int leaderRetriesWaitMs;
+  private final int leaderRetriesMaxWaitMs;
   private final LeaderForwardingClient leaderForwardingClient;
   private final IdGenerator idGenerator;
   private LeaderElector leaderElector = null;
@@ -143,6 +146,9 @@ public class KafkaSchemaRegistry extends AbstractSchemaRegistry implements
 
     this.leaderConnectTimeoutMs = config.getInt(SchemaRegistryConfig.LEADER_CONNECT_TIMEOUT_MS);
     this.leaderReadTimeoutMs = config.getInt(SchemaRegistryConfig.LEADER_READ_TIMEOUT_MS);
+    this.leaderConnectRetries = config.getInt(SchemaRegistryConfig.LEADER_CONNECT_RETRIES);
+    this.leaderRetriesWaitMs = config.getInt(SchemaRegistryConfig.LEADER_RETRIES_WAIT_MS);
+    this.leaderRetriesMaxWaitMs = config.getInt(SchemaRegistryConfig.LEADER_RETRIES_MAX_WAIT_MS);
     this.leaderForwardingClient = createLeaderForwardingClient(config);
     this.kafkaStoreTimeoutMs =
         config.getInt(SchemaRegistryConfig.KAFKASTORE_TIMEOUT_CONFIG);
@@ -345,6 +351,8 @@ public class KafkaSchemaRegistry extends AbstractSchemaRegistry implements
         leaderRestService = new RestService(leaderIdentity.getUrl(), true);
         leaderRestService.setHttpConnectTimeoutMs(leaderConnectTimeoutMs);
         leaderRestService.setHttpReadTimeoutMs(leaderReadTimeoutMs);
+        leaderRestService.setRetries(
+            leaderConnectRetries, leaderRetriesWaitMs, leaderRetriesMaxWaitMs);
         SSLSocketFactory forwardingSslSocketFactory = leaderForwardingClient != null
             ? leaderForwardingClient.sslSocketFactory() : null;
         if (forwardingSslSocketFactory != null) {


### PR DESCRIPTION




<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----
Schema Registry serves writes only from the leader; non-leader pods forward write requests (including the synthetic healthcheck write probes that drive the write SLO) to the leader over a fresh TCP+TLS connection per request. During a pod-by-pod rolling restart, these fresh-connect forwards intermittently fail with "Connect timed out" (a dropped SYN to the newly-elected leader) or "Connection refused" (the outgoing leader's port closing), while the leader otherwise serves pooled keep-alive traffic normally. Each failed probe burns write-SLO error budget, so a few per roll drop clusters below 99.99%.

The forwarding client already had retry machinery (RetryExecutor, which retries IOExceptions), but the leader RestService was built via the two-arg constructor with RetryExecutor(0, 0, 0) and never configured, so maxRetries was 0 and a transient connection failure failed the forwarded request immediately.

Give the leader-forwarding client a small, config-gated retry budget so a transient connection failure is retried against the same leader with jittered backoff before failing over. Forwarded mutations are idempotent (registering the same schema returns the same id), so retrying is safe, and a connect-timeout / connection-refused means the request almost certainly never reached the leader.

Changes:
- RestService.setRetries(maxRetries, retriesWaitMs, retriesMaxWaitMs) to install a configured RetryExecutor on an already-constructed service.
- New configs (LOW importance), mirroring the existing leader.*.timeout.ms:
  - leader.connect.retries       (default 1)
  - leader.retries.wait.ms       (default 100)
  - leader.retries.max.wait.ms   (default 1000)
  Set leader.connect.retries=0 to restore the previous behavior.
- KafkaSchemaRegistry wires these onto leaderRestService in updateLeader().
- Tests: RetryExecutor retries a "Connect timed out" once (and does not when
  disabled); RestService retries a first-attempt connect timeout to success and
  fails immediately without a retry policy.

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[N]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[Y]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA: https://confluentinc.atlassian.net/browse/DGS-25243

Test & Review
------------
Unit tests 
