### PR TITLE
[Common BOM] Remove redundant jackson.version overrides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,36 +236,6 @@
                 <version>${okio.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.dataformat</groupId>
-                <artifactId>jackson-dataformat-csv</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-guava</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-jdk8</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-joda</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.datatype</groupId>
-                <artifactId>jackson-datatype-jsr310</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-parameter-names</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.hubspot.jackson</groupId>
                 <artifactId>jackson-datatype-protobuf</artifactId>
                 <version>0.9.18</version>


### PR DESCRIPTION
## Summary
- Removes explicit `${jackson.version}` overrides on `jackson-dataformat-csv`, `jackson-datatype-guava`, `jackson-datatype-jdk8`, `jackson-datatype-joda`, `jackson-datatype-jsr310`, and `jackson-module-parameter-names` from `dependencyManagement` — all already managed at the same version (`2.22.1`) by `confluent-common-bom`'s `jackson-bom` import, transitively via the `common` parent POM.
- Scoped to `8.0.x` only for now; should cascade forward via `ci-sem-pint`/pint merge to `8.1.x`–`8.4.x`/`master` normally.


## Test plan
- [x] `mvn validate` passes (full reactor, all modules)
- [x] `mvn help:effective-pom` on every module referencing these artifacts (`schema-serializer`, `schema-rules`, `json-schema-provider`, `json-serializer`, `client`) confirms all resolve to `2.22.1`, unchanged
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)