### PR TITLE
fix: pin avro.version to 1.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,11 @@
         <wire.version>6.4.5</wire.version>
         <swagger.version>2.2.42</swagger.version>
         <io.confluent.schema-registry.version>8.1.6-0</io.confluent.schema-registry.version>
+        <!-- Pin Avro to 1.12.1. Avro 1.12.2 (AVRO-4176) rejects object-wrapped named-type
+             references like {"type":"my.Custom"}, which SR previously accepted; taking the
+             transitive 1.12.2 bump would break existing customer schemas that use that form.
+             Revisit once the customer-impact of the stricter parsing is resolved. -->
+        <avro.version>1.12.1</avro.version>
         <commons.compress.version>1.26.1</commons.compress.version>
         <commons.lang3.version>3.18.0</commons.lang3.version>
         <commons.validator.version>1.9.0</commons.validator.version>


### PR DESCRIPTION
## Why

Avro **1.12.2** ([AVRO-4176](https://issues.apache.org/jira/browse/AVRO-4176), apache/avro#3772) makes the Java parser reject a field whose `type` is an **object wrapping a named/custom type**, e.g. `{"type": "my.Custom"}` — a form the parser previously accepted (Java was more lenient than the spec/Python). Registering such a schema now fails validation with REST error **42201** (*"A schema \"type\" MUST be a primitive type or one of enum, fixed, record, error, array or map."*).

Schema Registry does **not** pin `avro.version`; it inherits it transitively from `confluent-common-bom`, which bumped **1.12.1 → 1.12.2**. This broke the build **branch-wide** — e.g. `RestApiTest.testSchemaReferencesMultipleLevels` (whose `ref1` uses exactly the object-wrapped named-reference form) now fails deterministically, and it surfaces on every downstream consumer that resolves the floating `kafka-schema-registry` range (confluent-cloud-plugins included).

## What

Pin `avro.version=1.12.1` in the root `pom.xml` `<properties>` to preserve the prior behavior. `avro` dependencies reference `${avro.version}` directly, so the locally-defined property overrides the inherited BOM value.

## ⚠️ Customer-impact caveat (needs follow-up)

This pin is a **hold**, not a resolution. Avro 1.12.2's stricter parsing is spec-correct, but taking it would **reject existing customer schemas** that use object-wrapped named-type references (`{"type":"my.Custom"}`). Before un-pinning, the team must decide how to handle that backward-incompatibility (accept and message it, or add a compatibility path). Tracking that discussion separately.

## Branch strategy

`8.1.x` is the **oldest affected release branch** (it resolves Avro 1.12.2; `8.0.x` still resolves 1.12.1 and `7.x` is on 1.11.5). Per the forward-merge model this pin originates here and should forward-merge up through **8.2.x → 8.3.x → 8.4.x → master**.

## Testing

`avro.version` is used at `pom.xml:149` and `pom.xml:580`; both resolve to the locally-pinned `1.12.1`. Locally reverting the transitive bump makes the previously-failing reference test pass (confirmed via the equivalent pin during investigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)