### PR TITLE
docs: pretty-print schema JSON with jq (#847)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ $ curl -X GET http://localhost:8081/subjects/Kafka-value/versions/1
 $ curl -X GET http://localhost:8081/subjects/Kafka-value/versions/latest
   {"subject":"Kafka-value","version":1,"id":1,"schema":"\"string\""}
 
+# Pretty-print the nested schema JSON (the schema field is an escaped string)
+$ curl -s http://localhost:8081/subjects/<topicname>-value/versions/latest | jq '.schema | fromjson'
+
 # Delete version 3 of the schema registered under subject "Kafka-value"
 $ curl -X DELETE http://localhost:8081/subjects/Kafka-value/versions/3
   3


### PR DESCRIPTION
What
----
The latest-schema response keeps the Avro/JSON schema in an escaped string. I added the `jq '.schema | fromjson'` example from #847 so that field prints as real JSON.

Checklist
------------------
- **[N]** Contains customer facing changes? Including API/behavior changes
- **[N]** Is this change gated behind config(s)?
- **[N]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - Docs-only README example
- **[N]** Does this change require modifying existing system tests or adding new system tests?
- **[N]** Must this be released together with other change(s), either in this repo or another one?

References
----------
#847

Test & Review
------------
Docs only. No code change.
