### PR TITLE
[Common BOM] Remove protobuf.version property references

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,16 +190,6 @@
                 <version>1.17.13</version>
             </dependency>
             <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java</artifactId>
-                <version>${protobuf.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.protobuf</groupId>
-                <artifactId>protobuf-java-util</artifactId>
-                <version>${protobuf.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.google.api.grpc</groupId>
                 <artifactId>proto-google-common-protos</artifactId>
                 <version>${proto-google-common-protos.version}</version>
@@ -591,7 +581,7 @@
                     <version>${protobuf.maven.plugin.version}</version>
 
                     <configuration>
-                        <protocVersion>${protobuf.version}</protocVersion>
+                        <protocVersion>4.34.0</protocVersion>
                         <outputDirectory>src/test/java</outputDirectory>
                         <sourceDirectories>
                             <include>src/test/proto</include>

--- a/pom.xml
+++ b/pom.xml
@@ -581,6 +581,7 @@
                     <version>${protobuf.maven.plugin.version}</version>
 
                     <configuration>
+                        <!-- keep in sync with confluent-common-bom's protobuf.version -->
                         <protocVersion>4.34.0</protocVersion>
                         <outputDirectory>src/test/java</outputDirectory>
                         <sourceDirectories>

--- a/protobuf-types/pom.xml
+++ b/protobuf-types/pom.xml
@@ -62,7 +62,7 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
 
                 <configuration>
-                    <protocVersion>${protobuf.version}</protocVersion>
+                    <protocVersion>4.34.0</protocVersion>
                     <outputDirectory>src/main/java</outputDirectory>
                     <sourceDirectories>
                         <include>src/main/proto</include>

--- a/protobuf-types/pom.xml
+++ b/protobuf-types/pom.xml
@@ -62,6 +62,7 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
 
                 <configuration>
+                    <!-- keep in sync with confluent-common-bom's protobuf.version -->
                     <protocVersion>4.34.0</protocVersion>
                     <outputDirectory>src/main/java</outputDirectory>
                     <sourceDirectories>


### PR DESCRIPTION
## Summary
- Removes the `protobuf.version` override for `com.google.protobuf:protobuf-java` and `com.google.protobuf:protobuf-java-util` (`dependencyManagement` entries, no exclusions, whole blocks removed).
- Also hardcodes the `protobuf-maven-plugin`'s `protocVersion` config to `4.34.0` in two places (root `pluginManagement`, actually consumed by 6 submodules, and `protobuf-types`' own `build/plugins`) — that plugin isn't managed anywhere upstream (only the `protobuf-java` dependency is BOM-managed, not this plugin), same pattern used for `ksql`'s `avro-maven-plugin`.
- Resolved chain: `rest-utils-parent:8.0.8-21` → `common:8.0.8-20`, which imports `confluent-common-bom:0.1.10` — confirmed managing `protobuf-java`/`protobuf-java-util` directly at `4.34.0`.
- Opened as **draft**: this sandbox has no CodeArtifact credentials, so a full `mvn compile`/`test` isn't possible here (confirmed identical failure with and without this change, for every third-party dependency) — relying on real CI to do the full build verification.

## Tracking
Part of the `common` dependency-property cleanup effort: https://claude.ai/code/artifact/854856e4-47a3-4455-9e22-326715a12c82

## Test plan
- [x] `mvn -N validate` passes
- [x] `mvn help:effective-pom` confirms both dependencies and every `protocVersion` resolve to `4.34.0` (unchanged)
- [ ] CI green