### PR TITLE
Exclude non-FIPS BouncyCastle jars from kafka-serde-tools package

### DIFF
--- a/package-kafka-serde-tools/src/assembly/package.xml
+++ b/package-kafka-serde-tools/src/assembly/package.xml
@@ -41,6 +41,11 @@
             <excludes>
                 <exclude>io.confluent:common-*</exclude>
                 <exclude>org.apache.kafka:kafka-clients</exclude>
+                <!-- FIPS: these non-FIPS-validated BouncyCastle jars are pulled in transitively
+                     but must not ship, since only the FIPS-validated BC provider is approved. -->
+                <exclude>org.bouncycastle:bcprov-jdk18on</exclude>
+                <exclude>org.bouncycastle:bcpkix-jdk18on</exclude>
+                <exclude>org.bouncycastle:bcutil-jdk18on</exclude>
             </excludes>
         </dependencySet>
     </dependencySets>


### PR DESCRIPTION
Cherry-pick of ca17699380fc5ba1a54d0bc2007fd0ce6dc3db08 from 7.6.x onto the 8.0.8 release branch.

bcprov-jdk18on, bcpkix-jdk18on, and bcutil-jdk18on are pulled in transitively and must not be shipped in the packaged kafka-serde-tools assembly, since only the FIPS-validated BouncyCastle provider is approved for use.