### PR TITLE
Add range-check for variants.as(v, "timestamp")

### DIFF
--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinOverload.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/BuiltinOverload.java
@@ -794,7 +794,22 @@ final class BuiltinOverload {
         if (t == Variant.Type.TIMESTAMP_TZ || t == Variant.Type.TIMESTAMP_NTZ
             || t == Variant.Type.TIMESTAMP_NANOS_TZ
             || t == Variant.Type.TIMESTAMP_NANOS_NTZ) {
-          return variantGetTimestamp(v);
+          Timestamp ts = variantGetTimestamp(v);
+          if (ts != null) {
+            return ts;
+          }
+          // A variant timestamp spans the whole int64 range while a CEL timestamp is
+          // 0001-9999, so an out-of-range value is reachable from data. Routed through
+          // nullOnError like a type mismatch: variants.as raises and names the range,
+          // variants.tryAs answers CEL null so a rule can guard. Building it instead left an
+          // invalid Timestamp in the type system - unrenderable (protobuf JSON refuses it),
+          // so only comparisons could consume it, which is where a wrong answer would hide.
+          if (nullOnError) {
+            return NullValue.NULL_VALUE;
+          }
+          throw new IllegalArgumentException(
+              "variants.as: timestamp " + v.getLong() + " is outside "
+                  + TimestampUtils.RANGE_TEXT);
         }
         break;
       case "bytes":
@@ -827,14 +842,17 @@ final class BuiltinOverload {
         "variants.as: variant is not " + typeStr + "-typed (type=" + t + ")");
   }
 
+  /**
+   * The variant's instant, or {@code null} when it falls outside the CEL timestamp range.
+   */
   private static Timestamp variantGetTimestamp(Variant v) {
     switch (v.getType()) {
       case TIMESTAMP_TZ:
       case TIMESTAMP_NTZ:
-        return TimestampUtils.fromEpochMicros(v.getLong());
+        return TimestampUtils.fromEpochMicrosOrNull(v.getLong());
       case TIMESTAMP_NANOS_TZ:
       case TIMESTAMP_NANOS_NTZ:
-        return TimestampUtils.fromEpochNanos(v.getLong());
+        return TimestampUtils.fromEpochNanosOrNull(v.getLong());
       default:
         // Unreachable: callers (variantAs) verify the type before invoking.
         throw new IllegalStateException(

--- a/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/TimestampUtils.java
+++ b/schema-rules/src/main/java/io/confluent/kafka/schemaregistry/rules/cel/builtin/TimestampUtils.java
@@ -33,6 +33,9 @@ final class TimestampUtils {
 
   // CEL's timestamp range: 0001-01-01T00:00:00Z through 9999-12-31T23:59:59.999999999Z,
   // the same bounds cel-java's standard timestamp(int) conversion enforces.
+  /** The CEL timestamp range, for an error message that names it. */
+  static final String RANGE_TEXT = "0001-01-01T00:00:00Z..9999-12-31T23:59:59.999999999Z";
+
   private static final long MIN_EPOCH_SECOND = -62135596800L;
   private static final long MAX_EPOCH_SECOND = 253402300799L;
 
@@ -102,23 +105,52 @@ final class TimestampUtils {
     // floorDiv/floorMod rather than / and %: a pre-epoch value is negative, and the
     // nano-of-second adjustment must stay non-negative.
     long seconds = Math.floorDiv(epoch, perSecond);
-    if (seconds < MIN_EPOCH_SECOND || seconds > MAX_EPOCH_SECOND) {
+    if (!isEpochSecondInRange(seconds)) {
       throw new IllegalArgumentException(
           "Timestamp out of range: " + seconds + " seconds since the epoch is outside "
-              + "0001-01-01T00:00:00Z..9999-12-31T23:59:59.999999999Z");
+              + RANGE_TEXT);
     }
     return Instant.ofEpochSecond(seconds, Math.floorMod(epoch, perSecond) * nanosPerUnit);
   }
 
-  static Timestamp fromEpochMicros(long us) {
-    long sec = Math.floorDiv(us, 1_000_000L);
-    int nanos = (int) (Math.floorMod(us, 1_000_000L) * 1_000L);
-    return Timestamp.newBuilder().setSeconds(sec).setNanos(nanos).build();
+  /**
+   * Whether an epoch-seconds value is inside the CEL timestamp range. One definition, shared by
+   * {@link #instantOfEpoch} - which refuses outright, being a constructor - and by the variant
+   * extraction path, which routes the refusal through {@code variants.as} / {@code tryAs}.
+   */
+  static boolean isEpochSecondInRange(long seconds) {
+    return seconds >= MIN_EPOCH_SECOND && seconds <= MAX_EPOCH_SECOND;
   }
 
-  static Timestamp fromEpochNanos(long ns) {
-    long sec = Math.floorDiv(ns, 1_000_000_000L);
-    int nanos = (int) Math.floorMod(ns, 1_000_000_000L);
+  /**
+   * A micros epoch as a Timestamp, or {@code null} when it falls outside the CEL range.
+   *
+   * <p>Null rather than an exception because the caller decides: {@code variants.as} raises and
+   * {@code variants.tryAs} answers CEL null, the same split those two already apply to a type
+   * mismatch. A variant timestamp spans the whole int64 range while a CEL timestamp is
+   * 0001-9999, so this is reachable from data - and an out-of-range Timestamp cannot be
+   * rendered anyway (protobuf JSON refuses it), leaving comparisons as the only thing it could
+   * do, which is exactly where a wrong answer would hide.
+   */
+  static Timestamp fromEpochMicrosOrNull(long us) {
+    return fromEpochOrNull(us, 1_000_000L, 1_000L);
+  }
+
+  /**
+   * A nanos epoch as a Timestamp, or {@code null} when outside the CEL range.
+   */
+  static Timestamp fromEpochNanosOrNull(long ns) {
+    return fromEpochOrNull(ns, 1_000_000_000L, 1L);
+  }
+
+  private static Timestamp fromEpochOrNull(long epoch, long perSecond, long nanosPerUnit) {
+    // floorDiv/floorMod, so a pre-epoch value keeps a non-negative nano-of-second - the same
+    // split instantOfEpoch uses.
+    long sec = Math.floorDiv(epoch, perSecond);
+    if (!isEpochSecondInRange(sec)) {
+      return null;
+    }
+    int nanos = (int) (Math.floorMod(epoch, perSecond) * nanosPerUnit);
     return Timestamp.newBuilder().setSeconds(sec).setNanos(nanos).build();
   }
 

--- a/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorVariantTest.java
+++ b/schema-rules/src/test/java/io/confluent/kafka/schemaregistry/rules/cel/CelValidatorVariantTest.java
@@ -27,6 +27,7 @@ import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.confluent.kafka.schemaregistry.rules.ValidationRuleError;
 import io.confluent.kafka.schemaregistry.type.Variant;
+import io.confluent.kafka.schemaregistry.type.VariantBuilder;
 import io.confluent.kafka.schemaregistry.type.VariantUtils;
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -43,6 +44,84 @@ public class CelValidatorVariantTest {
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   /** Build a Doc proto with a Variant field carrying the given JSON payload. */
+  private static DynamicMessage docWithVariant(ProtobufSchema schema, Variant v)
+      throws Exception {
+    Descriptor docDesc = schema.toDescriptor("test.Doc");
+    Descriptor variantDesc = docDesc.findFieldByName("payload").getMessageType();
+    DynamicMessage variantMsg = DynamicMessage.newBuilder(variantDesc)
+        .setField(variantDesc.findFieldByName("value"), toByteString(v.getValueBuffer()))
+        .setField(variantDesc.findFieldByName("metadata"), toByteString(v.getMetadataBuffer()))
+        .build();
+    return DynamicMessage.newBuilder(docDesc)
+        .setField(docDesc.findFieldByName("payload"), variantMsg)
+        .build();
+  }
+
+  private static Variant timestampVariant(long micros) {
+    VariantBuilder b = new VariantBuilder();
+    b.appendTimestampTz(micros);
+    return b.build();
+  }
+
+  /**
+   * A variant timestamp spans the whole int64 range while a CEL timestamp is 0001-9999, so an
+   * out-of-range value is reachable from data. {@code variants.as} has to refuse it and name the
+   * range; {@code variants.tryAs} has to answer CEL null, the same split the pair already
+   * applies to a type mismatch, so a rule can guard.
+   *
+   * <p>It used to build the Timestamp regardless, leaving an invalid instant in the type system:
+   * unrenderable - protobuf JSON refuses it - so comparisons were the only thing that could
+   * consume it, and {@code variants.as(v, "timestamp") < now} answered a confident false for a
+   * value that is not a time.
+   */
+  @Test
+  public void variantAsTimestampIsRangeChecked() throws Exception {
+    String template = "syntax = \"proto3\";\n"
+        + "package test;\n"
+        + "import \"confluent/meta.proto\";\n"
+        + "import \"confluent/type/variant.proto\";\n"
+        + "message Doc {\n"
+        + "  confluent.type.Variant payload = 1 [(confluent.field_meta) = {\n"
+        + "    rules: [{name: \"r\", expr: \"%s\"}]\n"
+        + "  }];\n"
+        + "}\n";
+
+    // In range: the epoch, and one microsecond inside each end.
+    long maxMicros = 253402300799L * 1_000_000L + 999_999L;
+    long minMicros = -62135596800L * 1_000_000L;
+    for (long micros : new long[] {0L, maxMicros, minMicros}) {
+      ProtobufSchema schema = new ProtobufSchema(String.format(template,
+          "variants.as(this, \\\"timestamp\\\") == variants.as(this, \\\"timestamp\\\")"));
+      List<ValidationRuleError> errs = schema.validateMessage(
+          new CelValidator(), docWithVariant(schema, timestampVariant(micros)));
+      assertTrue(errs.isEmpty(), micros + " should be in range -> " + dumpCauses(errs));
+    }
+
+    // Out of range: variants.as refuses and names the range.
+    for (long micros : new long[] {Long.MAX_VALUE, Long.MIN_VALUE, maxMicros + 1_000_000L}) {
+      ProtobufSchema schema = new ProtobufSchema(String.format(template,
+          "variants.as(this, \\\"timestamp\\\") == variants.as(this, \\\"timestamp\\\")"));
+      List<ValidationRuleError> errs = schema.validateMessage(
+          new CelValidator(), docWithVariant(schema, timestampVariant(micros)));
+      assertEquals(1, errs.size(), micros + " should be refused");
+      assertTrue(dumpCauses(errs).contains("is outside 0001-01-01T00:00:00Z"),
+          "should name the range: " + dumpCauses(errs));
+    }
+
+    // tryAs answers CEL null instead, so a rule can guard on it.
+    ProtobufSchema guard = new ProtobufSchema(String.format(template,
+        "variants.tryAs(this, \\\"timestamp\\\") == null"));
+    assertTrue(guard.validateMessage(
+            new CelValidator(), docWithVariant(guard, timestampVariant(Long.MAX_VALUE))).isEmpty(),
+        "tryAs should answer CEL null for an out-of-range timestamp");
+    // And is not null for one in range - otherwise the guard above proves nothing.
+    ProtobufSchema inRange = new ProtobufSchema(String.format(template,
+        "variants.tryAs(this, \\\"timestamp\\\") != null"));
+    assertTrue(inRange.validateMessage(
+            new CelValidator(), docWithVariant(inRange, timestampVariant(0L))).isEmpty(),
+        "tryAs should answer a timestamp for an in-range value");
+  }
+
   private static DynamicMessage docWithVariantJson(ProtobufSchema schema, String json)
       throws Exception {
     Variant v = VariantUtils.fromJsonNode(MAPPER.readTree(json));


### PR DESCRIPTION
<!--
Is there any breaking changes?  If so this is a major release, make sure '#major' is in at least one
commit message to get CI to bump the major.  This will prevent automatic down stream dependency
bumping / consuming.  For more information about semantic versioning see: https://semver.org/


Suggested PR template: Fill/delete/add sections as needed. Optionally delete any commented block.
-->
What
----

`variants.as(v, "timestamp")` built a `Timestamp` from the variant's epoch value without                                                                                          
  bounding it. A Variant timestamp carries a full int64 of micros or nanos, while a CEL                                                                                             
  timestamp is 0001-01-01..9999-12-31, so an out-of-range value is reachable from data and                                                                                          
  became an invalid instant inside the type system.                                                                                                                                 
                                                                                                                                                                                    
  That instant cannot be rendered — protobuf JSON refuses it — so the only thing a rule could                                                                                       
  do with it was compare it, which is exactly where the wrong answer hides:                                                                                                         
  `variants.as(v, "timestamp") < now` returned a confident `false` for a value that is not a                                                                                        
  time.                                                                                                                                                                             
                                                                                                                                                                                    
  `TimestampUtils` was already inconsistent with itself about this. `instantOfEpoch` — the                                                                                          
  epoch *constructor* path behind `timestamp(epoch, precision)` — checks the same bounds and                                                                                        
  raises "Timestamp out of range: N seconds since the epoch is outside 0001-…". Ten lines                                                                                           
  away, `fromEpochMicros`/`fromEpochNanos` built the value unchecked, and those were what                                                                                           
  `variantGetTimestamp` used. Same conversion, two rules, no stated reason.                                                                                                         
                                                                                                                                                                                    
  ## What changed                                                                                                                                                                   
                                                                                                                                                                                    
  - `TimestampUtils.isEpochSecondInRange(long)` holds the bounds once; `instantOfEpoch` now                                                                                         
    calls it, so the constructor path and the variant path cannot drift.                                                                                                            
  - `fromEpochMicrosOrNull` / `fromEpochNanosOrNull` replace the unchecked builders (the                                                                                            
    variant path was their only caller) and return `null` outside the range rather than                                                                                             
    throwing, because the caller decides what that means.                                                                                                                           
  - `variantAs`'s `"timestamp"` arm routes that `null` through `nullOnError`, the same split                                                                                        
    the pair already applies to a type mismatch:                                                                                                                                    
    - `variants.as(v, "timestamp")` raises and names the range.                                                                                                                     
    - `variants.tryAs(v, "timestamp")` answers CEL null, so a rule can guard with                                                                                                   
      `variants.tryAs(v, "timestamp") == null`.                                                                                                                                     
                                                                                                                                                                                    
  The `tryAs` half is the part that makes this safe rather than merely stricter. Variant                                                                                            
  timestamps legitimately span int64, so out-of-range values can exist in real data; without                                                                                        
  `tryAs` returning null there would be no way for a rule to cope with one, and a range                                                                                             
  exception thrown from the helper would have escaped `tryAs` too — worse than the original                                                                                         
  behaviour.                                              

<!--
Briefly describe **what** you have changed and **why**.
Optionally include implementation strategy.
-->

Checklist
------------------
Please answer the questions with Y, N or N/A if not applicable.
- **[Y]** Contains customer facing changes? Including API/behavior changes <!-- This can help identify if it has introduced any breaking changes -->
- **[N]** Is this change gated behind config(s)?
    - List the config(s) needed to be set to enable this change
- **[Y]** Did you add sufficient unit test and/or integration test coverage for this PR?
    - If not, please explain why it is not required
- **[N]** Does this change require modifying existing system tests or adding new system tests? <!-- Primarily for changes that could impact CCloud integrations -->
    - If so, include tracking information for the system test changes
- **[N]** Must this be released together with other change(s), either in this repo or another one?
    - If so, please include the link(s) to the changes that must be released together

References
----------
JIRA:
<!--
Copy&paste links: to Jira ticket, other PRs, issues, Slack conversations...
For code bumps: link to PR, tag or GitHub `/compare/master...master`
-->

Test & Review
------------
<!--
Has it been tested? how?
Copy&paste any handy instructions, steps or requirements that can save time to the reviewer or any reader.
-->

Open questions / Follow-ups
--------------------------
<!--
Optional: anything open to discussion for the reviewer, out of scope, or follow ups.
-->

<!--
Review stakeholders
------------------
<!--
Optional: mention stakeholders or if special context that is required to review.
-->
