### PR TITLE
Exclude non-FIPS BouncyCastle jars from kafka-serde-tools package

### DIFF
--- a/package-kafka-serde-tools/src/assembly/package.xml
+++ b/package-kafka-serde-tools/src/assembly/package.xml
@@ -41,6 +41,11 @@
             <excludes>
                 <exclude>io.confluent:common-*</exclude>
                 <exclude>org.apache.kafka:kafka-clients</exclude>
+                <!-- FIPS: these non-FIPS-validated BouncyCastle jars are pulled in transitively
+                     but must not ship, since only the FIPS-validated BC provider is approved. -->
+                <exclude>org.bouncycastle:bcprov-jdk18on</exclude>
+                <exclude>org.bouncycastle:bcpkix-jdk18on</exclude>
+                <exclude>org.bouncycastle:bcutil-jdk18on</exclude>
             </excludes>
         </dependencySet>
     </dependencySets>


### PR DESCRIPTION
## Summary
- The `kafka-serde-tools-package` assembly transitively pulls in the non-FIPS-validated BouncyCastle provider jars (`bcprov-jdk18on`, `bcpkix-jdk18on`, `bcutil-jdk18on`).
- Add them to the assembly's `<excludes>` so they are not shipped, since only the FIPS-validated BouncyCastle provider (`bctls-fips`, used by the client module) is approved.

## Test plan
- [ ] Build `package-kafka-serde-tools` and verify the assembled package no longer contains `bcprov-jdk18on`, `bcpkix-jdk18on`, or `bcutil-jdk18on` jars.